### PR TITLE
feat: add cloneUrl to POST /api/v1/projects

### DIFF
--- a/backend/internal/daemon/daemon.go
+++ b/backend/internal/daemon/daemon.go
@@ -157,7 +157,7 @@ func Run() error {
 	}
 	lcStack.LCM.SetCompletionTerminator(sessMgr)
 	lcStack.scmDone = startSCMObserver(ctx, store, lcStack.LCM, log)
-	projectSvc := projectsvc.NewWithDeps(projectsvc.Deps{Store: store, Sessions: sessionSvc, DefaultHarness: domain.AgentHarness(cfg.Agent), Telemetry: telemetrySink})
+	projectSvc := projectsvc.NewWithDeps(projectsvc.Deps{Store: store, Sessions: sessionSvc, DefaultHarness: domain.AgentHarness(cfg.Agent), Telemetry: telemetrySink, ReposRoot: filepath.Join(cfg.DataDir, "repos")})
 	if err := seedScratchProjectOnBoot(ctx, cfg, projectSvc); err != nil {
 		stop()
 		lcStack.Stop()

--- a/backend/internal/httpd/apispec/openapi.yaml
+++ b/backend/internal/httpd/apispec/openapi.yaml
@@ -643,7 +643,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/APIError'
           description: Internal Server Error
-      summary: Register a new project from a git repository path
+      summary: Register a new project from a local git repository path, or by cloning
+        a cloneUrl
       tags:
       - projects
   /api/v1/projects/{id}:
@@ -2232,6 +2233,8 @@ components:
       properties:
         asWorkspace:
           type: boolean
+        cloneUrl:
+          type: string
         config:
           $ref: '#/components/schemas/ProjectConfig'
         name:
@@ -2244,8 +2247,6 @@ components:
           type:
           - "null"
           - string
-      required:
-      - path
       type: object
     AgentConfig:
       properties:

--- a/backend/internal/httpd/apispec/specgen/build.go
+++ b/backend/internal/httpd/apispec/specgen/build.go
@@ -681,7 +681,7 @@ func projectOperations() []operation {
 		},
 		{
 			method: http.MethodPost, path: "/api/v1/projects", id: "addProject", tag: "projects",
-			summary: "Register a new project from a git repository path",
+			summary: "Register a new project from a local git repository path, or by cloning a cloneUrl",
 			reqBody: projectsvc.AddInput{},
 			resps: []respUnit{
 				{http.StatusCreated, controllers.ProjectResponse{}},

--- a/backend/internal/service/project/clone.go
+++ b/backend/internal/service/project/clone.go
@@ -1,0 +1,160 @@
+package project
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/httpd/apierr"
+	aoprocess "github.com/aoagents/agent-orchestrator/backend/internal/process"
+)
+
+// cloneTimeout bounds how long `git clone` may run. It is generous and
+// deliberately decoupled from the daemon's per-request HTTP timeout (see
+// cloneRepository) because project.Add clones synchronously — no job model
+// with progress reporting exists yet.
+const cloneTimeout = 5 * time.Minute
+
+// cloneRepository clones cloneURL into <reposRoot>/<owner>-<repo> and returns
+// the destination path. Every failure is mapped to a remediation-shaped
+// *apierr.Error; the raw git error text never reaches the caller.
+func (m *Service) cloneRepository(ctx context.Context, cloneURL string) (string, error) {
+	if strings.TrimSpace(m.reposRoot) == "" {
+		return "", apierr.Internal("CLONE_NOT_CONFIGURED", "Cloning by URL is not configured on this daemon")
+	}
+	owner, repo, err := parseCloneURL(cloneURL)
+	if err != nil {
+		return "", apierr.Invalid("CLONE_URL_INVALID", "Could not parse the git URL. Use an https:// or ssh git remote URL.", nil)
+	}
+	if err := os.MkdirAll(m.reposRoot, 0o750); err != nil {
+		return "", apierr.Internal("CLONE_DEST_UNAVAILABLE", "Could not prepare the clone destination directory")
+	}
+	dest := filepath.Join(m.reposRoot, owner+"-"+repo)
+	if _, err := os.Stat(dest); err == nil {
+		return "", apierr.Conflict("CLONE_DESTINATION_EXISTS",
+			fmt.Sprintf("A repository is already cloned at %s. Remove it or register the existing clone by path instead.", dest),
+			map[string]any{"path": dest})
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return "", apierr.Internal("CLONE_DEST_UNAVAILABLE", "Could not inspect the clone destination directory")
+	}
+
+	// Decoupled from the incoming request's own deadline (the daemon's REST
+	// group applies a short per-request timeout, see httpd/api.go): only this
+	// clone's own generous timeout should bound it.
+	cloneCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), cloneTimeout)
+	defer cancel()
+
+	cmd := aoprocess.CommandContext(cloneCtx, "git", "clone", "--", cloneURL, dest)
+	cmd.Env = append(os.Environ(),
+		"GIT_TERMINAL_PROMPT=0", // never block on an interactive credential prompt
+		"GIT_SSH_COMMAND=ssh -o BatchMode=yes -o ConnectTimeout=15", // never block on an SSH password/host-key prompt
+	)
+	out, cloneErr := cmd.CombinedOutput()
+	if cloneErr == nil {
+		return dest, nil
+	}
+	_ = os.RemoveAll(dest) // don't leave a partial clone blocking a retry under the same name
+
+	if cloneCtx.Err() != nil {
+		return "", apierr.Invalid("CLONE_TIMEOUT",
+			fmt.Sprintf("Clone timed out after %s. Check your network connection and try again.", cloneTimeout), nil)
+	}
+	return "", classifyCloneError(string(out))
+}
+
+// classifyCloneError maps common git clone failure text to actionable,
+// remediation-shaped errors. The raw git output is intentionally not included
+// in the returned error: callers must never see it.
+func classifyCloneError(output string) *apierr.Error {
+	lower := strings.ToLower(output)
+	switch {
+	case containsAny(lower, "could not read username", "could not read password", "authentication failed", "permission denied (publickey)", "terminal prompts disabled", "invalid credentials"):
+		return apierr.Invalid("CLONE_AUTH_FAILED",
+			"No git credentials on this machine. For an https:// URL, run `gh auth login`. For an SSH URL, add a deploy key or start an SSH agent, then try again.",
+			nil)
+	case containsAny(lower, "could not resolve host", "temporary failure in name resolution"):
+		return apierr.Invalid("CLONE_HOST_NOT_FOUND",
+			"Could not reach the git host. Check the URL and your network connection.",
+			nil)
+	case containsAny(lower, "host key verification failed"):
+		return apierr.Invalid("CLONE_HOST_KEY_UNVERIFIED",
+			"The SSH host key for this git host is not recognized on this machine. Run `ssh -T <user>@<host>` once to accept it, or use an https:// URL instead.",
+			nil)
+	case containsAny(lower, "repository not found", "not found"):
+		return apierr.Invalid("CLONE_REPO_NOT_FOUND",
+			"Repository not found. Check the URL and that you have access to it.",
+			nil)
+	default:
+		return apierr.Invalid("CLONE_FAILED", "Could not clone the repository. Check the URL and try again.", nil)
+	}
+}
+
+func containsAny(s string, substrs ...string) bool {
+	for _, sub := range substrs {
+		if strings.Contains(s, sub) {
+			return true
+		}
+	}
+	return false
+}
+
+// scpLikeCloneURL matches the scp-like git remote syntax, e.g.
+// "git@github.com:owner/repo.git" — a form net/url.Parse does not recognise
+// as having a scheme/host.
+var scpLikeCloneURL = regexp.MustCompile(`^[\w.-]+@[\w.-]+:(.+)$`)
+
+// safeDirComponent restricts a parsed owner/repo segment to characters safe
+// for a single path component, rejecting anything that could traverse or
+// otherwise misbehave once joined into reposRoot.
+var safeDirComponent = regexp.MustCompile(`^[A-Za-z0-9._-]+$`)
+
+// parseCloneURL extracts the owner and repository name from a git remote URL,
+// used to build the <owner>-<repo> clone destination name. It accepts
+// scheme-qualified URLs (https://, ssh://, git://, file://) and the scp-like
+// SSH shorthand (user@host:owner/repo.git).
+func parseCloneURL(raw string) (owner, repo string, err error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "", "", errors.New("clone url is required")
+	}
+
+	var pathPart string
+	if u, uerr := url.Parse(raw); uerr == nil && u.Scheme != "" {
+		pathPart = u.Path
+	} else if m := scpLikeCloneURL.FindStringSubmatch(raw); m != nil {
+		pathPart = m[1]
+	} else {
+		return "", "", fmt.Errorf("unrecognized clone url %q", raw)
+	}
+
+	pathPart = strings.Trim(pathPart, "/")
+	pathPart = strings.TrimSuffix(pathPart, ".git")
+	segments := strings.Split(pathPart, "/")
+	if len(segments) < 2 {
+		return "", "", fmt.Errorf("clone url %q must include an owner and a repository", raw)
+	}
+
+	repo, err = sanitizeDirComponent(segments[len(segments)-1])
+	if err != nil {
+		return "", "", err
+	}
+	owner, err = sanitizeDirComponent(segments[len(segments)-2])
+	if err != nil {
+		return "", "", err
+	}
+	return owner, repo, nil
+}
+
+func sanitizeDirComponent(s string) (string, error) {
+	s = strings.TrimSpace(s)
+	if s == "" || s == "." || s == ".." || !safeDirComponent.MatchString(s) {
+		return "", fmt.Errorf("invalid path component %q", s)
+	}
+	return s, nil
+}

--- a/backend/internal/service/project/dto.go
+++ b/backend/internal/service/project/dto.go
@@ -11,7 +11,13 @@ type GetResult struct {
 
 // AddInput is the body shape for POST /api/v1/projects.
 type AddInput struct {
-	Path        string                `json:"path"`
+	// Path is the local filesystem path to a git repository. Required unless
+	// CloneURL is set; the two are mutually exclusive.
+	Path string `json:"path,omitempty"`
+	// CloneURL is a git remote URL (https:// or ssh) to clone before
+	// registering the project. The daemon clones it into a managed directory
+	// under the AO data dir and uses that as the project path.
+	CloneURL    string                `json:"cloneUrl,omitempty"`
 	ProjectID   *string               `json:"projectId,omitempty"`
 	Name        *string               `json:"name,omitempty"`
 	Config      *domain.ProjectConfig `json:"config,omitempty"`

--- a/backend/internal/service/project/service.go
+++ b/backend/internal/service/project/service.go
@@ -61,10 +61,14 @@ type Service struct {
 	clock          func() time.Time
 	telemetry      ports.EventSink
 	defaultHarness domain.AgentHarness
+	// reposRoot is where POST /projects clones land when CloneURL is set:
+	// <reposRoot>/<owner>-<repo>. Empty means cloning by URL is not configured.
+	reposRoot string
 	// addMu serialises the whole body of Add. Workspace registration performs
 	// filesystem mutations (git init, .gitignore writes, commits) that are not
 	// covered by the store's own writeMu, so path/id conflict checks plus the
-	// subsequent mutation must be atomic from the perspective of concurrent callers.
+	// subsequent mutation (including a CloneURL clone) must be atomic from the
+	// perspective of concurrent callers.
 	addMu sync.Mutex
 }
 
@@ -81,6 +85,10 @@ type Deps struct {
 	Sessions       SessionTeardowner
 	Clock          func() time.Time
 	Telemetry      ports.EventSink
+	// ReposRoot is where POST /projects clones land when AddInput.CloneURL is
+	// set. Wired from the daemon's data dir (<DataDir>/repos) so it stays
+	// under ~/.ao and honours AO_DATA_DIR overrides.
+	ReposRoot string
 }
 
 // New returns a project service backed by the given durable store.
@@ -100,6 +108,7 @@ func NewWithDeps(d Deps) *Service {
 		clock:          d.Clock,
 		telemetry:      d.Telemetry,
 		defaultHarness: defaultHarness,
+		reposRoot:      d.ReposRoot,
 	}
 	if s.clock == nil {
 		s.clock = time.Now
@@ -150,14 +159,34 @@ func (m *Service) Get(ctx context.Context, id domain.ProjectID) (GetResult, erro
 	return GetResult{Status: "ok", Project: &p}, nil
 }
 
-// Add registers a local git repository as a project.
+// Add registers a git repository as a project, either from a local Path or by
+// cloning a CloneURL first (the two are mutually exclusive).
 //
 // The whole method body is serialised by addMu because workspace registration
 // mutates the filesystem (git init, .gitignore, commits) between the conflict
 // check and the store write — two concurrent calls for the same path would both
-// pass FindProjectByPath and then race on those mutations.
+// pass FindProjectByPath and then race on those mutations. A CloneURL clone is
+// itself such a mutation (two concurrent adds of the same URL would otherwise
+// race on the same destination directory), so it runs inside the same lock.
 func (m *Service) Add(ctx context.Context, in AddInput) (Project, error) {
-	path, err := normalizePath(in.Path)
+	rawPath := strings.TrimSpace(in.Path)
+	cloneURL := strings.TrimSpace(in.CloneURL)
+	if rawPath != "" && cloneURL != "" {
+		return Project{}, apierr.Invalid("PATH_AND_CLONE_URL_CONFLICT", "Provide either path or cloneUrl, not both", nil)
+	}
+
+	m.addMu.Lock()
+	defer m.addMu.Unlock()
+
+	if cloneURL != "" {
+		clonedPath, err := m.cloneRepository(ctx, cloneURL)
+		if err != nil {
+			return Project{}, err
+		}
+		rawPath = clonedPath
+	}
+
+	path, err := normalizePath(rawPath)
 	if err != nil {
 		return Project{}, err
 	}
@@ -168,9 +197,6 @@ func (m *Service) Add(ctx context.Context, in AddInput) (Project, error) {
 	if err := validateProjectID(id); err != nil {
 		return Project{}, err
 	}
-
-	m.addMu.Lock()
-	defer m.addMu.Unlock()
 
 	projectCountBefore, err := m.activeProjectCount(ctx)
 	if err != nil {

--- a/backend/internal/service/project/service_test.go
+++ b/backend/internal/service/project/service_test.go
@@ -3,6 +3,8 @@ package project_test
 import (
 	"context"
 	"errors"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -916,6 +918,116 @@ func TestManager_AddPopulatesRepoOriginURL(t *testing.T) {
 			}
 		})
 	}
+}
+
+// newManagerWithReposRoot is newManager plus a configured clone destination
+// root, needed by any test that adds a project via AddInput.CloneURL.
+func newManagerWithReposRoot(t *testing.T, reposRoot string) project.Manager {
+	t.Helper()
+	t.Setenv("GIT_CEILING_DIRECTORIES", os.TempDir())
+	store, err := sqlite.Open(t.TempDir())
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	return project.NewWithDeps(project.Deps{Store: store, ReposRoot: reposRoot})
+}
+
+// gitRepoNamed creates a real git repository at <t.TempDir()>/owner/repo, so
+// tests can build a predictable clone URL and assert the exact <owner>-<repo>
+// destination name and default project id.
+func gitRepoNamed(t *testing.T, owner, repo string) string {
+	t.Helper()
+	dir := filepath.Join(t.TempDir(), owner, repo)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if out, err := exec.Command("git", "init", "-b", "main", dir).CombinedOutput(); err != nil {
+		t.Fatalf("git unavailable: %v (%s)", err, out)
+	}
+	commitEmpty(t, dir)
+	return dir
+}
+
+func TestManager_AddClonesFromCloneURL(t *testing.T) {
+	ctx := context.Background()
+	reposRoot := t.TempDir()
+	m := newManagerWithReposRoot(t, reposRoot)
+
+	source := gitRepoNamed(t, "acme", "widgets")
+	cloneURL := "file://" + filepath.ToSlash(source)
+
+	proj, err := m.Add(ctx, project.AddInput{CloneURL: cloneURL})
+	if err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	wantPath := filepath.Join(reposRoot, "acme-widgets")
+	if proj.ID != "acme-widgets" {
+		t.Fatalf("ID = %q, want acme-widgets", proj.ID)
+	}
+	if proj.Path != wantPath {
+		t.Fatalf("Path = %q, want %q", proj.Path, wantPath)
+	}
+	if _, err := os.Stat(filepath.Join(wantPath, ".git")); err != nil {
+		t.Fatalf("cloned repo missing .git: %v", err)
+	}
+}
+
+func TestManager_AddCloneAuthFailureRemediation(t *testing.T) {
+	ctx := context.Background()
+	reposRoot := t.TempDir()
+	// Isolate from the host machine's global git config and any cached
+	// credential helpers so this never accidentally succeeds (or fails
+	// differently) on a developer's own laptop.
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	// A bare 401 is exactly what an unauthenticated git-over-HTTP clone gets
+	// from a host that requires credentials; with GIT_TERMINAL_PROMPT=0 git
+	// fails immediately instead of hanging on a prompt. This is a loopback
+	// httptest server, not a real network call.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("WWW-Authenticate", `Basic realm="test"`)
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	t.Cleanup(srv.Close)
+
+	m := newManagerWithReposRoot(t, reposRoot)
+	cloneURL := srv.URL + "/acme/widgets.git"
+
+	_, err := m.Add(ctx, project.AddInput{CloneURL: cloneURL})
+	wantCode(t, err, "CLONE_AUTH_FAILED")
+
+	var apiErr *apierr.Error
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("error = %v, want *apierr.Error", err)
+	}
+	if strings.Contains(apiErr.Message, "fatal:") || strings.Contains(apiErr.Message, srv.URL) {
+		t.Fatalf("remediation message leaked raw git output: %q", apiErr.Message)
+	}
+
+	if _, statErr := os.Stat(filepath.Join(reposRoot, "acme-widgets")); !os.IsNotExist(statErr) {
+		t.Fatalf("expected failed clone destination to be cleaned up, stat err = %v", statErr)
+	}
+}
+
+func TestManager_AddCloneURLValidation(t *testing.T) {
+	ctx := context.Background()
+	reposRoot := t.TempDir()
+	m := newManagerWithReposRoot(t, reposRoot)
+
+	_, err := m.Add(ctx, project.AddInput{Path: t.TempDir(), CloneURL: "https://example.com/o/r.git"})
+	wantCode(t, err, "PATH_AND_CLONE_URL_CONFLICT")
+
+	_, err = m.Add(ctx, project.AddInput{CloneURL: "not-a-git-url"})
+	wantCode(t, err, "CLONE_URL_INVALID")
+
+	source := gitRepoNamed(t, "acme", "widgets")
+	if err := os.MkdirAll(filepath.Join(reposRoot, "acme-widgets"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	_, err = m.Add(ctx, project.AddInput{CloneURL: "file://" + filepath.ToSlash(source)})
+	wantCode(t, err, "CLONE_DESTINATION_EXISTS")
 }
 
 func TestManager_GetUpdateRemoveErrors(t *testing.T) {

--- a/frontend/src/api/schema.ts
+++ b/frontend/src/api/schema.ts
@@ -288,7 +288,7 @@ export interface paths {
         /** List all registered projects (active + degraded) */
         get: operations["listProjects"];
         put?: never;
-        /** Register a new project from a git repository path */
+        /** Register a new project from a local git repository path, or by cloning a cloneUrl */
         post: operations["addProject"];
         delete?: never;
         options?: never;
@@ -812,9 +812,10 @@ export interface components {
         };
         AddProjectInput: {
             asWorkspace?: boolean;
+            cloneUrl?: string;
             config?: components["schemas"]["ProjectConfig"];
             name?: null | string;
-            path: string;
+            path?: string;
             projectId?: null | string;
         };
         AgentConfig: {


### PR DESCRIPTION
## Summary

- `POST /api/v1/projects` accepts an optional `cloneUrl`. When present, the daemon clones the repo synchronously into `<AO data dir>/repos/<owner>-<repo>` (honors `AO_DATA_DIR`, stays under `~/.ao`) and registers the clone, using the same code path in local and remote mode.
- Clone failures never surface raw git output. `classifyCloneError` maps common failure modes (missing credentials, unresolvable host, unrecognized SSH host key, repository not found, timeout) to actionable remediation text, e.g. "run `gh auth login`".
- The clone runs on its own generous timeout (5 minutes), decoupled from the daemon's per-request REST timeout (60s default), so a slow clone is not killed early by the route group's `middleware.Timeout`.
- `path` and `cloneUrl` are mutually exclusive (`PATH_AND_CLONE_URL_CONFLICT`).
- DTO change in `backend/internal/service/project/dto.go` (`AddInput.CloneURL`), operation summary updated in `backend/internal/httpd/apispec/specgen/build.go`, `openapi.yaml` and `frontend/src/api/schema.ts` regenerated via `npm run api` and committed.

Closes #3.

## Test plan

- [x] `go build ./...`, `go vet ./...` (backend)
- [x] `go test ./internal/service/project/...` — new tests cover the happy path (`TestManager_AddClonesFromCloneURL`), the auth-failure remediation path via a local `httptest` server returning 401 (`TestManager_AddCloneAuthFailureRemediation`, no real network calls), and input validation (`TestManager_AddCloneURLValidation`)
- [x] `go test ./internal/httpd/...` — spec drift / route-spec parity tests pass against the regenerated `openapi.yaml`
- [x] `go test ./...` (backend) — all passing except 5 pre-existing `internal/cli` spawn test failures confirmed present on the base branch before this change (unrelated to this PR)
- [x] `golangci-lint run` on touched packages — 0 issues
- [x] `npm run typecheck` (frontend) — clean after `schema.ts` regeneration

## Known risks / follow-ups

- The CLI's hand-mirrored `addProjectRequest` DTO (`backend/internal/cli/project.go`) is intentionally left without a `--clone-url` flag; this PR is scoped to the daemon HTTP endpoint per the task breakdown. A CLI flag can follow separately if wanted.