### PR TITLE
fix: always dispatch required Go workflows and dedupe job names

### DIFF
--- a/.github/workflows/controlplane-go.yml
+++ b/.github/workflows/controlplane-go.yml
@@ -4,15 +4,12 @@ on:
   push:
     branches: [main]
   pull_request:
-    paths:
-      - "controlplane/**"
-      - ".github/workflows/controlplane-go.yml"
 
 permissions:
   contents: read
 
 jobs:
-  build-test:
+  controlplane-build-test:
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -4,11 +4,6 @@ on:
   push:
     branches: [main]
   pull_request:
-    paths:
-      - "backend/**"
-      - "frontend/src/api/schema.ts"
-      - "package.json"
-      - ".github/workflows/go.yml"
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

The `Protect Default Branch` ruleset on `develop` requires four contexts: `build-test`, `api-drift`, `lint`, `scan`. Three of them live in workflows with `pull_request` `paths:` filters, so a PR that does not touch those paths never dispatches them, and GitHub holds the PR at "Expected, waiting for status to be reported" forever. This has been blocking issues #7 and #8 (both `controlplane/`-only PRs).

- Removed the `pull_request` `paths:` filters from `.github/workflows/go.yml` and `.github/workflows/controlplane-go.yml`, so both workflows always dispatch on pull requests and always report their required contexts. `push` triggers are untouched.
- Renamed the `Controlplane Go` job `build-test` to `controlplane-build-test`, since both `Go` and `Controlplane Go` previously exposed a job literally named `build-test`, making the required `build-test` context ambiguous between workflows.

No source changes; workflow files only.

Closes #10

## Action required after merge

**The human must add `controlplane-build-test` to the ruleset's required status checks list**, since it is a new context name that did not exist before. The required `build-test` context will from now on come from the `Go` workflow only.

## Test plan
- [x] YAML validity checked for both files
- [x] `git diff --stat` confirms only the two intended workflow files changed
- [ ] CI on this PR reports `build-test`, `lint`, `api-drift`, `scan`, and `controlplane-build-test` as distinct green checks