### PR TITLE
feat: control plane Google login with PKCE

### DIFF
--- a/controlplane/README.md
+++ b/controlplane/README.md
@@ -52,6 +52,11 @@ curl http://127.0.0.1:8080/healthz
 # {"status":"ok"}
 ```
 
+Open `http://127.0.0.1:8080/login` in a browser and sign in with Google to
+exercise the login flow end to end (see `internal/auth/` for the
+authorization-code exchange with PKCE, the `accounts` upsert, and the browser
+session cookie).
+
 ## Test
 
 ```bash

--- a/controlplane/cmd/controlplane/main.go
+++ b/controlplane/cmd/controlplane/main.go
@@ -13,6 +13,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/agentlab-in/hosted-ao/controlplane/internal/auth"
 	"github.com/agentlab-in/hosted-ao/controlplane/internal/config"
 	"github.com/agentlab-in/hosted-ao/controlplane/internal/server"
 	"github.com/agentlab-in/hosted-ao/controlplane/internal/storage/sqlite"
@@ -34,6 +35,12 @@ func main() {
 	defer db.Close()
 
 	mux := server.New(db)
+
+	authSvc, err := auth.NewService(db, cfg)
+	if err != nil {
+		log.Fatalf("init auth: %v", err)
+	}
+	authSvc.Register(mux)
 
 	// LISTEN_ADDR defaults to loopback (127.0.0.1:8080): this service sits
 	// behind Caddy on the same box, which terminates TLS and reverse-proxies

--- a/controlplane/go.mod
+++ b/controlplane/go.mod
@@ -3,13 +3,13 @@ module github.com/agentlab-in/hosted-ao/controlplane
 go 1.25.7
 
 require (
+	github.com/google/uuid v1.6.0
 	github.com/pressly/goose/v3 v3.27.3
 	modernc.org/sqlite v1.55.0
 )
 
 require (
 	github.com/dustin/go-humanize v1.0.1 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/mattn/go-isatty v0.0.23 // indirect
 	github.com/mfridman/interpolate v0.0.2 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect

--- a/controlplane/internal/auth/auth.go
+++ b/controlplane/internal/auth/auth.go
@@ -1,0 +1,95 @@
+// Package auth implements Google sign-in for the control plane: the
+// authorization-code exchange with PKCE, the accounts upsert keyed on the
+// Google subject, and a signed browser session cookie for the operator. It
+// owns its own routes and storage access and does not reach into the shared
+// server or config packages beyond reading Config, so it can be developed
+// and merged independently of the keys-and-tokens work landing in the same
+// tree.
+package auth
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"html/template"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/agentlab-in/hosted-ao/controlplane/internal/config"
+)
+
+// Service holds everything the Google login flow needs: the database for the
+// accounts upsert, the OAuth client configuration, the HTTP client used to
+// talk to Google, the session-signing key, and the parsed sign-in page
+// template.
+type Service struct {
+	db           *sql.DB
+	clientID     string
+	clientSecret string
+	redirectURI  string
+	endpoints    googleEndpoints
+	httpClient   *http.Client
+
+	sessionKey    []byte
+	secureCookies bool
+
+	tmpl *template.Template
+}
+
+// NewService builds the auth Service, loading (or generating, on first boot)
+// the session-signing key under cfg.DataDir and parsing the sign-in page
+// template. It does not talk to Google or the database beyond that.
+func NewService(db *sql.DB, cfg config.Config) (*Service, error) {
+	key, err := loadOrCreateSessionKey(cfg.DataDir)
+	if err != nil {
+		return nil, fmt.Errorf("load session key: %w", err)
+	}
+
+	tmpl, err := template.ParseFS(templatesFS, "templates/*.html")
+	if err != nil {
+		return nil, fmt.Errorf("parse templates: %w", err)
+	}
+
+	return &Service{
+		db:            db,
+		clientID:      cfg.GoogleClientID,
+		clientSecret:  cfg.GoogleClientSecret,
+		redirectURI:   strings.TrimRight(cfg.PublicOrigin, "/") + "/auth/google/callback",
+		endpoints:     defaultGoogleEndpoints,
+		httpClient:    &http.Client{Timeout: 10 * time.Second},
+		sessionKey:    key,
+		secureCookies: strings.HasPrefix(cfg.PublicOrigin, "https://"),
+		tmpl:          tmpl,
+	}, nil
+}
+
+// Register wires the auth routes onto mux: the sign-in page and the two
+// Google OAuth endpoints. This is the one call the rest of the control plane
+// needs to know about.
+func (s *Service) Register(mux *http.ServeMux) {
+	mux.HandleFunc("GET /login", s.handleSignInPage)
+	mux.HandleFunc("GET /auth/google/login", s.handleGoogleLogin)
+	mux.HandleFunc("GET /auth/google/callback", s.handleGoogleCallback)
+}
+
+// upsertAccount inserts a new account row for subject, or, if one already
+// exists, updates its email and returns the existing id. Accounts are keyed
+// on the Google subject rather than the email because emails change; the id
+// returned here is stable across repeat logins.
+func (s *Service) upsertAccount(ctx context.Context, subject, email string) (string, error) {
+	const q = `
+		INSERT INTO accounts (id, google_subject, email, created_at)
+		VALUES (?, ?, ?, ?)
+		ON CONFLICT (google_subject) DO UPDATE SET email = excluded.email
+		RETURNING id`
+
+	var id string
+	err := s.db.QueryRowContext(ctx, q, uuid.NewString(), subject, email, time.Now().UTC()).Scan(&id)
+	if err != nil {
+		return "", fmt.Errorf("upsert account: %w", err)
+	}
+	return id, nil
+}

--- a/controlplane/internal/auth/oauth.go
+++ b/controlplane/internal/auth/oauth.go
@@ -1,0 +1,304 @@
+package auth
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	flowCookieName = "ao_oauth_flow"
+	flowTTL        = 10 * time.Minute
+
+	googleScopes = "openid email profile"
+)
+
+// googleEndpoints are the three Google URLs the exchange needs. They are a
+// field on Service, not package-level constants, so tests can point them at
+// an httptest server instead of the real Google.
+type googleEndpoints struct {
+	AuthURL     string
+	TokenURL    string
+	UserinfoURL string
+}
+
+var defaultGoogleEndpoints = googleEndpoints{
+	AuthURL:     "https://accounts.google.com/o/oauth2/v2/auth",
+	TokenURL:    "https://oauth2.googleapis.com/token",
+	UserinfoURL: "https://openidconnect.googleapis.com/v1/userinfo",
+}
+
+// flowState is the data carried across the redirect to Google and back,
+// packed into the signed ao_oauth_flow cookie: the CSRF state, the PKCE code
+// verifier, and where to send the operator once signed in.
+type flowState struct {
+	State    string
+	Verifier string
+	Next     string
+}
+
+// generatePKCE returns a random RFC 7636 code verifier and its S256
+// challenge.
+func generatePKCE() (verifier, challenge string, err error) {
+	b := make([]byte, 32)
+	if _, err = rand.Read(b); err != nil {
+		return "", "", fmt.Errorf("generate code verifier: %w", err)
+	}
+	verifier = base64.RawURLEncoding.EncodeToString(b)
+	sum := sha256.Sum256([]byte(verifier))
+	challenge = base64.RawURLEncoding.EncodeToString(sum[:])
+	return verifier, challenge, nil
+}
+
+// generateState returns a random CSRF state value for the authorization
+// request.
+func generateState() (string, error) {
+	b := make([]byte, 24)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("generate state: %w", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(b), nil
+}
+
+// sanitizeNext restricts a caller-supplied redirect target to a same-site
+// relative path, so the login flow can't be used as an open redirect.
+func sanitizeNext(next string) string {
+	if next == "" || !strings.HasPrefix(next, "/") || strings.HasPrefix(next, "//") {
+		return "/"
+	}
+	return next
+}
+
+func (s *Service) setFlowCookie(w http.ResponseWriter, f flowState) {
+	exp := time.Now().Add(flowTTL)
+	payload := strings.Join([]string{f.State, f.Verifier, f.Next, strconv.FormatInt(exp.Unix(), 10)}, "|")
+	http.SetCookie(w, &http.Cookie{
+		Name:     flowCookieName,
+		Value:    s.signedCookieValue(payload),
+		Path:     "/",
+		Expires:  exp,
+		HttpOnly: true,
+		Secure:   s.secureCookies,
+		SameSite: http.SameSiteLaxMode,
+	})
+}
+
+func (s *Service) clearFlowCookie(w http.ResponseWriter) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     flowCookieName,
+		Value:    "",
+		Path:     "/",
+		MaxAge:   -1,
+		HttpOnly: true,
+		Secure:   s.secureCookies,
+		SameSite: http.SameSiteLaxMode,
+	})
+}
+
+// flowFromRequest recovers the flow state set by handleGoogleLogin, if the
+// callback still carries a valid, unexpired ao_oauth_flow cookie.
+func (s *Service) flowFromRequest(r *http.Request) (flowState, bool) {
+	c, err := r.Cookie(flowCookieName)
+	if err != nil {
+		return flowState{}, false
+	}
+	payload, ok := s.verifySignedCookieValue(c.Value)
+	if !ok {
+		return flowState{}, false
+	}
+	parts := strings.Split(payload, "|")
+	if len(parts) != 4 {
+		return flowState{}, false
+	}
+	exp, err := strconv.ParseInt(parts[3], 10, 64)
+	if err != nil {
+		return flowState{}, false
+	}
+	if time.Now().Unix() > exp {
+		return flowState{}, false
+	}
+	return flowState{State: parts[0], Verifier: parts[1], Next: parts[2]}, true
+}
+
+func (s *Service) handleGoogleLogin(w http.ResponseWriter, r *http.Request) {
+	next := sanitizeNext(r.URL.Query().Get("next"))
+
+	verifier, challenge, err := generatePKCE()
+	if err != nil {
+		log.Printf("auth: %v", err)
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+	state, err := generateState()
+	if err != nil {
+		log.Printf("auth: %v", err)
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+	s.setFlowCookie(w, flowState{State: state, Verifier: verifier, Next: next})
+
+	u, err := url.Parse(s.endpoints.AuthURL)
+	if err != nil {
+		log.Printf("auth: parse google auth url: %v", err)
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+	q := u.Query()
+	q.Set("client_id", s.clientID)
+	q.Set("redirect_uri", s.redirectURI)
+	q.Set("response_type", "code")
+	q.Set("scope", googleScopes)
+	q.Set("state", state)
+	q.Set("code_challenge", challenge)
+	q.Set("code_challenge_method", "S256")
+	u.RawQuery = q.Encode()
+
+	http.Redirect(w, r, u.String(), http.StatusFound)
+}
+
+func (s *Service) handleGoogleCallback(w http.ResponseWriter, r *http.Request) {
+	if errParam := r.URL.Query().Get("error"); errParam != "" {
+		s.clearFlowCookie(w)
+		http.Redirect(w, r, "/login?error=access_denied", http.StatusFound)
+		return
+	}
+
+	flow, ok := s.flowFromRequest(r)
+	s.clearFlowCookie(w)
+	if !ok {
+		http.Redirect(w, r, "/login?error=expired", http.StatusFound)
+		return
+	}
+	if state := r.URL.Query().Get("state"); state == "" || state != flow.State {
+		http.Redirect(w, r, "/login?error=state_mismatch", http.StatusFound)
+		return
+	}
+	code := r.URL.Query().Get("code")
+	if code == "" {
+		http.Redirect(w, r, "/login?error=missing_code", http.StatusFound)
+		return
+	}
+
+	tok, err := s.exchangeCode(r.Context(), code, flow.Verifier)
+	if err != nil {
+		log.Printf("auth: google token exchange failed: %v", err)
+		http.Redirect(w, r, "/login?error=exchange_failed", http.StatusFound)
+		return
+	}
+
+	profile, err := s.fetchUserinfo(r.Context(), tok.AccessToken)
+	if err != nil {
+		log.Printf("auth: google userinfo fetch failed: %v", err)
+		http.Redirect(w, r, "/login?error=profile_failed", http.StatusFound)
+		return
+	}
+
+	accountID, err := s.upsertAccount(r.Context(), profile.Subject, profile.Email)
+	if err != nil {
+		log.Printf("auth: account upsert failed: %v", err)
+		http.Redirect(w, r, "/login?error=internal", http.StatusFound)
+		return
+	}
+
+	s.issueSession(w, accountID)
+	http.Redirect(w, r, flow.Next, http.StatusFound)
+}
+
+// tokenResponse is the subset of Google's token endpoint response the
+// control plane needs. id_token is not parsed: the access token is used
+// directly against the userinfo endpoint instead, so login never has to
+// verify a Google-issued JWT signature itself.
+type tokenResponse struct {
+	AccessToken string `json:"access_token"`
+}
+
+func (s *Service) exchangeCode(ctx context.Context, code, verifier string) (*tokenResponse, error) {
+	form := url.Values{}
+	form.Set("code", code)
+	form.Set("client_id", s.clientID)
+	form.Set("client_secret", s.clientSecret)
+	form.Set("redirect_uri", s.redirectURI)
+	form.Set("grant_type", "authorization_code")
+	form.Set("code_verifier", verifier)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, s.endpoints.TokenURL, strings.NewReader(form.Encode()))
+	if err != nil {
+		return nil, fmt.Errorf("build token request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := s.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("token request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read token response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("token endpoint returned %d: %s", resp.StatusCode, body)
+	}
+
+	var tok tokenResponse
+	if err := json.Unmarshal(body, &tok); err != nil {
+		return nil, fmt.Errorf("decode token response: %w", err)
+	}
+	if tok.AccessToken == "" {
+		return nil, errors.New("token response missing access_token")
+	}
+	return &tok, nil
+}
+
+// googleProfile is the subset of the OpenID Connect userinfo response the
+// control plane needs to identify the account.
+type googleProfile struct {
+	Subject string `json:"sub"`
+	Email   string `json:"email"`
+}
+
+func (s *Service) fetchUserinfo(ctx context.Context, accessToken string) (*googleProfile, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, s.endpoints.UserinfoURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build userinfo request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+
+	resp, err := s.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("userinfo request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read userinfo response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("userinfo endpoint returned %d: %s", resp.StatusCode, body)
+	}
+
+	var profile googleProfile
+	if err := json.Unmarshal(body, &profile); err != nil {
+		return nil, fmt.Errorf("decode userinfo response: %w", err)
+	}
+	if profile.Subject == "" {
+		return nil, errors.New("userinfo response missing sub")
+	}
+	if profile.Email == "" {
+		return nil, errors.New("userinfo response missing email")
+	}
+	return &profile, nil
+}

--- a/controlplane/internal/auth/oauth_test.go
+++ b/controlplane/internal/auth/oauth_test.go
@@ -1,0 +1,326 @@
+package auth
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/agentlab-in/hosted-ao/controlplane/internal/storage/sqlite"
+)
+
+func TestGeneratePKCE_ChallengeMatchesVerifier(t *testing.T) {
+	verifier, challenge, err := generatePKCE()
+	if err != nil {
+		t.Fatalf("generatePKCE() error: %v", err)
+	}
+	if len(verifier) < 43 {
+		t.Errorf("verifier length = %d, want at least 43 per RFC 7636", len(verifier))
+	}
+
+	sum := sha256.Sum256([]byte(verifier))
+	want := base64.RawURLEncoding.EncodeToString(sum[:])
+	if challenge != want {
+		t.Errorf("challenge = %q, want %q", challenge, want)
+	}
+}
+
+func TestGeneratePKCE_Unique(t *testing.T) {
+	v1, _, err := generatePKCE()
+	if err != nil {
+		t.Fatalf("generatePKCE() error: %v", err)
+	}
+	v2, _, err := generatePKCE()
+	if err != nil {
+		t.Fatalf("generatePKCE() error: %v", err)
+	}
+	if v1 == v2 {
+		t.Error("generatePKCE() produced the same verifier twice")
+	}
+}
+
+func TestSanitizeNext(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"", "/"},
+		{"/device", "/device"},
+		{"/device?code=1", "/device?code=1"},
+		{"//evil.example", "/"},
+		{"https://evil.example", "/"},
+		{"not-a-path", "/"},
+	}
+	for _, tt := range tests {
+		if got := sanitizeNext(tt.in); got != tt.want {
+			t.Errorf("sanitizeNext(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+// newTestServiceWithGoogle builds a Service wired to a fake Google backend
+// (tokenHandler and userinfoHandler) instead of the real endpoints, and to a
+// throwaway SQLite database with the real schema, so the exchange and
+// account upsert can be exercised end to end without a network call.
+func newTestServiceWithGoogle(t *testing.T, tokenHandler, userinfoHandler http.HandlerFunc) (*Service, *httptest.Server) {
+	t.Helper()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/token", tokenHandler)
+	mux.HandleFunc("/userinfo", userinfoHandler)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	db, err := sqlite.Open(t.TempDir())
+	if err != nil {
+		t.Fatalf("sqlite.Open() error: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	key, err := loadOrCreateSessionKey(t.TempDir())
+	if err != nil {
+		t.Fatalf("loadOrCreateSessionKey() error: %v", err)
+	}
+
+	return &Service{
+		db:           db,
+		clientID:     "test-client-id",
+		clientSecret: "test-client-secret",
+		redirectURI:  "http://localhost:8080/auth/google/callback",
+		endpoints: googleEndpoints{
+			AuthURL:     "https://accounts.google.com/o/oauth2/v2/auth",
+			TokenURL:    srv.URL + "/token",
+			UserinfoURL: srv.URL + "/userinfo",
+		},
+		httpClient:    srv.Client(),
+		sessionKey:    key,
+		secureCookies: false,
+	}, srv
+}
+
+func fakeGoogleHandlers(t *testing.T, subject, email string) (http.HandlerFunc, http.HandlerFunc) {
+	t.Helper()
+
+	tokenHandler := func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("parse token request form: %v", err)
+		}
+		if r.FormValue("grant_type") != "authorization_code" {
+			t.Errorf("grant_type = %q, want authorization_code", r.FormValue("grant_type"))
+		}
+		if r.FormValue("code_verifier") == "" {
+			t.Error("token request missing code_verifier")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{"access_token": "test-access-token"})
+	}
+
+	userinfoHandler := func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer test-access-token" {
+			t.Errorf("Authorization header = %q, want Bearer test-access-token", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{"sub": subject, "email": email})
+	}
+
+	return tokenHandler, userinfoHandler
+}
+
+// runLoginFlow drives handleGoogleLogin then handleGoogleCallback against s,
+// simulating the browser round trip: it carries the flow cookie from the
+// login redirect into the callback request and returns the callback
+// response.
+func runLoginFlow(t *testing.T, s *Service, next string) *http.Response {
+	t.Helper()
+
+	loginURL := "/auth/google/login"
+	if next != "" {
+		loginURL += "?next=" + url.QueryEscape(next)
+	}
+	loginReq := httptest.NewRequest(http.MethodGet, loginURL, nil)
+	loginRec := httptest.NewRecorder()
+	s.handleGoogleLogin(loginRec, loginReq)
+
+	if loginRec.Code != http.StatusFound {
+		t.Fatalf("handleGoogleLogin() status = %d, want %d", loginRec.Code, http.StatusFound)
+	}
+	redirectURL, err := url.Parse(loginRec.Header().Get("Location"))
+	if err != nil {
+		t.Fatalf("parse login redirect: %v", err)
+	}
+	state := redirectURL.Query().Get("state")
+	if state == "" {
+		t.Fatal("login redirect missing state")
+	}
+
+	callbackReq := httptest.NewRequest(http.MethodGet, "/auth/google/callback?code=test-code&state="+state, nil)
+	for _, c := range loginRec.Result().Cookies() {
+		callbackReq.AddCookie(c)
+	}
+	callbackRec := httptest.NewRecorder()
+	s.handleGoogleCallback(callbackRec, callbackReq)
+
+	return callbackRec.Result()
+}
+
+func TestLoginFlow_UpsertsAccountAndIssuesSession(t *testing.T) {
+	tokenHandler, userinfoHandler := fakeGoogleHandlers(t, "google-subject-1", "operator@example.test")
+	s, _ := newTestServiceWithGoogle(t, tokenHandler, userinfoHandler)
+
+	resp := runLoginFlow(t, s, "/device")
+
+	if resp.StatusCode != http.StatusFound {
+		t.Fatalf("callback status = %d, want %d", resp.StatusCode, http.StatusFound)
+	}
+	if loc := resp.Header.Get("Location"); loc != "/device" {
+		t.Errorf("callback redirect = %q, want %q", loc, "/device")
+	}
+
+	var sessionCookie *http.Cookie
+	for _, c := range resp.Cookies() {
+		if c.Name == sessionCookieName {
+			sessionCookie = c
+		}
+	}
+	if sessionCookie == nil {
+		t.Fatal("callback did not set a session cookie")
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/device", nil)
+	req.AddCookie(sessionCookie)
+	accountID, ok := s.AccountFromRequest(req)
+	if !ok {
+		t.Fatal("AccountFromRequest() ok = false after login, want true")
+	}
+
+	var email string
+	if err := s.db.QueryRow("SELECT email FROM accounts WHERE id = ?", accountID).Scan(&email); err != nil {
+		t.Fatalf("query account: %v", err)
+	}
+	if email != "operator@example.test" {
+		t.Errorf("account email = %q, want %q", email, "operator@example.test")
+	}
+}
+
+func TestLoginFlow_SecondLoginSameSubjectReusesAccountAndUpdatesEmail(t *testing.T) {
+	tokenHandler1, userinfoHandler1 := fakeGoogleHandlers(t, "google-subject-1", "old@example.test")
+	s, srv := newTestServiceWithGoogle(t, tokenHandler1, userinfoHandler1)
+
+	firstResp := runLoginFlow(t, s, "")
+	firstAccountID := accountIDFromResponse(t, s, firstResp)
+
+	// Same subject, new email: re-point the fake Google backend's userinfo
+	// handler at the updated profile and log in again.
+	mux := http.NewServeMux()
+	mux.HandleFunc("/token", tokenHandler1)
+	mux.HandleFunc("/userinfo", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{"sub": "google-subject-1", "email": "new@example.test"})
+	})
+	srv.Config.Handler = mux
+
+	secondResp := runLoginFlow(t, s, "")
+	secondAccountID := accountIDFromResponse(t, s, secondResp)
+
+	if firstAccountID != secondAccountID {
+		t.Errorf("account id changed across logins: %q then %q, want the same id", firstAccountID, secondAccountID)
+	}
+
+	var email string
+	if err := s.db.QueryRow("SELECT email FROM accounts WHERE id = ?", firstAccountID).Scan(&email); err != nil {
+		t.Fatalf("query account: %v", err)
+	}
+	if email != "new@example.test" {
+		t.Errorf("account email = %q, want updated email %q", email, "new@example.test")
+	}
+
+	var count int
+	if err := s.db.QueryRow("SELECT count(*) FROM accounts").Scan(&count); err != nil {
+		t.Fatalf("count accounts: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("accounts table has %d rows, want 1", count)
+	}
+}
+
+func accountIDFromResponse(t *testing.T, s *Service, resp *http.Response) string {
+	t.Helper()
+	for _, c := range resp.Cookies() {
+		if c.Name == sessionCookieName {
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			req.AddCookie(c)
+			accountID, ok := s.AccountFromRequest(req)
+			if !ok {
+				t.Fatal("session cookie from login response did not verify")
+			}
+			return accountID
+		}
+	}
+	t.Fatal("login response did not set a session cookie")
+	return ""
+}
+
+func TestLoginFlow_StateMismatchRejected(t *testing.T) {
+	tokenHandler, userinfoHandler := fakeGoogleHandlers(t, "google-subject-1", "operator@example.test")
+	s, _ := newTestServiceWithGoogle(t, tokenHandler, userinfoHandler)
+
+	loginReq := httptest.NewRequest(http.MethodGet, "/auth/google/login", nil)
+	loginRec := httptest.NewRecorder()
+	s.handleGoogleLogin(loginRec, loginReq)
+
+	callbackReq := httptest.NewRequest(http.MethodGet, "/auth/google/callback?code=test-code&state=wrong-state", nil)
+	for _, c := range loginRec.Result().Cookies() {
+		callbackReq.AddCookie(c)
+	}
+	callbackRec := httptest.NewRecorder()
+	s.handleGoogleCallback(callbackRec, callbackReq)
+
+	if callbackRec.Code != http.StatusFound {
+		t.Fatalf("callback status = %d, want %d", callbackRec.Code, http.StatusFound)
+	}
+	loc := callbackRec.Header().Get("Location")
+	if !strings.Contains(loc, "error=state_mismatch") {
+		t.Errorf("callback redirect = %q, want it to contain error=state_mismatch", loc)
+	}
+	for _, c := range callbackRec.Result().Cookies() {
+		if c.Name == sessionCookieName {
+			t.Error("callback set a session cookie despite a state mismatch")
+		}
+	}
+}
+
+func TestLoginFlow_MissingFlowCookieRejected(t *testing.T) {
+	tokenHandler, userinfoHandler := fakeGoogleHandlers(t, "google-subject-1", "operator@example.test")
+	s, _ := newTestServiceWithGoogle(t, tokenHandler, userinfoHandler)
+
+	callbackReq := httptest.NewRequest(http.MethodGet, "/auth/google/callback?code=test-code&state=any", nil)
+	callbackRec := httptest.NewRecorder()
+	s.handleGoogleCallback(callbackRec, callbackReq)
+
+	if callbackRec.Code != http.StatusFound {
+		t.Fatalf("callback status = %d, want %d", callbackRec.Code, http.StatusFound)
+	}
+	if loc := callbackRec.Header().Get("Location"); !strings.Contains(loc, "error=expired") {
+		t.Errorf("callback redirect = %q, want it to contain error=expired", loc)
+	}
+}
+
+func TestLoginFlow_GoogleErrorRejected(t *testing.T) {
+	tokenHandler, userinfoHandler := fakeGoogleHandlers(t, "google-subject-1", "operator@example.test")
+	s, _ := newTestServiceWithGoogle(t, tokenHandler, userinfoHandler)
+
+	callbackReq := httptest.NewRequest(http.MethodGet, "/auth/google/callback?error=access_denied", nil)
+	callbackRec := httptest.NewRecorder()
+	s.handleGoogleCallback(callbackRec, callbackReq)
+
+	if callbackRec.Code != http.StatusFound {
+		t.Fatalf("callback status = %d, want %d", callbackRec.Code, http.StatusFound)
+	}
+	if loc := callbackRec.Header().Get("Location"); !strings.Contains(loc, "error=access_denied") {
+		t.Errorf("callback redirect = %q, want it to contain error=access_denied", loc)
+	}
+}

--- a/controlplane/internal/auth/pages.go
+++ b/controlplane/internal/auth/pages.go
@@ -1,0 +1,52 @@
+package auth
+
+import (
+	"embed"
+	"log"
+	"net/http"
+	"net/url"
+)
+
+//go:embed templates/*.html
+var templatesFS embed.FS
+
+// signInPageData is the html/template data for templates/signin.html.
+type signInPageData struct {
+	LoginURL string
+	Error    string
+}
+
+func (s *Service) handleSignInPage(w http.ResponseWriter, r *http.Request) {
+	next := sanitizeNext(r.URL.Query().Get("next"))
+
+	loginURL := "/auth/google/login"
+	if next != "/" {
+		loginURL += "?next=" + url.QueryEscape(next)
+	}
+
+	data := signInPageData{
+		LoginURL: loginURL,
+		Error:    errorMessage(r.URL.Query().Get("error")),
+	}
+
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	if err := s.tmpl.ExecuteTemplate(w, "signin.html", data); err != nil {
+		log.Printf("auth: render sign-in page: %v", err)
+		http.Error(w, "internal error", http.StatusInternalServerError)
+	}
+}
+
+// errorMessage maps the ?error= codes the OAuth handlers redirect back to
+// the sign-in page with into operator-facing text.
+func errorMessage(code string) string {
+	switch code {
+	case "":
+		return ""
+	case "access_denied":
+		return "Sign-in was cancelled."
+	case "expired", "state_mismatch":
+		return "Sign-in could not be verified. Please try again."
+	default:
+		return "Sign-in failed. Please try again."
+	}
+}

--- a/controlplane/internal/auth/pages_test.go
+++ b/controlplane/internal/auth/pages_test.go
@@ -1,0 +1,71 @@
+package auth
+
+import (
+	"html/template"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func newTestServiceWithTemplate(t *testing.T) *Service {
+	t.Helper()
+	tmpl, err := template.ParseFS(templatesFS, "templates/*.html")
+	if err != nil {
+		t.Fatalf("parse templates: %v", err)
+	}
+	return &Service{tmpl: tmpl}
+}
+
+func TestHandleSignInPage_RendersGoogleLoginLink(t *testing.T) {
+	s := newTestServiceWithTemplate(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/login", nil)
+	rec := httptest.NewRecorder()
+	s.handleSignInPage(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, `href="/auth/google/login"`) {
+		t.Errorf("body missing google login link, got: %s", body)
+	}
+	if strings.Contains(body, `class="error"`) {
+		t.Error("body has an error message with no ?error= param")
+	}
+}
+
+func TestHandleSignInPage_ForwardsNextAndRendersError(t *testing.T) {
+	s := newTestServiceWithTemplate(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/login?next=%2Fdevice&error=access_denied", nil)
+	rec := httptest.NewRecorder()
+	s.handleSignInPage(rec, req)
+
+	body := rec.Body.String()
+	if !strings.Contains(body, `href="/auth/google/login?next=%2Fdevice"`) {
+		t.Errorf("body missing next-forwarding login link, got: %s", body)
+	}
+	if !strings.Contains(body, "Sign-in was cancelled.") {
+		t.Errorf("body missing access_denied error message, got: %s", body)
+	}
+}
+
+func TestErrorMessage(t *testing.T) {
+	tests := []struct {
+		code string
+		want string
+	}{
+		{"", ""},
+		{"access_denied", "Sign-in was cancelled."},
+		{"expired", "Sign-in could not be verified. Please try again."},
+		{"state_mismatch", "Sign-in could not be verified. Please try again."},
+		{"something_else", "Sign-in failed. Please try again."},
+	}
+	for _, tt := range tests {
+		if got := errorMessage(tt.code); got != tt.want {
+			t.Errorf("errorMessage(%q) = %q, want %q", tt.code, got, tt.want)
+		}
+	}
+}

--- a/controlplane/internal/auth/session.go
+++ b/controlplane/internal/auth/session.go
@@ -1,0 +1,135 @@
+package auth
+
+import (
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	sessionCookieName = "ao_session"
+
+	// sessionTTL is deliberately long: this cookie only carries the operator
+	// through the browser pages the control plane serves (sign-in today,
+	// device approval once a later task adds it). It is unrelated to the
+	// short-lived access tokens the keys-and-tokens work issues for
+	// machine-facing API calls.
+	sessionTTL = 30 * 24 * time.Hour
+
+	sessionKeyFile = "session_key"
+	sessionKeyLen  = 32
+)
+
+// loadOrCreateSessionKey reads the HMAC key used to sign session and OAuth
+// flow cookies from dataDir, generating and persisting one on first boot.
+// Losing this file just signs everyone out; it is not the EdDSA signing key
+// the keys-and-tokens work manages separately.
+func loadOrCreateSessionKey(dataDir string) ([]byte, error) {
+	path := filepath.Join(dataDir, sessionKeyFile)
+
+	if b, err := os.ReadFile(path); err == nil {
+		if len(b) != sessionKeyLen {
+			return nil, fmt.Errorf("session key at %s has wrong length %d, want %d", path, len(b), sessionKeyLen)
+		}
+		return b, nil
+	} else if !os.IsNotExist(err) {
+		return nil, fmt.Errorf("read session key: %w", err)
+	}
+
+	if err := os.MkdirAll(dataDir, 0o750); err != nil {
+		return nil, fmt.Errorf("create data dir: %w", err)
+	}
+
+	key := make([]byte, sessionKeyLen)
+	if _, err := rand.Read(key); err != nil {
+		return nil, fmt.Errorf("generate session key: %w", err)
+	}
+	if err := os.WriteFile(path, key, 0o600); err != nil {
+		return nil, fmt.Errorf("write session key: %w", err)
+	}
+	return key, nil
+}
+
+// sign returns the HMAC-SHA256 of payload under the service's session key.
+func (s *Service) sign(payload string) []byte {
+	mac := hmac.New(sha256.New, s.sessionKey)
+	mac.Write([]byte(payload))
+	return mac.Sum(nil)
+}
+
+// signedCookieValue packages payload with its HMAC signature into a cookie
+// value: base64url(payload) + "." + base64url(signature).
+func (s *Service) signedCookieValue(payload string) string {
+	return base64.RawURLEncoding.EncodeToString([]byte(payload)) + "." + base64.RawURLEncoding.EncodeToString(s.sign(payload))
+}
+
+// verifySignedCookieValue reverses signedCookieValue, returning the payload
+// only if the signature matches.
+func (s *Service) verifySignedCookieValue(value string) (string, bool) {
+	encPayload, encSig, ok := strings.Cut(value, ".")
+	if !ok {
+		return "", false
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(encPayload)
+	if err != nil {
+		return "", false
+	}
+	sig, err := base64.RawURLEncoding.DecodeString(encSig)
+	if err != nil {
+		return "", false
+	}
+	if !hmac.Equal(sig, s.sign(string(payload))) {
+		return "", false
+	}
+	return string(payload), true
+}
+
+// issueSession sets the signed session cookie identifying accountID as the
+// signed-in operator.
+func (s *Service) issueSession(w http.ResponseWriter, accountID string) {
+	exp := time.Now().Add(sessionTTL)
+	payload := accountID + "|" + strconv.FormatInt(exp.Unix(), 10)
+	http.SetCookie(w, &http.Cookie{
+		Name:     sessionCookieName,
+		Value:    s.signedCookieValue(payload),
+		Path:     "/",
+		Expires:  exp,
+		HttpOnly: true,
+		Secure:   s.secureCookies,
+		SameSite: http.SameSiteLaxMode,
+	})
+}
+
+// AccountFromRequest returns the signed-in account id from the session
+// cookie, if the request carries a valid, unexpired one. Later pages (the
+// device-approval flow) use this to identify the operator.
+func (s *Service) AccountFromRequest(r *http.Request) (string, bool) {
+	c, err := r.Cookie(sessionCookieName)
+	if err != nil {
+		return "", false
+	}
+	payload, ok := s.verifySignedCookieValue(c.Value)
+	if !ok {
+		return "", false
+	}
+	accountID, expRaw, ok := strings.Cut(payload, "|")
+	if !ok {
+		return "", false
+	}
+	exp, err := strconv.ParseInt(expRaw, 10, 64)
+	if err != nil {
+		return "", false
+	}
+	if time.Now().Unix() > exp {
+		return "", false
+	}
+	return accountID, true
+}

--- a/controlplane/internal/auth/session_test.go
+++ b/controlplane/internal/auth/session_test.go
@@ -1,0 +1,122 @@
+package auth
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+	"time"
+)
+
+func newTestService(t *testing.T) *Service {
+	t.Helper()
+	key, err := loadOrCreateSessionKey(t.TempDir())
+	if err != nil {
+		t.Fatalf("loadOrCreateSessionKey() error: %v", err)
+	}
+	return &Service{sessionKey: key}
+}
+
+func TestLoadOrCreateSessionKey_PersistsAcrossCalls(t *testing.T) {
+	dir := t.TempDir()
+
+	first, err := loadOrCreateSessionKey(dir)
+	if err != nil {
+		t.Fatalf("first loadOrCreateSessionKey() error: %v", err)
+	}
+	if len(first) != sessionKeyLen {
+		t.Fatalf("key length = %d, want %d", len(first), sessionKeyLen)
+	}
+
+	second, err := loadOrCreateSessionKey(dir)
+	if err != nil {
+		t.Fatalf("second loadOrCreateSessionKey() error: %v", err)
+	}
+	if string(first) != string(second) {
+		t.Fatal("loadOrCreateSessionKey() returned a different key on the second call, want the persisted one")
+	}
+}
+
+func TestSession_IssueAndReadRoundTrip(t *testing.T) {
+	s := newTestService(t)
+
+	rec := httptest.NewRecorder()
+	s.issueSession(rec, "account-123")
+
+	req := httptest.NewRequest(http.MethodGet, "/device", nil)
+	for _, c := range rec.Result().Cookies() {
+		req.AddCookie(c)
+	}
+
+	accountID, ok := s.AccountFromRequest(req)
+	if !ok {
+		t.Fatal("AccountFromRequest() ok = false, want true")
+	}
+	if accountID != "account-123" {
+		t.Errorf("accountID = %q, want %q", accountID, "account-123")
+	}
+}
+
+func TestSession_NoCookieRejected(t *testing.T) {
+	s := newTestService(t)
+	req := httptest.NewRequest(http.MethodGet, "/device", nil)
+
+	if _, ok := s.AccountFromRequest(req); ok {
+		t.Fatal("AccountFromRequest() ok = true with no cookie, want false")
+	}
+}
+
+func TestSession_TamperedCookieRejected(t *testing.T) {
+	s := newTestService(t)
+
+	rec := httptest.NewRecorder()
+	s.issueSession(rec, "account-123")
+	cookies := rec.Result().Cookies()
+	if len(cookies) != 1 {
+		t.Fatalf("got %d cookies, want 1", len(cookies))
+	}
+
+	tampered := *cookies[0]
+	tampered.Value += "x"
+
+	req := httptest.NewRequest(http.MethodGet, "/device", nil)
+	req.AddCookie(&tampered)
+
+	if _, ok := s.AccountFromRequest(req); ok {
+		t.Fatal("AccountFromRequest() ok = true with a tampered cookie, want false")
+	}
+}
+
+func TestSession_DifferentKeyRejected(t *testing.T) {
+	issuer := newTestService(t)
+	verifier := newTestService(t)
+
+	rec := httptest.NewRecorder()
+	issuer.issueSession(rec, "account-123")
+
+	req := httptest.NewRequest(http.MethodGet, "/device", nil)
+	for _, c := range rec.Result().Cookies() {
+		req.AddCookie(c)
+	}
+
+	if _, ok := verifier.AccountFromRequest(req); ok {
+		t.Fatal("AccountFromRequest() ok = true for a cookie signed with a different key, want false")
+	}
+}
+
+func TestSession_ExpiredCookieRejected(t *testing.T) {
+	s := newTestService(t)
+
+	// Sign a payload that is already in the past directly, exercising the
+	// expiry check independently of the 30-day sessionTTL.
+	past := time.Now().Add(-time.Minute).Unix()
+	expiredPayload := "account-123|" + strconv.FormatInt(past, 10)
+	expiredCookie := &http.Cookie{Name: sessionCookieName, Value: s.signedCookieValue(expiredPayload)}
+
+	expiredReq := httptest.NewRequest(http.MethodGet, "/device", nil)
+	expiredReq.AddCookie(expiredCookie)
+
+	if _, ok := s.AccountFromRequest(expiredReq); ok {
+		t.Fatal("AccountFromRequest() ok = true for an expired session, want false")
+	}
+}

--- a/controlplane/internal/auth/templates/signin.html
+++ b/controlplane/internal/auth/templates/signin.html
@@ -1,0 +1,56 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Sign in - AO</title>
+  <style>
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      background: #0b0d12;
+      color: #e6e8eb;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      min-height: 100vh;
+      margin: 0;
+    }
+    .card {
+      background: #151821;
+      border: 1px solid #262b36;
+      border-radius: 12px;
+      padding: 2.5rem;
+      width: 320px;
+      text-align: center;
+    }
+    h1 {
+      font-size: 1.25rem;
+      margin: 0 0 1.5rem;
+    }
+    a.button {
+      display: block;
+      background: #3b82f6;
+      color: #fff;
+      text-decoration: none;
+      padding: 0.75rem 1rem;
+      border-radius: 8px;
+      font-weight: 600;
+    }
+    a.button:hover {
+      background: #2563eb;
+    }
+    p.error {
+      color: #f87171;
+      font-size: 0.875rem;
+      margin-top: 0;
+    }
+  </style>
+</head>
+<body>
+  <div class="card">
+    <h1>Sign in to AO</h1>
+    {{if .Error}}<p class="error">{{.Error}}</p>{{end}}
+    <a class="button" href="{{.LoginURL}}">Continue with Google</a>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- Google OAuth authorization-code exchange with PKCE (S256), state-checked CSRF protection via a signed, short-lived flow cookie.
- `accounts` upsert keyed on the Google subject (not email, since emails change), preserving `created_at` and updating `email` on repeat logins.
- A signed, HttpOnly browser session cookie for the operator (`internal/auth/session.go`), good enough to carry them into the device-approval pages a later task adds.
- The sign-in page, rendered with `html/template` from an embedded template.
- All of it lives in a new `controlplane/internal/auth` package with a single `Register(mux)` call from `main.go`. `internal/server/server.go` is untouched, and `main.go` only gained the one wiring block, to keep the merge clean with the parallel keys-and-tokens work (#8) in the same tree.

Out of scope, per the task: EdDSA keys, JWKS, access/refresh token issuance (task 5), and the RFC 8628 device flow / machines registry (task 7).

Closes #7

## Test plan

- [x] `gofmt -l .` clean
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race ./...` (28 tests across 5 packages, including a full login round trip against a fake Google backend via `httptest`, upsert-by-subject/email-update behavior, PKCE challenge correctness, state-mismatch/expired-flow/Google-denied rejection paths, and session cookie sign/verify/tamper/expiry)
- [x] Manual smoke test: ran the service locally, confirmed `/healthz`, `/login` renders the sign-in page, and `/auth/google/login` redirects to a correctly-formed Google authorization URL with PKCE params

## Known follow-ups

- Session cookie signing key is a random 32-byte value generated on first boot and persisted under `DATA_DIR/session_key`; losing it just signs everyone out.
- The `next` redirect target is restricted to a same-site relative path to avoid open-redirect abuse.