### PR TITLE
feat(controlplane): EdDSA signing keys, JWKS, and token issuance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,11 @@ agent-orchestrator.yaml
 session-events.jsonl
 session-events.jsonl.*
 
+# Control plane local data dir: SQLite database and EdDSA signing keys
+# (DATA_DIR defaults to controlplane/data when run locally). The keys must
+# never be committed.
+/controlplane/data/
+
 # Agent Orchestrator local session state
 .ao/
 

--- a/controlplane/.env.example
+++ b/controlplane/.env.example
@@ -23,5 +23,10 @@ PUBLIC_ORIGIN=https://ao.agentlab.in
 # Listen address for the service itself. It sits behind Caddy in production.
 LISTEN_ADDR=127.0.0.1:8080
 
-# Data directory for the SQLite database and the EdDSA signing keys.
+# Data directory for the SQLite database and the EdDSA signing keys (under
+# DATA_DIR/keys, generated at first boot, mode 0600, never committed).
 DATA_DIR=./data
+
+# Access token lifetime, a Go duration. May move between 10m and 30m after
+# measuring refresh chatter; see TOKEN_CONTRACT.md.
+ACCESS_TOKEN_TTL=15m

--- a/controlplane/cmd/controlplane/main.go
+++ b/controlplane/cmd/controlplane/main.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/agentlab-in/hosted-ao/controlplane/internal/config"
+	"github.com/agentlab-in/hosted-ao/controlplane/internal/keys"
 	"github.com/agentlab-in/hosted-ao/controlplane/internal/server"
 	"github.com/agentlab-in/hosted-ao/controlplane/internal/storage/sqlite"
 )
@@ -33,7 +34,12 @@ func main() {
 	}
 	defer db.Close()
 
-	mux := server.New(db)
+	km, err := keys.Load(cfg.DataDir)
+	if err != nil {
+		log.Fatalf("load signing keys: %v", err)
+	}
+
+	mux := server.New(db, km)
 
 	// LISTEN_ADDR defaults to loopback (127.0.0.1:8080): this service sits
 	// behind Caddy on the same box, which terminates TLS and reverse-proxies

--- a/controlplane/go.mod
+++ b/controlplane/go.mod
@@ -3,13 +3,13 @@ module github.com/agentlab-in/hosted-ao/controlplane
 go 1.25.7
 
 require (
+	github.com/google/uuid v1.6.0
 	github.com/pressly/goose/v3 v3.27.3
 	modernc.org/sqlite v1.55.0
 )
 
 require (
 	github.com/dustin/go-humanize v1.0.1 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/mattn/go-isatty v0.0.23 // indirect
 	github.com/mfridman/interpolate v0.0.2 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect

--- a/controlplane/internal/config/config.go
+++ b/controlplane/internal/config/config.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"time"
 )
 
 const (
@@ -22,6 +23,11 @@ const (
 	DefaultDataDir = "./data"
 	// DefaultPublicOrigin is the origin used when PUBLIC_ORIGIN is unset.
 	DefaultPublicOrigin = "https://ao.agentlab.in"
+	// DefaultAccessTokenTTL is the access token lifetime used when
+	// ACCESS_TOKEN_TTL is unset. The spec allows this to move between 10 and
+	// 30 minutes after measuring refresh chatter, which is why it is
+	// configurable rather than hardcoded in the tokens package.
+	DefaultAccessTokenTTL = 15 * time.Minute
 )
 
 // Config is the fully resolved control plane configuration. It is immutable
@@ -41,6 +47,8 @@ type Config struct {
 	// GoogleClientSecret is the OAuth web client secret. Required; Load
 	// fails if it is empty.
 	GoogleClientSecret string
+	// AccessTokenTTL is the lifetime of issued access tokens.
+	AccessTokenTTL time.Duration
 }
 
 // Load resolves configuration from the environment, applying defaults for
@@ -54,13 +62,15 @@ type Config struct {
 //	LISTEN_ADDR            bind address                (default 127.0.0.1:8080)
 //	DATA_DIR               SQLite data directory       (default ./data)
 //	PUBLIC_ORIGIN          public origin for redirect URIs and the iss claim (default https://ao.agentlab.in)
+//	ACCESS_TOKEN_TTL       access token lifetime, a Go duration (default 15m)
 //	AO_SH_G_CLIENT_ID      Google OAuth client id      (required)
 //	AO_SH_G_CLIENT_SECRET  Google OAuth client secret  (required)
 func Load() (Config, error) {
 	cfg := Config{
-		ListenAddr:   DefaultListenAddr,
-		DataDir:      DefaultDataDir,
-		PublicOrigin: DefaultPublicOrigin,
+		ListenAddr:     DefaultListenAddr,
+		DataDir:        DefaultDataDir,
+		PublicOrigin:   DefaultPublicOrigin,
+		AccessTokenTTL: DefaultAccessTokenTTL,
 	}
 
 	if raw := os.Getenv("LISTEN_ADDR"); raw != "" {
@@ -76,6 +86,14 @@ func Load() (Config, error) {
 
 	if raw := os.Getenv("PUBLIC_ORIGIN"); raw != "" {
 		cfg.PublicOrigin = raw
+	}
+
+	if raw := os.Getenv("ACCESS_TOKEN_TTL"); raw != "" {
+		ttl, err := time.ParseDuration(raw)
+		if err != nil {
+			return Config{}, fmt.Errorf("invalid ACCESS_TOKEN_TTL %q: %w", raw, err)
+		}
+		cfg.AccessTokenTTL = ttl
 	}
 
 	cfg.GoogleClientID = os.Getenv("AO_SH_G_CLIENT_ID")

--- a/controlplane/internal/config/config_test.go
+++ b/controlplane/internal/config/config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestLoad_MissingGoogleCredentials(t *testing.T) {
@@ -64,6 +65,9 @@ func TestLoad_DefaultsAppliedWhenCredentialsSet(t *testing.T) {
 	}
 	if cfg.PublicOrigin != DefaultPublicOrigin {
 		t.Errorf("PublicOrigin = %q, want default %q", cfg.PublicOrigin, DefaultPublicOrigin)
+	}
+	if cfg.AccessTokenTTL != DefaultAccessTokenTTL {
+		t.Errorf("AccessTokenTTL = %v, want default %v", cfg.AccessTokenTTL, DefaultAccessTokenTTL)
 	}
 	if cfg.GoogleClientID != "client-id" {
 		t.Errorf("GoogleClientID = %q, want %q", cfg.GoogleClientID, "client-id")
@@ -128,5 +132,33 @@ func TestLoad_DataDirAndPublicOriginOverrideHonored(t *testing.T) {
 	}
 	if cfg.PublicOrigin != "https://example.test" {
 		t.Errorf("PublicOrigin = %q, want %q", cfg.PublicOrigin, "https://example.test")
+	}
+}
+
+func TestLoad_AccessTokenTTLOverrideHonored(t *testing.T) {
+	t.Setenv("AO_SH_G_CLIENT_ID", "client-id")
+	t.Setenv("AO_SH_G_CLIENT_SECRET", "client-secret")
+	t.Setenv("ACCESS_TOKEN_TTL", "30m")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() unexpected error: %v", err)
+	}
+	if cfg.AccessTokenTTL != 30*time.Minute {
+		t.Errorf("AccessTokenTTL = %v, want 30m", cfg.AccessTokenTTL)
+	}
+}
+
+func TestLoad_InvalidAccessTokenTTLRejected(t *testing.T) {
+	t.Setenv("AO_SH_G_CLIENT_ID", "client-id")
+	t.Setenv("AO_SH_G_CLIENT_SECRET", "client-secret")
+	t.Setenv("ACCESS_TOKEN_TTL", "not-a-duration")
+
+	_, err := Load()
+	if err == nil {
+		t.Fatal("Load() = nil error, want error")
+	}
+	if !strings.Contains(err.Error(), "ACCESS_TOKEN_TTL") {
+		t.Fatalf("Load() error = %q, want it to mention ACCESS_TOKEN_TTL", err.Error())
 	}
 }

--- a/controlplane/internal/keys/http.go
+++ b/controlplane/internal/keys/http.go
@@ -1,0 +1,24 @@
+package keys
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// Register adds the JWKS endpoint to mux. Called once from server.New so the
+// keys package owns its own route instead of server.go growing a handler for
+// it.
+func Register(mux *http.ServeMux, m *Manager) {
+	mux.HandleFunc("GET /.well-known/jwks.json", jwksHandler(m))
+}
+
+func jwksHandler(m *Manager) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		// Matches the "JWKS cache: 1 hour" clause of TOKEN_CONTRACT.md;
+		// stale-if-error is the fetching verifier's responsibility, not
+		// this server's.
+		w.Header().Set("Cache-Control", "public, max-age=3600")
+		_ = json.NewEncoder(w).Encode(m.JWKS())
+	}
+}

--- a/controlplane/internal/keys/jwks.go
+++ b/controlplane/internal/keys/jwks.go
@@ -1,0 +1,37 @@
+package keys
+
+import "encoding/base64"
+
+// jwk is one entry of a JSON Web Key Set, RFC 8037 shape for an OKP
+// (Ed25519) public key: only the public half is ever published.
+type jwk struct {
+	Kty string `json:"kty"`
+	Crv string `json:"crv"`
+	Kid string `json:"kid"`
+	X   string `json:"x"`
+	Use string `json:"use"`
+	Alg string `json:"alg"`
+}
+
+type jwksDoc struct {
+	Keys []jwk `json:"keys"`
+}
+
+// JWKS returns the JSON Web Key Set publishing the active and next public
+// keys, so a verifier can resolve either kid.
+func (m *Manager) JWKS() jwksDoc {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return jwksDoc{Keys: []jwk{toJWK(m.active), toJWK(m.next)}}
+}
+
+func toJWK(kp keyPair) jwk {
+	return jwk{
+		Kty: "OKP",
+		Crv: "Ed25519",
+		Kid: kp.KID,
+		X:   base64.RawURLEncoding.EncodeToString(kp.PublicKey),
+		Use: "sig",
+		Alg: "EdDSA",
+	}
+}

--- a/controlplane/internal/keys/keys.go
+++ b/controlplane/internal/keys/keys.go
@@ -1,0 +1,154 @@
+// Package keys manages the control plane's EdDSA signing keys: generation,
+// on-disk storage with an active and next-key rotation slot, and the public
+// JWKS document served at /.well-known/jwks.json.
+package keys
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+// keySubdir is the directory under the service data dir holding the signing
+// key files.
+const keySubdir = "keys"
+
+// keyPair is one EdDSA key pair plus a stable kid derived from the public
+// key. PrivateKey and PublicKey marshal to JSON as base64 (the default for
+// []byte), which is why the on-disk file must be mode 0600 and gitignored.
+type keyPair struct {
+	KID        string             `json:"kid"`
+	PrivateKey ed25519.PrivateKey `json:"private_key"`
+	PublicKey  ed25519.PublicKey  `json:"public_key"`
+	CreatedAt  time.Time          `json:"created_at"`
+}
+
+// Manager holds the active and next EdDSA key pairs, persisted on disk under
+// dataDir/keys. The active key signs newly issued access tokens; the next
+// key is published in JWKS ahead of a future rotation so verifiers can cache
+// it before it is ever used to sign.
+type Manager struct {
+	mu     sync.RWMutex
+	dir    string
+	active keyPair
+	next   keyPair
+}
+
+// Load reads the active and next signing keys from dataDir/keys, generating
+// and persisting whichever file is missing. On first boot neither exists, so
+// both are generated. File permissions are 0600; the containing directory is
+// 0700.
+func Load(dataDir string) (*Manager, error) {
+	dir := filepath.Join(dataDir, keySubdir)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return nil, fmt.Errorf("create keys dir: %w", err)
+	}
+
+	active, err := loadOrGenerate(filepath.Join(dir, "active.json"))
+	if err != nil {
+		return nil, fmt.Errorf("load active key: %w", err)
+	}
+	next, err := loadOrGenerate(filepath.Join(dir, "next.json"))
+	if err != nil {
+		return nil, fmt.Errorf("load next key: %w", err)
+	}
+
+	return &Manager{dir: dir, active: active, next: next}, nil
+}
+
+func loadOrGenerate(path string) (keyPair, error) {
+	raw, err := os.ReadFile(path)
+	if err == nil {
+		var kp keyPair
+		if err := json.Unmarshal(raw, &kp); err != nil {
+			return keyPair{}, fmt.Errorf("parse %s: %w", path, err)
+		}
+		return kp, nil
+	}
+	if !os.IsNotExist(err) {
+		return keyPair{}, fmt.Errorf("read %s: %w", path, err)
+	}
+
+	kp, err := generate()
+	if err != nil {
+		return keyPair{}, err
+	}
+	if err := writeKeyPair(path, kp); err != nil {
+		return keyPair{}, err
+	}
+	return kp, nil
+}
+
+func generate() (keyPair, error) {
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return keyPair{}, fmt.Errorf("generate ed25519 key: %w", err)
+	}
+	return keyPair{
+		KID:        kidFor(pub),
+		PrivateKey: priv,
+		PublicKey:  pub,
+		CreatedAt:  time.Now().UTC(),
+	}, nil
+}
+
+// kidFor derives a stable key id from the public key, so a kid can always be
+// recomputed from the key material alone rather than needing its own
+// separately tracked identity.
+func kidFor(pub ed25519.PublicKey) string {
+	sum := sha256.Sum256(pub)
+	return hex.EncodeToString(sum[:])[:16]
+}
+
+func writeKeyPair(path string, kp keyPair) error {
+	raw, err := json.Marshal(kp)
+	if err != nil {
+		return fmt.Errorf("marshal key: %w", err)
+	}
+	if err := os.WriteFile(path, raw, 0o600); err != nil {
+		return fmt.Errorf("write %s: %w", path, err)
+	}
+	return nil
+}
+
+// Active returns the kid and private key currently used to sign access
+// tokens.
+func (m *Manager) Active() (kid string, priv ed25519.PrivateKey) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.active.KID, m.active.PrivateKey
+}
+
+// Rotate promotes the next key to active and generates a fresh next key,
+// persisting both to disk. The previously active key is discarded and no
+// longer published in JWKS, so callers should only rotate when it is safe
+// for tokens signed by the old active key to stop verifying (they are
+// short-lived per TOKEN_CONTRACT.md, so this is bounded by the access token
+// TTL plus the JWKS cache lifetime).
+func (m *Manager) Rotate() error {
+	newNext, err := generate()
+	if err != nil {
+		return err
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if err := writeKeyPair(filepath.Join(m.dir, "active.json"), m.next); err != nil {
+		return fmt.Errorf("persist promoted active key: %w", err)
+	}
+	if err := writeKeyPair(filepath.Join(m.dir, "next.json"), newNext); err != nil {
+		return fmt.Errorf("persist new next key: %w", err)
+	}
+
+	m.active = m.next
+	m.next = newNext
+	return nil
+}

--- a/controlplane/internal/keys/keys_test.go
+++ b/controlplane/internal/keys/keys_test.go
@@ -1,0 +1,176 @@
+package keys
+
+import (
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoad_GeneratesDistinctActiveAndNextKeys(t *testing.T) {
+	m, err := Load(t.TempDir())
+	if err != nil {
+		t.Fatalf("Load() unexpected error: %v", err)
+	}
+
+	if m.active.KID == m.next.KID {
+		t.Fatalf("active and next keys have the same kid %q, want distinct", m.active.KID)
+	}
+	if len(m.active.PrivateKey) != ed25519.PrivateKeySize {
+		t.Fatalf("active private key length = %d, want %d", len(m.active.PrivateKey), ed25519.PrivateKeySize)
+	}
+	if len(m.next.PublicKey) != ed25519.PublicKeySize {
+		t.Fatalf("next public key length = %d, want %d", len(m.next.PublicKey), ed25519.PublicKeySize)
+	}
+}
+
+func TestLoad_KeyFilesAreMode0600(t *testing.T) {
+	dir := t.TempDir()
+	if _, err := Load(dir); err != nil {
+		t.Fatalf("Load() unexpected error: %v", err)
+	}
+
+	for _, name := range []string{"active.json", "next.json"} {
+		info, err := os.Stat(filepath.Join(dir, "keys", name))
+		if err != nil {
+			t.Fatalf("stat %s: %v", name, err)
+		}
+		if perm := info.Mode().Perm(); perm != 0o600 {
+			t.Errorf("%s mode = %o, want 0600", name, perm)
+		}
+	}
+}
+
+func TestLoad_PersistsKeysAcrossReload(t *testing.T) {
+	dir := t.TempDir()
+
+	first, err := Load(dir)
+	if err != nil {
+		t.Fatalf("first Load() unexpected error: %v", err)
+	}
+
+	second, err := Load(dir)
+	if err != nil {
+		t.Fatalf("second Load() unexpected error: %v", err)
+	}
+
+	if first.active.KID != second.active.KID {
+		t.Errorf("active kid changed across reload: %q != %q", first.active.KID, second.active.KID)
+	}
+	if first.next.KID != second.next.KID {
+		t.Errorf("next kid changed across reload: %q != %q", first.next.KID, second.next.KID)
+	}
+}
+
+func TestActive_SignsVerifiableMessages(t *testing.T) {
+	m, err := Load(t.TempDir())
+	if err != nil {
+		t.Fatalf("Load() unexpected error: %v", err)
+	}
+
+	kid, priv := m.Active()
+	if kid != m.active.KID {
+		t.Fatalf("Active() kid = %q, want %q", kid, m.active.KID)
+	}
+
+	msg := []byte("hello")
+	sig := ed25519.Sign(priv, msg)
+	if !ed25519.Verify(priv.Public().(ed25519.PublicKey), msg, sig) {
+		t.Fatal("signature produced by Active() private key did not verify")
+	}
+}
+
+func TestRotate_PromotesNextAndGeneratesFreshNext(t *testing.T) {
+	dir := t.TempDir()
+	m, err := Load(dir)
+	if err != nil {
+		t.Fatalf("Load() unexpected error: %v", err)
+	}
+
+	oldNextKID := m.next.KID
+
+	if err := m.Rotate(); err != nil {
+		t.Fatalf("Rotate() unexpected error: %v", err)
+	}
+
+	if m.active.KID != oldNextKID {
+		t.Errorf("active kid after Rotate() = %q, want promoted next kid %q", m.active.KID, oldNextKID)
+	}
+	if m.next.KID == oldNextKID {
+		t.Error("next kid did not change after Rotate()")
+	}
+
+	reloaded, err := Load(dir)
+	if err != nil {
+		t.Fatalf("reload after Rotate() unexpected error: %v", err)
+	}
+	if reloaded.active.KID != m.active.KID {
+		t.Errorf("rotation did not persist: reloaded active kid = %q, want %q", reloaded.active.KID, m.active.KID)
+	}
+}
+
+func TestJWKS_PublishesActiveAndNextPublicKeysOnly(t *testing.T) {
+	m, err := Load(t.TempDir())
+	if err != nil {
+		t.Fatalf("Load() unexpected error: %v", err)
+	}
+
+	doc := m.JWKS()
+	if len(doc.Keys) != 2 {
+		t.Fatalf("len(JWKS().Keys) = %d, want 2", len(doc.Keys))
+	}
+
+	kids := map[string]jwk{doc.Keys[0].Kid: doc.Keys[0], doc.Keys[1].Kid: doc.Keys[1]}
+	for _, want := range []keyPair{m.active, m.next} {
+		got, ok := kids[want.KID]
+		if !ok {
+			t.Fatalf("JWKS missing kid %q", want.KID)
+		}
+		if got.Kty != "OKP" || got.Crv != "Ed25519" || got.Alg != "EdDSA" || got.Use != "sig" {
+			t.Errorf("jwk %q has unexpected shape: %+v", want.KID, got)
+		}
+		x, err := base64.RawURLEncoding.DecodeString(got.X)
+		if err != nil {
+			t.Fatalf("jwk %q x is not valid base64url: %v", want.KID, err)
+		}
+		if string(x) != string(want.PublicKey) {
+			t.Errorf("jwk %q x does not decode to the stored public key", want.KID)
+		}
+	}
+}
+
+func TestRegister_ServesJWKS(t *testing.T) {
+	m, err := Load(t.TempDir())
+	if err != nil {
+		t.Fatalf("Load() unexpected error: %v", err)
+	}
+
+	mux := http.NewServeMux()
+	Register(mux, m)
+
+	req := httptest.NewRequest(http.MethodGet, "/.well-known/jwks.json", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", ct)
+	}
+	if cc := rec.Header().Get("Cache-Control"); cc != "public, max-age=3600" {
+		t.Errorf("Cache-Control = %q, want public, max-age=3600", cc)
+	}
+
+	var doc jwksDoc
+	if err := json.Unmarshal(rec.Body.Bytes(), &doc); err != nil {
+		t.Fatalf("response body is not valid JSON: %v", err)
+	}
+	if len(doc.Keys) != 2 {
+		t.Fatalf("response has %d keys, want 2", len(doc.Keys))
+	}
+}

--- a/controlplane/internal/server/server.go
+++ b/controlplane/internal/server/server.go
@@ -5,13 +5,17 @@ import (
 	"database/sql"
 	"encoding/json"
 	"net/http"
+
+	"github.com/agentlab-in/hosted-ao/controlplane/internal/keys"
 )
 
-// New builds the control plane's HTTP handler, registering /healthz. Later
-// batches add the OAuth, JWKS, and device-flow routes to the same mux.
-func New(db *sql.DB) *http.ServeMux {
+// New builds the control plane's HTTP handler, registering /healthz and the
+// JWKS endpoint. Later batches add the OAuth and device-flow routes to the
+// same mux.
+func New(db *sql.DB, km *keys.Manager) *http.ServeMux {
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /healthz", healthHandler(db))
+	keys.Register(mux, km)
 	return mux
 }
 

--- a/controlplane/internal/tokens/access.go
+++ b/controlplane/internal/tokens/access.go
@@ -1,0 +1,98 @@
+// Package tokens issues and manages the control plane's access and refresh
+// tokens per TOKEN_CONTRACT.md: short-lived EdDSA JWTs for access, and
+// opaque, hashed, rotating refresh tokens for long-lived desktop sessions.
+package tokens
+
+import (
+	"crypto/ed25519"
+	"database/sql"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/agentlab-in/hosted-ao/controlplane/internal/keys"
+)
+
+// DefaultAccessTokenTTL is used when NewIssuer is given a zero TTL. The spec
+// allows this to move between 10 and 30 minutes after measuring refresh
+// chatter, hence it is a parameter on Issuer rather than a hardcoded
+// constant used directly by IssueAccessToken.
+const DefaultAccessTokenTTL = 15 * time.Minute
+
+// Issuer mints and manages access and refresh tokens for one control plane
+// instance.
+type Issuer struct {
+	keys      *keys.Manager
+	db        *sql.DB
+	issuer    string
+	accessTTL time.Duration
+}
+
+// NewIssuer builds an Issuer. issuerURL becomes the `iss` claim on every
+// access token it mints (the control plane's public origin); accessTTL is
+// the access token lifetime, or DefaultAccessTokenTTL if zero.
+func NewIssuer(km *keys.Manager, db *sql.DB, issuerURL string, accessTTL time.Duration) *Issuer {
+	if accessTTL <= 0 {
+		accessTTL = DefaultAccessTokenTTL
+	}
+	return &Issuer{keys: km, db: db, issuer: issuerURL, accessTTL: accessTTL}
+}
+
+type accessClaims struct {
+	Iss string `json:"iss"`
+	Sub string `json:"sub"`
+	Aud string `json:"aud"`
+	Exp int64  `json:"exp"`
+	Iat int64  `json:"iat"`
+	Jti string `json:"jti"`
+}
+
+// IssueAccessToken mints an EdDSA JWT for accountID scoped to machineID, per
+// TOKEN_CONTRACT.md: iss is this control plane's origin, sub is the account
+// id, aud is the machine id, exp is now plus the configured access token
+// lifetime, plus iat and a fresh jti.
+func (i *Issuer) IssueAccessToken(accountID, machineID string) (string, error) {
+	kid, priv := i.keys.Active()
+	now := time.Now().UTC()
+	claims := accessClaims{
+		Iss: i.issuer,
+		Sub: accountID,
+		Aud: machineID,
+		Exp: now.Add(i.accessTTL).Unix(),
+		Iat: now.Unix(),
+		Jti: uuid.NewString(),
+	}
+	return signEdDSA(kid, priv, claims)
+}
+
+type jwtHeader struct {
+	Alg string `json:"alg"`
+	Kid string `json:"kid"`
+	Typ string `json:"typ"`
+}
+
+// signEdDSA builds and signs a compact JWT: base64url(header) + "." +
+// base64url(payload) + "." + base64url(signature). Verification happens
+// downstream (the VM gateway, against cached JWKS), so this package only
+// ever needs to construct and sign, not parse, which is why it does not
+// depend on a JWT library.
+func signEdDSA(kid string, priv ed25519.PrivateKey, claims any) (string, error) {
+	header, err := json.Marshal(jwtHeader{Alg: "EdDSA", Kid: kid, Typ: "JWT"})
+	if err != nil {
+		return "", fmt.Errorf("marshal jwt header: %w", err)
+	}
+	payload, err := json.Marshal(claims)
+	if err != nil {
+		return "", fmt.Errorf("marshal jwt claims: %w", err)
+	}
+	signingInput := b64(header) + "." + b64(payload)
+	sig := ed25519.Sign(priv, []byte(signingInput))
+	return signingInput + "." + b64(sig), nil
+}
+
+func b64(b []byte) string {
+	return base64.RawURLEncoding.EncodeToString(b)
+}

--- a/controlplane/internal/tokens/refresh.go
+++ b/controlplane/internal/tokens/refresh.go
@@ -1,0 +1,161 @@
+package tokens
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/base64"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// DefaultRefreshTokenTTL is how long a refresh token is valid from issuance
+// if never rotated or revoked first. Refresh tokens rotate on every use, so
+// in practice this mostly bounds how long a desktop install can stay signed
+// in without contacting the control plane at all.
+const DefaultRefreshTokenTTL = 90 * 24 * time.Hour
+
+// refreshTokenBytes is the entropy of an opaque refresh token before
+// base64url encoding: 32 bytes is 256 bits.
+const refreshTokenBytes = 32
+
+var (
+	// ErrInvalidRefreshToken is returned when a presented refresh token does
+	// not match any stored hash.
+	ErrInvalidRefreshToken = errors.New("invalid refresh token")
+	// ErrRefreshTokenRevoked is returned when a presented refresh token
+	// matches a row that has already been revoked, including by a prior
+	// rotation, so it cannot be exchanged again.
+	ErrRefreshTokenRevoked = errors.New("refresh token revoked")
+	// ErrRefreshTokenExpired is returned when a presented refresh token has
+	// passed its expiry.
+	ErrRefreshTokenExpired = errors.New("refresh token expired")
+)
+
+// IssueRefreshToken mints a new opaque refresh token bound to accountID and
+// installID, stores only its hash in refresh_tokens, and returns the
+// plaintext token. The plaintext is never stored and cannot be recovered
+// once returned.
+func (i *Issuer) IssueRefreshToken(ctx context.Context, accountID, installID string) (string, error) {
+	plaintext, err := randomToken()
+	if err != nil {
+		return "", err
+	}
+	now := time.Now().UTC()
+	_, err = i.db.ExecContext(ctx,
+		`INSERT INTO refresh_tokens (id, account_id, install_id, token_hash, created_at, expires_at)
+		 VALUES (?, ?, ?, ?, ?, ?)`,
+		uuid.NewString(), accountID, installID, hashToken(plaintext), now, now.Add(DefaultRefreshTokenTTL),
+	)
+	if err != nil {
+		return "", fmt.Errorf("insert refresh token: %w", err)
+	}
+	return plaintext, nil
+}
+
+// RotateRefreshToken validates a presented refresh token, revokes it, and
+// issues a replacement bound to the same account and install, per the token
+// contract's rotate-on-use rule. It returns the new plaintext token and the
+// account and install it belongs to, so the caller can also mint a fresh
+// access token for the same account.
+func (i *Issuer) RotateRefreshToken(ctx context.Context, presented string) (newToken, accountID, installID string, err error) {
+	tx, err := i.db.BeginTx(ctx, nil)
+	if err != nil {
+		return "", "", "", fmt.Errorf("begin rotation tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	var (
+		id        string
+		expiresAt sql.NullTime
+		revokedAt sql.NullTime
+	)
+	row := tx.QueryRowContext(ctx,
+		`SELECT id, account_id, install_id, expires_at, revoked_at FROM refresh_tokens WHERE token_hash = ?`,
+		hashToken(presented),
+	)
+	if err := row.Scan(&id, &accountID, &installID, &expiresAt, &revokedAt); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return "", "", "", ErrInvalidRefreshToken
+		}
+		return "", "", "", fmt.Errorf("look up refresh token: %w", err)
+	}
+	if revokedAt.Valid {
+		return "", "", "", ErrRefreshTokenRevoked
+	}
+	if expiresAt.Valid && time.Now().UTC().After(expiresAt.Time) {
+		return "", "", "", ErrRefreshTokenExpired
+	}
+
+	now := time.Now().UTC()
+	if _, err := tx.ExecContext(ctx,
+		`UPDATE refresh_tokens SET revoked_at = ?, last_used_at = ? WHERE id = ?`, now, now, id,
+	); err != nil {
+		return "", "", "", fmt.Errorf("revoke rotated refresh token: %w", err)
+	}
+
+	newToken, err = randomToken()
+	if err != nil {
+		return "", "", "", err
+	}
+	if _, err := tx.ExecContext(ctx,
+		`INSERT INTO refresh_tokens (id, account_id, install_id, token_hash, created_at, expires_at)
+		 VALUES (?, ?, ?, ?, ?, ?)`,
+		uuid.NewString(), accountID, installID, hashToken(newToken), now, now.Add(DefaultRefreshTokenTTL),
+	); err != nil {
+		return "", "", "", fmt.Errorf("insert rotated refresh token: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return "", "", "", fmt.Errorf("commit rotation: %w", err)
+	}
+	return newToken, accountID, installID, nil
+}
+
+// RevokeRefreshToken revokes a refresh token so it can no longer be
+// exchanged. It is idempotent: revoking an already-revoked token is not an
+// error. Revoking a token whose hash matches no row returns
+// ErrInvalidRefreshToken.
+func (i *Issuer) RevokeRefreshToken(ctx context.Context, presented string) error {
+	hash := hashToken(presented)
+
+	res, err := i.db.ExecContext(ctx,
+		`UPDATE refresh_tokens SET revoked_at = ? WHERE token_hash = ? AND revoked_at IS NULL`,
+		time.Now().UTC(), hash,
+	)
+	if err != nil {
+		return fmt.Errorf("revoke refresh token: %w", err)
+	}
+	if n, _ := res.RowsAffected(); n > 0 {
+		return nil
+	}
+
+	var exists bool
+	if err := i.db.QueryRowContext(ctx,
+		`SELECT EXISTS(SELECT 1 FROM refresh_tokens WHERE token_hash = ?)`, hash,
+	).Scan(&exists); err != nil {
+		return fmt.Errorf("check refresh token existence: %w", err)
+	}
+	if !exists {
+		return ErrInvalidRefreshToken
+	}
+	return nil // already revoked
+}
+
+func randomToken() (string, error) {
+	buf := make([]byte, refreshTokenBytes)
+	if _, err := rand.Read(buf); err != nil {
+		return "", fmt.Errorf("generate refresh token entropy: %w", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(buf), nil
+}
+
+func hashToken(plaintext string) string {
+	sum := sha256.Sum256([]byte(plaintext))
+	return hex.EncodeToString(sum[:])
+}

--- a/controlplane/internal/tokens/tokens_test.go
+++ b/controlplane/internal/tokens/tokens_test.go
@@ -1,0 +1,259 @@
+package tokens
+
+import (
+	"context"
+	"crypto/ed25519"
+	"database/sql"
+	"encoding/base64"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/agentlab-in/hosted-ao/controlplane/internal/keys"
+	"github.com/agentlab-in/hosted-ao/controlplane/internal/storage/sqlite"
+)
+
+const testAccountID = "acct_test"
+
+func newTestIssuer(t *testing.T) (*Issuer, *keys.Manager, *sql.DB) {
+	t.Helper()
+
+	db, err := sqlite.Open(t.TempDir())
+	if err != nil {
+		t.Fatalf("sqlite.Open() unexpected error: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	if _, err := db.Exec(
+		`INSERT INTO accounts (id, google_subject, email, created_at) VALUES (?, ?, ?, ?)`,
+		testAccountID, "google-subject", "test@example.test", time.Now().UTC(),
+	); err != nil {
+		t.Fatalf("seed account: %v", err)
+	}
+
+	km, err := keys.Load(t.TempDir())
+	if err != nil {
+		t.Fatalf("keys.Load() unexpected error: %v", err)
+	}
+
+	return NewIssuer(km, db, "https://ao.agentlab.in", 15*time.Minute), km, db
+}
+
+func decodeJWT(t *testing.T, token string) (header jwtHeader, claims accessClaims, signingInput, sig []byte) {
+	t.Helper()
+
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		t.Fatalf("token has %d parts, want 3: %q", len(parts), token)
+	}
+
+	rawHeader, err := base64.RawURLEncoding.DecodeString(parts[0])
+	if err != nil {
+		t.Fatalf("decode header: %v", err)
+	}
+	if err := json.Unmarshal(rawHeader, &header); err != nil {
+		t.Fatalf("unmarshal header: %v", err)
+	}
+
+	rawClaims, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		t.Fatalf("decode claims: %v", err)
+	}
+	if err := json.Unmarshal(rawClaims, &claims); err != nil {
+		t.Fatalf("unmarshal claims: %v", err)
+	}
+
+	sig, err = base64.RawURLEncoding.DecodeString(parts[2])
+	if err != nil {
+		t.Fatalf("decode signature: %v", err)
+	}
+
+	return header, claims, []byte(parts[0] + "." + parts[1]), sig
+}
+
+func TestIssueAccessToken_ClaimsMatchContract(t *testing.T) {
+	issuer, km, _ := newTestIssuer(t)
+
+	before := time.Now().UTC()
+	token, err := issuer.IssueAccessToken(testAccountID, "machine-1")
+	if err != nil {
+		t.Fatalf("IssueAccessToken() unexpected error: %v", err)
+	}
+	after := time.Now().UTC()
+
+	header, claims, signingInput, sig := decodeJWT(t, token)
+
+	if header.Alg != "EdDSA" {
+		t.Errorf("alg = %q, want EdDSA", header.Alg)
+	}
+	if header.Typ != "JWT" {
+		t.Errorf("typ = %q, want JWT", header.Typ)
+	}
+	wantKID, priv := km.Active()
+	if header.Kid != wantKID {
+		t.Errorf("kid = %q, want %q", header.Kid, wantKID)
+	}
+
+	if claims.Iss != "https://ao.agentlab.in" {
+		t.Errorf("iss = %q, want https://ao.agentlab.in", claims.Iss)
+	}
+	if claims.Sub != testAccountID {
+		t.Errorf("sub = %q, want %q", claims.Sub, testAccountID)
+	}
+	if claims.Aud != "machine-1" {
+		t.Errorf("aud = %q, want machine-1", claims.Aud)
+	}
+	if claims.Jti == "" {
+		t.Error("jti is empty, want a unique id")
+	}
+
+	wantExpFloor := before.Add(15 * time.Minute).Unix()
+	wantExpCeil := after.Add(15 * time.Minute).Unix()
+	if claims.Exp < wantExpFloor || claims.Exp > wantExpCeil {
+		t.Errorf("exp = %d, want between %d and %d", claims.Exp, wantExpFloor, wantExpCeil)
+	}
+	if claims.Iat < before.Unix() || claims.Iat > after.Unix() {
+		t.Errorf("iat = %d, want between %d and %d", claims.Iat, before.Unix(), after.Unix())
+	}
+
+	if !ed25519.Verify(priv.Public().(ed25519.PublicKey), signingInput, sig) {
+		t.Error("signature does not verify against the active key published in JWKS")
+	}
+}
+
+func TestIssueAccessToken_DefaultTTLAppliedWhenZero(t *testing.T) {
+	db, err := sqlite.Open(t.TempDir())
+	if err != nil {
+		t.Fatalf("sqlite.Open() unexpected error: %v", err)
+	}
+	defer db.Close()
+	km, err := keys.Load(t.TempDir())
+	if err != nil {
+		t.Fatalf("keys.Load() unexpected error: %v", err)
+	}
+
+	issuer := NewIssuer(km, db, "https://ao.agentlab.in", 0)
+	if issuer.accessTTL != DefaultAccessTokenTTL {
+		t.Errorf("accessTTL = %v, want default %v", issuer.accessTTL, DefaultAccessTokenTTL)
+	}
+}
+
+func TestIssueRefreshToken_StoresOnlyTheHash(t *testing.T) {
+	issuer, _, db := newTestIssuer(t)
+
+	plaintext, err := issuer.IssueRefreshToken(context.Background(), testAccountID, "install-1")
+	if err != nil {
+		t.Fatalf("IssueRefreshToken() unexpected error: %v", err)
+	}
+	if plaintext == "" {
+		t.Fatal("IssueRefreshToken() returned empty token")
+	}
+
+	var storedHash, accountID, installID string
+	err = db.QueryRow(
+		`SELECT token_hash, account_id, install_id FROM refresh_tokens WHERE account_id = ?`, testAccountID,
+	).Scan(&storedHash, &accountID, &installID)
+	if err != nil {
+		t.Fatalf("query stored refresh token: %v", err)
+	}
+
+	if storedHash == plaintext {
+		t.Fatal("plaintext token stored verbatim in refresh_tokens, want it hashed")
+	}
+	if storedHash != hashToken(plaintext) {
+		t.Error("stored hash does not match hashToken(plaintext)")
+	}
+	if installID != "install-1" {
+		t.Errorf("install_id = %q, want install-1", installID)
+	}
+}
+
+func TestRotateRefreshToken_RotatesAndRevokesThePrevious(t *testing.T) {
+	issuer, _, _ := newTestIssuer(t)
+	ctx := context.Background()
+
+	original, err := issuer.IssueRefreshToken(ctx, testAccountID, "install-1")
+	if err != nil {
+		t.Fatalf("IssueRefreshToken() unexpected error: %v", err)
+	}
+
+	rotated, accountID, installID, err := issuer.RotateRefreshToken(ctx, original)
+	if err != nil {
+		t.Fatalf("RotateRefreshToken() unexpected error: %v", err)
+	}
+	if rotated == original {
+		t.Fatal("RotateRefreshToken() returned the same token")
+	}
+	if accountID != testAccountID {
+		t.Errorf("accountID = %q, want %q", accountID, testAccountID)
+	}
+	if installID != "install-1" {
+		t.Errorf("installID = %q, want install-1", installID)
+	}
+
+	// The original token is now revoked and cannot be exchanged again.
+	if _, _, _, err := issuer.RotateRefreshToken(ctx, original); err != ErrRefreshTokenRevoked {
+		t.Errorf("re-rotating the original token: err = %v, want ErrRefreshTokenRevoked", err)
+	}
+
+	// The rotated token works and itself rotates cleanly.
+	if _, _, _, err := issuer.RotateRefreshToken(ctx, rotated); err != nil {
+		t.Errorf("rotating the new token: unexpected error: %v", err)
+	}
+}
+
+func TestRotateRefreshToken_UnknownTokenRejected(t *testing.T) {
+	issuer, _, _ := newTestIssuer(t)
+
+	_, _, _, err := issuer.RotateRefreshToken(context.Background(), "not-a-real-token")
+	if err != ErrInvalidRefreshToken {
+		t.Errorf("err = %v, want ErrInvalidRefreshToken", err)
+	}
+}
+
+func TestRotateRefreshToken_ExpiredTokenRejected(t *testing.T) {
+	issuer, _, db := newTestIssuer(t)
+	ctx := context.Background()
+
+	plaintext, err := issuer.IssueRefreshToken(ctx, testAccountID, "install-1")
+	if err != nil {
+		t.Fatalf("IssueRefreshToken() unexpected error: %v", err)
+	}
+
+	if _, err := db.Exec(
+		`UPDATE refresh_tokens SET expires_at = ? WHERE token_hash = ?`,
+		time.Now().UTC().Add(-time.Hour), hashToken(plaintext),
+	); err != nil {
+		t.Fatalf("force-expire token: %v", err)
+	}
+
+	if _, _, _, err := issuer.RotateRefreshToken(ctx, plaintext); err != ErrRefreshTokenExpired {
+		t.Errorf("err = %v, want ErrRefreshTokenExpired", err)
+	}
+}
+
+func TestRevokeRefreshToken_IsIdempotentAndRejectsUnknown(t *testing.T) {
+	issuer, _, _ := newTestIssuer(t)
+	ctx := context.Background()
+
+	plaintext, err := issuer.IssueRefreshToken(ctx, testAccountID, "install-1")
+	if err != nil {
+		t.Fatalf("IssueRefreshToken() unexpected error: %v", err)
+	}
+
+	if err := issuer.RevokeRefreshToken(ctx, plaintext); err != nil {
+		t.Fatalf("first RevokeRefreshToken() unexpected error: %v", err)
+	}
+	if err := issuer.RevokeRefreshToken(ctx, plaintext); err != nil {
+		t.Fatalf("second RevokeRefreshToken() (idempotent) unexpected error: %v", err)
+	}
+
+	if _, _, _, err := issuer.RotateRefreshToken(ctx, plaintext); err != ErrRefreshTokenRevoked {
+		t.Errorf("rotating a revoked token: err = %v, want ErrRefreshTokenRevoked", err)
+	}
+
+	if err := issuer.RevokeRefreshToken(ctx, "not-a-real-token"); err != ErrInvalidRefreshToken {
+		t.Errorf("revoking an unknown token: err = %v, want ErrInvalidRefreshToken", err)
+	}
+}


### PR DESCRIPTION
## Summary

- `controlplane/internal/keys`: Ed25519 signing key generation and on-disk storage under `DATA_DIR/keys`, with an active key and a next-key rotation slot. Key files are mode 0600 and gitignored (`/controlplane/data/`). Serves `GET /.well-known/jwks.json` publishing both public keys with stable `kid`s, `Cache-Control: public, max-age=3600` matching the 1 hour JWKS cache clause in `TOKEN_CONTRACT.md`.
- `controlplane/internal/tokens`: access token issuance, a hand-signed EdDSA JWT (no JWT library dependency needed since this package only signs, never parses) with `iss`, `sub`, `aud`, `exp`, `iat`, `jti` exactly per `TOKEN_CONTRACT.md`. Lifetime is configurable via the new `ACCESS_TOKEN_TTL` env var (default 15m), not hardcoded, so it can move within the 10 to 30 minute range the spec allows.
- Refresh tokens: opaque, 256 bits of entropy, stored hashed (SHA-256) in `refresh_tokens`, bound to an account and a desktop install, rotated on use in a transaction (old row revoked, new row inserted), and revocable (`RevokeRefreshToken`, idempotent).
- `server.New` and `main.go` touched minimally: one `keys.Register(mux, km)` call and one `keys.Load` call, per the coordination note in the task brief since `controlplane/` is shared with the parallel Google login worker (task 4, issue #7).

No new third-party dependency: `go.mod` only moves `github.com/google/uuid` from indirect to direct (already vendored transitively via goose).

Out of scope, not built here: Google login (task 4), the RFC 8628 device flow and machines registry (task 7), gateway-side JWT verification (task 6). Those tasks call into `tokens.Issuer` and `keys.Manager` directly as Go packages once they land; no HTTP endpoint for minting or refreshing tokens is added here since the request/response shape for that depends on the not-yet-built device/machine flow.

Closes #8

## Test plan

- [x] `gofmt -l .` clean
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race ./...` (27 tests, 6 packages)
- [x] Manual smoke test: ran the service locally, confirmed `/healthz`, `/.well-known/jwks.json` (two valid Ed25519 JWKs), and that `active.json`/`next.json` are written under `DATA_DIR/keys` at mode 0600.