### PR TITLE
fix(controlplane): correct the token contract and its config hazards

### DIFF
--- a/controlplane/.env.example
+++ b/controlplane/.env.example
@@ -25,8 +25,18 @@ LISTEN_ADDR=127.0.0.1:8080
 
 # Data directory for the SQLite database and the EdDSA signing keys (under
 # DATA_DIR/keys, generated at first boot, mode 0600, never committed).
+#
+# Required: there is deliberately no default. A relative path resolves against
+# the process working directory, so a service unit without WorkingDirectory=
+# would point somewhere else, find no key files, generate a fresh signing key
+# pair, and reject every already-issued token until each VM's JWKS cache
+# expires. Use an absolute path under systemd (for example
+# /var/lib/ao-controlplane); ./data is fine for a local run from this
+# directory. The resolved absolute path and the active kid are logged at boot.
 DATA_DIR=./data
 
 # Access token lifetime, a Go duration. May move between 10m and 30m after
-# measuring refresh chatter; see TOKEN_CONTRACT.md.
+# measuring refresh chatter; see TOKEN_CONTRACT.md. Values outside that range
+# are rejected at boot, because nothing checks an access token against a
+# revocation list, so this is the entire revocation window.
 ACCESS_TOKEN_TTL=15m

--- a/controlplane/README.md
+++ b/controlplane/README.md
@@ -19,7 +19,8 @@ standalone Go binary with no Caddy in front; hit it directly on
 
 Copy the example env file and fill in the two required Google OAuth values
 (see the "Operator setup: Google OAuth client" section of the spec doc for
-how to obtain them):
+how to obtain them). The example file already sets the third required
+variable, `DATA_DIR`:
 
 ```bash
 cp .env.example .env
@@ -32,12 +33,23 @@ Or export the variables directly:
 ```bash
 export AO_SH_G_CLIENT_ID=your-client-id
 export AO_SH_G_CLIENT_SECRET=your-client-secret
+export DATA_DIR=./data
 ```
 
-`LISTEN_ADDR` (default `127.0.0.1:8080`), `DATA_DIR` (default `./data`), and
-`PUBLIC_ORIGIN` (default `https://ao.agentlab.in`) are optional; see
+`DATA_DIR` is required and has no default, because the EdDSA signing keys live
+inside it: a working-directory-relative default would silently resolve
+elsewhere under a service manager that does not set `WorkingDirectory=`,
+generating a fresh key pair and rejecting every already-issued token until each
+VM's JWKS cache expires. Use an absolute path in a service unit. The service
+logs the resolved absolute data dir and the active `kid` at boot, so an
+unintended regeneration is visible.
+
+`LISTEN_ADDR` (default `127.0.0.1:8080`), `PUBLIC_ORIGIN` (default
+`https://ao.agentlab.in`, trailing slashes stripped), and `ACCESS_TOKEN_TTL`
+(default `15m`, must be between `10m` and `30m`) are optional; see
 `internal/config/config.go` for the full list. The service fails to start
-(`log.Fatal`) if either Google credential is missing.
+(`log.Fatal`) if a Google credential or `DATA_DIR` is missing, or if
+`ACCESS_TOKEN_TTL` is out of range.
 
 ## Run
 

--- a/controlplane/TOKEN_CONTRACT.md
+++ b/controlplane/TOKEN_CONTRACT.md
@@ -2,21 +2,71 @@
 
 This is the shared token contract for the control plane, the VM gateway
 (`ao vm serve`), and the desktop transport. It is defined once so the three
-can be built in parallel. It must stay in sync with the "Token contract"
-section of
-[`docs/superpowers/specs/2026-07-29-hosted-ao-v1-accounts-and-machines.md`](../docs/superpowers/specs/2026-07-29-hosted-ao-v1-accounts-and-machines.md),
-which it was copied from; if that section changes, update this file to match.
+can be built in parallel. It was copied from the "Token contract" section of
+[`docs/superpowers/specs/2026-07-29-hosted-ao-v1-accounts-and-machines.md`](../docs/superpowers/specs/2026-07-29-hosted-ao-v1-accounts-and-machines.md);
+where this file is more specific than that section, this file is the one to
+build against, and if that section changes, update this file to match.
 
 - Access token: JWT, EdDSA, `iss` = `https://ao.agentlab.in`, `sub` = account
-  id, `aud` = machine id, `exp` = 15 minutes, `iat`, `jti`.
-- Refresh token: opaque, high entropy, stored hashed in `refresh_tokens`, bound
-  to an account and a desktop install, long-lived, revocable.
-- Transport: `Authorization: Bearer <jwt>` for REST and SSE. Browsers cannot set
-  headers on a WebSocket handshake, so `/mux` continues to use a cookie, whose
-  value is the same short-lived JWT rather than a shared secret. The cookie is
-  Secure, HttpOnly, host-only, and installed by the Electron main process.
-- Verification on the VM: signature against cached JWKS, `iss`, `aud` equal to
-  this machine's id, `exp` with 60s skew tolerance, and `sub` equal to the
-  single account id in the machine's allowlist.
+  id, `aud` = machine id, `exp` = 15 minutes, `iat`, `jti`. The audience is
+  the machine id (`machines.id`), never the machine's hostname or public URL.
+- Access token lifetime: 15 minutes by default, configurable via
+  `ACCESS_TOKEN_TTL` but only within 10 to 30 minutes. Nothing checks an
+  access token against a revocation list, so the lifetime is the whole
+  revocation window; the control plane refuses to start outside that range.
+- Refresh token: opaque, high entropy, stored hashed in `refresh_tokens`,
+  bound to an account and a desktop install, revocable.
+- Refresh token lifetime: 90 days from issuance, and it **rotates on every
+  use**. Exchanging a refresh token revokes the presented one in the same
+  transaction that issues its replacement, so a refresh token is single-use
+  and a replayed one is rejected as revoked rather than honoured. The desktop
+  install must therefore persist the replacement it gets back on every
+  refresh, and the 90 days mostly bound how long an install may go without
+  contacting the control plane at all.
+
+## Transport
+
+- **`Authorization: Bearer <jwt>` for REST.** This is the only accepted
+  credential for every state-changing method and every route other than the
+  two below.
+- **Cookie for `/mux` (the terminal WebSocket) and for `GET /api/v1/events`
+  (SSE).** Browsers cannot set headers on either: the WebSocket handshake has
+  no header API, and `EventSource` has none either. Both therefore
+  authenticate with the cookie, whose value is the same short-lived JWT rather
+  than a shared secret.
+- The cookie is **deliberately not** accepted on any other route, and never on
+  a state-changing method. It is ambient, so widening it would leave the
+  gateway's CORS origin check as the only CSRF defence. New browser-reachable
+  routes that cannot send a header need an explicit decision here first, not a
+  quiet addition.
+
+### The `/mux` and SSE cookie
+
+- **Name: `ao_gw_token`.** Value: the current access token.
+- Attributes: `Secure`, `HttpOnly`, `SameSite=None`, host-only (no `Domain`),
+  `Path=/`.
+- `SameSite=None` is required, not optional. The renderer runs on the
+  `app://renderer` origin and talks to `https://vm.example.com`, which is a
+  cross-site context, so under the browser default (`Lax`) the cookie is not
+  attached to the WebSocket handshake or the `EventSource` request at all and
+  both fail 401 with nothing to see on the client. `SameSite=None` is only
+  honoured together with `Secure`, which is why the pair is stated together.
+- Installed by the Electron main process, which owns it: it must be refreshed
+  whenever the access token is, since it carries the same 15-minute
+  expiry as the token inside it.
+- The gateway strips both `Authorization` and this cookie before proxying to
+  the daemon, so the credential never reaches the daemon.
+
+## Verification on the VM
+
+- Signature against the cached JWKS, then `iss`, then `aud` equal to this
+  machine's id, then `exp` with 60s skew tolerance, then `sub` equal to the
+  single account id in the machine's allowlist. Signature first, claims after,
+  and a missing `exp` is a rejection rather than "no expiry".
+- `iss` and `aud` are compared byte for byte. The control plane strips any
+  trailing slash from `PUBLIC_ORIGIN` so the `iss` it mints matches the value
+  the gateway pins.
 - JWKS cache: 1 hour, with stale-if-error so a brief control-plane outage does
   not disconnect working users.
+- The JWKS publishes the active key plus the next-rotation key, so a verifier
+  caches the next key before it ever signs anything.

--- a/controlplane/cmd/controlplane/main.go
+++ b/controlplane/cmd/controlplane/main.go
@@ -40,6 +40,16 @@ func main() {
 		log.Fatalf("load signing keys: %v", err)
 	}
 
+	// Log the resolved absolute data dir and the active kid on every boot.
+	// The signing keys live under the data dir, so if a deployment change ever
+	// points the service at a different path, keys.Load silently generates a
+	// fresh pair and every issued token starts failing verification until each
+	// VM's JWKS cache expires. A kid that changed unexpectedly across a restart
+	// is the one signal that makes that diagnosable.
+	activeKID, _ := km.Active()
+	log.Printf("data dir %s, active signing kid %s, access token ttl %v, public origin %s",
+		cfg.DataDir, activeKID, cfg.AccessTokenTTL, cfg.PublicOrigin)
+
 	mux := server.New(db, km)
 
 	authSvc, err := auth.NewService(db, cfg)

--- a/controlplane/internal/auth/auth.go
+++ b/controlplane/internal/auth/auth.go
@@ -54,10 +54,12 @@ func NewService(db *sql.DB, cfg config.Config) (*Service, error) {
 	}
 
 	return &Service{
-		db:            db,
-		clientID:      cfg.GoogleClientID,
-		clientSecret:  cfg.GoogleClientSecret,
-		redirectURI:   strings.TrimRight(cfg.PublicOrigin, "/") + "/auth/google/callback",
+		db:           db,
+		clientID:     cfg.GoogleClientID,
+		clientSecret: cfg.GoogleClientSecret,
+		// config.Load already strips any trailing slash from PublicOrigin, so
+		// this concatenation cannot produce a double slash.
+		redirectURI:   cfg.PublicOrigin + "/auth/google/callback",
 		endpoints:     defaultGoogleEndpoints,
 		httpClient:    &http.Client{Timeout: 10 * time.Second},
 		sessionKey:    key,

--- a/controlplane/internal/auth/session.go
+++ b/controlplane/internal/auth/session.go
@@ -44,7 +44,9 @@ func loadOrCreateSessionKey(dataDir string) ([]byte, error) {
 		return nil, fmt.Errorf("read session key: %w", err)
 	}
 
-	if err := os.MkdirAll(dataDir, 0o750); err != nil {
+	// 0700 to match storage/sqlite.Open: everything under the data dir is
+	// sensitive, including this key and the EdDSA signing keys.
+	if err := os.MkdirAll(dataDir, 0o700); err != nil {
 		return nil, fmt.Errorf("create data dir: %w", err)
 	}
 

--- a/controlplane/internal/auth/session_test.go
+++ b/controlplane/internal/auth/session_test.go
@@ -3,6 +3,8 @@ package auth
 import (
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strconv"
 	"testing"
 	"time"
@@ -34,6 +36,24 @@ func TestLoadOrCreateSessionKey_PersistsAcrossCalls(t *testing.T) {
 	}
 	if string(first) != string(second) {
 		t.Fatal("loadOrCreateSessionKey() returned a different key on the second call, want the persisted one")
+	}
+}
+
+// Creating the data dir on demand must use the same 0700 as
+// storage/sqlite.Open: everything in it is sensitive, this key included.
+func TestLoadOrCreateSessionKey_CreatesDataDirMode0700(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "controlplane-data")
+
+	if _, err := loadOrCreateSessionKey(dir); err != nil {
+		t.Fatalf("loadOrCreateSessionKey() error: %v", err)
+	}
+
+	info, err := os.Stat(dir)
+	if err != nil {
+		t.Fatalf("stat %s: %v", dir, err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o700 {
+		t.Errorf("data dir mode = %o, want 0700", perm)
 	}
 }
 

--- a/controlplane/internal/config/config.go
+++ b/controlplane/internal/config/config.go
@@ -9,6 +9,8 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"path/filepath"
+	"strings"
 	"time"
 )
 
@@ -16,11 +18,6 @@ const (
 	// DefaultListenAddr is the address the control plane binds when
 	// LISTEN_ADDR is unset. Caddy fronts it in production.
 	DefaultListenAddr = "127.0.0.1:8080"
-	// DefaultDataDir is the SQLite data directory used when DATA_DIR is
-	// unset, relative to the process's working directory. This service
-	// manages its own data directory independently of the desktop app's
-	// ~/.ao; it must never reference that path.
-	DefaultDataDir = "./data"
 	// DefaultPublicOrigin is the origin used when PUBLIC_ORIGIN is unset.
 	DefaultPublicOrigin = "https://ao.agentlab.in"
 	// DefaultAccessTokenTTL is the access token lifetime used when
@@ -28,6 +25,13 @@ const (
 	// 30 minutes after measuring refresh chatter, which is why it is
 	// configurable rather than hardcoded in the tokens package.
 	DefaultAccessTokenTTL = 15 * time.Minute
+	// MinAccessTokenTTL and MaxAccessTokenTTL bound ACCESS_TOKEN_TTL to the
+	// range the spec allows. Nothing checks an issued access token against a
+	// revocation list, so the TTL is the entire revocation window: a typo
+	// like 720h would mint month-long unrevocable tokens. Load rejects
+	// anything outside these bounds rather than trusting the operator.
+	MinAccessTokenTTL = 10 * time.Minute
+	MaxAccessTokenTTL = 30 * time.Minute
 )
 
 // Config is the fully resolved control plane configuration. It is immutable
@@ -35,11 +39,16 @@ const (
 type Config struct {
 	// ListenAddr is the host:port the HTTP server binds.
 	ListenAddr string
-	// DataDir is the directory holding the SQLite database.
+	// DataDir is the absolute path of the directory holding the SQLite
+	// database and the EdDSA signing keys. Load resolves it to an absolute
+	// path so it never depends on the process's working directory, which a
+	// service manager may not set.
 	DataDir string
 	// PublicOrigin is the origin this service is served from. Later batches
 	// use it to build the OAuth redirect URI and the `iss` claim on issued
-	// access tokens; this skeleton only loads and validates it.
+	// access tokens; this skeleton only loads and validates it. Load strips
+	// any trailing slash, so consumers can concatenate paths onto it and the
+	// `iss` claim matches what verifiers pin byte for byte.
 	PublicOrigin string
 	// GoogleClientID is the OAuth web client id from the Google Cloud
 	// console. Required; Load fails if it is empty.
@@ -53,22 +62,31 @@ type Config struct {
 
 // Load resolves configuration from the environment, applying defaults for
 // optional values and failing loudly for required ones. It returns an error
-// if AO_SH_G_CLIENT_ID or AO_SH_G_CLIENT_SECRET is missing, or if LISTEN_ADDR
-// is present but malformed, so a misconfigured deployment never starts
-// serving traffic it cannot correctly authenticate.
+// if DATA_DIR, AO_SH_G_CLIENT_ID, or AO_SH_G_CLIENT_SECRET is missing, if
+// LISTEN_ADDR is present but malformed, or if ACCESS_TOKEN_TTL is outside the
+// range the spec allows, so a misconfigured deployment never starts serving
+// traffic it cannot correctly authenticate.
+//
+// DATA_DIR is required rather than defaulted because the EdDSA signing keys
+// live inside it. A working-directory-relative default (it used to be ./data)
+// silently resolves somewhere else under a service manager that does not set
+// WorkingDirectory, where the keys package would find no key files and
+// generate a fresh pair whose kid no verifier has cached, rejecting every
+// token for up to the JWKS cache lifetime and orphaning the refresh-token
+// rows. An explicit path plus the boot log in cmd/controlplane makes that
+// visible instead.
 //
 // Recognised variables:
 //
 //	LISTEN_ADDR            bind address                (default 127.0.0.1:8080)
-//	DATA_DIR               SQLite data directory       (default ./data)
+//	DATA_DIR               SQLite and signing key directory, absolute path recommended (required)
 //	PUBLIC_ORIGIN          public origin for redirect URIs and the iss claim (default https://ao.agentlab.in)
-//	ACCESS_TOKEN_TTL       access token lifetime, a Go duration (default 15m)
+//	ACCESS_TOKEN_TTL       access token lifetime, a Go duration between 10m and 30m (default 15m)
 //	AO_SH_G_CLIENT_ID      Google OAuth client id      (required)
 //	AO_SH_G_CLIENT_SECRET  Google OAuth client secret  (required)
 func Load() (Config, error) {
 	cfg := Config{
 		ListenAddr:     DefaultListenAddr,
-		DataDir:        DefaultDataDir,
 		PublicOrigin:   DefaultPublicOrigin,
 		AccessTokenTTL: DefaultAccessTokenTTL,
 	}
@@ -80,18 +98,33 @@ func Load() (Config, error) {
 		cfg.ListenAddr = raw
 	}
 
-	if raw := os.Getenv("DATA_DIR"); raw != "" {
-		cfg.DataDir = raw
+	rawDataDir := os.Getenv("DATA_DIR")
+	if rawDataDir == "" {
+		return Config{}, fmt.Errorf("DATA_DIR is required: set it to the directory holding the SQLite database and the EdDSA signing keys, ideally an absolute path (see controlplane/.env.example)")
 	}
+	dataDir, err := filepath.Abs(rawDataDir)
+	if err != nil {
+		return Config{}, fmt.Errorf("resolve DATA_DIR %q: %w", rawDataDir, err)
+	}
+	cfg.DataDir = dataDir
 
 	if raw := os.Getenv("PUBLIC_ORIGIN"); raw != "" {
 		cfg.PublicOrigin = raw
 	}
+	// Normalize once here so every consumer sees the same string: the OAuth
+	// redirect URI must match Google's registered value byte for byte, and
+	// the `iss` claim must match what the VM gateway pins, which it compares
+	// with !=. A trailing slash in the environment would otherwise reject
+	// every token on every VM with nothing in the logs but "token rejected".
+	cfg.PublicOrigin = strings.TrimRight(cfg.PublicOrigin, "/")
 
 	if raw := os.Getenv("ACCESS_TOKEN_TTL"); raw != "" {
 		ttl, err := time.ParseDuration(raw)
 		if err != nil {
 			return Config{}, fmt.Errorf("invalid ACCESS_TOKEN_TTL %q: %w", raw, err)
+		}
+		if ttl < MinAccessTokenTTL || ttl > MaxAccessTokenTTL {
+			return Config{}, fmt.Errorf("ACCESS_TOKEN_TTL %v is outside the allowed range %v to %v: an access token is not checked against a revocation list, so its lifetime is the whole revocation window", ttl, MinAccessTokenTTL, MaxAccessTokenTTL)
 		}
 		cfg.AccessTokenTTL = ttl
 	}

--- a/controlplane/internal/config/config_test.go
+++ b/controlplane/internal/config/config_test.go
@@ -1,10 +1,20 @@
 package config
 
 import (
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 )
+
+// setRequired sets every variable Load requires, so each test only has to
+// supply the one it is exercising.
+func setRequired(t *testing.T) {
+	t.Helper()
+	t.Setenv("AO_SH_G_CLIENT_ID", "client-id")
+	t.Setenv("AO_SH_G_CLIENT_SECRET", "client-secret")
+	t.Setenv("DATA_DIR", t.TempDir())
+}
 
 func TestLoad_MissingGoogleCredentials(t *testing.T) {
 	tests := []struct {
@@ -35,6 +45,7 @@ func TestLoad_MissingGoogleCredentials(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("DATA_DIR", t.TempDir())
 			t.Setenv("AO_SH_G_CLIENT_ID", tt.clientID)
 			t.Setenv("AO_SH_G_CLIENT_SECRET", tt.secret)
 
@@ -49,9 +60,42 @@ func TestLoad_MissingGoogleCredentials(t *testing.T) {
 	}
 }
 
-func TestLoad_DefaultsAppliedWhenCredentialsSet(t *testing.T) {
+func TestLoad_MissingDataDir(t *testing.T) {
 	t.Setenv("AO_SH_G_CLIENT_ID", "client-id")
 	t.Setenv("AO_SH_G_CLIENT_SECRET", "client-secret")
+	t.Setenv("DATA_DIR", "")
+
+	_, err := Load()
+	if err == nil {
+		t.Fatal("Load() with DATA_DIR unset = nil error, want error")
+	}
+	if !strings.Contains(err.Error(), "DATA_DIR") {
+		t.Fatalf("Load() error = %q, want it to mention DATA_DIR", err.Error())
+	}
+}
+
+// A relative DATA_DIR must not stay relative: the EdDSA signing keys live
+// inside it, and a service manager that does not set WorkingDirectory would
+// otherwise resolve it somewhere else and silently generate a fresh key pair.
+func TestLoad_DataDirResolvedToAbsolutePath(t *testing.T) {
+	t.Setenv("AO_SH_G_CLIENT_ID", "client-id")
+	t.Setenv("AO_SH_G_CLIENT_SECRET", "client-secret")
+	t.Setenv("DATA_DIR", "./data")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() unexpected error: %v", err)
+	}
+	if !filepath.IsAbs(cfg.DataDir) {
+		t.Fatalf("DataDir = %q, want an absolute path", cfg.DataDir)
+	}
+	if filepath.Base(cfg.DataDir) != "data" {
+		t.Errorf("DataDir = %q, want it to end in %q", cfg.DataDir, "data")
+	}
+}
+
+func TestLoad_DefaultsAppliedWhenCredentialsSet(t *testing.T) {
+	setRequired(t)
 
 	cfg, err := Load()
 	if err != nil {
@@ -59,9 +103,6 @@ func TestLoad_DefaultsAppliedWhenCredentialsSet(t *testing.T) {
 	}
 	if cfg.ListenAddr != DefaultListenAddr {
 		t.Errorf("ListenAddr = %q, want default %q", cfg.ListenAddr, DefaultListenAddr)
-	}
-	if cfg.DataDir != DefaultDataDir {
-		t.Errorf("DataDir = %q, want default %q", cfg.DataDir, DefaultDataDir)
 	}
 	if cfg.PublicOrigin != DefaultPublicOrigin {
 		t.Errorf("PublicOrigin = %q, want default %q", cfg.PublicOrigin, DefaultPublicOrigin)
@@ -78,8 +119,7 @@ func TestLoad_DefaultsAppliedWhenCredentialsSet(t *testing.T) {
 }
 
 func TestLoad_ListenAddrOverrideHonored(t *testing.T) {
-	t.Setenv("AO_SH_G_CLIENT_ID", "client-id")
-	t.Setenv("AO_SH_G_CLIENT_SECRET", "client-secret")
+	setRequired(t)
 	t.Setenv("LISTEN_ADDR", "0.0.0.0:9090")
 
 	cfg, err := Load()
@@ -102,8 +142,7 @@ func TestLoad_InvalidListenAddrRejected(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Setenv("AO_SH_G_CLIENT_ID", "client-id")
-			t.Setenv("AO_SH_G_CLIENT_SECRET", "client-secret")
+			setRequired(t)
 			t.Setenv("LISTEN_ADDR", tt.addr)
 
 			_, err := Load()
@@ -118,8 +157,7 @@ func TestLoad_InvalidListenAddrRejected(t *testing.T) {
 }
 
 func TestLoad_DataDirAndPublicOriginOverrideHonored(t *testing.T) {
-	t.Setenv("AO_SH_G_CLIENT_ID", "client-id")
-	t.Setenv("AO_SH_G_CLIENT_SECRET", "client-secret")
+	setRequired(t)
 	t.Setenv("DATA_DIR", "/tmp/cp-data")
 	t.Setenv("PUBLIC_ORIGIN", "https://example.test")
 
@@ -135,23 +173,59 @@ func TestLoad_DataDirAndPublicOriginOverrideHonored(t *testing.T) {
 	}
 }
 
-func TestLoad_AccessTokenTTLOverrideHonored(t *testing.T) {
-	t.Setenv("AO_SH_G_CLIENT_ID", "client-id")
-	t.Setenv("AO_SH_G_CLIENT_SECRET", "client-secret")
-	t.Setenv("ACCESS_TOKEN_TTL", "30m")
-
-	cfg, err := Load()
-	if err != nil {
-		t.Fatalf("Load() unexpected error: %v", err)
+// A trailing slash on PUBLIC_ORIGIN must not survive into the config: it ends
+// up in the `iss` claim, which the VM gateway pins and compares with !=, so
+// one extra byte would reject every token on every VM.
+func TestLoad_PublicOriginTrailingSlashesStripped(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{name: "one slash", raw: "https://ao.agentlab.in/", want: "https://ao.agentlab.in"},
+		{name: "several slashes", raw: "https://ao.agentlab.in///", want: "https://ao.agentlab.in"},
+		{name: "already clean", raw: "https://ao.agentlab.in", want: "https://ao.agentlab.in"},
 	}
-	if cfg.AccessTokenTTL != 30*time.Minute {
-		t.Errorf("AccessTokenTTL = %v, want 30m", cfg.AccessTokenTTL)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setRequired(t)
+			t.Setenv("PUBLIC_ORIGIN", tt.raw)
+
+			cfg, err := Load()
+			if err != nil {
+				t.Fatalf("Load() unexpected error: %v", err)
+			}
+			if cfg.PublicOrigin != tt.want {
+				t.Errorf("PublicOrigin = %q, want %q", cfg.PublicOrigin, tt.want)
+			}
+		})
+	}
+}
+
+func TestLoad_AccessTokenTTLOverrideHonored(t *testing.T) {
+	for _, raw := range []string{"10m", "15m", "30m"} {
+		t.Run(raw, func(t *testing.T) {
+			setRequired(t)
+			t.Setenv("ACCESS_TOKEN_TTL", raw)
+
+			cfg, err := Load()
+			if err != nil {
+				t.Fatalf("Load() unexpected error: %v", err)
+			}
+			want, err := time.ParseDuration(raw)
+			if err != nil {
+				t.Fatalf("ParseDuration(%q): %v", raw, err)
+			}
+			if cfg.AccessTokenTTL != want {
+				t.Errorf("AccessTokenTTL = %v, want %v", cfg.AccessTokenTTL, want)
+			}
+		})
 	}
 }
 
 func TestLoad_InvalidAccessTokenTTLRejected(t *testing.T) {
-	t.Setenv("AO_SH_G_CLIENT_ID", "client-id")
-	t.Setenv("AO_SH_G_CLIENT_SECRET", "client-secret")
+	setRequired(t)
 	t.Setenv("ACCESS_TOKEN_TTL", "not-a-duration")
 
 	_, err := Load()
@@ -160,5 +234,37 @@ func TestLoad_InvalidAccessTokenTTLRejected(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "ACCESS_TOKEN_TTL") {
 		t.Fatalf("Load() error = %q, want it to mention ACCESS_TOKEN_TTL", err.Error())
+	}
+}
+
+// An access token is never checked against a revocation list, so its TTL is
+// the whole revocation window. Anything outside the range the spec allows has
+// to fail at boot rather than quietly minting long-lived tokens.
+func TestLoad_OutOfRangeAccessTokenTTLRejected(t *testing.T) {
+	tests := []struct {
+		name string
+		ttl  string
+	}{
+		{name: "well below the minimum", ttl: "30s"},
+		{name: "just below the minimum", ttl: "9m59s"},
+		{name: "just above the maximum", ttl: "30m1s"},
+		{name: "fat fingered hours for minutes", ttl: "720h"},
+		{name: "zero", ttl: "0s"},
+		{name: "negative", ttl: "-15m"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setRequired(t)
+			t.Setenv("ACCESS_TOKEN_TTL", tt.ttl)
+
+			_, err := Load()
+			if err == nil {
+				t.Fatalf("Load() with ACCESS_TOKEN_TTL=%q = nil error, want error", tt.ttl)
+			}
+			if !strings.Contains(err.Error(), "ACCESS_TOKEN_TTL") {
+				t.Fatalf("Load() error = %q, want it to mention ACCESS_TOKEN_TTL", err.Error())
+			}
+		})
 	}
 }

--- a/controlplane/internal/keys/keys.go
+++ b/controlplane/internal/keys/keys.go
@@ -132,6 +132,15 @@ func (m *Manager) Active() (kid string, priv ed25519.PrivateKey) {
 // for tokens signed by the old active key to stop verifying (they are
 // short-lived per TOKEN_CONTRACT.md, so this is bounded by the access token
 // TTL plus the JWKS cache lifetime).
+//
+// The write order matters and is deliberate: next.json is written before
+// active.json, and memory is updated only after both succeed. Writing the
+// promoted key into active.json first would mean a failure on the second
+// write (disk full, EPERM) left the same key in both files, so the next Load
+// would publish a duplicate kid and lose the rotation slot entirely. In this
+// order a failed second write leaves active.json holding the still-valid old
+// active key, and the only casualty is the unused next key: signing keeps
+// working and the caller can retry.
 func (m *Manager) Rotate() error {
 	newNext, err := generate()
 	if err != nil {
@@ -141,11 +150,11 @@ func (m *Manager) Rotate() error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if err := writeKeyPair(filepath.Join(m.dir, "active.json"), m.next); err != nil {
-		return fmt.Errorf("persist promoted active key: %w", err)
-	}
 	if err := writeKeyPair(filepath.Join(m.dir, "next.json"), newNext); err != nil {
 		return fmt.Errorf("persist new next key: %w", err)
+	}
+	if err := writeKeyPair(filepath.Join(m.dir, "active.json"), m.next); err != nil {
+		return fmt.Errorf("persist promoted active key: %w", err)
 	}
 
 	m.active = m.next

--- a/controlplane/internal/keys/keys_test.go
+++ b/controlplane/internal/keys/keys_test.go
@@ -113,6 +113,59 @@ func TestRotate_PromotesNextAndGeneratesFreshNext(t *testing.T) {
 	}
 }
 
+// Rotate writes two files. If the second write fails, the promoted key must
+// not already be sitting in active.json, or a restart would read the same key
+// from both files, publish a duplicate kid in JWKS, and lose the rotation slot
+// with no way to tell from either side.
+func TestRotate_FailedSecondWriteLeavesActiveAndNextDistinct(t *testing.T) {
+	dir := t.TempDir()
+	m, err := Load(dir)
+	if err != nil {
+		t.Fatalf("Load() unexpected error: %v", err)
+	}
+	origActive, origNext := m.active.KID, m.next.KID
+
+	// Make exactly one of the two writes fail, by putting a directory where
+	// Rotate wants to write a file. os.WriteFile cannot overwrite a directory
+	// even as root, so this does not depend on the test user's privileges.
+	failing := filepath.Join(dir, "keys", "next.json")
+	if err := os.Remove(failing); err != nil {
+		t.Fatalf("remove %s: %v", failing, err)
+	}
+	if err := os.Mkdir(failing, 0o700); err != nil {
+		t.Fatalf("mkdir %s: %v", failing, err)
+	}
+
+	if err := m.Rotate(); err == nil {
+		t.Fatal("Rotate() = nil error, want the injected write failure")
+	}
+
+	onDisk := readKeyPair(t, filepath.Join(dir, "keys", "active.json"))
+	if onDisk.KID == origNext {
+		t.Errorf("active.json holds the promoted next key %q after a failed Rotate(): a restart would publish a duplicate kid", origNext)
+	}
+	if onDisk.KID != origActive {
+		t.Errorf("active.json kid = %q, want the untouched original active kid %q", onDisk.KID, origActive)
+	}
+	if m.active.KID != origActive || m.next.KID != origNext {
+		t.Errorf("in-memory keys changed after a failed Rotate(): active %q, next %q, want %q and %q",
+			m.active.KID, m.next.KID, origActive, origNext)
+	}
+}
+
+func readKeyPair(t *testing.T, path string) keyPair {
+	t.Helper()
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	var kp keyPair
+	if err := json.Unmarshal(raw, &kp); err != nil {
+		t.Fatalf("parse %s: %v", path, err)
+	}
+	return kp
+}
+
 func TestJWKS_PublishesActiveAndNextPublicKeysOnly(t *testing.T) {
 	m, err := Load(t.TempDir())
 	if err != nil {

--- a/controlplane/internal/storage/sqlite/db.go
+++ b/controlplane/internal/storage/sqlite/db.go
@@ -35,8 +35,12 @@ const pragmas = "?_pragma=journal_mode(WAL)" +
 // writer/reader split: there is no store layer yet to justify the split, and
 // this is a single-process service, so there is no concurrent Open() to
 // guard against with a migration mutex either.
+// The directory is created 0700, not 0750: controlplane.db holds Google
+// subjects, emails, and refresh-token hashes, and the EdDSA signing keys sit
+// in a subdirectory of the same tree, so nothing in it should be group
+// readable.
 func Open(dataDir string) (*sql.DB, error) {
-	if err := os.MkdirAll(dataDir, 0o750); err != nil {
+	if err := os.MkdirAll(dataDir, 0o700); err != nil {
 		return nil, fmt.Errorf("create data dir: %w", err)
 	}
 	dsn := "file:" + filepath.Join(dataDir, "controlplane.db") + pragmas

--- a/controlplane/internal/storage/sqlite/migrate_test.go
+++ b/controlplane/internal/storage/sqlite/migrate_test.go
@@ -1,6 +1,10 @@
 package sqlite
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
 
 // TestOpen_CreatesAllTables is the runnable check for the schema: it fails if
 // a future migration change breaks one of the four tables the control plane
@@ -17,5 +21,25 @@ func TestOpen_CreatesAllTables(t *testing.T) {
 		if err := db.QueryRow("SELECT count(*) FROM " + table).Scan(&count); err != nil {
 			t.Errorf("querying table %q: %v", table, err)
 		}
+	}
+}
+
+// The data dir holds controlplane.db (Google subjects, emails, refresh-token
+// hashes) and the EdDSA signing keys, so it must not be group readable.
+func TestOpen_CreatesDataDirMode0700(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "controlplane-data")
+
+	db, err := Open(dir)
+	if err != nil {
+		t.Fatalf("Open() unexpected error: %v", err)
+	}
+	defer db.Close()
+
+	info, err := os.Stat(dir)
+	if err != nil {
+		t.Fatalf("stat %s: %v", dir, err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o700 {
+		t.Errorf("data dir mode = %o, want 0700", perm)
 	}
 }

--- a/controlplane/internal/storage/sqlite/migrations/0001_init.sql
+++ b/controlplane/internal/storage/sqlite/migrations/0001_init.sql
@@ -12,9 +12,11 @@ CREATE TABLE accounts (
 );
 
 -- machines holds one row per VM bound to an account via ao setup-vm. hostname
--- is the machine's public URL, used as both the JWT audience and the
--- reverse-proxy target. revoked_at, once set, ends the machine's ability to
--- verify tokens against it.
+-- is the machine's public URL, used as the reverse-proxy target. The JWT
+-- audience is machines.id, not this column: see TOKEN_CONTRACT.md, the issuer
+-- (internal/tokens/access.go), and the gateway verifier, which all use the
+-- machine id. revoked_at, once set, ends the machine's ability to verify
+-- tokens against it.
 CREATE TABLE machines (
     id          TEXT PRIMARY KEY,
     account_id  TEXT NOT NULL REFERENCES accounts (id),


### PR DESCRIPTION
Closes #16. Fixes the control plane contract-correctness findings from the batch 1 and 2 review (`hosted-ao-12`) that block batch 3, and closes the `TOKEN_CONTRACT.md` gaps that three other workers build against.

Scope is `controlplane/` only. `backend/internal/vmgateway/` (issue #15) and `backend/internal/service/project/` (issue #17) are owned by parallel workers and are untouched here.

## Code findings

| Finding | Fix |
|---|---|
| **M1** `0001_init.sql` claimed `machines.hostname` is the JWT audience | The audience is `machines.id`. Comment corrected in place, no new migration. This is the one that would have sent a batch 3 worker down a path where every request 401s with no visible cause. |
| **M4** `PUBLIC_ORIGIN` stored raw | Normalized once in `config.Load`; the now-redundant `strings.TrimRight` in `auth.NewService` is gone. A trailing slash produced an `iss` the gateway rejects with a byte-for-byte `!=`. |
| **M3** `DATA_DIR` defaulted to a relative `./data` | `DATA_DIR` is now required (same treatment as the Google credentials) and resolved with `filepath.Abs`. The resolved data dir and the active `kid` are logged at boot. |
| **L1** `keys.Rotate` partial write | `next.json` is written before `active.json`, memory still updated only after both succeed. A failed second write no longer leaves the promoted key in both files. |
| **L5** `ACCESS_TOKEN_TTL` unbounded | Validated into `[10m, 30m]` in `Load`, still configurable within the range the spec allows. |
| **L7** data dir 0750 | Created 0700 in both `storage/sqlite.Open` and `auth.loadOrCreateSessionKey`. |

### Why `DATA_DIR` became required rather than absolute-defaulted

The review offered either. Required is the one that removes the failure class instead of relocating it: there is no absolute default that is right both for a systemd unit and for `go run ./cmd/controlplane` from this directory. `.env.example` already set `DATA_DIR=./data`, so the local flow is unchanged, and it now carries a warning about relative paths under a service manager. An explicitly relative path still resolves against the working directory, which is why the boot log exists.

## `TOKEN_CONTRACT.md`

- **`SameSite=None; Secure` on the `/mux` cookie**, stated as required rather than optional, with the reason: `app://renderer` reaching `https://vm.example.com` is a cross-site context, so under the `Lax` default the browser never attaches the cookie to the WebSocket handshake at all.
- **The cookie name, `ao_gw_token`**, which previously existed only in gateway Go source.
- **The refresh token TTL (90 days) and the rotate-on-use rule**, including the consequence for the desktop install: a refresh token is single-use, so the replacement must be persisted on every refresh.
- **The SSE transport line corrected.** `EventSource` has no header API, so the cookie also carries `GET /api/v1/events`. Header-only everywhere else, deliberately: the cookie is ambient, and widening it to state-changing methods would leave CORS as the sole CSRF defence. #15 makes the gateway match; this PR owns only the document.

## Tests

Every code finding has a test that fails without its fix. Verified by reverting each fix in turn and watching the specific test fail:

- `TestLoad_PublicOriginTrailingSlashesStripped`, `TestLoad_DataDirResolvedToAbsolutePath`, `TestLoad_MissingDataDir`, `TestLoad_OutOfRangeAccessTokenTTLRejected` (six cases including `720h` and a negative)
- `TestRotate_FailedSecondWriteLeavesActiveAndNextDistinct`, which injects the failure with a directory where `next.json` belongs, so it does not depend on the test user's privileges (a read-only file would be bypassed by root in a container)
- `TestOpen_CreatesDataDirMode0700`, `TestLoadOrCreateSessionKey_CreatesDataDirMode0700`

`gofmt -l .` clean, `go build ./...`, `go vet ./...`, `go test -race ./...`: 63 passed across 7 packages.

## Note for the reviewer

`docs/superpowers/specs/2026-07-29-hosted-ao-v1-accounts-and-machines.md:93-110` still carries the older, less specific wording (including the "Bearer for REST and SSE" line). The scope limit kept this PR inside `controlplane/`, so `TOKEN_CONTRACT.md` now says so explicitly: where it is more specific than the spec section, it is the one to build against. Worth a follow-up to bring that spec section back in line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)