### PR TITLE
fix(vmgateway): duplicate CORS, publicUrl domain, SSE auth, JWKS backoff

### DIFF
--- a/backend/internal/vmgateway/config.go
+++ b/backend/internal/vmgateway/config.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -37,7 +38,9 @@ const (
 // built by Resolve.
 type Config struct {
 	// Domain is the single hostname this gateway serves and the only one
-	// autocert will ever request a certificate for.
+	// autocert will ever request a certificate for. Always a bare hostname:
+	// machine.json's publicUrl is a full origin and Resolve reduces it, see
+	// normalizeDomain.
 	Domain string
 	// MachineID is this machine's id, checked against the token's `aud`.
 	MachineID string
@@ -116,6 +119,12 @@ func Resolve(opts Options, dataDir string) (Config, error) {
 	cfg.Domain = firstNonEmpty(opts.Domain, os.Getenv("AO_VM_DOMAIN"))
 	cfg.MachineID = firstNonEmpty(opts.MachineID, os.Getenv("AO_VM_MACHINE_ID"))
 	cfg.AccountID = firstNonEmpty(opts.AccountID, os.Getenv("AO_VM_ACCOUNT_ID"))
+	// domainSource names where Domain came from so a rejected value points at
+	// the file or the flag the operator actually has to fix.
+	domainSource := "--domain or AO_VM_DOMAIN"
+	if cfg.Domain == "" {
+		domainSource = fmt.Sprintf("publicUrl in %s", machineFilePath)
+	}
 	if mf != nil {
 		cfg.Domain = firstNonEmpty(cfg.Domain, mf.PublicURL)
 		cfg.MachineID = firstNonEmpty(cfg.MachineID, mf.MachineID)
@@ -150,11 +159,41 @@ func Resolve(opts Options, dataDir string) (Config, error) {
 		return Config{}, fmt.Errorf("ao vm serve: missing required configuration: %s (%s)", strings.Join(missing, ", "), hint)
 	}
 
+	domain, err := normalizeDomain(cfg.Domain, domainSource)
+	if err != nil {
+		return Config{}, err
+	}
+	cfg.Domain = domain
+
 	if _, _, err := net.SplitHostPort(cfg.DaemonAddr); err != nil {
 		return Config{}, fmt.Errorf("invalid daemon address %q: %w", cfg.DaemonAddr, err)
 	}
 
 	return cfg, nil
+}
+
+// normalizeDomain reduces a configured domain to the bare hostname
+// autocert.HostWhitelist requires. machine.json's publicUrl is a full origin
+// ("https://vm.example.com"), which the desktop and the control plane both
+// want, but HostWhitelist runs its argument through idna.Lookup.ToASCII and,
+// per its own documentation, silently ignores anything that fails. A scheme
+// or a slash therefore leaves the whitelist empty, so no certificate is ever
+// issued and every TLS handshake fails while the gateway logs a clean
+// start. Reject here, loudly, at boot, whatever cannot be reduced to a
+// hostname.
+func normalizeDomain(domain, source string) (string, error) {
+	domain = strings.TrimSpace(domain)
+	if strings.Contains(domain, "://") {
+		u, err := url.Parse(domain)
+		if err != nil || u.Hostname() == "" {
+			return "", fmt.Errorf("invalid public url %q (from %s): expected an origin like https://vm.example.com", domain, source)
+		}
+		domain = u.Hostname()
+	}
+	if domain == "" || strings.ContainsAny(domain, ":/") {
+		return "", fmt.Errorf("invalid domain %q (from %s): expected a bare hostname like vm.example.com", domain, source)
+	}
+	return domain, nil
 }
 
 func defaultMachineFilePath() (string, error) {

--- a/backend/internal/vmgateway/config_test.go
+++ b/backend/internal/vmgateway/config_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -109,6 +110,72 @@ func TestResolve_EnvOverridesMachineFileButNotFlag(t *testing.T) {
 	}
 	if cfg.AccountID != "flag-account" {
 		t.Errorf("AccountID = %q, want flag to win over machine.json", cfg.AccountID)
+	}
+}
+
+// machine.json's publicUrl is a full origin, but Domain is handed to
+// autocert.HostWhitelist, which silently ignores anything that is not a bare
+// hostname and would then never obtain a certificate.
+func TestResolve_MachineFilePublicURLIsReducedToHostname(t *testing.T) {
+	for _, tc := range []struct{ publicURL, want string }{
+		{"https://vm.example.com", "vm.example.com"},
+		{"https://vm.example.com/", "vm.example.com"},
+		{"https://vm.example.com:8443", "vm.example.com"},
+		{"http://vm.example.com", "vm.example.com"},
+		{"vm.example.com", "vm.example.com"},
+	} {
+		t.Run(tc.publicURL, func(t *testing.T) {
+			path := writeMachineFile(t, MachineFile{
+				MachineID: "mf-machine",
+				AccountID: "mf-account",
+				PublicURL: tc.publicURL,
+			})
+			cfg, err := Resolve(Options{MachineFile: path}, t.TempDir())
+			if err != nil {
+				t.Fatalf("Resolve: %v", err)
+			}
+			if cfg.Domain != tc.want {
+				t.Errorf("Domain = %q, want %q", cfg.Domain, tc.want)
+			}
+		})
+	}
+}
+
+func TestResolve_UnusableDomainIsRejected(t *testing.T) {
+	for _, domain := range []string{
+		"https://",
+		"vm.example.com:443",
+		"vm.example.com/path",
+	} {
+		t.Run(domain, func(t *testing.T) {
+			path := writeMachineFile(t, MachineFile{
+				MachineID: "mf-machine",
+				AccountID: "mf-account",
+				PublicURL: domain,
+			})
+			_, err := Resolve(Options{MachineFile: path}, t.TempDir())
+			if err == nil {
+				t.Fatalf("expected an error: %q cannot be reduced to a hostname autocert will accept", domain)
+			}
+			if !strings.Contains(err.Error(), path) {
+				t.Errorf("error %q should name %s, the file the operator has to fix", err, path)
+			}
+		})
+	}
+}
+
+func TestResolve_UnusableFlagDomainIsRejected(t *testing.T) {
+	_, err := Resolve(Options{
+		Domain:      "vm.example.com:443",
+		MachineID:   "machine-1",
+		AccountID:   "account-1",
+		MachineFile: filepath.Join(t.TempDir(), "missing.json"),
+	}, t.TempDir())
+	if err == nil {
+		t.Fatal("expected an error for a --domain that is not a bare hostname")
+	}
+	if !strings.Contains(err.Error(), "--domain") {
+		t.Errorf("error %q should name the flag it came from", err)
 	}
 }
 

--- a/backend/internal/vmgateway/jwks.go
+++ b/backend/internal/vmgateway/jwks.go
@@ -81,9 +81,10 @@ func (ks *KeySet) candidates(kid string) []ed25519.PublicKey {
 
 // JWKSCache fetches and caches the control plane's published signing keys. It
 // refreshes at most once per ttl. A refresh that fails after a keyset has
-// already been cached serves the stale keyset instead (stale-if-error), so a
-// brief control-plane outage does not disconnect working users, per
-// TOKEN_CONTRACT.md. A refresh that fails before any keyset has ever been
+// already been cached serves the stale keyset instead (stale-if-error) and
+// is not retried for failureBackoff, so a brief control-plane outage does not
+// disconnect working users, per TOKEN_CONTRACT.md. A refresh that fails
+// before any keyset has ever been
 // cached fails closed: Get returns the error and callers must treat every
 // token as unverifiable.
 type JWKSCache struct {
@@ -92,10 +93,17 @@ type JWKSCache struct {
 	client *http.Client
 	now    func() time.Time
 
-	mu        sync.Mutex
-	keys      *KeySet
-	fetchedAt time.Time
+	mu         sync.Mutex
+	keys       *KeySet
+	fetchedAt  time.Time
+	refreshing bool
 }
+
+// failureBackoff is how long a failed refresh suppresses the next attempt
+// while a stale keyset is still cached. Without it, every request during a
+// control-plane outage starts its own fetch and waits out the client
+// timeout, which is the opposite of what stale-if-error exists to do.
+const failureBackoff = 30 * time.Second
 
 // NewJWKSCache builds a cache for url with the spec's 1 hour TTL. client
 // defaults to one with a bounded timeout when nil.
@@ -109,17 +117,33 @@ func NewJWKSCache(url string, client *http.Client) *JWKSCache {
 // Get returns the current key set, refreshing it first if the cache is empty
 // or older than the TTL. See the JWKSCache doc comment for the
 // stale-if-error and fail-closed behavior.
+//
+// The refresh runs without c.mu held, and a caller that arrives while one is
+// already in flight is served the cached keyset immediately rather than
+// queueing on the mutex: an unreachable control plane must cost one request
+// the client timeout, not every concurrent request that timeout in turn.
+// Only a cold start (nothing cached at all) can fetch concurrently, and
+// there the alternative would be rejecting valid tokens.
 func (c *JWKSCache) Get(ctx context.Context) (*KeySet, error) {
 	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	if c.keys != nil && c.now().Sub(c.fetchedAt) < c.ttl {
-		return c.keys, nil
+	if cached := c.keys; cached != nil && (c.refreshing || c.now().Sub(c.fetchedAt) < c.ttl) {
+		c.mu.Unlock()
+		return cached, nil
 	}
+	c.refreshing = true
+	c.mu.Unlock()
 
 	fresh, err := c.fetch(ctx)
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.refreshing = false
 	if err != nil {
 		if c.keys != nil {
+			// Record the failed attempt as if it were a fetch that expires
+			// failureBackoff from now, so the next request serves the stale
+			// keyset outright instead of retrying immediately.
+			c.fetchedAt = c.now().Add(failureBackoff - c.ttl)
 			return c.keys, nil
 		}
 		return nil, err

--- a/backend/internal/vmgateway/jwks_test.go
+++ b/backend/internal/vmgateway/jwks_test.go
@@ -1,11 +1,13 @@
 package vmgateway
 
 import (
+	"context"
 	"crypto/ed25519"
 	"encoding/base64"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -137,6 +139,114 @@ func TestJWKSCache_StaleIfError(t *testing.T) {
 	if len(ks.candidates(testKid)) != 1 {
 		t.Fatal("expected the stale keyset to still be usable")
 	}
+}
+
+// A failed refresh must not be retried per request: with the control plane
+// down, every request would otherwise start its own fetch and wait out the
+// client timeout, which is what stale-if-error exists to prevent.
+func TestJWKSCache_StaleIfError_BacksOffInsteadOfRefetching(t *testing.T) {
+	pub, _, _ := ed25519.GenerateKey(nil)
+	healthy := int32(1)
+	var fetches int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&fetches, 1)
+		if atomic.LoadInt32(&healthy) == 0 {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(jwksBody(t, testKid, pub))
+	}))
+	defer srv.Close()
+
+	now := time.Now()
+	cache := NewJWKSCache(srv.URL, srv.Client())
+	cache.now = func() time.Time { return now }
+
+	if _, err := cache.Get(t.Context()); err != nil {
+		t.Fatalf("initial Get: %v", err)
+	}
+
+	atomic.StoreInt32(&healthy, 0)
+	now = now.Add(time.Hour + time.Second)
+	for i := range 5 {
+		if _, err := cache.Get(t.Context()); err != nil {
+			t.Fatalf("Get %d during outage: %v", i, err)
+		}
+	}
+	if got := atomic.LoadInt32(&fetches); got != 2 {
+		t.Errorf("fetches = %d, want 2 (one success, then one failure that backs off)", got)
+	}
+
+	now = now.Add(failureBackoff + time.Second)
+	if _, err := cache.Get(t.Context()); err != nil {
+		t.Fatalf("Get after the backoff window: %v", err)
+	}
+	if got := atomic.LoadInt32(&fetches); got != 3 {
+		t.Errorf("fetches = %d, want 3 (the backoff window has passed, so retry once)", got)
+	}
+}
+
+// The refresh must not run under the cache mutex: a slow or hanging control
+// plane would otherwise queue every concurrent request behind the client
+// timeout, one after another.
+func TestJWKSCache_RefreshDoesNotBlockOtherCallers(t *testing.T) {
+	pub, _, _ := ed25519.GenerateKey(nil)
+	entered := make(chan struct{}, 1)
+	release := make(chan struct{})
+	var fetches int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if atomic.AddInt32(&fetches, 1) > 1 {
+			entered <- struct{}{}
+			<-release // model a control plane that has stopped answering
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(jwksBody(t, testKid, pub))
+	}))
+	defer srv.Close()
+	var releaseOnce sync.Once
+	releaseAll := func() { releaseOnce.Do(func() { close(release) }) }
+	defer releaseAll()
+
+	now := time.Now()
+	cache := NewJWKSCache(srv.URL, srv.Client())
+	cache.now = func() time.Time { return now }
+
+	if _, err := cache.Get(t.Context()); err != nil {
+		t.Fatalf("initial Get: %v", err)
+	}
+
+	now = now.Add(time.Hour + time.Second)
+	slow := make(chan struct{})
+	go func() {
+		defer close(slow)
+		_, _ = cache.Get(context.Background())
+	}()
+	<-entered // the refresh is now in flight and will not return on its own
+
+	second := make(chan *KeySet, 1)
+	go func() {
+		ks, err := cache.Get(context.Background())
+		if err != nil {
+			t.Errorf("Get while a refresh is in flight: %v", err)
+		}
+		second <- ks
+	}()
+
+	select {
+	case ks := <-second:
+		if ks == nil || len(ks.candidates(testKid)) != 1 {
+			t.Fatal("expected the cached keyset while the refresh is in flight")
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("Get queued behind the in-flight refresh instead of serving the cached keyset")
+	}
+	if got := atomic.LoadInt32(&fetches); got != 2 {
+		t.Errorf("fetches = %d, want 2 (the second caller must not start its own)", got)
+	}
+
+	releaseAll()
+	<-slow
 }
 
 func TestJWKSCache_FailsClosedWithoutEverSucceeding(t *testing.T) {

--- a/backend/internal/vmgateway/proxy.go
+++ b/backend/internal/vmgateway/proxy.go
@@ -10,14 +10,32 @@ import (
 	"github.com/aoagents/agent-orchestrator/backend/internal/httpd/envelope"
 )
 
-// gatewayCookieName carries the JWT for the /mux WebSocket upgrade, since
-// browsers cannot set an Authorization header on a WebSocket handshake. Set
-// by the Electron main process, per TOKEN_CONTRACT.md's transport rule.
+// gatewayCookieName carries the JWT for the two routes a browser cannot
+// attach an Authorization header to: the /mux WebSocket handshake and the
+// EventSource stream on eventsPath. Set by the Electron main process, per
+// TOKEN_CONTRACT.md's transport rule.
 const gatewayCookieName = "ao_gw_token"
 
 // muxPath is the terminal-mux WebSocket route: the one route whose token
 // travels in gatewayCookieName instead of the Authorization header.
 const muxPath = "/mux"
+
+// eventsPath is the daemon's SSE stream. The renderer opens it with the
+// browser EventSource API, which has no way to set a request header at all,
+// so this is the second and last route where the cookie may authenticate.
+const eventsPath = "/api/v1/events"
+
+// upstreamCORSHeaders are the response headers the daemon sets for itself
+// (internal/httpd/cors.go) and that the gateway must own instead. See
+// dropUpstreamCORS.
+var upstreamCORSHeaders = []string{
+	"Access-Control-Allow-Origin",
+	"Access-Control-Allow-Credentials",
+	"Access-Control-Allow-Methods",
+	"Access-Control-Allow-Headers",
+	"Access-Control-Max-Age",
+	"Access-Control-Allow-Private-Network",
+}
 
 // blockedAPIPrefixes are never proxied even though they sit under the
 // otherwise-allowed /api/v1 prefix: Connect Mobile control and developer
@@ -68,13 +86,40 @@ func newReverseProxy(target *url.URL, log *slog.Logger) *httputil.ReverseProxy {
 	proxy.Director = func(r *http.Request) {
 		director(r)
 		stripCredentials(r)
+		stripForwardedFor(r)
 	}
+	proxy.ModifyResponse = dropUpstreamCORS
 	proxy.ErrorHandler = func(w http.ResponseWriter, r *http.Request, err error) {
 		log.Warn("vm gateway: proxy error", "err", err, "path", r.URL.Path)
 		envelope.WriteAPIError(w, r, http.StatusBadGateway, "bad_gateway", "DAEMON_UNREACHABLE",
 			"the local daemon is not reachable", nil)
 	}
 	return proxy
+}
+
+// dropUpstreamCORS removes the CORS headers the daemon set for itself before
+// they are merged into the gateway's own response. The forwarded request
+// still carries the renderer's Origin, which the daemon also allows, so
+// without this both sides answer: httputil.ReverseProxy copies upstream
+// headers with Add, not Set, so the client would receive
+// "Access-Control-Allow-Origin: app://renderer, app://renderer" and every
+// browser rejects a multi-valued one outright. corsGate is the single owner
+// of these headers on the public listener.
+func dropUpstreamCORS(res *http.Response) error {
+	for _, h := range upstreamCORSHeaders {
+		res.Header.Del(h)
+	}
+	return nil
+}
+
+// stripForwardedFor drops the client's own claim about who it is, so that
+// httputil.ReverseProxy's own X-Forwarded-For append (which runs after the
+// director) starts from the real peer address rather than extending an
+// attacker-supplied chain. The daemon runs middleware.RealIP behind us and
+// trusts both headers.
+func stripForwardedFor(r *http.Request) {
+	r.Header.Del("X-Real-IP")
+	r.Header.Del("X-Forwarded-For")
 }
 
 func stripCredentials(r *http.Request) {
@@ -161,18 +206,18 @@ func requireToken(jwks *JWKSCache, verify VerifyOptions, log *slog.Logger) func(
 	}
 }
 
-// extractToken reads the bearer token per TOKEN_CONTRACT.md's transport
-// rule: Authorization: Bearer <jwt> everywhere except /mux, whose WebSocket
-// handshake a browser cannot attach a header to, so it travels in
-// gatewayCookieName instead. The raw token is returned only to be handed
-// straight to VerifyToken; it must never be logged.
+// extractToken reads the token per TOKEN_CONTRACT.md's transport rule:
+// Authorization: Bearer <jwt> everywhere, plus the gatewayCookieName cookie
+// on the two routes whose browser API cannot send a header (see
+// cookieAuthAllowed). The cookie is tried first on those routes and the
+// header is still accepted there, so a non-browser client (the CLI, a test
+// harness) can open /mux or the event stream too. The raw token is returned
+// only to be handed straight to VerifyToken; it must never be logged.
 func extractToken(r *http.Request) (string, bool) {
-	if r.URL.Path == muxPath {
-		c, err := r.Cookie(gatewayCookieName)
-		if err != nil || c.Value == "" {
-			return "", false
+	if cookieAuthAllowed(r) {
+		if c, err := r.Cookie(gatewayCookieName); err == nil && c.Value != "" {
+			return c.Value, true
 		}
-		return c.Value, true
 	}
 	const prefix = "Bearer "
 	auth := r.Header.Get("Authorization")
@@ -184,6 +229,21 @@ func extractToken(r *http.Request) (string, bool) {
 		return "", false
 	}
 	return tok, true
+}
+
+// cookieAuthAllowed reports whether the ambient gatewayCookieName cookie may
+// authenticate this request. Exactly two routes qualify, both because the
+// browser API the renderer must use cannot carry a header: the /mux
+// WebSocket handshake, and GET on the SSE stream, which the renderer opens
+// with EventSource. Everything else stays header-only deliberately. The
+// cookie is attached by the browser to any request to this host, so
+// accepting it on a state-changing method would leave corsGate as the sole
+// CSRF defence.
+func cookieAuthAllowed(r *http.Request) bool {
+	if r.URL.Path == muxPath {
+		return true
+	}
+	return r.Method == http.MethodGet && r.URL.Path == eventsPath
 }
 
 func unauthorized(w http.ResponseWriter, r *http.Request) {
@@ -229,6 +289,14 @@ func corsGate(allowedOrigins []string) func(http.Handler) http.Handler {
 			h.Set("Access-Control-Allow-Credentials", "true")
 
 			if r.Method == http.MethodOptions && r.Header.Get("Access-Control-Request-Method") != "" {
+				// Answer a preflight only for a route that actually exists
+				// here. corsGate runs before denyByDefault, so without this
+				// a 204 would confirm the existence of a route every real
+				// method 404s.
+				if !isProxyablePath(r.URL.Path) {
+					notFoundJSON(w, r)
+					return
+				}
 				h.Set("Access-Control-Allow-Methods", "GET, POST, PATCH, PUT, DELETE, OPTIONS")
 				if reqHeaders := r.Header.Get("Access-Control-Request-Headers"); reqHeaders != "" {
 					h.Set("Access-Control-Allow-Headers", reqHeaders)

--- a/backend/internal/vmgateway/proxy_test.go
+++ b/backend/internal/vmgateway/proxy_test.go
@@ -38,6 +38,15 @@ func newTestGateway(t *testing.T) *testGateway {
 		clone := r.Clone(r.Context())
 		tg.daemonCalls = append(tg.daemonCalls, clone)
 		w.Header().Set("X-From", "daemon")
+		// The real daemon runs its own corsMiddleware (internal/httpd/cors.go)
+		// and app://renderer is in its allowed set, so a forwarded request
+		// comes back carrying these. Modelled here because the gateway has to
+		// strip them; see dropUpstreamCORS.
+		if origin := r.Header.Get("Origin"); origin != "" {
+			w.Header().Set("Access-Control-Allow-Origin", origin)
+			w.Header().Set("Access-Control-Allow-Credentials", "true")
+			w.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+		}
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte("ok"))
 	}))
@@ -228,17 +237,20 @@ func TestGateway_AllowsSiblingOfBlockedPrefix(t *testing.T) {
 	}
 }
 
-func TestGateway_Mux_UsesCookieNotHeader(t *testing.T) {
+func TestGateway_Mux_AcceptsCookieOrHeader(t *testing.T) {
 	tg := newTestGateway(t)
 	token := tg.validToken(t)
 
+	// A browser can only send the cookie, but the CLI and any other
+	// non-browser client have nothing but the header.
 	req := httptest.NewRequest(http.MethodGet, muxPath, nil)
-	req.Header.Set("Authorization", "Bearer "+token) // must be ignored on /mux
+	req.Header.Set("Authorization", "Bearer "+token)
 	rec := httptest.NewRecorder()
 	tg.handler.ServeHTTP(rec, req)
-	if rec.Code != http.StatusUnauthorized {
-		t.Fatalf("/mux with only an Authorization header: status = %d, want 401", rec.Code)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("/mux with only an Authorization header: status = %d, want 200", rec.Code)
 	}
+	tg.daemonCalls = nil
 
 	req = httptest.NewRequest(http.MethodGet, muxPath, nil)
 	req.AddCookie(&http.Cookie{Name: gatewayCookieName, Value: token})
@@ -252,6 +264,134 @@ func TestGateway_Mux_UsesCookieNotHeader(t *testing.T) {
 	}
 	if _, err := tg.daemonCalls[0].Cookie(gatewayCookieName); err == nil {
 		t.Error("the gateway auth cookie must not be forwarded to the daemon")
+	}
+}
+
+// The daemon behind the gateway sets its own CORS headers and
+// httputil.ReverseProxy merges upstream headers with Add, so without
+// dropUpstreamCORS the client sees each value twice and every browser
+// rejects the response outright.
+func TestGateway_UpstreamCORSHeaders_NotDuplicated(t *testing.T) {
+	tg := newTestGateway(t)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/projects", nil)
+	req.Header.Set("Origin", testOrigin)
+	req.Header.Set("Authorization", "Bearer "+tg.validToken(t))
+	rec := httptest.NewRecorder()
+
+	tg.handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200, body: %s", rec.Code, rec.Body.String())
+	}
+	if got := rec.Header().Values("Access-Control-Allow-Origin"); len(got) != 1 || got[0] != testOrigin {
+		t.Errorf("Access-Control-Allow-Origin = %q, want exactly one value %q", got, testOrigin)
+	}
+	if got := rec.Header().Values("Access-Control-Allow-Credentials"); len(got) != 1 || got[0] != "true" {
+		t.Errorf("Access-Control-Allow-Credentials = %q, want exactly one value \"true\"", got)
+	}
+	// The gateway does not answer a non-preflight with this header at all, so
+	// the only way it could appear is the upstream's copy surviving.
+	if got := rec.Header().Values("Access-Control-Allow-Methods"); len(got) != 0 {
+		t.Errorf("Access-Control-Allow-Methods = %q, want the upstream's copy dropped", got)
+	}
+	if len(tg.daemonCalls) != 1 {
+		t.Fatalf("daemon calls = %d, want 1", len(tg.daemonCalls))
+	}
+	if got := tg.daemonCalls[0].Header.Get("Origin"); got != testOrigin {
+		t.Fatalf("Origin = %q, want the daemon to have seen the renderer origin (otherwise this test proves nothing)", got)
+	}
+}
+
+// EventSource has no header API, so the SSE stream is unreachable from the
+// renderer unless the cookie authenticates it.
+func TestGateway_Events_AcceptsCookie(t *testing.T) {
+	tg := newTestGateway(t)
+	req := httptest.NewRequest(http.MethodGet, eventsPath, nil)
+	req.AddCookie(&http.Cookie{Name: gatewayCookieName, Value: tg.validToken(t)})
+	rec := httptest.NewRecorder()
+
+	tg.handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET %s with the gateway cookie: status = %d, want 200", eventsPath, rec.Code)
+	}
+	if len(tg.daemonCalls) != 1 {
+		t.Fatalf("daemon calls = %d, want 1", len(tg.daemonCalls))
+	}
+	if _, err := tg.daemonCalls[0].Cookie(gatewayCookieName); err == nil {
+		t.Error("the gateway auth cookie must not be forwarded to the daemon")
+	}
+}
+
+// The cookie is ambient, so widening it beyond the two routes that cannot
+// send a header would make corsGate the only CSRF defence.
+func TestGateway_Cookie_RejectedOnEveryOtherRoute(t *testing.T) {
+	tg := newTestGateway(t)
+	token := tg.validToken(t)
+
+	for _, tc := range []struct{ method, path string }{
+		{http.MethodGet, "/api/v1/projects"},
+		{http.MethodPost, "/api/v1/projects"},
+		{http.MethodPost, eventsPath},
+		{http.MethodDelete, eventsPath},
+	} {
+		t.Run(tc.method+" "+tc.path, func(t *testing.T) {
+			req := httptest.NewRequest(tc.method, tc.path, nil)
+			req.AddCookie(&http.Cookie{Name: gatewayCookieName, Value: token})
+			rec := httptest.NewRecorder()
+
+			tg.handler.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusUnauthorized {
+				t.Errorf("status = %d, want 401: only /mux and GET %s may use the cookie", rec.Code, eventsPath)
+			}
+		})
+	}
+	if len(tg.daemonCalls) != 0 {
+		t.Errorf("a cookie-only request must never reach the daemon, got %d calls", len(tg.daemonCalls))
+	}
+}
+
+// The daemon runs middleware.RealIP and gates its loopback-only routes on
+// what it believes the peer is, so a client must not be able to write its own
+// answer.
+func TestGateway_ClientForwardingHeaders_NotForwarded(t *testing.T) {
+	tg := newTestGateway(t)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/projects", nil)
+	req.Header.Set("Authorization", "Bearer "+tg.validToken(t))
+	req.Header.Set("X-Real-IP", "127.0.0.1")
+	req.Header.Set("X-Forwarded-For", "127.0.0.1")
+	rec := httptest.NewRecorder()
+
+	tg.handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if len(tg.daemonCalls) != 1 {
+		t.Fatalf("daemon calls = %d, want 1", len(tg.daemonCalls))
+	}
+	forwarded := tg.daemonCalls[0].Header
+	if got := forwarded.Get("X-Real-IP"); got != "" {
+		t.Errorf("X-Real-IP = %q, want the client's own claim dropped", got)
+	}
+	// httptest.NewRequest's RemoteAddr, i.e. the real peer and nothing else.
+	if got := forwarded.Get("X-Forwarded-For"); got != "192.0.2.1" {
+		t.Errorf("X-Forwarded-For = %q, want only the true peer address", got)
+	}
+}
+
+func TestGateway_PreflightOnBlockedPath_Is404(t *testing.T) {
+	tg := newTestGateway(t)
+	req := httptest.NewRequest(http.MethodOptions, "/api/v1/mobile/status", nil)
+	req.Header.Set("Origin", testOrigin)
+	req.Header.Set("Access-Control-Request-Method", "GET")
+	rec := httptest.NewRecorder()
+
+	tg.handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("preflight status = %d, want 404: a 204 confirms a route every real method 404s", rec.Code)
 	}
 }
 


### PR DESCRIPTION
Closes #15.

Fixes the four high findings plus L2, L3, L4 from the batch 1-2 review. Every
one of them was invisible to the suite as merged, so each fix ships with a test
that fails without it.

## What was wrong

**H1, duplicate CORS headers.** The daemon behind the gateway sets its own
`Access-Control-Allow-Origin` and `Access-Control-Allow-Credentials` (the
forwarded request still carries `Origin: app://renderer`, which the daemon also
allows), and `httputil.ReverseProxy` merges upstream response headers with
`Add`, not `Set`. Every browser request came back with each value twice, which
Chromium rejects outright. `ModifyResponse` now drops the upstream's copy;
`corsGate` is the single owner of these headers on the public listener.

**H2, publicUrl silently disabled TLS.** `machine.json`'s `publicUrl` is a full
origin, but it went straight to `autocert.HostWhitelist`, which runs its
argument through `idna.Lookup.ToASCII` and, per its own doc comment, silently
ignores what fails. The whitelist ended up empty, so no certificate was ever
issued and every TLS handshake failed while the gateway logged a clean start.
Per the decision on the issue, the field stays a full origin and the reader was
fixed: `Resolve` reduces it with `url.Parse` plus `u.Hostname()`, and rejects at
boot what cannot be reduced, naming the file or flag the value came from.

**H3, SSE could not authenticate.** The renderer opens `/api/v1/events` with
`EventSource`, which has no header API at all, so the stream was unreachable
through a gateway that wanted `Authorization: Bearer`. The cookie is now
accepted on `GET /api/v1/events`, and on `/mux`. Everything else stays
header-only deliberately: the cookie is ambient, so accepting it on a
state-changing method would leave `corsGate` as the only CSRF defence.

**H4, stale-if-error made an outage worse.** `Get` held the cache mutex across
the fetch and never recorded the failure, so with the control plane down every
request started its own fetch and queued behind the 10s client timeout: 20
concurrent requests meant the last one waited about 200 seconds. The refresh now
runs unlocked, a caller arriving while one is in flight is served the cached
keyset immediately, and a failed refresh backs off for 30s.

**L2** strips the client's own `X-Real-IP` and `X-Forwarded-For` in the director
so `ReverseProxy`'s append starts from the true peer. `Host` is deliberately
left as the public domain: that is what makes the daemon's
`localControlRequest` correctly refuse. **L3** checks the path allowlist inside
the preflight branch, so a blocked route is no longer confirmed by a 204 that
every real method answers 404. **L4** accepts the `Authorization` header on
`/mux` as well as the cookie, so the CLI and other non-browser clients can open
the terminal mux.

## Tests

Nine new tests plus one rewritten. The fake daemon in `proxy_test.go` now emits
CORS headers, without which H1 stays invisible. Each new test was confirmed to
fail with only its own fix reverted, including the two halves of H4
independently (backoff removed, and the fetch put back under the mutex).

- `TestGateway_UpstreamCORSHeaders_NotDuplicated`
- `TestGateway_Events_AcceptsCookie`, `TestGateway_Cookie_RejectedOnEveryOtherRoute`
- `TestGateway_Mux_AcceptsCookieOrHeader` (replaces `TestGateway_Mux_UsesCookieNotHeader`, whose assertion L4 reverses)
- `TestGateway_ClientForwardingHeaders_NotForwarded`, `TestGateway_PreflightOnBlockedPath_Is404`
- `TestResolve_MachineFilePublicURLIsReducedToHostname`, `TestResolve_UnusableDomainIsRejected`, `TestResolve_UnusableFlagDomainIsRejected`
- `TestJWKSCache_StaleIfError_BacksOffInsteadOfRefetching`, `TestJWKSCache_RefreshDoesNotBlockOtherCallers`

Verification run locally: `go test ./internal/vmgateway/ -race` 74 passed,
`golangci-lint run ./internal/vmgateway/...` 0 issues, `go build ./...` clean.
`go test ./...` has 5 failures in `internal/cli` (`TestSpawn*`, all "daemon
returned HTTP 404"), pre-existing on develop and unrelated: nothing here touches
`internal/cli`.

## Risks and follow-ups

- `TOKEN_CONTRACT.md`'s transport line still says Bearer for SSE. Updating it is
  #16, owned by another worker; this PR does not touch `controlplane/`.
- The 30s JWKS failure backoff is a constant, not configurable. If a
  control-plane outage ever needs a different retry cadence, that is the knob.
- Cold start is the one case where two concurrent callers can each fetch the
  JWKS. The alternative there is rejecting valid tokens, so it is deliberate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)