### PR TITLE
fix(project): strip credentials from the recorded git origin URL

### DIFF
--- a/backend/internal/service/project/clone.go
+++ b/backend/internal/service/project/clone.go
@@ -19,7 +19,21 @@ import (
 // deliberately decoupled from the daemon's per-request HTTP timeout (see
 // cloneRepository) because project.Add clones synchronously — no job model
 // with progress reporting exists yet.
-const cloneTimeout = 5 * time.Minute
+//
+// A var rather than a const only so the timeout rejection path is testable
+// without a five minute test.
+var cloneTimeout = 5 * time.Minute
+
+// cloneWaitDelay bounds how long CombinedOutput may keep waiting on the output
+// pipes after the clone deadline has killed `git`. Without it CLONE_TIMEOUT is
+// unreachable in practice: `git clone` delegates to a `git-remote-http` (or
+// `ssh`) child that inherits the pipe, killing the parent does not kill the
+// child, and a child blocked on a stalled server holds the pipe open for as
+// long as it likes. cloneRepository would then never return, and because it
+// runs under Add's addMu, every later project add would block behind it.
+//
+// Also a var only so the test does not have to wait it out.
+var cloneWaitDelay = 5 * time.Second
 
 // cloneRepository clones cloneURL into <reposRoot>/<owner>-<repo> and returns
 // the destination path. Every failure is mapped to a remediation-shaped
@@ -51,6 +65,7 @@ func (m *Service) cloneRepository(ctx context.Context, cloneURL string) (string,
 	defer cancel()
 
 	cmd := aoprocess.CommandContext(cloneCtx, "git", "clone", "--", cloneURL, dest)
+	cmd.WaitDelay = cloneWaitDelay
 	cmd.Env = append(os.Environ(),
 		"GIT_TERMINAL_PROMPT=0", // never block on an interactive credential prompt
 		"GIT_SSH_COMMAND=ssh -o BatchMode=yes -o ConnectTimeout=15", // never block on an SSH password/host-key prompt
@@ -149,6 +164,44 @@ func parseCloneURL(raw string) (owner, repo string, err error) {
 		return "", "", err
 	}
 	return owner, repo, nil
+}
+
+// sanitizeOriginURL removes any credential embedded in a git remote URL. A
+// client may legitimately POST `cloneUrl` as
+// `https://x-access-token:<token>@github.com/owner/repo.git`, which is how
+// non-interactive https git auth is normally expressed and what
+// GIT_TERMINAL_PROMPT=0 leaves as the practical option; git then records that
+// string verbatim as the repo's `origin`. The token has a job to do there, so
+// the clone's own .git/config keeps it, but it must not travel any further.
+// See resolveGitOriginURL.
+//
+// raw is returned unchanged when there is nothing to strip, when it does not
+// parse as a URL at all, and for the scp-like SSH shorthand
+// (git@host:owner/repo.git), which url.Parse rejects outright and whose
+// userinfo is an SSH login name rather than a secret.
+func sanitizeOriginURL(raw string) string {
+	if !strings.Contains(raw, "@") {
+		return raw
+	}
+	u, err := url.Parse(raw)
+	if err != nil || u.Scheme == "" || u.User == nil {
+		return raw
+	}
+	switch strings.ToLower(u.Scheme) {
+	case "ssh", "git+ssh":
+		// An ssh:// URL's userinfo is the login name (`git`), which is not a
+		// secret and which the remote stops working without. Drop only a
+		// password, which has no legitimate use over SSH.
+		if _, hasPassword := u.User.Password(); !hasPassword {
+			return raw
+		}
+		u.User = url.User(u.User.Username())
+	default:
+		// Over http(s) the username alone is a credential too: a bare
+		// `https://<token>@github.com/...` authenticates with no password.
+		u.User = nil
+	}
+	return u.String()
 }
 
 func sanitizeDirComponent(s string) (string, error) {

--- a/backend/internal/service/project/clone_test.go
+++ b/backend/internal/service/project/clone_test.go
@@ -1,0 +1,534 @@
+package project
+
+// Internal tests for the clone flow's rejection paths. They exercise
+// cloneRepository, parseCloneURL, sanitizeDirComponent, classifyCloneError, and
+// sanitizeOriginURL directly, which the external project_test package cannot
+// reach. End-to-end coverage through Service.Add lives in service_test.go.
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/httpd/apierr"
+)
+
+// wantCloneCode asserts err is an *apierr.Error with the given code and that it
+// never carries raw git output.
+func wantCloneCode(t *testing.T, err error, code string) *apierr.Error {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("error = nil, want %s", code)
+	}
+	var apiErr *apierr.Error
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("error = %v (%T), want *apierr.Error", err, err)
+	}
+	if apiErr.Code != code {
+		t.Fatalf("code = %q, want %q (message %q)", apiErr.Code, code, apiErr.Message)
+	}
+	if strings.Contains(apiErr.Message, "fatal:") || strings.Contains(apiErr.Message, "error:") {
+		t.Fatalf("message leaked raw git output: %q", apiErr.Message)
+	}
+	return apiErr
+}
+
+// gitSource creates a real git repository at <base>/<owner>/<repo> so a
+// file:// clone URL yields a predictable <owner>-<repo> destination.
+func gitSource(t *testing.T, owner, repo string) string {
+	t.Helper()
+	dir := filepath.Join(t.TempDir(), owner, repo)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	git := func(args ...string) {
+		t.Helper()
+		if out, err := exec.Command("git", args...).CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v (%s)", args, err, out)
+		}
+	}
+	git("init", "-b", "main", dir)
+	git("-C", dir, "-c", "user.email=t@example.com", "-c", "user.name=t", "commit", "--allow-empty", "-m", "init")
+	return dir
+}
+
+func TestCloneRepository_NotConfigured(t *testing.T) {
+	// An empty reposRoot means the daemon was started without a clone
+	// destination, so cloning by URL is unavailable rather than invalid.
+	for _, reposRoot := range []string{"", "   "} {
+		m := &Service{reposRoot: reposRoot}
+		_, err := m.cloneRepository(context.Background(), "https://github.com/o/r.git")
+		wantCloneCode(t, err, "CLONE_NOT_CONFIGURED")
+	}
+}
+
+func TestCloneRepository_DestUnavailable(t *testing.T) {
+	// reposRoot below a regular file: MkdirAll cannot create it (ENOTDIR).
+	file := filepath.Join(t.TempDir(), "not-a-dir")
+	if err := os.WriteFile(file, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	m := &Service{reposRoot: filepath.Join(file, "repos")}
+	_, err := m.cloneRepository(context.Background(), "https://github.com/o/r.git")
+	wantCloneCode(t, err, "CLONE_DEST_UNAVAILABLE")
+}
+
+func TestCloneRepository_DestStatUnavailable(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root ignores directory permissions, so the stat cannot be made to fail")
+	}
+	// reposRoot exists but is not searchable, so MkdirAll succeeds (the
+	// directory is already there) and the destination Stat fails with EACCES,
+	// which is neither success nor os.ErrNotExist.
+	reposRoot := filepath.Join(t.TempDir(), "repos")
+	if err := os.Mkdir(reposRoot, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(reposRoot, 0o700) })
+
+	m := &Service{reposRoot: reposRoot}
+	_, err := m.cloneRepository(context.Background(), "https://github.com/o/r.git")
+	wantCloneCode(t, err, "CLONE_DEST_UNAVAILABLE")
+}
+
+func TestCloneRepository_Timeout(t *testing.T) {
+	// A loopback server that never answers, so git blocks until the clone's own
+	// deadline fires. Shrinking cloneTimeout keeps the test fast.
+	blocked := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-blocked
+	}))
+	t.Cleanup(func() {
+		close(blocked)
+		srv.Close()
+	})
+
+	originalTimeout, originalWaitDelay := cloneTimeout, cloneWaitDelay
+	cloneTimeout, cloneWaitDelay = 500*time.Millisecond, 500*time.Millisecond
+	t.Cleanup(func() { cloneTimeout, cloneWaitDelay = originalTimeout, originalWaitDelay })
+
+	reposRoot := t.TempDir()
+	m := &Service{reposRoot: reposRoot}
+	_, err := m.cloneRepository(context.Background(), srv.URL+"/acme/widgets.git")
+	apiErr := wantCloneCode(t, err, "CLONE_TIMEOUT")
+	if !strings.Contains(apiErr.Message, cloneTimeout.String()) {
+		t.Fatalf("message %q does not mention the timeout %s", apiErr.Message, cloneTimeout)
+	}
+	if _, statErr := os.Stat(filepath.Join(reposRoot, "acme-widgets")); !os.IsNotExist(statErr) {
+		t.Fatalf("expected the timed-out clone destination to be cleaned up, stat err = %v", statErr)
+	}
+}
+
+func TestCloneRepository_TimeoutSurvivesCallerCancellation(t *testing.T) {
+	// The clone deliberately runs on a context.WithoutCancel of the request
+	// context, so a cancelled caller must not turn into a spurious CLONE_TIMEOUT
+	// before git has even been given its own deadline.
+	src := gitSource(t, "acme", "widgets")
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	reposRoot := t.TempDir()
+	m := &Service{reposRoot: reposRoot}
+	dest, err := m.cloneRepository(ctx, "file://"+filepath.ToSlash(src))
+	if err != nil {
+		t.Fatalf("cloneRepository with a cancelled caller context: %v", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(dest, ".git")); statErr != nil {
+		t.Fatalf("cloned repo missing .git: %v", statErr)
+	}
+}
+
+func TestCloneRepository_RepoNotFound(t *testing.T) {
+	// 404 on the smart-http discovery request is exactly what a missing or
+	// inaccessible repository returns.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	}))
+	t.Cleanup(srv.Close)
+
+	m := &Service{reposRoot: t.TempDir()}
+	_, err := m.cloneRepository(context.Background(), srv.URL+"/acme/widgets.git")
+	apiErr := wantCloneCode(t, err, "CLONE_REPO_NOT_FOUND")
+	if strings.Contains(apiErr.Message, srv.URL) {
+		t.Fatalf("message leaked the clone URL: %q", apiErr.Message)
+	}
+}
+
+func TestCloneRepository_UnclassifiedFailureIsGeneric(t *testing.T) {
+	// A directory that exists but is not a git repository: git fails with
+	// "does not exist", which matches no classifier branch.
+	notARepo := filepath.Join(t.TempDir(), "acme", "widgets")
+	if err := os.MkdirAll(notARepo, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	m := &Service{reposRoot: t.TempDir()}
+	_, err := m.cloneRepository(context.Background(), "file://"+filepath.ToSlash(notARepo))
+	wantCloneCode(t, err, "CLONE_FAILED")
+}
+
+func TestClassifyCloneError(t *testing.T) {
+	// Representative real git output for each branch.
+	for _, tc := range []struct {
+		name     string
+		output   string
+		wantCode string
+	}{
+		{
+			name:     "https no credentials",
+			output:   "fatal: could not read Username for 'https://github.com': terminal prompts disabled",
+			wantCode: "CLONE_AUTH_FAILED",
+		},
+		{
+			name:     "https bad credentials",
+			output:   "remote: Invalid username or password.\nfatal: Authentication failed for 'https://github.com/o/r.git/'",
+			wantCode: "CLONE_AUTH_FAILED",
+		},
+		{
+			name:     "ssh no key",
+			output:   "git@github.com: Permission denied (publickey).\nfatal: Could not read from remote repository.",
+			wantCode: "CLONE_AUTH_FAILED",
+		},
+		{
+			name:     "dns failure",
+			output:   "fatal: unable to access 'https://githu.com/o/r.git/': Could not resolve host: githu.com",
+			wantCode: "CLONE_HOST_NOT_FOUND",
+		},
+		{
+			name:     "dns failure glibc wording",
+			output:   "ssh: Could not resolve hostname host: Temporary failure in name resolution",
+			wantCode: "CLONE_HOST_NOT_FOUND",
+		},
+		{
+			name:     "unknown host key",
+			output:   "Host key verification failed.\nfatal: Could not read from remote repository.",
+			wantCode: "CLONE_HOST_KEY_UNVERIFIED",
+		},
+		{
+			name:     "repo missing",
+			output:   "remote: Repository not found.\nfatal: repository 'https://github.com/o/r.git/' not found",
+			wantCode: "CLONE_REPO_NOT_FOUND",
+		},
+		{
+			name:     "http 404",
+			output:   "fatal: repository 'http://127.0.0.1:1/o/r.git/' not found",
+			wantCode: "CLONE_REPO_NOT_FOUND",
+		},
+		{
+			name:     "anything else",
+			output:   "fatal: early EOF\nfatal: index-pack failed",
+			wantCode: "CLONE_FAILED",
+		},
+		{
+			name:     "empty output",
+			output:   "",
+			wantCode: "CLONE_FAILED",
+		},
+		{
+			name:     "mixed case is still classified",
+			output:   "FATAL: AUTHENTICATION FAILED for 'https://github.com/o/r.git/'",
+			wantCode: "CLONE_AUTH_FAILED",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := classifyCloneError(tc.output)
+			if err.Code != tc.wantCode {
+				t.Fatalf("code = %q, want %q", err.Code, tc.wantCode)
+			}
+			// No branch, including the default, may echo git's own text.
+			if err.Message == "" {
+				t.Fatal("message is empty, callers need remediation text")
+			}
+			for _, line := range strings.Split(tc.output, "\n") {
+				if line = strings.TrimSpace(line); line != "" && strings.Contains(err.Message, line) {
+					t.Fatalf("message %q leaked raw git output %q", err.Message, line)
+				}
+			}
+			if err.Details != nil {
+				t.Fatalf("details = %v, want nil", err.Details)
+			}
+		})
+	}
+}
+
+func TestParseCloneURL(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		raw       string
+		wantOwner string
+		wantRepo  string
+	}{
+		{name: "https with .git", raw: "https://github.com/acme/widgets.git", wantOwner: "acme", wantRepo: "widgets"},
+		{name: "https without .git", raw: "https://github.com/acme/widgets", wantOwner: "acme", wantRepo: "widgets"},
+		{name: "https with trailing slash", raw: "https://github.com/acme/widgets/", wantOwner: "acme", wantRepo: "widgets"},
+		{name: "https with credentials", raw: "https://x-access-token:ghp_TOKEN@github.com/acme/widgets.git", wantOwner: "acme", wantRepo: "widgets"},
+		{name: "surrounding whitespace", raw: "  https://github.com/acme/widgets.git\n", wantOwner: "acme", wantRepo: "widgets"},
+		{name: "scp-like shorthand", raw: "git@github.com:acme/widgets.git", wantOwner: "acme", wantRepo: "widgets"},
+		{name: "scp-like without .git", raw: "git@github.com:acme/widgets", wantOwner: "acme", wantRepo: "widgets"},
+		{name: "scp-like with a port-looking host", raw: "git@my-host.example.com:acme/widgets.git", wantOwner: "acme", wantRepo: "widgets"},
+		{name: "ssh scheme", raw: "ssh://git@github.com/acme/widgets.git", wantOwner: "acme", wantRepo: "widgets"},
+		{name: "ssh scheme with port", raw: "ssh://git@github.com:2222/acme/widgets.git", wantOwner: "acme", wantRepo: "widgets"},
+		{name: "git scheme", raw: "git://github.com/acme/widgets.git", wantOwner: "acme", wantRepo: "widgets"},
+		{name: "file scheme", raw: "file:///srv/git/acme/widgets.git", wantOwner: "acme", wantRepo: "widgets"},
+		// Only the last two segments are used, which is what keeps a deep or
+		// hostile path from reaching the destination name.
+		{name: "self-hosted subgroups use the last two segments", raw: "https://gitlab.example.com/group/subgroup/acme/widgets.git", wantOwner: "acme", wantRepo: "widgets"},
+		{name: "dots inside a segment are allowed", raw: "https://github.com/acme/widgets.js.git", wantOwner: "acme", wantRepo: "widgets.js"},
+		{name: "double dot inside a segment is allowed", raw: "https://github.com/ac..me/wid..gets.git", wantOwner: "ac..me", wantRepo: "wid..gets"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			owner, repo, err := parseCloneURL(tc.raw)
+			if err != nil {
+				t.Fatalf("parseCloneURL(%q): %v", tc.raw, err)
+			}
+			if owner != tc.wantOwner || repo != tc.wantRepo {
+				t.Fatalf("parseCloneURL(%q) = %q, %q, want %q, %q", tc.raw, owner, repo, tc.wantOwner, tc.wantRepo)
+			}
+		})
+	}
+}
+
+func TestParseCloneURL_Rejects(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		raw  string
+	}{
+		{name: "empty", raw: ""},
+		{name: "whitespace only", raw: "   \t\n"},
+		{name: "not a url", raw: "not-a-git-url"},
+		{name: "bare host", raw: "https://github.com"},
+		{name: "one segment", raw: "https://github.com/widgets.git"},
+		{name: "scp-like with one segment", raw: "git@github.com:widgets.git"},
+		{name: "scheme relative", raw: "//github.com/acme/widgets.git"},
+		{name: "plain relative path", raw: "acme/widgets.git"},
+		{name: "absolute path", raw: "/srv/git/acme/widgets.git"},
+
+		// Traversal segments that reach sanitizeDirComponent verbatim.
+		{name: "traversal in the repo segment", raw: "https://host/acme/...git"},
+		{name: "dot repo segment", raw: "https://host/acme/."},
+		{name: "dotdot repo segment", raw: "https://host/acme/.."},
+		{name: "dot owner segment", raw: "https://host/./widgets.git"},
+		{name: "dotdot owner segment", raw: "https://host/../widgets.git"},
+		{name: "backslash traversal", raw: `https://host/acme/..\..\windows.git`},
+		{name: "tilde expansion", raw: "https://host/acme/~root.git"},
+
+		// Injection-shaped segments. safeDirComponent admits none of these.
+		{name: "space in the repo segment", raw: "https://host/acme/wid gets.git"},
+		{name: "shell metacharacters", raw: "https://host/acme/widgets;rm -rf x.git"},
+		{name: "command substitution", raw: "https://host/acme/$(whoami).git"},
+		{name: "newline in the repo segment", raw: "https://host/acme/widgets\nx.git"},
+		{name: "null byte", raw: "https://host/acme/widgets\x00.git"},
+		{name: "colon in the repo segment", raw: "https://host/acme/wid:gets.git"},
+		{name: "non-ascii", raw: "https://host/acme/wídgets.git"},
+		{name: "empty repo segment after stripping .git", raw: "https://host/acme/.git"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			owner, repo, err := parseCloneURL(tc.raw)
+			if err == nil {
+				t.Fatalf("parseCloneURL(%q) = %q, %q, want an error", tc.raw, owner, repo)
+			}
+		})
+	}
+}
+
+// TestParseCloneURL_HostileInputsStayInsideReposRoot locks in the traversal
+// defence. A hostile URL is not always rejected: because only the last two path
+// segments are ever used, something like https://host/../../etc/x.git reduces to
+// the inert pair ("etc", "x"). That is the property that matters, so assert it
+// directly: whatever parseCloneURL accepts must join into a direct child of
+// reposRoot.
+func TestParseCloneURL_HostileInputsStayInsideReposRoot(t *testing.T) {
+	const reposRoot = "/srv/ao/repos"
+	for _, tc := range []struct {
+		name string
+		raw  string
+		want string // the <owner>-<repo> destination name, "" when rejected
+	}{
+		{name: "ordinary https", raw: "https://github.com/acme/widgets.git", want: "acme-widgets"},
+		{name: "deep path uses the last two segments", raw: "https://gitlab.example.com/group/subgroup/acme/widgets.git", want: "acme-widgets"},
+		{name: "scp-like", raw: "git@github.com:acme/widgets.git", want: "acme-widgets"},
+		{name: "ssh with a port and dots", raw: "ssh://git@github.com:2222/ac..me/wid..gets.git", want: "ac..me-wid..gets"},
+		{name: "credentialed https", raw: "https://x-access-token:ghp_TOKEN@github.com/acme/widgets.git", want: "acme-widgets"},
+		{name: "file url", raw: "file:///srv/git/acme/widgets.git", want: "acme-widgets"},
+
+		// Traversal attempts. These reduce, they do not escape.
+		{name: "parent traversal", raw: "https://host/../../etc/x.git", want: "etc-x"},
+		{name: "leading double slash", raw: "https://host//etc/passwd", want: "etc-passwd"},
+		{name: "percent-encoded traversal", raw: "https://host/acme/%2e%2e%2fetc%2fpasswd.git", want: "etc-passwd"},
+		{name: "percent-encoded slash", raw: "https://host/acme/wid%2Fgets.git", want: "wid-gets"},
+		{name: "scp-like traversal", raw: "git@host:../../etc/x.git", want: "etc-x"},
+		{name: "scp-like absolute path", raw: "git@host:/etc/passwd.git", want: "etc-passwd"},
+		{name: "deep traversal", raw: "https://host/a/../../../../../../etc/shadow", want: "etc-shadow"},
+		{name: "traversal that reduces to nothing", raw: "https://host/../..", want: ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			owner, repo, err := parseCloneURL(tc.raw)
+			if tc.want == "" {
+				if err == nil {
+					t.Fatalf("parseCloneURL(%q) = %q, %q, want an error", tc.raw, owner, repo)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseCloneURL(%q): %v", tc.raw, err)
+			}
+			if got := owner + "-" + repo; got != tc.want {
+				t.Fatalf("parseCloneURL(%q) destination name = %q, want %q", tc.raw, got, tc.want)
+			}
+			dest := filepath.Join(reposRoot, owner+"-"+repo)
+			if filepath.Dir(dest) != filepath.FromSlash(reposRoot) {
+				t.Fatalf("parseCloneURL(%q) escaped reposRoot: dest = %q", tc.raw, dest)
+			}
+			if filepath.Clean(dest) != dest {
+				t.Fatalf("parseCloneURL(%q) produced an uncleaned dest = %q", tc.raw, dest)
+			}
+		})
+	}
+}
+
+func TestSanitizeDirComponent(t *testing.T) {
+	for _, ok := range []string{"widgets", "widgets.js", "ac..me", "a", "_", "-", ".hidden", "A1-b_2.c", "..a"} {
+		if got, err := sanitizeDirComponent(ok); err != nil || got != ok {
+			t.Fatalf("sanitizeDirComponent(%q) = %q, %v, want %q, nil", ok, got, err, ok)
+		}
+	}
+	// Leading and trailing whitespace is trimmed, not rejected.
+	if got, err := sanitizeDirComponent("  widgets  "); err != nil || got != "widgets" {
+		t.Fatalf(`sanitizeDirComponent("  widgets  ") = %q, %v, want "widgets", nil`, got, err)
+	}
+	for _, bad := range []string{
+		"", "   ", ".", "..", "a/b", `a\b`, "a b", "a;b", "a|b", "a&b", "$a", "a$", "`a`", "a'b", `a"b`,
+		"a*b", "a?b", "a:b", "a\nb", "a\x00b", "~", "~root", "a%2Fb", "wídgets", "..\\..", "../..",
+	} {
+		if got, err := sanitizeDirComponent(bad); err == nil {
+			t.Fatalf("sanitizeDirComponent(%q) = %q, want an error", bad, got)
+		}
+	}
+}
+
+func TestSanitizeOriginURL(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{
+			name: "https token as username and password",
+			raw:  "https://x-access-token:ghp_SECRET@github.com/acme/widgets.git",
+			want: "https://github.com/acme/widgets.git",
+		},
+		{
+			name: "https token as username only",
+			raw:  "https://ghp_SECRET@github.com/acme/widgets.git",
+			want: "https://github.com/acme/widgets.git",
+		},
+		{
+			name: "https user and password",
+			raw:  "https://alice:s3cr3t@git.example.com/acme/widgets.git",
+			want: "https://git.example.com/acme/widgets.git",
+		},
+		{
+			name: "https percent-encoded password",
+			raw:  "https://alice:p%40ss%3Aword@git.example.com/acme/widgets.git",
+			want: "https://git.example.com/acme/widgets.git",
+		},
+		{
+			name: "http is treated the same as https",
+			raw:  "http://alice:s3cr3t@git.example.com/acme/widgets.git",
+			want: "http://git.example.com/acme/widgets.git",
+		},
+		{
+			name: "port and query are preserved",
+			raw:  "https://alice:s3cr3t@git.example.com:8443/acme/widgets.git",
+			want: "https://git.example.com:8443/acme/widgets.git",
+		},
+		{
+			name: "uppercase scheme",
+			raw:  "HTTPS://alice:s3cr3t@git.example.com/acme/widgets.git",
+			want: "https://git.example.com/acme/widgets.git",
+		},
+
+		// Everything below must survive untouched.
+		{
+			name: "plain https is unchanged",
+			raw:  "https://github.com/acme/widgets.git",
+			want: "https://github.com/acme/widgets.git",
+		},
+		{
+			name: "scp-like shorthand keeps its ssh user",
+			raw:  "git@github.com:acme/widgets.git",
+			want: "git@github.com:acme/widgets.git",
+		},
+		{
+			name: "ssh scheme keeps its login name",
+			raw:  "ssh://git@github.com/acme/widgets.git",
+			want: "ssh://git@github.com/acme/widgets.git",
+		},
+		{
+			name: "ssh scheme with a port keeps its login name",
+			raw:  "ssh://git@github.com:2222/acme/widgets.git",
+			want: "ssh://git@github.com:2222/acme/widgets.git",
+		},
+		{
+			name: "ssh scheme drops a password but keeps the login name",
+			raw:  "ssh://git:s3cr3t@github.com/acme/widgets.git",
+			want: "ssh://git@github.com/acme/widgets.git",
+		},
+		{
+			name: "git+ssh keeps its login name",
+			raw:  "git+ssh://git@github.com/acme/widgets.git",
+			want: "git+ssh://git@github.com/acme/widgets.git",
+		},
+		{
+			name: "local path is unchanged",
+			raw:  "/srv/git/acme/widgets.git",
+			want: "/srv/git/acme/widgets.git",
+		},
+		{
+			name: "file url is unchanged",
+			raw:  "file:///srv/git/acme/widgets.git",
+			want: "file:///srv/git/acme/widgets.git",
+		},
+		{
+			name: "empty is unchanged",
+			raw:  "",
+			want: "",
+		},
+		{
+			name: "an at sign in the path is not userinfo",
+			raw:  "https://git.example.com/acme/wid@gets.git",
+			want: "https://git.example.com/acme/wid@gets.git",
+		},
+		{
+			name: "unparseable input is returned verbatim",
+			raw:  "git@host:acme/wid\x7fgets.git",
+			want: "git@host:acme/wid\x7fgets.git",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := sanitizeOriginURL(tc.raw); got != tc.want {
+				t.Fatalf("sanitizeOriginURL(%q) = %q, want %q", tc.raw, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSanitizeOriginURL_LeaksNoSecret(t *testing.T) {
+	const secret = "ghp_SUPERSECRET"
+	for _, raw := range []string{
+		"https://x-access-token:" + secret + "@github.com/acme/widgets.git",
+		"https://" + secret + "@github.com/acme/widgets.git",
+		"https://alice:" + secret + "@git.example.com:8443/acme/widgets.git",
+		"ssh://git:" + secret + "@github.com/acme/widgets.git",
+	} {
+		if got := sanitizeOriginURL(raw); strings.Contains(got, secret) {
+			t.Fatalf("sanitizeOriginURL(%q) still contains the secret: %q", raw, got)
+		}
+	}
+}

--- a/backend/internal/service/project/clone_test.go
+++ b/backend/internal/service/project/clone_test.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -81,6 +82,13 @@ func TestCloneRepository_DestUnavailable(t *testing.T) {
 }
 
 func TestCloneRepository_DestStatUnavailable(t *testing.T) {
+	// This branch needs a directory whose permissions make Stat fail, which
+	// only Unix modes can express: Windows Chmod toggles a read-only bit that
+	// directories ignore, and root bypasses the check entirely. Without the
+	// guards the clone would proceed and reach for the network.
+	if runtime.GOOS == "windows" {
+		t.Skip("directory permissions are not enforced this way on Windows")
+	}
 	if os.Geteuid() == 0 {
 		t.Skip("root ignores directory permissions, so the stat cannot be made to fail")
 	}

--- a/backend/internal/service/project/service.go
+++ b/backend/internal/service/project/service.go
@@ -679,12 +679,19 @@ func validateScratchProjectConfig(cfg domain.ProjectConfig) error {
 // `git -C path remote get-url origin`. A missing remote, missing repo, or any
 // other git error returns an empty string — `project add` must not fail just
 // because no origin is configured (the SCM observer skips such projects).
+//
+// The result is passed through sanitizeOriginURL, because everything downstream
+// of this function is a place a credential must never reach: it is persisted to
+// projects.repo_origin_url, served as Project.Repo, and logged. This is the
+// single choke point for every RepoOriginURL assignment, so stripping here
+// covers both a credentialed AddInput.CloneURL (git records it verbatim as
+// origin) and a repo added by path whose own origin already carries one.
 func resolveGitOriginURL(path string) string {
 	out, err := aoprocess.Command("git", "-C", path, "remote", "get-url", "origin").Output()
 	if err != nil {
 		return ""
 	}
-	return strings.TrimSpace(string(out))
+	return sanitizeOriginURL(strings.TrimSpace(string(out)))
 }
 
 // resolveDefaultBranch returns the repo's default branch, preferring the

--- a/backend/internal/service/project/service_test.go
+++ b/backend/internal/service/project/service_test.go
@@ -905,6 +905,27 @@ func TestManager_AddPopulatesRepoOriginURL(t *testing.T) {
 			setup:   func(t *testing.T) string { return gitRepo(t) },
 			wantURL: "",
 		},
+		{
+			// The credential must not reach the persisted row, the API
+			// response, or the daemon log.
+			name: "credentialed https origin is stripped",
+			setup: func(t *testing.T) string {
+				return gitRepoWithOrigin(t, "https://x-access-token:ghp_SECRET@github.com/o/r.git")
+			},
+			wantURL: "https://github.com/o/r.git",
+		},
+		{
+			// An scp-like remote's userinfo is an SSH login name, not a
+			// secret, and the remote does not work without it.
+			name:    "scp-style origin is preserved verbatim",
+			setup:   func(t *testing.T) string { return gitRepoWithOrigin(t, "git@github.com:o/r.git") },
+			wantURL: "git@github.com:o/r.git",
+		},
+		{
+			name:    "ssh origin keeps its login name",
+			setup:   func(t *testing.T) string { return gitRepoWithOrigin(t, "ssh://git@github.com:2222/o/r.git") },
+			wantURL: "ssh://git@github.com:2222/o/r.git",
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			m := newManager(t)
@@ -970,6 +991,88 @@ func TestManager_AddClonesFromCloneURL(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(wantPath, ".git")); err != nil {
 		t.Fatalf("cloned repo missing .git: %v", err)
+	}
+}
+
+// TestManager_AddCloneURLCredentialIsNotPersisted is the M2 failure scenario end
+// to end: a client POSTs a cloneUrl carrying a PAT, which is the natural
+// non-interactive form and the only one that works under GIT_TERMINAL_PROMPT=0.
+// git records that string verbatim as `origin`, so the token must be stripped
+// before it reaches the projects row, the API response, or the daemon log.
+//
+// The repository is served over dumb git-HTTP from a loopback httptest server
+// (a plain file server over a real repo's .git directory, which is what
+// `git update-server-info` prepares), gated on HTTP basic auth so the clone only
+// succeeds if git actually uses the credential from the URL.
+func TestManager_AddCloneURLCredentialIsNotPersisted(t *testing.T) {
+	ctx := context.Background()
+	const (
+		user  = "x-access-token"
+		token = "ghp_TESTONLYTOKEN"
+	)
+	// Isolate from the developer's own git config and credential helpers.
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	source := gitRepoNamed(t, "acme", "widgets")
+	if out, err := exec.Command("git", "-C", source, "update-server-info").CombinedOutput(); err != nil {
+		t.Fatalf("git update-server-info: %v (%s)", err, out)
+	}
+
+	var authenticated bool
+	files := http.StripPrefix("/acme/widgets.git", http.FileServer(http.Dir(filepath.Join(source, ".git"))))
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if u, p, ok := r.BasicAuth(); !ok || u != user || p != token {
+			w.Header().Set("WWW-Authenticate", `Basic realm="test"`)
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		authenticated = true
+		files.ServeHTTP(w, r)
+	}))
+	t.Cleanup(srv.Close)
+
+	reposRoot := t.TempDir()
+	m := newManagerWithReposRoot(t, reposRoot)
+	cloneURL := "http://" + user + ":" + token + "@" + srv.Listener.Addr().String() + "/acme/widgets.git"
+	wantRepo := "http://" + srv.Listener.Addr().String() + "/acme/widgets.git"
+
+	proj, err := m.Add(ctx, project.AddInput{CloneURL: cloneURL})
+	if err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if !authenticated {
+		t.Fatal("the clone never authenticated, so this test would pass even without the credential")
+	}
+	if strings.Contains(proj.Repo, token) {
+		t.Fatalf("Repo leaked the credential: %q", proj.Repo)
+	}
+	if proj.Repo != wantRepo {
+		t.Fatalf("Repo = %q, want %q", proj.Repo, wantRepo)
+	}
+
+	// And the same for the value that was written to the store, which is what
+	// GET /api/v1/projects/{id} and the tracker-intake log both read back.
+	got, err := m.Get(ctx, proj.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Project.Repo != wantRepo {
+		t.Fatalf("persisted Repo = %q, want %q", got.Project.Repo, wantRepo)
+	}
+
+	// Deliberate, documented scope of the fix: the credential stays in the
+	// clone's own .git/config, which is where git needs it for the fetches and
+	// pushes the project's session worktrees will do. Stripping it there would
+	// break the non-interactive flow a credentialed cloneUrl exists to enable.
+	// If that decision is ever revisited, update this assertion and the docs
+	// together rather than silently.
+	cfg, err := os.ReadFile(filepath.Join(reposRoot, "acme-widgets", ".git", "config"))
+	if err != nil {
+		t.Fatalf("read cloned .git/config: %v", err)
+	}
+	if !strings.Contains(string(cfg), token) {
+		t.Fatal("the clone's own .git/config no longer holds the credential; if that is intended, update the comment above and the PR-documented decision")
 	}
 }
 


### PR DESCRIPTION
Closes #17

Fixes review finding **M2** (a credential leak) and the clone half of **L8**
(untested rejection paths), both in `backend/internal/service/project/`.

## M2, the credential leak

A client can POST `{"cloneUrl": "https://x-access-token:<PAT>@github.com/owner/repo.git"}`,
which is how non-interactive https git auth is normally expressed and what
`GIT_TERMINAL_PROMPT=0` leaves as the practical option. `git clone` records that
string verbatim as `origin`, and the daemon then read it back into
`projects.repo_origin_url`, returned it as `Project.repo` from
`GET /api/v1/projects/{id}`, and logged it from the tracker-intake observer. On a
hosted VM the PAT sat on disk, in every projects API response, and in journald
indefinitely.

### Where the stripping happens, and why there

In `resolveGitOriginURL`, not at the two `RepoOriginURL` assignments. It is the
single choke point all four assignments go through (`service.go:254`,
`service.go:282`, `workspace_registration.go:178`, `:216`), so one line covers
the persisted, served, and logged copies at once, and it also cleans a project
added by **path** whose own `origin` already carried a credential, which the
assignment sites would not have.

The stripping is scheme-aware so it cannot break a working remote:

| input | result |
| --- | --- |
| `https://x-access-token:TOKEN@host/o/r.git` | `https://host/o/r.git` |
| `https://TOKEN@host/o/r.git` (username-only auth) | `https://host/o/r.git` |
| `git@github.com:o/r.git` (scp-like) | unchanged |
| `ssh://git@host:2222/o/r.git` | unchanged |
| `ssh://git:pass@host/o/r.git` | `ssh://git@host/o/r.git` |
| no `@`, unparseable, or no userinfo | unchanged, byte for byte |

An scp-like remote's userinfo is an SSH login name, not a secret, and `url.Parse`
rejects that form outright anyway. Over http(s) the username alone **is** a
credential (`https://<token>@github.com/...` authenticates with no password), so
the whole userinfo goes. The non-credentialed case is never re-serialized: there
is an early return before `u.String()` is ever reached.

### The copy in `.git/config`: decision

**I did not rewrite the remote after cloning.** The credential stays in the
clone's own `.git/config`, where git put it.

Why: that is the one place the credential still has a job. The project's session
worktrees fetch and push through that same `origin` (git worktrees share the main
repo's config), so stripping it would break the exact non-interactive flow that a
credentialed `cloneUrl` exists to enable, and it would fail later and less
legibly, at push time. It also would not raise the bar much: the file sits in the
daemon's own data dir, owned by the same user the agents run as, and those agents
already have shell access to it by design.

What the copies in the DB, the API response, and journald have in common is that
none of them has a function, and all three outlive the repo: backups, log
shipping, and an HTTP response to any client with daemon access. Those are the
ones worth closing, and this PR closes them.

`TestManager_AddCloneURLCredentialIsNotPersisted` asserts both halves, including
that the credential is still in `.git/config`, so a future change to that
decision has to be deliberate rather than silent.

### Also fixed: `CLONE_TIMEOUT` never actually returned

Found while writing the test for it. `git clone` delegates to a
`git-remote-http` (or `ssh`) child that inherits the output pipe. The clone
deadline kills the parent, but not the child, so `CombinedOutput` kept waiting on
a pipe held open by a child blocked on a stalled server. `cloneRepository` would
never return, and since it runs under `Add`'s `addMu`, every later project add
would block behind it forever. One line: `cmd.WaitDelay = cloneWaitDelay` (5s).
Without it the new timeout test hangs until the Go test binary's own deadline,
which is how it turned up.

`cloneTimeout` and `cloneWaitDelay` became `var` instead of `const` purely so
that test does not have to wait five minutes.

### Not done, on purpose

**No migration for existing rows.** Out of scope per the brief. One is arguably
warranted if any hosted VM has already served this path: a rewrite of
`projects.repo_origin_url` values containing userinfo. Worth noting that a
migration cannot un-log the value from journald or un-serve it from responses
already sent, so rotating an exposed token is the real remedy either way. Happy
to do it as a follow-up if you want it.

## L8, the rejection-path tests

New `clone_test.go` (internal `package project`, since these symbols are
unexported; the existing `service_test.go` is `package project_test`):

- `CLONE_NOT_CONFIGURED`, both the empty and whitespace `reposRoot` cases.
- `CLONE_DEST_UNAVAILABLE`, both branches: `MkdirAll` failing under a regular
  file, and the destination `Stat` failing with `EACCES` (skipped as root, which
  ignores directory permissions).
- `CLONE_TIMEOUT` against a loopback server that never answers, with a shrunk
  deadline, plus cleanup of the partial destination. Also a companion test that a
  **cancelled caller context** does not become a spurious `CLONE_TIMEOUT`, which
  is the point of the `context.WithoutCancel`.
- `CLONE_REPO_NOT_FOUND` end to end from an httptest 404, and
  `CLONE_FAILED` end to end from a `file://` path that exists but is not a repo.
- `classifyCloneError` across all five branches with representative real git
  output (11 cases, including empty and mixed-case input). Every case also
  asserts no line of git's own output appears in the message, which locks in the
  "never return raw git output" property in the default branch too.
- `parseCloneURL`: https with and without `.git`, trailing slash, credentials,
  surrounding whitespace, scp-like with and without `.git`, `ssh://` with and
  without a port, `git://`, `file://`, self-hosted subgroups, and dots inside
  segments.
- `parseCloneURL` rejections: 26 adversarial inputs, covering traversal segments,
  shell metacharacters, command substitution, newlines, a null byte, non-ASCII,
  and tilde.
- `sanitizeDirComponent` directly, 9 accepted and 24 rejected inputs.
- `sanitizeOriginURL`, 19 cases, plus a leak test asserting a known secret never
  survives any credentialed form.

**The traversal defence is asserted, not changed.** The reviewer confirmed it
sound and it is. One correction to the brief's framing though: hostile inputs are
not always *rejected*. Because only the last two path segments are used,
`https://host/../../etc/x.git` reduces to the inert pair `("etc", "x")` and is
accepted, giving destination `etc-x`. That is safe, but "expect an error" was the
wrong assertion, so
`TestParseCloneURL_HostileInputsStayInsideReposRoot` states the property that
actually matters instead: whatever `parseCloneURL` accepts must join into a
*direct child* of `reposRoot`, with the reduced destination name pinned per input.

In `service_test.go`: three cases added to `TestManager_AddPopulatesRepoOriginURL`
(credentialed https stripped, scp-style preserved, `ssh://` login name
preserved), plus `TestManager_AddCloneURLCredentialIsNotPersisted`, the M2
scenario end to end. That one serves a real repo over dumb git-HTTP from a
loopback httptest server gated on basic auth, so the clone only succeeds if git
actually uses the credential from the URL. It asserts `authenticated` was
reached, so the test cannot pass vacuously.

## Verification

- `go test ./internal/service/project/` green; `go test -race` on that package
  and all of `./internal/observe/...` green.
- `go test ./...`: only the 5 documented pre-existing `internal/cli` spawn
  failures, unchanged from `develop` and untouched here.
- `golangci-lint v2.12.2` on the package: 0 issues.
- `gitleaks detect` on the package: no leaks (the test tokens are short
  placeholders, well under the `ghp_` rule's length).
- `go generate ./internal/httpd/apispec/...` produces no diff. The HTTP surface
  is unchanged, so `openapi.yaml` and `frontend/src/api/schema.ts` are untouched.

## Risks

- `WaitDelay` means a timed-out clone now force-closes the pipes 5 seconds after
  the deadline. That is the intended semantics of a timeout, and the only
  behavior change is that it now returns at all.
- Anything that treated `Project.repo` as a directly usable, pre-authenticated
  clone URL would now get the credential-free form. Nothing in the repo does; the
  consumers are display and the GitHub `owner/repo` parse in
  `trackerintake/observer.go:328`, which is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
