### PR TITLE
feat(desktop): AO account login via system-browser PKCE

### DIFF
--- a/docs/desktop-login-contract.md
+++ b/docs/desktop-login-contract.md
@@ -1,0 +1,95 @@
+# Desktop login contract
+
+The two control-plane endpoints the desktop app's sign-in talks to. Written by the
+desktop side (issue #25) while the control plane's own routes were being built in
+parallel (issue #23), so the app builds against this contract rather than waiting.
+If the control plane lands different paths or field names, this file and
+`frontend/src/main/ao-pkce.ts` change together.
+
+Token shapes, lifetimes, and the rotate-on-use rule live in
+[`controlplane/TOKEN_CONTRACT.md`](../controlplane/TOKEN_CONTRACT.md); this file is
+only the desktop login exchange.
+
+## Why this shape
+
+The desktop app is a **public client**: it ships no secret. Google blocks OAuth in
+embedded webviews, so login runs in the user's real browser and comes back through
+an RFC 8252 loopback redirect. PKCE (S256) plus a CSPRNG `state` is the whole
+defence against another local process stealing the authorization code.
+
+`AO_CONTROL_URL` selects which control plane the app trusts (default
+`https://ao.agentlab.in`; plain HTTP is accepted only on the loopback, for a
+locally-run control plane). It can never skip authentication, and there is no flag
+that does.
+
+## `GET /oauth/desktop/authorize`
+
+Opened in the system browser. Query parameters:
+
+| Parameter | Value |
+| --- | --- |
+| `response_type` | `code` |
+| `client_id` | `ao-desktop` |
+| `redirect_uri` | `http://127.0.0.1:<ephemeral>/callback` |
+| `code_challenge` | base64url(SHA-256(verifier)) |
+| `code_challenge_method` | `S256` |
+| `state` | 32 CSPRNG bytes, base64url |
+
+The control plane signs the user in with Google (its existing `/auth/google/login`
+session), then redirects to `redirect_uri` with `code` and the unmodified `state`,
+or with `error` plus optional `error_description`.
+
+The redirect URI is a loopback address on an ephemeral port, per RFC 8252 section
+7.3, so the control plane must accept any port for `127.0.0.1` on this client. The
+desktop listener accepts exactly one callback, validates `state` before reading the
+code, and shuts down immediately.
+
+## `POST /oauth/desktop/token`
+
+`Content-Type: application/x-www-form-urlencoded`:
+
+```
+grant_type=authorization_code
+client_id=ao-desktop
+code=<from the callback>
+code_verifier=<the PKCE verifier>
+redirect_uri=<the same loopback URI>
+```
+
+Success, `200`, JSON:
+
+```json
+{
+  "refresh_token": "<opaque, high entropy>",
+  "account": { "id": "<accounts.id>", "email": "<google email>" }
+}
+```
+
+Failure returns a non-2xx with the OAuth error envelope `{"error": "...",
+"error_description": "..."}`; `invalid_grant` covers a reused code, a mismatched
+verifier, and a mismatched `redirect_uri`.
+
+**No access token is issued here.** An access token's `aud` is a machine id
+(`controlplane/TOKEN_CONTRACT.md`) and no machine is selected at login time, so
+access tokens come from a later refresh exchange scoped to the chosen machine. That
+exchange, along with attaching credentials to REST, SSE, and `/mux`, is task 13 in
+batch 5 and is deliberately not implemented here.
+
+## What the desktop stores
+
+`~/.ao/ao-account.json`, mode 0600 (the `~/.ao` state dir, `AO_RUN_FILE`-relative,
+never an OS default app-data location):
+
+```json
+{ "version": 1, "accountId": "...", "email": "...", "refreshToken": "<base64 ciphertext>" }
+```
+
+The refresh token is encrypted with Electron `safeStorage` (macOS Keychain,
+libsecret, DPAPI). When `safeStorage.isEncryptionAvailable()` is false the app
+refuses to sign in and says why, rather than writing the credential in plaintext.
+Sign-out deletes this file, so the credential is actually gone from this end.
+
+Because refresh tokens rotate on every use, the refresh exchange must persist each
+replacement through `writeStoredAccount` in
+`frontend/src/main/ao-account-store.ts` or the next refresh replays a revoked
+token.

--- a/docs/desktop-login-contract.md
+++ b/docs/desktop-login-contract.md
@@ -69,11 +69,32 @@ Failure returns a non-2xx with the OAuth error envelope `{"error": "...",
 "error_description": "..."}`; `invalid_grant` covers a reused code, a mismatched
 verifier, and a mismatched `redirect_uri`.
 
-**No access token is issued here.** An access token's `aud` is a machine id
-(`controlplane/TOKEN_CONTRACT.md`) and no machine is selected at login time, so
-access tokens come from a later refresh exchange scoped to the chosen machine. That
-exchange, along with attaching credentials to REST, SSE, and `/mux`, is task 13 in
-batch 5 and is deliberately not implemented here.
+**No access token is issued here.** Login yields identity plus the refresh token and
+nothing else; every access token comes from a later exchange at the token endpoint.
+
+## Two token audiences, deliberately not interchangeable
+
+Decided by the orchestrator after `controlplane/TOKEN_CONTRACT.md` merged, because
+that file only covered machine-audience tokens and said nothing about how a desktop
+install authenticates to the control plane itself, which it must do before it has
+picked any machine. `hosted-ao-17` is implementing the token endpoint and adding a
+section to `TOKEN_CONTRACT.md` defining both audiences; that file wins once it does.
+
+- **Control-plane audience.** `aud` is the control plane origin
+  (`https://ao.agentlab.in`). This is what authenticates control-plane API calls
+  such as `GET /api/v1/machines`. Obtained by exchanging the refresh token at the
+  token endpoint.
+- **Machine audience.** `aud` is a `machines.id`, verified by that machine's
+  gateway. Obtained per machine, and only after one is chosen. Task 13 in batch 5.
+
+The refresh token goes **only** to the control plane's token endpoint. It is never a
+Bearer credential on a resource route, never in a URL, and never in a log line. An
+access token of one audience is never sent to the other.
+
+Neither exchange is implemented here: this task ends at "a refresh token is stored".
+When task 13 adds a cached control-plane access token, **sign-out must discard that
+cache as well as the stored refresh token.** Today there is nothing cached to
+discard, so deleting the file is the whole of sign-out.
 
 ## What the desktop stores
 

--- a/frontend/e2e/smoke-t0.spec.ts
+++ b/frontend/e2e/smoke-t0.spec.ts
@@ -190,11 +190,16 @@ test("renderer: route nav home to board to session detail and back @T0 @BRD", as
 // #2483 SET-001.
 test("renderer: global settings page renders all sections @T0 @SET", async ({ page }) => {
 	// The settings revamp (#2797) reduced the page to General + Updates + Get
-	// help; the Migration section no longer renders there, so "all sections"
-	// means these. Updates keeps its per-section hook; General/help are asserted
-	// by their user-visible headings.
+	// help; the Migration section no longer renders there. AO account sign-in
+	// (#25) added Account, so "all sections" means these four. Updates and
+	// Account keep per-section hooks; General/help are asserted by their
+	// user-visible headings.
 	await page.goto("/#/settings");
 	await expect(page.getByTestId("settings-page")).toBeVisible();
 	await expect(page.locator('[data-testid="settings-section"][data-section="updates"]')).toBeVisible();
+	await expect(page.locator('[data-testid="settings-section"][data-section="account"]')).toBeVisible();
+	// Local use never requires an account, so the fresh state is signed out and
+	// nothing here blocks the rest of the app.
+	await expect(page.getByTestId("ao-account-identity")).toHaveText("Not signed in");
 	await expect(page.getByRole("heading", { name: "Get help" })).toBeVisible();
 });

--- a/frontend/e2e/support/fake-bridge.ts
+++ b/frontend/e2e/support/fake-bridge.ts
@@ -43,6 +43,7 @@ export async function installFakeBridge(page: Page, opts: FakeBridgeOptions = {}
 	await page.addInitScript(
 		({ version, daemonState, daemonPort }) => {
 			const unsubscribe = () => () => undefined;
+			const signedOutAoAccount = { status: "signed-out" as const, controlPlaneUrl: "https://ao.agentlab.in" };
 			const status: DaemonStatus =
 				daemonState === "ready" ? { state: "ready", port: daemonPort } : { state: daemonState };
 			const navState = (viewId: string) => ({
@@ -140,6 +141,14 @@ export async function installFakeBridge(page: Page, opts: FakeBridgeOptions = {}
 				featureBuilds: {
 					list: async () => [],
 					getActive: async () => null,
+				},
+				// AccountSection reads account.getState() on mount. Signed out is the honest
+				// shape here: the browser harness has no main process, so no OS keychain and
+				// no loopback listener.
+				account: {
+					getState: async () => signedOutAoAccount,
+					signIn: async () => signedOutAoAccount,
+					signOut: async () => signedOutAoAccount,
 				},
 			} satisfies AoBridge;
 			(window as unknown as { ao: unknown }).ao = ao;
@@ -406,6 +415,7 @@ export async function installFakeAgent(page: Page, opts: FakeAgentOptions = {}):
 			(window as unknown as { __aoFakeAgent: unknown }).__aoFakeAgent = controller;
 
 			const unsubscribe = () => () => undefined;
+			const signedOutAoAccount = { status: "signed-out" as const, controlPlaneUrl: "https://ao.agentlab.in" };
 			const status: DaemonStatus = { state: "ready", port: daemonPort };
 			const navState = (viewId: string, url = "", error?: string) => ({
 				viewId,
@@ -489,6 +499,14 @@ export async function installFakeAgent(page: Page, opts: FakeAgentOptions = {}):
 				featureBuilds: {
 					list: async () => [],
 					getActive: async () => null,
+				},
+				// AccountSection reads account.getState() on mount. Signed out is the honest
+				// shape here: the browser harness has no main process, so no OS keychain and
+				// no loopback listener.
+				account: {
+					getState: async () => signedOutAoAccount,
+					signIn: async () => signedOutAoAccount,
+					signOut: async () => signedOutAoAccount,
 				},
 			} satisfies AoBridge;
 			(window as unknown as { ao: unknown }).ao = ao;

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -10,6 +10,7 @@ import {
 	nativeImage,
 	Notification as ElectronNotification,
 	protocol,
+	safeStorage,
 	session,
 	shell,
 	WebContentsView,
@@ -58,6 +59,7 @@ import { createBrowserViewHost, type BrowserViewHost } from "./main/browser-view
 import { connectSupervisor, type SupervisorLinkHandle } from "./main/supervisor-link";
 import { keepDaemonAlive, shouldLinkOnAttach } from "./main/daemon-owner";
 import { readMigrationState, updateMigration, writeAppStateMarker, type MigrationState } from "./main/app-state";
+import { createAoAccountController } from "./main/ao-account";
 import { isAllowedAppExternalURL, openAllowedAppExternalURL } from "./main/external-open";
 import { buildWindowsAppMenuTemplate } from "./main/menu";
 import { createRemoteDaemonLifecycle } from "./main/remote-daemon";
@@ -1405,6 +1407,28 @@ ipcMain.handle("updateSettings:set", async (_event, settings: UpdateSettings) =>
 
 ipcMain.handle("featureBuilds:list", () => listFeatureBuilds());
 ipcMain.handle("featureBuilds:getActive", () => getActiveFeatureBuild());
+
+// AO account sign-in. The stored refresh token lives beside the other ~/.ao state
+// files, encrypted with safeStorage. Local mode never consults this: it exists only
+// so a remote machine can be reached later (batches 4 and 5).
+let aoAccountController: ReturnType<typeof createAoAccountController> | null = null;
+function aoAccount(): ReturnType<typeof createAoAccountController> {
+	if (aoAccountController) return aoAccountController;
+	const runFile = runFilePath();
+	aoAccountController = createAoAccountController({
+		stateDir: runFile ? path.dirname(runFile) : null,
+		env: process.env,
+		safeStorage,
+		// The system browser, never an embedded BrowserWindow: Google blocks OAuth in
+		// embedded webviews (RFC 8252 is the supported shape anyway).
+		openExternal: (url: string) => openAllowedAppExternalURL(url, shell),
+	});
+	return aoAccountController;
+}
+
+ipcMain.handle("aoAccount:getState", () => aoAccount().getState());
+ipcMain.handle("aoAccount:signIn", () => aoAccount().signIn());
+ipcMain.handle("aoAccount:signOut", () => aoAccount().signOut());
 
 ipcMain.handle("updates:getStatus", (): UpdateStatus => getUpdateStatus());
 ipcMain.handle("updates:check", async (_event, options?: UpdateCheckOptions) => {

--- a/frontend/src/main/ao-account-store.test.ts
+++ b/frontend/src/main/ao-account-store.test.ts
@@ -1,0 +1,99 @@
+// @vitest-environment node
+import { mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, expect, test } from "vitest";
+import {
+	AO_ACCOUNT_FILE_NAME,
+	clearStoredAccount,
+	readStoredAccount,
+	SAFE_STORAGE_UNAVAILABLE_MESSAGE,
+	writeStoredAccount,
+	type SafeStorageLike,
+} from "./ao-account-store";
+
+// Stand-in for the OS credential store. XOR is not encryption; it only has to be
+// reversible and to make the on-disk bytes different from the plaintext, which is
+// what these tests assert about.
+function fakeSafeStorage(available = true): SafeStorageLike {
+	return {
+		isEncryptionAvailable: () => available,
+		encryptString: (plain) => Buffer.from(Array.from(Buffer.from(plain, "utf8"), (b) => b ^ 0x5a)),
+		decryptString: (cipher) => Buffer.from(Array.from(cipher, (b) => b ^ 0x5a)).toString("utf8"),
+	};
+}
+
+const account = { id: "acct_1", email: "dev@example.com" };
+let stateDir = "";
+
+beforeEach(async () => {
+	stateDir = await mkdtemp(path.join(os.tmpdir(), "ao-account-"));
+});
+afterEach(async () => {
+	await rm(stateDir, { recursive: true, force: true });
+});
+
+test("round-trips the account and refresh token", async () => {
+	const safeStorage = fakeSafeStorage();
+	await writeStoredAccount(stateDir, safeStorage, { account, refreshToken: "rt_secret" });
+	await expect(readStoredAccount(stateDir, safeStorage)).resolves.toEqual({ account, refreshToken: "rt_secret" });
+});
+
+test("the refresh token never appears on disk in plaintext, and the file is owner-only", async () => {
+	const file = path.join(stateDir, AO_ACCOUNT_FILE_NAME);
+	await writeStoredAccount(stateDir, fakeSafeStorage(), { account, refreshToken: "rt_secret" });
+
+	const raw = await readFile(file, "utf8");
+	expect(raw).not.toContain("rt_secret");
+	// Identity stays readable so the signed-in row renders without a keychain unlock.
+	expect(raw).toContain("dev@example.com");
+	expect((await stat(file)).mode & 0o777).toBe(0o600);
+});
+
+test("nothing at all is written when the OS has no credential store", async () => {
+	await expect(
+		writeStoredAccount(stateDir, fakeSafeStorage(false), { account, refreshToken: "rt_secret" }),
+	).rejects.toThrow(SAFE_STORAGE_UNAVAILABLE_MESSAGE);
+	await expect(readFile(path.join(stateDir, AO_ACCOUNT_FILE_NAME), "utf8")).rejects.toThrow();
+});
+
+test("an empty refresh token is refused rather than stored", async () => {
+	await expect(writeStoredAccount(stateDir, fakeSafeStorage(), { account, refreshToken: "" })).rejects.toThrow(
+		/empty AO refresh token/,
+	);
+});
+
+test("no stored sign-in reads as null, not as an error", async () => {
+	await expect(readStoredAccount(stateDir, fakeSafeStorage())).resolves.toBeNull();
+});
+
+test("a garbage or future-version file reads as no stored sign-in", async () => {
+	const file = path.join(stateDir, AO_ACCOUNT_FILE_NAME);
+	await writeFile(file, "{not json");
+	await expect(readStoredAccount(stateDir, fakeSafeStorage())).resolves.toBeNull();
+	await writeFile(file, JSON.stringify({ version: 99, accountId: "a", email: "e", refreshToken: "x" }));
+	await expect(readStoredAccount(stateDir, fakeSafeStorage())).resolves.toBeNull();
+});
+
+test("a stored token that cannot be decrypted here fails loudly", async () => {
+	await writeStoredAccount(stateDir, fakeSafeStorage(), { account, refreshToken: "rt_secret" });
+	await expect(readStoredAccount(stateDir, fakeSafeStorage(false))).rejects.toThrow(SAFE_STORAGE_UNAVAILABLE_MESSAGE);
+
+	const broken: SafeStorageLike = {
+		isEncryptionAvailable: () => true,
+		encryptString: () => Buffer.from(""),
+		decryptString: () => {
+			throw new Error("keychain says no");
+		},
+	};
+	await expect(readStoredAccount(stateDir, broken)).rejects.toThrow(/could not be decrypted/);
+});
+
+test("sign-out deletes the token file, and is fine when there is none", async () => {
+	const safeStorage = fakeSafeStorage();
+	await writeStoredAccount(stateDir, safeStorage, { account, refreshToken: "rt_secret" });
+	await clearStoredAccount(stateDir);
+	await expect(readFile(path.join(stateDir, AO_ACCOUNT_FILE_NAME), "utf8")).rejects.toThrow();
+	await expect(readStoredAccount(stateDir, safeStorage)).resolves.toBeNull();
+	await expect(clearStoredAccount(stateDir)).resolves.toBeUndefined();
+});

--- a/frontend/src/main/ao-account-store.ts
+++ b/frontend/src/main/ao-account-store.ts
@@ -96,7 +96,9 @@ export async function readStoredAccount(
  *
  * Also the seam the refresh exchange writes through: the refresh token rotates on
  * every use (controlplane/TOKEN_CONTRACT.md), so the replacement must land here or
- * the next refresh replays a revoked token.
+ * the next refresh replays a revoked token. Only the refresh token belongs on disk;
+ * access tokens are short-lived, audience-scoped, and not stored here at all (see
+ * docs/desktop-login-contract.md).
  */
 export async function writeStoredAccount(
 	stateDir: string,

--- a/frontend/src/main/ao-account-store.ts
+++ b/frontend/src/main/ao-account-store.ts
@@ -1,0 +1,127 @@
+import { mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+import type { AoAccount } from "../shared/ao-account";
+
+/**
+ * The signed-in AO account plus its refresh token, on disk under the ~/.ao state
+ * dir (never an OS default app-data location, see the hard rule in AGENTS.md).
+ *
+ * The refresh token is encrypted with Electron `safeStorage`, which is backed by
+ * the macOS Keychain, libsecret on Linux, and DPAPI on Windows. The account id and
+ * email are stored in the clear: they are identity, not a credential, and keeping
+ * them readable means the signed-in row can render without a keychain unlock.
+ */
+
+/** File under the ~/.ao state dir, beside app-state.json and update-settings.json. */
+export const AO_ACCOUNT_FILE_NAME = "ao-account.json";
+
+const SCHEMA_VERSION = 1;
+
+export const SAFE_STORAGE_UNAVAILABLE_MESSAGE =
+	"This system has no OS credential store available, so the AO refresh token cannot be " +
+	"encrypted. Signing in would mean writing a long-lived credential to disk in plaintext, " +
+	"which the app will not do. On Linux, install and run a Secret Service provider (for " +
+	"example gnome-keyring or kwallet), then restart the app. Local mode needs no account.";
+
+/** The subset of Electron's safeStorage this module needs, so tests can fake it. */
+export type SafeStorageLike = {
+	isEncryptionAvailable: () => boolean;
+	encryptString: (plainText: string) => Buffer;
+	decryptString: (encrypted: Buffer) => string;
+};
+
+export type StoredAoAccount = {
+	account: AoAccount;
+	refreshToken: string;
+};
+
+type AccountFile = {
+	version: number;
+	accountId: string;
+	email: string;
+	/** base64 of safeStorage.encryptString(refreshToken). */
+	refreshToken: string;
+};
+
+function accountFilePath(stateDir: string): string {
+	return path.join(stateDir, AO_ACCOUNT_FILE_NAME);
+}
+
+/**
+ * Read the stored sign-in. Returns null when there is nothing stored.
+ *
+ * Throws when a stored token exists but cannot be decrypted (no credential store,
+ * or a keychain the OS re-keyed). The caller surfaces that as signed-out with the
+ * reason instead of pretending the file is absent.
+ */
+export async function readStoredAccount(
+	stateDir: string,
+	safeStorage: SafeStorageLike,
+): Promise<StoredAoAccount | null> {
+	let raw: string;
+	try {
+		raw = await readFile(accountFilePath(stateDir), "utf8");
+	} catch {
+		return null;
+	}
+
+	let parsed: Partial<AccountFile>;
+	try {
+		parsed = JSON.parse(raw) as Partial<AccountFile>;
+	} catch {
+		return null;
+	}
+	if (parsed.version !== SCHEMA_VERSION) return null;
+	const { accountId, email, refreshToken } = parsed;
+	if (typeof accountId !== "string" || !accountId) return null;
+	if (typeof email !== "string") return null;
+	if (typeof refreshToken !== "string" || !refreshToken) return null;
+
+	if (!safeStorage.isEncryptionAvailable()) throw new Error(SAFE_STORAGE_UNAVAILABLE_MESSAGE);
+
+	let decrypted: string;
+	try {
+		decrypted = safeStorage.decryptString(Buffer.from(refreshToken, "base64"));
+	} catch {
+		throw new Error("The stored AO sign-in could not be decrypted on this machine. Sign in again.");
+	}
+	if (!decrypted) throw new Error("The stored AO sign-in was empty. Sign in again.");
+
+	return { account: { id: accountId, email }, refreshToken: decrypted };
+}
+
+/**
+ * Persist the account and its refresh token. Refuses to write anything when
+ * encryption is unavailable, rather than falling back to plaintext.
+ *
+ * Also the seam the refresh exchange writes through: the refresh token rotates on
+ * every use (controlplane/TOKEN_CONTRACT.md), so the replacement must land here or
+ * the next refresh replays a revoked token.
+ */
+export async function writeStoredAccount(
+	stateDir: string,
+	safeStorage: SafeStorageLike,
+	stored: StoredAoAccount,
+): Promise<void> {
+	if (!stored.refreshToken) throw new Error("Refusing to store an empty AO refresh token.");
+	if (!safeStorage.isEncryptionAvailable()) throw new Error(SAFE_STORAGE_UNAVAILABLE_MESSAGE);
+
+	const file: AccountFile = {
+		version: SCHEMA_VERSION,
+		accountId: stored.account.id,
+		email: stored.account.email,
+		refreshToken: safeStorage.encryptString(stored.refreshToken).toString("base64"),
+	};
+
+	// Atomic write, mirroring app-state.json: a temp file in the same dir then a
+	// rename, so a reader never sees a half-written credential.
+	await mkdir(stateDir, { recursive: true, mode: 0o750 });
+	const tmp = path.join(stateDir, `.ao-account-${process.pid}.json`);
+	await writeFile(tmp, `${JSON.stringify(file, null, 2)}\n`, { mode: 0o600 });
+	await rename(tmp, accountFilePath(stateDir));
+}
+
+/** Sign-out: delete the stored token. Absent file is success, not an error. */
+export async function clearStoredAccount(stateDir: string): Promise<void> {
+	await rm(accountFilePath(stateDir), { force: true });
+}

--- a/frontend/src/main/ao-account.test.ts
+++ b/frontend/src/main/ao-account.test.ts
@@ -1,0 +1,198 @@
+// @vitest-environment node
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+import { createAoAccountController, type AoAccountControllerDeps } from "./ao-account";
+import { AO_ACCOUNT_FILE_NAME, type SafeStorageLike } from "./ao-account-store";
+import { codeChallenge } from "./ao-pkce";
+import type { LoopbackCallback } from "./loopback-callback";
+
+const account = { id: "acct_1", email: "dev@example.com" };
+
+function fakeSafeStorage(available = true): SafeStorageLike {
+	return {
+		isEncryptionAvailable: () => available,
+		encryptString: (plain) => Buffer.from(Array.from(Buffer.from(plain, "utf8"), (b) => b ^ 0x5a)),
+		decryptString: (cipher) => Buffer.from(Array.from(cipher, (b) => b ^ 0x5a)).toString("utf8"),
+	};
+}
+
+/** A loopback listener that reports a code without any browser or socket. */
+function fakeCallback(result: Promise<string> | string): (state: string) => Promise<LoopbackCallback> {
+	return async () => ({
+		redirectUri: "http://127.0.0.1:51234/callback",
+		code: typeof result === "string" ? Promise.resolve(result) : result,
+		close: () => undefined,
+	});
+}
+
+let stateDir = "";
+let opened: string[] = [];
+
+function deps(overrides: Partial<AoAccountControllerDeps> = {}): AoAccountControllerDeps {
+	return {
+		stateDir,
+		env: {},
+		safeStorage: fakeSafeStorage(),
+		openExternal: async (url) => {
+			opened.push(url);
+		},
+		startCallback: fakeCallback("code_abc"),
+		fetchImpl: async () =>
+			new Response(JSON.stringify({ refresh_token: "rt_secret", account }), {
+				status: 200,
+				headers: { "content-type": "application/json" },
+			}),
+		...overrides,
+	};
+}
+
+beforeEach(async () => {
+	stateDir = await mkdtemp(path.join(os.tmpdir(), "ao-account-ctl-"));
+	opened = [];
+});
+afterEach(async () => {
+	await rm(stateDir, { recursive: true, force: true });
+});
+
+test("a fresh install is signed out, and says which control plane it trusts", async () => {
+	const controller = createAoAccountController(deps());
+	await expect(controller.getState()).resolves.toEqual({
+		status: "signed-out",
+		controlPlaneUrl: "https://ao.agentlab.in",
+	});
+});
+
+test("sign-in opens the system browser, exchanges the code with PKCE, and stores the token", async () => {
+	const fetchImpl = vi.fn(deps().fetchImpl as typeof fetch);
+	const controller = createAoAccountController(deps({ env: { AO_CONTROL_URL: "http://127.0.0.1:8080" }, fetchImpl }));
+
+	await expect(controller.signIn()).resolves.toEqual({
+		status: "signed-in",
+		controlPlaneUrl: "http://127.0.0.1:8080",
+		account,
+	});
+
+	// Exactly one authorization URL, opened externally, against the dev control plane.
+	expect(opened).toHaveLength(1);
+	const authorize = new URL(opened[0]);
+	expect(authorize.origin + authorize.pathname).toBe("http://127.0.0.1:8080/oauth/desktop/authorize");
+	expect(authorize.searchParams.get("code_challenge_method")).toBe("S256");
+	const state = authorize.searchParams.get("state") ?? "";
+	expect(state).not.toBe("");
+
+	const [url, init] = fetchImpl.mock.calls[0] as [string, RequestInit];
+	expect(url).toBe("http://127.0.0.1:8080/oauth/desktop/token");
+	const body = new URLSearchParams(String(init.body));
+	expect(body.get("grant_type")).toBe("authorization_code");
+	expect(body.get("code")).toBe("code_abc");
+	expect(body.get("redirect_uri")).toBe("http://127.0.0.1:51234/callback");
+	// The verifier sent to the token endpoint is the pre-image of the challenge the
+	// browser was sent, which is the whole point of PKCE.
+	expect(codeChallenge(body.get("code_verifier") ?? "")).toBe(authorize.searchParams.get("code_challenge"));
+
+	// Persisted, encrypted, and readable again through a new controller.
+	const raw = await readFile(path.join(stateDir, AO_ACCOUNT_FILE_NAME), "utf8");
+	expect(raw).not.toContain("rt_secret");
+	await expect(createAoAccountController(deps()).getState()).resolves.toMatchObject({ status: "signed-in", account });
+});
+
+test("sign-out discards the stored refresh token, not just the UI state", async () => {
+	const controller = createAoAccountController(deps());
+	await controller.signIn();
+	await expect(controller.signOut()).resolves.toEqual({
+		status: "signed-out",
+		controlPlaneUrl: "https://ao.agentlab.in",
+	});
+	await expect(readFile(path.join(stateDir, AO_ACCOUNT_FILE_NAME), "utf8")).rejects.toThrow();
+	// A new controller cannot resurrect it either: the credential is gone from disk.
+	await expect(createAoAccountController(deps()).getState()).resolves.toMatchObject({ status: "signed-out" });
+});
+
+test("a rejected callback leaves the app signed out with the reason", async () => {
+	const controller = createAoAccountController(
+		deps({ startCallback: async () => ({
+			redirectUri: "http://127.0.0.1:51234/callback",
+			code: Promise.reject(new Error("The sign-in callback did not match this request and was rejected.")),
+			close: () => undefined,
+		}) }),
+	);
+	const state = await controller.signIn();
+	expect(state.status).toBe("signed-out");
+	expect(state.error).toMatch(/did not match/);
+	await expect(readFile(path.join(stateDir, AO_ACCOUNT_FILE_NAME), "utf8")).rejects.toThrow();
+});
+
+test("an unreachable control plane is reported plainly and points at local mode", async () => {
+	const controller = createAoAccountController(
+		deps({
+			fetchImpl: async () => {
+				throw new Error("ECONNREFUSED");
+			},
+		}),
+	);
+	const state = await controller.signIn();
+	expect(state.status).toBe("signed-out");
+	expect(state.error).toMatch(/Could not reach the AO control plane/);
+	expect(state.error).toMatch(/local mode/);
+});
+
+test("an OAuth error from the token endpoint surfaces its description", async () => {
+	const controller = createAoAccountController(
+		deps({
+			fetchImpl: async () =>
+				new Response(JSON.stringify({ error: "invalid_grant", error_description: "code already used" }), {
+					status: 400,
+					headers: { "content-type": "application/json" },
+				}),
+		}),
+	);
+	await expect(controller.signIn()).resolves.toMatchObject({
+		status: "signed-out",
+		error: "Sign-in failed: code already used",
+	});
+});
+
+test("no OS credential store means sign-in fails loudly and no browser is opened", async () => {
+	const controller = createAoAccountController(deps({ safeStorage: fakeSafeStorage(false) }));
+	const state = await controller.signIn();
+	expect(state.status).toBe("unavailable");
+	expect(state.error).toMatch(/plaintext/);
+	expect(opened).toEqual([]);
+});
+
+test("an unusable AO_CONTROL_URL blocks sign-in instead of falling back to production", async () => {
+	const controller = createAoAccountController(deps({ env: { AO_CONTROL_URL: "http://ao.agentlab.in" } }));
+	await expect(controller.getState()).resolves.toMatchObject({ status: "unavailable" });
+	const state = await controller.signIn();
+	expect(state.status).toBe("unavailable");
+	expect(opened).toEqual([]);
+});
+
+test("a second sign-in click joins the attempt already in flight", async () => {
+	let release: (code: string) => void = () => undefined;
+	const pending = new Promise<string>((resolve) => {
+		release = resolve;
+	});
+	const controller = createAoAccountController(deps({ startCallback: fakeCallback(pending) }));
+
+	const first = controller.signIn();
+	// Give the flow a turn to open the browser before the second click lands.
+	await Promise.resolve();
+	const second = controller.signIn();
+	await expect(controller.getState()).resolves.toMatchObject({ status: "signing-in" });
+
+	release("code_abc");
+	await expect(first).resolves.toMatchObject({ status: "signed-in" });
+	await expect(second).resolves.toMatchObject({ status: "signed-in" });
+	// One browser tab, one state, one exchange.
+	expect(opened).toHaveLength(1);
+});
+
+test("with no resolvable ~/.ao state dir, sign-in is unavailable rather than silent", async () => {
+	const controller = createAoAccountController(deps({ stateDir: null }));
+	await expect(controller.getState()).resolves.toMatchObject({ status: "unavailable" });
+	await expect(controller.signIn()).resolves.toMatchObject({ status: "unavailable" });
+	expect(opened).toEqual([]);
+});

--- a/frontend/src/main/ao-account.ts
+++ b/frontend/src/main/ao-account.ts
@@ -123,6 +123,8 @@ export function createAoAccountController(deps: AoAccountControllerDeps): AoAcco
 			lastError = null;
 			// Discards the refresh token itself, not just the UI flag. The control plane
 			// keeps its own revocation list; this end stops holding the credential.
+			// Nothing else is held: no access token of either audience is cached yet. When
+			// task 13 caches a control-plane-audience token, clear it here too.
 			if (deps.stateDir) await clearStoredAccount(deps.stateDir);
 			return currentState();
 		},

--- a/frontend/src/main/ao-account.ts
+++ b/frontend/src/main/ao-account.ts
@@ -1,0 +1,130 @@
+import type { AoAccountState } from "../shared/ao-account";
+import { readControlPlaneUrl } from "../shared/control-plane";
+import {
+	clearStoredAccount,
+	readStoredAccount,
+	SAFE_STORAGE_UNAVAILABLE_MESSAGE,
+	writeStoredAccount,
+	type SafeStorageLike,
+} from "./ao-account-store";
+import { runDesktopLogin, type DesktopLoginDeps } from "./ao-login";
+
+/**
+ * Main-process owner of the desktop app's AO sign-in state.
+ *
+ * Signing in is only ever needed to reach a remote machine. Local mode does not
+ * consult this at all, so nothing here gates app startup or the local daemon.
+ */
+
+export type AoAccountControllerDeps = {
+	/** The ~/.ao state dir, or null when the home dir is unresolvable. */
+	stateDir: string | null;
+	env: Record<string, string | undefined>;
+	safeStorage: SafeStorageLike;
+	openExternal: (url: string) => Promise<void>;
+	/** Test seams, forwarded to the login flow. */
+	startCallback?: DesktopLoginDeps["startCallback"];
+	fetchImpl?: typeof fetch;
+};
+
+export type AoAccountController = {
+	getState: () => Promise<AoAccountState>;
+	signIn: () => Promise<AoAccountState>;
+	signOut: () => Promise<AoAccountState>;
+};
+
+const errorMessage = (err: unknown): string => (err instanceof Error ? err.message : String(err));
+
+export function createAoAccountController(deps: AoAccountControllerDeps): AoAccountController {
+	// Resolved once: AO_CONTROL_URL selects which control plane to trust, and a bad
+	// value must be visible in the UI rather than silently falling back to production.
+	let configError: string | null = null;
+	let controlPlaneUrl = "";
+	try {
+		controlPlaneUrl = readControlPlaneUrl(deps.env);
+	} catch (err) {
+		configError = errorMessage(err);
+	}
+
+	let inFlight: Promise<AoAccountState> | null = null;
+	// Survives a failed attempt so the settings row can explain what went wrong.
+	let lastError: string | null = null;
+
+	const state = (status: AoAccountState["status"], extra?: Partial<AoAccountState>): AoAccountState => ({
+		status,
+		controlPlaneUrl,
+		...extra,
+	});
+
+	async function currentState(): Promise<AoAccountState> {
+		if (configError) return state("unavailable", { error: configError });
+		if (!deps.stateDir) {
+			return state("unavailable", { error: "Could not resolve the ~/.ao state directory, so sign-in cannot be stored." });
+		}
+		if (inFlight) return state("signing-in");
+		try {
+			const stored = await readStoredAccount(deps.stateDir, deps.safeStorage);
+			if (!stored) return state("signed-out", lastError ? { error: lastError } : undefined);
+			return state("signed-in", { account: stored.account });
+		} catch (err) {
+			// A stored token that cannot be decrypted, or no credential store at all.
+			// Signed-out with the reason: the app never falls back to plaintext.
+			return state(deps.safeStorage.isEncryptionAvailable() ? "signed-out" : "unavailable", {
+				error: errorMessage(err),
+			});
+		}
+	}
+
+	async function performSignIn(stateDir: string): Promise<AoAccountState> {
+		// Checked before opening a browser: on a system with no credential store there
+		// is nowhere to put the refresh token, so failing here beats failing after the
+		// user has already signed in with Google.
+		if (!deps.safeStorage.isEncryptionAvailable()) {
+			return state("unavailable", { error: SAFE_STORAGE_UNAVAILABLE_MESSAGE });
+		}
+		const stored = await runDesktopLogin({
+			controlPlaneUrl,
+			openExternal: deps.openExternal,
+			startCallback: deps.startCallback,
+			fetchImpl: deps.fetchImpl,
+		});
+		await writeStoredAccount(stateDir, deps.safeStorage, stored);
+		return state("signed-in", { account: stored.account });
+	}
+
+	return {
+		getState: currentState,
+
+		async signIn(): Promise<AoAccountState> {
+			if (configError) return state("unavailable", { error: configError });
+			if (!deps.stateDir) return currentState();
+			// One login at a time: a second click joins the running attempt instead of
+			// opening a second browser tab with a second state.
+			if (inFlight) return inFlight;
+			const stateDir = deps.stateDir;
+			// Deferred by one microtask so `inFlight` is assigned before the body can
+			// clear it, whatever the flow does.
+			const attempt = Promise.resolve().then(async () => {
+				try {
+					lastError = null;
+					return await performSignIn(stateDir);
+				} catch (err) {
+					lastError = errorMessage(err);
+					return state("signed-out", { error: lastError });
+				} finally {
+					inFlight = null;
+				}
+			});
+			inFlight = attempt;
+			return attempt;
+		},
+
+		async signOut(): Promise<AoAccountState> {
+			lastError = null;
+			// Discards the refresh token itself, not just the UI flag. The control plane
+			// keeps its own revocation list; this end stops holding the credential.
+			if (deps.stateDir) await clearStoredAccount(deps.stateDir);
+			return currentState();
+		},
+	};
+}

--- a/frontend/src/main/ao-login.ts
+++ b/frontend/src/main/ao-login.ts
@@ -1,0 +1,131 @@
+import type { AoAccount } from "../shared/ao-account";
+import {
+	buildAuthorizeUrl,
+	codeChallenge,
+	createCodeVerifier,
+	createState,
+	DESKTOP_CLIENT_ID,
+	describeOauthError,
+	TOKEN_PATH,
+} from "./ao-pkce";
+import { startLoopbackCallback, type LoopbackCallback } from "./loopback-callback";
+import type { StoredAoAccount } from "./ao-account-store";
+
+/**
+ * The desktop sign-in flow: system browser, PKCE, loopback redirect (RFC 8252).
+ *
+ * Google blocks OAuth in embedded webviews, so the browser here is always the
+ * user's real browser via shell.openExternal. There is no in-app BrowserWindow
+ * login and no path that skips this exchange.
+ *
+ * Contract with the control plane: docs/desktop-login-contract.md.
+ */
+
+export type DesktopLoginDeps = {
+	controlPlaneUrl: string;
+	openExternal: (url: string) => Promise<void>;
+	/** Injected for tests; defaults to the real loopback listener. */
+	startCallback?: (expectedState: string) => Promise<LoopbackCallback>;
+	fetchImpl?: typeof fetch;
+};
+
+type TokenResponse = {
+	refresh_token?: unknown;
+	account?: { id?: unknown; email?: unknown };
+	error?: unknown;
+	error_description?: unknown;
+};
+
+export async function runDesktopLogin(deps: DesktopLoginDeps): Promise<StoredAoAccount> {
+	const verifier = createCodeVerifier();
+	const state = createState();
+	const startCallback = deps.startCallback ?? startLoopbackCallback;
+	const callback = await startCallback(state);
+
+	try {
+		await deps.openExternal(
+			buildAuthorizeUrl({
+				controlPlaneUrl: deps.controlPlaneUrl,
+				redirectUri: callback.redirectUri,
+				codeChallenge: codeChallenge(verifier),
+				state,
+			}),
+		);
+		const code = await callback.code;
+		return await exchangeCode({
+			controlPlaneUrl: deps.controlPlaneUrl,
+			code,
+			codeVerifier: verifier,
+			redirectUri: callback.redirectUri,
+			fetchImpl: deps.fetchImpl ?? fetch,
+		});
+	} finally {
+		// The listener closes itself on a delivered callback; this covers the abort
+		// paths (openExternal failed, exchange threw) so no port is left bound.
+		callback.close();
+	}
+}
+
+type ExchangeInput = {
+	controlPlaneUrl: string;
+	code: string;
+	codeVerifier: string;
+	redirectUri: string;
+	fetchImpl: typeof fetch;
+};
+
+async function exchangeCode(input: ExchangeInput): Promise<StoredAoAccount> {
+	const body = new URLSearchParams({
+		grant_type: "authorization_code",
+		client_id: DESKTOP_CLIENT_ID,
+		code: input.code,
+		code_verifier: input.codeVerifier,
+		redirect_uri: input.redirectUri,
+	});
+
+	let response: Response;
+	try {
+		response = await input.fetchImpl(`${input.controlPlaneUrl}${TOKEN_PATH}`, {
+			method: "POST",
+			headers: { "content-type": "application/x-www-form-urlencoded", accept: "application/json" },
+			body: body.toString(),
+		});
+	} catch {
+		// Spec: control plane unreachable at login is reported plainly, and local
+		// mode still works without it.
+		throw new Error(
+			`Could not reach the AO control plane at ${input.controlPlaneUrl}. Check your connection, or keep working in local mode, which needs no account.`,
+		);
+	}
+
+	let payload: TokenResponse = {};
+	try {
+		payload = (await response.json()) as TokenResponse;
+	} catch {
+		// Fall through to the status-based message below.
+	}
+
+	if (!response.ok) {
+		if (typeof payload.error === "string") {
+			throw new Error(
+				describeOauthError(payload.error, typeof payload.error_description === "string" ? payload.error_description : null),
+			);
+		}
+		throw new Error(`The AO control plane rejected the sign-in (HTTP ${response.status}).`);
+	}
+
+	const refreshToken = typeof payload.refresh_token === "string" ? payload.refresh_token : "";
+	const account = readAccount(payload.account);
+	if (!refreshToken || !account) {
+		throw new Error("The AO control plane returned an unexpected sign-in response.");
+	}
+	return { account, refreshToken };
+}
+
+function readAccount(raw: TokenResponse["account"]): AoAccount | null {
+	if (!raw || typeof raw !== "object") return null;
+	const id = typeof raw.id === "string" ? raw.id : "";
+	const email = typeof raw.email === "string" ? raw.email : "";
+	if (!id) return null;
+	return { id, email };
+}

--- a/frontend/src/main/ao-pkce.test.ts
+++ b/frontend/src/main/ao-pkce.test.ts
@@ -1,0 +1,73 @@
+// @vitest-environment node
+import { createHash } from "node:crypto";
+import { expect, test } from "vitest";
+import {
+	buildAuthorizeUrl,
+	codeChallenge,
+	createCodeVerifier,
+	createState,
+	DESKTOP_CLIENT_ID,
+	parseCallback,
+} from "./ao-pkce";
+
+test("verifier and state are unguessable, distinct, and URL-safe", () => {
+	const verifiers = new Set(Array.from({ length: 50 }, () => createCodeVerifier()));
+	expect(verifiers.size).toBe(50);
+	for (const verifier of verifiers) {
+		// 32 CSPRNG bytes as base64url: 43 chars, inside RFC 7636's 43..128 range.
+		expect(verifier).toMatch(/^[A-Za-z0-9_-]{43}$/);
+	}
+	expect(new Set(Array.from({ length: 50 }, () => createState())).size).toBe(50);
+	expect(createState()).toMatch(/^[A-Za-z0-9_-]{43}$/);
+});
+
+test("challenge is base64url(SHA-256(verifier)), not the verifier itself", () => {
+	const verifier = createCodeVerifier();
+	const challenge = codeChallenge(verifier);
+	expect(challenge).toBe(createHash("sha256").update(verifier).digest("base64url"));
+	expect(challenge).not.toBe(verifier);
+});
+
+test("authorize URL carries S256 PKCE, the loopback redirect, and state", () => {
+	const url = new URL(
+		buildAuthorizeUrl({
+			controlPlaneUrl: "http://127.0.0.1:8080",
+			redirectUri: "http://127.0.0.1:51234/callback",
+			codeChallenge: "chal",
+			state: "st",
+		}),
+	);
+	expect(url.origin + url.pathname).toBe("http://127.0.0.1:8080/oauth/desktop/authorize");
+	expect(Object.fromEntries(url.searchParams)).toEqual({
+		response_type: "code",
+		client_id: DESKTOP_CLIENT_ID,
+		redirect_uri: "http://127.0.0.1:51234/callback",
+		code_challenge: "chal",
+		code_challenge_method: "S256",
+		state: "st",
+	});
+});
+
+test("a matching callback yields the code", () => {
+	expect(parseCallback("/callback?code=abc&state=st", "st")).toEqual({ code: "abc" });
+});
+
+test("a callback whose state does not match is rejected, not exchanged", () => {
+	expect(parseCallback("/callback?code=abc&state=other", "st")).toEqual({
+		error: expect.stringContaining("did not match"),
+	});
+	// A missing state is a mismatch too, and an empty expectation never matches.
+	expect(parseCallback("/callback?code=abc", "st")).toEqual({ error: expect.stringContaining("did not match") });
+	expect(parseCallback("/callback?code=abc&state=", "")).toEqual({ error: expect.stringContaining("did not match") });
+});
+
+test("an OAuth error is reported, and access_denied reads as a decline", () => {
+	expect(parseCallback("/callback?error=access_denied&state=st", "st")).toEqual({ error: "Sign-in was declined." });
+	expect(parseCallback("/callback?error=server_error&error_description=boom&state=st", "st")).toEqual({
+		error: "Sign-in failed: boom",
+	});
+});
+
+test("a state-matching callback with no code is rejected", () => {
+	expect(parseCallback("/callback?state=st", "st")).toEqual({ error: expect.stringContaining("no authorization code") });
+});

--- a/frontend/src/main/ao-pkce.ts
+++ b/frontend/src/main/ao-pkce.ts
@@ -1,0 +1,94 @@
+import { createHash, randomBytes } from "node:crypto";
+
+/**
+ * PKCE (RFC 7636) and authorization-request helpers for the desktop login flow.
+ *
+ * The desktop app is a public client: it ships no secret, so the code challenge
+ * plus the `state` check are the whole defence against another local process
+ * stealing the authorization code off the loopback redirect.
+ *
+ * Nothing in this module logs. The verifier and the code are secrets for the
+ * length of one exchange and must never reach stdout, a log file, or telemetry.
+ */
+
+/** The client id the control plane knows the desktop app by. Public, not a secret. */
+export const DESKTOP_CLIENT_ID = "ao-desktop";
+
+/** Authorization endpoint on the control plane (see docs/desktop-login-contract.md). */
+export const AUTHORIZE_PATH = "/oauth/desktop/authorize";
+/** Token endpoint on the control plane. */
+export const TOKEN_PATH = "/oauth/desktop/token";
+
+const VERIFIER_BYTES = 32;
+const STATE_BYTES = 32;
+
+/** 43-char base64url verifier from 32 CSPRNG bytes, the RFC 7636 recommendation. */
+export function createCodeVerifier(): string {
+	return randomBytes(VERIFIER_BYTES).toString("base64url");
+}
+
+/** Opaque CSPRNG `state`, bound to this one authorization request. */
+export function createState(): string {
+	return randomBytes(STATE_BYTES).toString("base64url");
+}
+
+/** S256 challenge: base64url(SHA-256(verifier)). `plain` is never used. */
+export function codeChallenge(verifier: string): string {
+	return createHash("sha256").update(verifier).digest("base64url");
+}
+
+export type AuthorizeUrlInput = {
+	controlPlaneUrl: string;
+	redirectUri: string;
+	codeChallenge: string;
+	state: string;
+};
+
+export function buildAuthorizeUrl(input: AuthorizeUrlInput): string {
+	const url = new URL(AUTHORIZE_PATH, `${input.controlPlaneUrl}/`);
+	url.search = new URLSearchParams({
+		response_type: "code",
+		client_id: DESKTOP_CLIENT_ID,
+		redirect_uri: input.redirectUri,
+		code_challenge: input.codeChallenge,
+		code_challenge_method: "S256",
+		state: input.state,
+	}).toString();
+	return url.toString();
+}
+
+export type CallbackResult = { code: string } | { error: string };
+
+/**
+ * Validate a loopback callback. `state` is checked before anything else is read,
+ * so a callback that did not come from our own authorization request is rejected
+ * rather than exchanged.
+ */
+export function parseCallback(rawUrl: string, expectedState: string): CallbackResult {
+	let params: URLSearchParams;
+	try {
+		params = new URL(rawUrl, "http://127.0.0.1").searchParams;
+	} catch {
+		return { error: "The sign-in callback URL was malformed." };
+	}
+
+	const state = params.get("state") ?? "";
+	if (!expectedState || state !== expectedState) {
+		return { error: "The sign-in callback did not match this request and was rejected." };
+	}
+
+	const oauthError = params.get("error");
+	if (oauthError) {
+		return { error: describeOauthError(oauthError, params.get("error_description")) };
+	}
+
+	const code = params.get("code") ?? "";
+	if (!code) return { error: "The sign-in callback carried no authorization code." };
+	return { code };
+}
+
+export function describeOauthError(error: string, description?: string | null): string {
+	if (error === "access_denied") return "Sign-in was declined.";
+	const detail = description?.trim();
+	return detail ? `Sign-in failed: ${detail}` : `Sign-in failed (${error}).`;
+}

--- a/frontend/src/main/loopback-callback.test.ts
+++ b/frontend/src/main/loopback-callback.test.ts
@@ -1,0 +1,57 @@
+// @vitest-environment node
+import { expect, test } from "vitest";
+import { startLoopbackCallback } from "./loopback-callback";
+
+// These hit a real listener, but it is this process's own loopback socket on an
+// ephemeral port, the same shape as a Go httptest server. No external network.
+async function get(url: string): Promise<{ status: number; body: string }> {
+	const res = await fetch(url);
+	return { status: res.status, body: await res.text() };
+}
+
+test("binds loopback on an ephemeral port and hands back the matching code", async () => {
+	const callback = await startLoopbackCallback("st");
+	const redirect = new URL(callback.redirectUri);
+	expect(redirect.hostname).toBe("127.0.0.1");
+	expect(Number(redirect.port)).toBeGreaterThan(0);
+	expect(redirect.pathname).toBe("/callback");
+
+	const page = await get(`${callback.redirectUri}?code=abc&state=st`);
+	expect(page.status).toBe(200);
+	await expect(callback.code).resolves.toBe("abc");
+
+	// Shut down immediately after the one callback it accepts.
+	await expect(fetch(callback.redirectUri)).rejects.toThrow();
+});
+
+test("rejects a callback whose state does not match and never resolves a code", async () => {
+	const callback = await startLoopbackCallback("st");
+	const page = await get(`${callback.redirectUri}?code=abc&state=forged`);
+	expect(page.status).toBe(400);
+	await expect(callback.code).rejects.toThrow(/did not match/);
+});
+
+test("ignores a request on any other path without consuming the one callback", async () => {
+	const callback = await startLoopbackCallback("st");
+	const origin = new URL(callback.redirectUri).origin;
+	expect((await get(`${origin}/favicon.ico`)).status).toBe(404);
+
+	const page = await get(`${callback.redirectUri}?code=abc&state=st`);
+	expect(page.status).toBe(200);
+	await expect(callback.code).resolves.toBe("abc");
+});
+
+test("times out rather than listening forever", async () => {
+	const callback = await startLoopbackCallback("st", 20);
+	await expect(callback.code).rejects.toThrow(/timed out/);
+	callback.close();
+});
+
+test("close() releases the port even when no callback ever arrives", async () => {
+	const callback = await startLoopbackCallback("st");
+	const url = callback.redirectUri;
+	callback.close();
+	await expect(fetch(url)).rejects.toThrow();
+	// Idempotent: the flow's finally block may close an already-closed listener.
+	expect(() => callback.close()).not.toThrow();
+});

--- a/frontend/src/main/loopback-callback.ts
+++ b/frontend/src/main/loopback-callback.ts
@@ -1,0 +1,102 @@
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import type { AddressInfo } from "node:net";
+import { parseCallback } from "./ao-pkce";
+
+/**
+ * The RFC 8252 loopback redirect receiver for desktop login.
+ *
+ * Binds 127.0.0.1 on an ephemeral port (never 0.0.0.0: the redirect is for this
+ * machine only), accepts exactly one callback, validates `state` before touching
+ * the code, and shuts down immediately afterwards so nothing is left listening.
+ */
+
+export const CALLBACK_PATH = "/callback";
+
+/** How long the browser has to come back before the listener gives up. */
+export const CALLBACK_TIMEOUT_MS = 5 * 60 * 1000;
+
+export type LoopbackCallback = {
+	/** The exact redirect_uri to send in the authorization request. */
+	redirectUri: string;
+	/** Resolves with the authorization code, rejects on a bad or absent callback. */
+	code: Promise<string>;
+	/** Idempotent. Safe to call after the callback has already closed the listener. */
+	close: () => void;
+};
+
+const PAGE = (heading: string, body: string) =>
+	`<!doctype html><meta charset="utf-8"><title>${heading}</title>` +
+	`<body style="font:15px system-ui;margin:14vh auto;max-width:26rem;text-align:center">` +
+	`<h1 style="font-size:1.1rem">${heading}</h1><p style="color:#666">${body}</p></body>`;
+
+function respond(res: ServerResponse, status: number, heading: string, body: string): void {
+	res.writeHead(status, { "content-type": "text/html; charset=utf-8", connection: "close" });
+	res.end(PAGE(heading, body));
+}
+
+export async function startLoopbackCallback(
+	expectedState: string,
+	timeoutMs = CALLBACK_TIMEOUT_MS,
+): Promise<LoopbackCallback> {
+	let settle: ((result: { code: string } | { error: Error }) => void) | null = null;
+	const code = new Promise<string>((resolve, reject) => {
+		settle = (result) => ("code" in result ? resolve(result.code) : reject(result.error));
+	});
+	// Swallow the rejection until the caller awaits `code`: the flow can reject
+	// while the caller is still awaiting the browser open.
+	code.catch(() => undefined);
+
+	let done = false;
+	const finish = (result: { code: string } | { error: Error }): void => {
+		if (done) return;
+		done = true;
+		clearTimeout(timer);
+		settle?.(result);
+		close();
+	};
+
+	const server = createServer((req: IncomingMessage, res: ServerResponse) => {
+		// One callback only. Anything else, including a favicon fetch or a second
+		// hit on an already-used code, gets 404 and changes no state.
+		const url = req.url ?? "";
+		if (done || !url.startsWith(CALLBACK_PATH)) {
+			respond(res, 404, "Not found", "This local sign-in listener has nothing to serve.");
+			return;
+		}
+		const result = parseCallback(url, expectedState);
+		if ("error" in result) {
+			respond(res, 400, "Sign-in was rejected", result.error);
+			finish({ error: new Error(result.error) });
+			return;
+		}
+		respond(res, 200, "You are signed in", "You can close this tab and go back to Agent Orchestrator.");
+		finish({ code: result.code });
+	});
+
+	const timer = setTimeout(() => {
+		finish({ error: new Error("Sign-in timed out waiting for the browser.") });
+	}, timeoutMs);
+	// Never hold app exit open on the login listener.
+	timer.unref?.();
+
+	function close(): void {
+		clearTimeout(timer);
+		// closeAllConnections drops the keep-alive socket the browser may still be
+		// holding, so the port is released now rather than whenever the browser lets go.
+		server.closeAllConnections?.();
+		server.close();
+	}
+
+	await new Promise<void>((resolve, reject) => {
+		server.once("error", reject);
+		server.listen(0, "127.0.0.1", resolve);
+	});
+
+	const address = server.address() as AddressInfo | null;
+	if (!address) {
+		close();
+		throw new Error("Could not open a local sign-in listener.");
+	}
+
+	return { redirectUri: `http://127.0.0.1:${address.port}${CALLBACK_PATH}`, code, close };
+}

--- a/frontend/src/preload.test.ts
+++ b/frontend/src/preload.test.ts
@@ -92,3 +92,16 @@ describe("preload application shortcut bridges", () => {
 		expect(electronMocks.off).toHaveBeenCalledWith(channel, wrapped);
 	});
 });
+
+describe("preload AO account bridge", () => {
+	it.each([
+		["aoAccount:getState", () => exposedBridge().account.getState()],
+		["aoAccount:signIn", () => exposedBridge().account.signIn()],
+		["aoAccount:signOut", () => exposedBridge().account.signOut()],
+	] as const)("invokes %s", async (channel, call) => {
+		// The main-process handler names are the contract here; a typo on either side
+		// would only ever surface at runtime.
+		await call();
+		expect(electronMocks.invoke).toHaveBeenCalledWith(channel);
+	});
+});

--- a/frontend/src/preload.ts
+++ b/frontend/src/preload.ts
@@ -1,6 +1,7 @@
 import { contextBridge, ipcRenderer } from "electron";
 import { FOCUS_TERMINAL_SHORTCUT_CHANNEL, KEYBOARD_SHORTCUTS_HELP_CHANNEL, NEXT_SESSION_SHORTCUT_CHANNEL, NEW_SESSION_SHORTCUT_CHANNEL, NEW_SHELL_TERMINAL_SHORTCUT_CHANNEL, OPEN_SETTINGS_SHORTCUT_CHANNEL, PREVIOUS_SESSION_SHORTCUT_CHANNEL } from "./shared/shortcuts";
 import type { BrowserNavState, BrowserRect } from "./main/browser-view-host";
+import type { AoAccountState } from "./shared/ao-account";
 import type { DaemonStatus } from "./shared/daemon-status";
 import type { TelemetryBootstrap } from "./shared/telemetry";
 import type { MigrationState } from "./main/app-state";
@@ -223,6 +224,14 @@ const api = {
 	featureBuilds: {
 		list: () => ipcRenderer.invoke("featureBuilds:list") as Promise<FeatureBuild[]>,
 		getActive: () => ipcRenderer.invoke("featureBuilds:getActive") as Promise<{ pr: number } | null>,
+	},
+	// AO account sign-in. The renderer only ever sees identity and status: the
+	// refresh token stays in the main process, encrypted on disk, and the whole
+	// PKCE exchange happens there too.
+	account: {
+		getState: () => ipcRenderer.invoke("aoAccount:getState") as Promise<AoAccountState>,
+		signIn: () => ipcRenderer.invoke("aoAccount:signIn") as Promise<AoAccountState>,
+		signOut: () => ipcRenderer.invoke("aoAccount:signOut") as Promise<AoAccountState>,
 	},
 };
 

--- a/frontend/src/renderer/components/GlobalSettingsForm.tsx
+++ b/frontend/src/renderer/components/GlobalSettingsForm.tsx
@@ -2,6 +2,7 @@ import { useNavigate } from "@tanstack/react-router";
 import { useState } from "react";
 import { Mail } from "lucide-react";
 import { ConnectMobileModal } from "./ConnectMobileModal";
+import { AccountSection } from "./settings/AccountSection";
 import { DeveloperModeSection } from "./settings/DeveloperModeSection";
 import { GeneralSettingsSection } from "./settings/GeneralSettingsSection";
 import { ReportProblemDialog } from "./settings/ReportProblemDialog";
@@ -21,6 +22,7 @@ export function GlobalSettingsForm() {
 			<SettingsPageShell>
 				<SettingsPanel onClose={() => navigate({ to: "/" })}>
 					<GeneralSettingsSection onConnectMobile={() => setMobileOpen(true)} />
+					<AccountSection />
 					<UpdatesSection />
 					<DeveloperModeSection />
 					<SettingsSection title="Get help">

--- a/frontend/src/renderer/components/settings/AccountSection.test.tsx
+++ b/frontend/src/renderer/components/settings/AccountSection.test.tsx
@@ -1,0 +1,86 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, expect, test, vi } from "vitest";
+import type { AoAccountState } from "../../../shared/ao-account";
+import { AccountSection } from "./AccountSection";
+
+const { getState, signIn, signOut } = vi.hoisted(() => ({
+	getState: vi.fn(),
+	signIn: vi.fn(),
+	signOut: vi.fn(),
+}));
+
+vi.mock("../../lib/bridge", () => ({
+	aoBridge: { account: { getState, signIn, signOut } },
+}));
+
+const SIGNED_OUT: AoAccountState = { status: "signed-out", controlPlaneUrl: "https://ao.agentlab.in" };
+const SIGNED_IN: AoAccountState = {
+	status: "signed-in",
+	controlPlaneUrl: "https://ao.agentlab.in",
+	account: { id: "acct_1", email: "dev@example.com" },
+};
+
+function renderSection() {
+	const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+	return render(
+		<QueryClientProvider client={client}>
+			<AccountSection />
+		</QueryClientProvider>,
+	);
+}
+
+beforeEach(() => {
+	getState.mockReset().mockResolvedValue(SIGNED_OUT);
+	signIn.mockReset().mockResolvedValue(SIGNED_IN);
+	signOut.mockReset().mockResolvedValue(SIGNED_OUT);
+});
+
+test("signed out offers sign-in and says an account is not needed locally", async () => {
+	renderSection();
+	expect(await screen.findByText("Not signed in")).toBeInTheDocument();
+	expect(screen.getByText(/works without an account/i)).toBeInTheDocument();
+
+	await userEvent.click(screen.getByRole("button", { name: /sign in/i }));
+	expect(signIn).toHaveBeenCalledTimes(1);
+	expect(await screen.findByText("dev@example.com")).toBeInTheDocument();
+	expect(screen.getByRole("button", { name: /sign out/i })).toBeInTheDocument();
+});
+
+test("signed in shows the account and signs out through the bridge", async () => {
+	getState.mockResolvedValue(SIGNED_IN);
+	renderSection();
+	await userEvent.click(await screen.findByRole("button", { name: /sign out/i }));
+	expect(signOut).toHaveBeenCalledTimes(1);
+	expect(await screen.findByText("Not signed in")).toBeInTheDocument();
+});
+
+test("a failed sign-in shows the reason and keeps the sign-in button", async () => {
+	signIn.mockResolvedValue({
+		...SIGNED_OUT,
+		error: "Could not reach the AO control plane at https://ao.agentlab.in.",
+	} satisfies AoAccountState);
+	renderSection();
+	await userEvent.click(await screen.findByRole("button", { name: /sign in/i }));
+	expect(await screen.findByTestId("ao-account-error")).toHaveTextContent(/Could not reach the AO control plane/);
+	expect(screen.getByRole("button", { name: /sign in/i })).toBeEnabled();
+});
+
+test("no credential store disables sign-in and explains why", async () => {
+	getState.mockResolvedValue({
+		status: "unavailable",
+		controlPlaneUrl: "https://ao.agentlab.in",
+		error: "This system has no OS credential store available.",
+	} satisfies AoAccountState);
+	renderSection();
+	expect(await screen.findByTestId("ao-account-error")).toHaveTextContent(/no OS credential store/);
+	expect(screen.getByRole("button", { name: /sign in/i })).toBeDisabled();
+	expect(signIn).not.toHaveBeenCalled();
+});
+
+test("a development control plane is named in the UI, never silent", async () => {
+	getState.mockResolvedValue({ status: "signed-out", controlPlaneUrl: "http://127.0.0.1:8080" } satisfies AoAccountState);
+	renderSection();
+	expect(await screen.findByText(/Development control plane/)).toHaveTextContent("http://127.0.0.1:8080");
+});

--- a/frontend/src/renderer/components/settings/AccountSection.tsx
+++ b/frontend/src/renderer/components/settings/AccountSection.tsx
@@ -1,0 +1,94 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { AlertTriangle, Loader2, UserRound } from "lucide-react";
+import { aoBridge } from "../../lib/bridge";
+import { DEFAULT_CONTROL_PLANE_URL } from "../../../shared/control-plane";
+import type { AoAccountState } from "../../../shared/ao-account";
+import { Button } from "../ui/button";
+import { SettingsRow } from "./SettingsRow";
+import { SettingsSection } from "./SettingsSection";
+
+export const aoAccountQueryKey = ["ao-account"] as const;
+
+/**
+ * AO account sign-in. Signing in is needed only to reach a machine you have
+ * registered; everything on this computer keeps working with no account, so this
+ * section never blocks anything and there is no sign-in wall anywhere else.
+ */
+export function AccountSection() {
+	const queryClient = useQueryClient();
+	const query = useQuery({ queryKey: aoAccountQueryKey, queryFn: () => aoBridge.account.getState() });
+
+	const apply = (next: AoAccountState) => queryClient.setQueryData(aoAccountQueryKey, next);
+
+	const signIn = useMutation({
+		mutationFn: () => aoBridge.account.signIn(),
+		onSuccess: apply,
+	});
+	const signOut = useMutation({
+		mutationFn: () => aoBridge.account.signOut(),
+		onSuccess: apply,
+	});
+
+	const state = query.data;
+	const status = state?.status ?? "signed-out";
+	const busy = signIn.isPending || signOut.isPending || status === "signing-in";
+	const unavailable = status === "unavailable";
+	const signedIn = status === "signed-in";
+	const mutationError = signIn.error ?? signOut.error;
+	const error = state?.error ?? (mutationError instanceof Error ? mutationError.message : null);
+	const nonDefaultControlPlane =
+		state && state.controlPlaneUrl !== DEFAULT_CONTROL_PLANE_URL ? state.controlPlaneUrl : null;
+
+	return (
+		<SettingsSection title="Account" sectionId="account">
+			<SettingsRow icon={UserRound} label="AO account">
+				<div className="flex min-w-0 items-center gap-2">
+					<span className="min-w-0 truncate text-control text-settings-muted" data-testid="ao-account-identity">
+						{signedIn ? (state?.account?.email || state?.account?.id) : busy ? "Waiting for your browser…" : "Not signed in"}
+					</span>
+					{signedIn ? (
+						<Button type="button" variant="outline" size="sm" disabled={busy} onClick={() => signOut.mutate()}>
+							Sign out
+						</Button>
+					) : (
+						<Button
+							type="button"
+							variant="primary"
+							size="sm"
+							disabled={busy || unavailable || query.isLoading}
+							onClick={() => signIn.mutate()}
+						>
+							{busy ? <Loader2 className="size-icon-sm animate-spin" aria-hidden="true" /> : null}
+							Sign in
+						</Button>
+					)}
+				</div>
+			</SettingsRow>
+
+			<p className="px-1 text-xs leading-row text-settings-muted">
+				{signedIn
+					? "Signing out discards the stored credential on this computer. Sessions on this computer keep running."
+					: "Sign in to reach a machine you have registered with AO. Everything on this computer works without an account."}
+			</p>
+
+			{busy && !signedIn ? (
+				<p className="px-1 text-xs leading-row text-settings-muted">
+					Sign-in opens in your browser. Finish there, then come back here.
+				</p>
+			) : null}
+
+			{error ? (
+				<p className="flex items-start gap-2 px-1 text-xs leading-row text-error" data-testid="ao-account-error">
+					<AlertTriangle className="mt-0.5 size-icon-sm shrink-0" aria-hidden="true" />
+					<span>{error}</span>
+				</p>
+			) : null}
+
+			{nonDefaultControlPlane ? (
+				<p className="px-1 text-xs leading-row text-warning">
+					Development control plane: <span className="font-mono">{nonDefaultControlPlane}</span> (AO_CONTROL_URL).
+				</p>
+			) : null}
+		</SettingsSection>
+	);
+}

--- a/frontend/src/renderer/lib/bridge.ts
+++ b/frontend/src/renderer/lib/bridge.ts
@@ -1,5 +1,13 @@
 import type { AoBridge } from "../../preload";
+import type { AoAccountState } from "../../shared/ao-account";
+import { DEFAULT_CONTROL_PLANE_URL } from "../../shared/control-plane";
 export type { FeatureBuild } from "../../main/feature-builds";
+
+const BROWSER_PREVIEW_ACCOUNT_STATE: AoAccountState = {
+	status: "unavailable",
+	controlPlaneUrl: DEFAULT_CONTROL_PLANE_URL,
+	error: "Signing in needs the desktop app; it is not available in browser preview.",
+};
 
 export const aoBridge: AoBridge =
 	window.ao ??
@@ -143,5 +151,12 @@ export const aoBridge: AoBridge =
 		featureBuilds: {
 			list: async () => [],
 			getActive: async () => null,
+		},
+		// Browser preview has no main process, so no keychain and no loopback listener.
+		// Report it as unavailable rather than offering a button that cannot work.
+		account: {
+			getState: async () => BROWSER_PREVIEW_ACCOUNT_STATE,
+			signIn: async () => BROWSER_PREVIEW_ACCOUNT_STATE,
+			signOut: async () => BROWSER_PREVIEW_ACCOUNT_STATE,
 		},
 	} satisfies AoBridge);

--- a/frontend/src/renderer/test/setup.ts
+++ b/frontend/src/renderer/test/setup.ts
@@ -1,4 +1,8 @@
 import "@testing-library/jest-dom/vitest";
+import type { AoAccountState } from "../../shared/ao-account";
+import { DEFAULT_CONTROL_PLANE_URL } from "../../shared/control-plane";
+
+const signedOutAoAccount: AoAccountState = { status: "signed-out", controlPlaneUrl: DEFAULT_CONTROL_PLANE_URL };
 
 // Guard: src/main/** tests run in the Node.js environment (no DOM). vitest still
 // routes setupFiles here, so only install the DOM stubs when a DOM exists.
@@ -185,6 +189,11 @@ if (typeof window !== "undefined") {
 		featureBuilds: {
 			list: async () => [],
 			getActive: async () => null,
+		},
+		account: {
+			getState: async () => signedOutAoAccount,
+			signIn: async () => signedOutAoAccount,
+			signOut: async () => signedOutAoAccount,
 		},
 	};
 } // end if (typeof window !== "undefined")

--- a/frontend/src/shared/ao-account.ts
+++ b/frontend/src/shared/ao-account.ts
@@ -1,0 +1,25 @@
+/** The AO account the desktop install is signed in as. Identity only, no credentials. */
+export type AoAccount = {
+	id: string;
+	email: string;
+};
+
+export type AoAccountStatus =
+	// No stored sign-in. Local mode works exactly the same in this state.
+	| "signed-out"
+	// A system-browser login is in flight in this app instance.
+	| "signing-in"
+	| "signed-in"
+	// Sign-in cannot be attempted at all: no OS credential store to encrypt the
+	// refresh token with, or an unusable AO_CONTROL_URL. `error` says which.
+	| "unavailable";
+
+export type AoAccountState = {
+	status: AoAccountStatus;
+	/** Which control plane this app trusts, so a dev hatch is never invisible. */
+	controlPlaneUrl: string;
+	/** Present when status is "signed-in". */
+	account?: AoAccount;
+	/** Last failure, or the reason status is "unavailable". Never contains a token. */
+	error?: string;
+};

--- a/frontend/src/shared/control-plane.test.ts
+++ b/frontend/src/shared/control-plane.test.ts
@@ -1,0 +1,26 @@
+import { expect, test } from "vitest";
+import { DEFAULT_CONTROL_PLANE_URL, readControlPlaneUrl } from "./control-plane";
+
+test("defaults to the hosted control plane when AO_CONTROL_URL is unset or blank", () => {
+	expect(readControlPlaneUrl({})).toBe(DEFAULT_CONTROL_PLANE_URL);
+	expect(readControlPlaneUrl({ AO_CONTROL_URL: "   " })).toBe(DEFAULT_CONTROL_PLANE_URL);
+});
+
+test("accepts a loopback control plane over plain HTTP and normalizes to an origin", () => {
+	expect(readControlPlaneUrl({ AO_CONTROL_URL: "http://127.0.0.1:8080/" })).toBe("http://127.0.0.1:8080");
+	expect(readControlPlaneUrl({ AO_CONTROL_URL: "http://localhost:8080" })).toBe("http://localhost:8080");
+});
+
+test("accepts an HTTPS control plane on any host", () => {
+	expect(readControlPlaneUrl({ AO_CONTROL_URL: "https://staging.example.com" })).toBe("https://staging.example.com");
+});
+
+test("rejects plain HTTP off the loopback, so a typo cannot downgrade the login", () => {
+	expect(() => readControlPlaneUrl({ AO_CONTROL_URL: "http://ao.agentlab.in" })).toThrow(/must be HTTPS/);
+});
+
+test("rejects a value that is not a bare origin", () => {
+	expect(() => readControlPlaneUrl({ AO_CONTROL_URL: "ao.agentlab.in" })).toThrow(/absolute origin/);
+	expect(() => readControlPlaneUrl({ AO_CONTROL_URL: "https://ao.agentlab.in/oauth" })).toThrow(/without a path/);
+	expect(() => readControlPlaneUrl({ AO_CONTROL_URL: "https://user:pw@ao.agentlab.in" })).toThrow(/without a path/);
+});

--- a/frontend/src/shared/control-plane.ts
+++ b/frontend/src/shared/control-plane.ts
@@ -1,0 +1,44 @@
+/**
+ * Which AO control plane the desktop app trusts.
+ *
+ * `AO_CONTROL_URL` is the development hatch for pointing the app at a
+ * locally-run control plane (`go run ./cmd/controlplane`, default
+ * `127.0.0.1:8080`). It selects WHICH control plane issues and signs tokens; it
+ * can never skip authentication. There is deliberately no env var and no flag
+ * that bypasses login: sign-in always runs the same PKCE flow against whatever
+ * origin this resolves to.
+ */
+export const DEFAULT_CONTROL_PLANE_URL = "https://ao.agentlab.in";
+
+const LOOPBACK_HOSTS = new Set(["127.0.0.1", "::1", "localhost"]);
+
+/**
+ * Resolve the control-plane origin from the environment. Returns an origin with
+ * no trailing slash so it can be concatenated with a path, matching the way the
+ * control plane pins `iss` from `PUBLIC_ORIGIN` (see controlplane/TOKEN_CONTRACT.md).
+ *
+ * Throws on a malformed value rather than falling back to the production origin:
+ * a typo in the dev hatch must not silently send a developer's login to the real
+ * control plane.
+ */
+export function readControlPlaneUrl(env: Record<string, string | undefined>): string {
+	const raw = env.AO_CONTROL_URL?.trim() ?? "";
+	if (!raw) return DEFAULT_CONTROL_PLANE_URL;
+
+	let url: URL;
+	try {
+		url = new URL(raw);
+	} catch {
+		throw new Error("AO_CONTROL_URL must be an absolute origin, for example http://127.0.0.1:8080");
+	}
+	if (url.pathname !== "/" || url.search || url.hash || url.username || url.password) {
+		throw new Error("AO_CONTROL_URL must be an origin without a path, query, fragment, or credentials");
+	}
+	// Plain HTTP is allowed only for a control plane on this machine, which is the
+	// one case where there is no network to intercept the authorization code.
+	const loopback = LOOPBACK_HOSTS.has(url.hostname) || LOOPBACK_HOSTS.has(url.hostname.replace(/^\[|\]$/g, ""));
+	if (url.protocol !== "https:" && !(url.protocol === "http:" && loopback)) {
+		throw new Error("AO_CONTROL_URL must be HTTPS, or HTTP on 127.0.0.1 for a locally-run control plane");
+	}
+	return url.origin;
+}


### PR DESCRIPTION
Closes #25. Item 9 of batch 3 in `docs/superpowers/specs/2026-07-29-hosted-ao-v1-accounts-and-machines.md`.

## What this adds

AO account sign-in in the desktop app, and nothing else. No machine list, no machine picker, no authenticated remote transport: those are tasks 12 and 13 in later batches.

**Login in the system browser, PKCE, loopback redirect (RFC 8252).** Google blocks OAuth in embedded webviews, so login goes through `shell.openExternal` and comes back to a listener on `127.0.0.1` on an ephemeral port. The verifier and `state` are 32 CSPRNG bytes each; the challenge is S256. The listener accepts exactly one callback, validates `state` before it reads the code, and shuts down immediately (including `closeAllConnections`, so the port is released rather than held by a browser keep-alive). A callback whose `state` does not match is rejected with a 400, not exchanged. Nothing logs the authorization code, the verifier, the refresh token, or an access token.

**Refresh token encrypted with `safeStorage`, under `~/.ao`.** Stored at `<~/.ao state dir>/ao-account.json`, mode 0600, atomic temp-file-plus-rename like `app-state.json`. The account id and email stay in the clear (identity, not a credential) so the signed-in row renders without a keychain unlock; the token itself is `safeStorage` ciphertext. When `safeStorage.isEncryptionAvailable()` is false, a real case on Linux without a Secret Service provider, the app refuses to sign in and says what to install, rather than writing a 90-day credential in plaintext. That check runs *before* a browser is opened.

**Signed-in state and a sign-out that discards the token.** Sign-out deletes the file, so a fresh controller cannot resurrect the credential. Covered by a test that asserts exactly that.

**`AO_CONTROL_URL` as the dev hatch.** It selects which control plane is trusted (default `https://ao.agentlab.in`; plain HTTP accepted only on the loopback, for `go run ./cmd/controlplane`). A malformed value is a hard error surfaced in the UI, not a silent fallback to production. When it is set to anything non-default the Settings row names it, so a dev hatch is never invisible. It cannot skip authentication and nothing added here can.

## Hard rules

- **Nothing to an OS default app-data location.** All new state resolves under the `~/.ao` state dir via the existing `runFilePath()` seam (so `AO_RUN_FILE` still redirects it). The `app.setPath("userData", ~/.ao/electron)` pin in `frontend/src/main.ts` is untouched.
- **Local use never requires an account.** The only new surface is a Settings section. Nothing gates startup, the local daemon, or the board, and there is no first-run sign-in wall. The section says so in copy: "Everything on this computer works without an account."
- **`AO_REMOTE_URL` and `AO_REMOTE_TOKEN` are untouched.** `shared/remote-daemon.ts`, `main/remote-daemon.ts`, and their wiring in `main.ts` are not modified by this PR.

## Control-plane contract

The desktop endpoints are being built in parallel under issue #23, so this builds against a written contract rather than waiting: `docs/desktop-login-contract.md` specifies `GET /oauth/desktop/authorize` and `POST /oauth/desktop/token`, the client id `ao-desktop`, and the token response `{ refresh_token, account: { id, email } }`. **If issue #23 lands different paths or field names, that doc and `frontend/src/main/ao-pkce.ts` change together.**

Login deliberately returns no access token: `aud` is a machine id per `controlplane/TOKEN_CONTRACT.md` and no machine is chosen at login time. The doc also records that refresh tokens rotate on use, and points task 13 at `writeStoredAccount` as the seam that must persist each replacement.

## UI

One new Settings section built from the existing `SettingsSection` / `SettingsRow` / `Button` primitives, in the same visual language as General and Updates, per the clone-agent-orchestrator-verbatim banner in `DESIGN.md`. Verified in the app with `ao preview http://localhost:5173/#/settings`.

Signed out: `AO account | Not signed in | [Sign in]`, plus the "works without an account" line.
Signed in: `AO account | dev@example.com | [Sign out]`, plus "Signing out discards the stored credential on this computer."

## Tests run

- `npx vitest run` (the CI command): **95 files, 1152 tests, all passing**, including 49 new ones across the PKCE helpers, the loopback listener, the on-disk store, the controller, the control-plane URL parser, the preload channels, and the settings section.
- `npm run typecheck` and `npm run typecheck:e2e`: clean. The e2e typecheck matters here because `satisfies AoBridge` in `e2e/support/fake-bridge.ts` is the preload-drift tripwire; both fake bridges and the jsdom setup bridge gained the `account` namespace.
- `CI=true npx playwright test --grep "@T0|@P0"` (renderer-smoke): **20 passed**. SET-001 now asserts the Account section renders and reads "Not signed in", since local use must not require an account.

Notable test cases: the verifier sent to the token endpoint is the pre-image of the challenge the browser was sent; the refresh token never appears in plaintext on disk and the file is 0600; nothing at all is written when encryption is unavailable; a forged `state` is rejected and no token is stored; an unreachable control plane reports plainly and points at local mode; a second Sign in click joins the attempt already in flight instead of opening a second tab.

## Not in scope

No `controlplane/` or `backend/` changes (issues #23 and #24 own those), so no HTTP surface change: `openapi.yaml` and `frontend/src/api/schema.ts` are untouched, as intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)