### PR TITLE
feat(cli): ao setup-vm part one, Ubuntu gate, preflight, install, summary

### DIFF
--- a/backend/internal/cli/root.go
+++ b/backend/internal/cli/root.go
@@ -200,6 +200,7 @@ func NewRootCommand(deps Deps) *cobra.Command {
 	root.AddCommand(newPRCommand(ctx))
 	root.AddCommand(newReviewCommand(ctx))
 	root.AddCommand(newVMCommand(ctx))
+	root.AddCommand(newSetupVMCommand(ctx))
 	root.AddCommand(newCompletionCommand())
 	root.AddCommand(newVersionCommand())
 

--- a/backend/internal/cli/setupvm.go
+++ b/backend/internal/cli/setupvm.go
@@ -1,0 +1,626 @@
+package cli
+
+// setupvm.go is the thin, privileged half of `ao setup-vm`: the probes that
+// look at the box and the commands that mutate it. Every decision it makes
+// lives in setupvm_plan.go, which is pure and unit-tested on every OS in the
+// CLI E2E matrix. Keep this file mechanical: probe, hand the observation to a
+// pure function, execute what it says.
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"os/user"
+	"path/filepath"
+	"runtime"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/vmgateway"
+)
+
+const (
+	// setupVMHTTPTimeout covers the public-IP lookup and the reachability
+	// probe. Both talk to the internet from a fresh VM, so the CLI's default
+	// 2s loopback budget is too tight.
+	setupVMHTTPTimeout = 10 * time.Second
+	setupVMUserAgent   = "ao-agent-orchestrator/setup-vm"
+	// defaultSetupVMProbeURL is the off-box port prober. A cloud firewall is
+	// invisible from inside the box, so confirming 80 and 443 needs a host that
+	// is not this one, and the AO control plane is the one such host setup-vm
+	// already depends on. Contract: GET ?host=<domain>&ports=80,443 answers
+	// {"ports":{"80":true,"443":false}} after attempting a TCP connect from
+	// outside. An unreachable prober is reported as unverified, never as a
+	// closed port.
+	defaultSetupVMProbeURL = vmgateway.DefaultIssuer + "/api/v1/reachability"
+)
+
+// setupVMPublicIPEndpoints are tried in order to learn this box's address as
+// the internet sees it, which is what the DNS record has to match.
+var setupVMPublicIPEndpoints = []string{"https://api.ipify.org", "https://ifconfig.me/ip"}
+
+type setupVMOptions struct {
+	Domain   string
+	PublicIP string
+	ProbeURL string
+	DryRun   bool
+}
+
+func newSetupVMCommand(ctx *commandContext) *cobra.Command {
+	var opts setupVMOptions
+	cmd := &cobra.Command{
+		Use:   "setup-vm",
+		Short: "Preflight and install AO on a hosted Ubuntu VM",
+		Long: "ao setup-vm prepares a hosted Ubuntu LTS VM to run remote agents. It gates\n" +
+			"on the platform, preflights DNS, the public ports, and sudo before it touches\n" +
+			"anything, then installs the ao binary, tmux, git, and gh, and writes two\n" +
+			"systemd units: one for the loopback daemon and one for the public TLS gateway\n" +
+			"(see docs/adr/0002-hosted-public-gateway.md).\n\n" +
+			"A failed preflight changes nothing at all: it prints exactly what to fix and\n" +
+			"exits. A successful run is idempotent, so running it again is safe, and it ends\n" +
+			"by listing what is still missing with the exact command for each.\n\n" +
+			"It does not install an agent harness and does not configure git credentials,\n" +
+			"because both need an interactive login.",
+		Args: noArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return ctx.runSetupVM(cmd, opts)
+		},
+	}
+	flags := cmd.Flags()
+	flags.StringVar(&opts.Domain, "domain", "", "Public hostname you own, with a DNS record pointing at this machine (required)")
+	flags.StringVar(&opts.PublicIP, "public-ip", "", "This machine's public IP, for when it cannot be discovered automatically")
+	flags.StringVar(&opts.ProbeURL, "reachability-probe-url", defaultSetupVMProbeURL, "Off-box prober used to confirm 80 and 443 are reachable from the internet")
+	flags.BoolVar(&opts.DryRun, "dry-run", false, "Gate, preflight, print the plan and both unit files, and change nothing")
+	return cmd
+}
+
+func (c *commandContext) runSetupVM(cmd *cobra.Command, opts setupVMOptions) error {
+	ctx := cmd.Context()
+	out := cmd.OutOrStdout()
+
+	domain, err := normalizeSetupDomain(opts.Domain)
+	if err != nil {
+		return usageError{err}
+	}
+
+	platform := c.probeSetupPlatform()
+	warnings, err := checkSetupPlatform(platform)
+	if err != nil {
+		if writeErr := writeSetupText(out, renderManualPath(platform, domain)); writeErr != nil {
+			return writeErr
+		}
+		return err
+	}
+
+	preflight := c.probeSetupPreflight(ctx, domain, opts)
+	problems, preflightWarnings := evaluatePreflight(preflight)
+	warnings = append(warnings, preflightWarnings...)
+	if len(problems) > 0 {
+		if writeErr := writeSetupText(out, renderPreflightFailure(problems)); writeErr != nil {
+			return writeErr
+		}
+		return errors.New("ao setup-vm preflight failed, so nothing on this machine was changed")
+	}
+
+	plan, err := c.buildSetupVMPlan(domain)
+	if err != nil {
+		return err
+	}
+
+	if opts.DryRun {
+		return writeSetupText(out, renderSetupDryRun(plan, warnings))
+	}
+
+	gatewayStarted, notes, err := c.installSetupVM(ctx, out, plan)
+	if err != nil {
+		return err
+	}
+	return writeSetupText(out, renderSetupSummary(plan, gatewayStarted, append(warnings, notes...)))
+}
+
+// ---------------------------------------------------------------------------
+// probes
+// ---------------------------------------------------------------------------
+
+func (c *commandContext) probeSetupPlatform() setupPlatform {
+	platform := setupPlatform{GOOS: runtime.GOOS, OSRelease: map[string]string{}}
+	if runtime.GOOS != "linux" {
+		return platform
+	}
+	if content, err := os.ReadFile("/etc/os-release"); err == nil {
+		platform.OSRelease = parseOSRelease(string(content))
+	}
+	_, systemctlErr := c.deps.LookPath("systemctl")
+	_, aptErr := c.deps.LookPath("apt-get")
+	platform.HasSystemctl = systemctlErr == nil
+	platform.HasAptGet = aptErr == nil
+	return platform
+}
+
+func (c *commandContext) probeSetupPreflight(ctx context.Context, domain string, opts setupVMOptions) setupPreflight {
+	preflight := setupPreflight{Domain: domain, UID: os.Getuid()}
+
+	if sudoPath, err := c.deps.LookPath("sudo"); err == nil {
+		preflight.SudoPath = sudoPath
+		_, sudoErr := c.deps.CommandOutput(ctx, "sudo", "-n", "true")
+		preflight.SudoPasswordless = sudoErr == nil
+	}
+
+	// The DMI vendor only selects which cloud's firewall instructions to print,
+	// so an unreadable file is not worth reporting.
+	if vendor, err := os.ReadFile("/sys/class/dmi/id/sys_vendor"); err == nil {
+		preflight.Cloud = setupCloudFromVendor(string(vendor))
+	}
+
+	preflight.PublicIP = strings.TrimSpace(opts.PublicIP)
+	switch {
+	case preflight.PublicIP == "":
+		preflight.PublicIP, preflight.PublicIPErr = c.discoverPublicIP(ctx)
+	case net.ParseIP(preflight.PublicIP) == nil:
+		preflight.PublicIPErr = fmt.Errorf("--public-ip %q is not an IP address", preflight.PublicIP)
+	}
+
+	preflight.ResolvedIPs, preflight.ResolveErr = net.DefaultResolver.LookupHost(ctx, domain)
+
+	gatewayActive := c.setupUnitActive(ctx, setupVMGatewayUnit)
+	preflight.GatewayActive = gatewayActive
+	preflight.Ports = probeSetupPorts(setupVMPorts, gatewayActive)
+	preflight.Reach = c.probeSetupReachability(ctx, opts.ProbeURL, domain, gatewayActive)
+	return preflight
+}
+
+// probeSetupPorts checks that :80 and :443 can be bound, by binding them on
+// the loopback interface and releasing them immediately. Loopback is enough to
+// catch both real failures: privilege (ports under 1024 need it, on loopback
+// too) and a conflicting listener such as a distro nginx on 0.0.0.0:80. It is
+// deliberately not a public bind: AGENTS.md permits exactly one of those,
+// `ao vm serve`, and a preflight check is not it.
+func probeSetupPorts(ports []int, gatewayActive bool) []setupPortProbe {
+	probes := make([]setupPortProbe, 0, len(ports))
+	for _, port := range ports {
+		probe := setupPortProbe{Port: port}
+		listener, err := net.Listen("tcp", net.JoinHostPort("127.0.0.1", strconv.Itoa(port)))
+		if err == nil {
+			if closeErr := listener.Close(); closeErr != nil {
+				probe.Err = closeErr
+			}
+		} else {
+			probe.Err = err
+			probe.HeldByGateway = gatewayActive && isSetupAddrInUse(err)
+		}
+		probes = append(probes, probe)
+	}
+	return probes
+}
+
+// isSetupAddrInUse classifies a bind failure by message rather than errno so
+// this stays one code path on every OS the CLI is built for.
+func isSetupAddrInUse(err error) bool {
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "in use") || strings.Contains(msg, "address already")
+}
+
+func (c *commandContext) setupUnitActive(ctx context.Context, unit string) bool {
+	if runtime.GOOS != "linux" {
+		return false
+	}
+	_, err := c.deps.CommandOutput(ctx, "systemctl", "is-active", "--quiet", unit)
+	return err == nil
+}
+
+func (c *commandContext) setupHTTPClient() *http.Client {
+	client := *c.deps.HTTPClient
+	client.Timeout = setupVMHTTPTimeout
+	return &client
+}
+
+func (c *commandContext) discoverPublicIP(ctx context.Context) (string, error) {
+	client := c.setupHTTPClient()
+	var lastErr error
+	for _, endpoint := range setupVMPublicIPEndpoints {
+		ip, err := fetchSetupPublicIP(ctx, client, endpoint)
+		if err == nil {
+			return ip, nil
+		}
+		lastErr = err
+	}
+	if lastErr == nil {
+		lastErr = errors.New("no public IP endpoint configured")
+	}
+	return "", lastErr
+}
+
+func fetchSetupPublicIP(ctx context.Context, client *http.Client, endpoint string) (string, error) {
+	body, err := setupHTTPGet(ctx, client, endpoint, 256)
+	if err != nil {
+		return "", err
+	}
+	raw := strings.TrimSpace(string(body))
+	if net.ParseIP(raw) == nil {
+		return "", fmt.Errorf("%s did not answer with an IP address", endpoint)
+	}
+	return raw, nil
+}
+
+// probeSetupReachability asks an off-box prober whether 80 and 443 accept
+// connections. It only runs when this machine's own gateway is already
+// listening: with nothing bound, a closed answer would mean "no listener", not
+// "blocked firewall", and reporting that as a firewall problem would be a lie.
+// On a first run the check therefore reports unverified, and preflight prints
+// the firewall instructions and the off-box command to confirm by hand.
+func (c *commandContext) probeSetupReachability(ctx context.Context, probeURL, domain string, gatewayActive bool) setupReachability {
+	if !gatewayActive {
+		// evaluatePreflight words this case from GatewayActive: no error here,
+		// because nothing failed.
+		return setupReachability{}
+	}
+	probeURL = strings.TrimSpace(probeURL)
+	if probeURL == "" {
+		return setupReachability{Err: errors.New("no prober configured (--reachability-probe-url is empty)")}
+	}
+	parsed, err := url.Parse(probeURL)
+	if err != nil {
+		return setupReachability{Err: fmt.Errorf("invalid --reachability-probe-url %q: %w", probeURL, err)}
+	}
+	query := parsed.Query()
+	query.Set("host", domain)
+	query.Set("ports", joinSetupPorts(setupVMPorts))
+	parsed.RawQuery = query.Encode()
+
+	body, err := setupHTTPGet(ctx, c.setupHTTPClient(), parsed.String(), 4096)
+	if err != nil {
+		return setupReachability{Err: err}
+	}
+	open, err := parseSetupReachability(body, setupVMPorts)
+	if err != nil {
+		return setupReachability{Err: err}
+	}
+	return setupReachability{Ran: true, Open: open}
+}
+
+func setupHTTPGet(ctx context.Context, client *http.Client, endpoint string, limit int64) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, http.NoBody)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("User-Agent", setupVMUserAgent)
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("%s returned %s", endpoint, resp.Status)
+	}
+	return io.ReadAll(io.LimitReader(resp.Body, limit))
+}
+
+func joinSetupPorts(ports []int) string {
+	parts := make([]string, 0, len(ports))
+	for _, port := range ports {
+		parts = append(parts, strconv.Itoa(port))
+	}
+	return strings.Join(parts, ",")
+}
+
+// ---------------------------------------------------------------------------
+// the plan
+// ---------------------------------------------------------------------------
+
+// buildSetupVMPlan resolves the user the units run as and every absolute path
+// they need. Under sudo the invoking process is root but the machine belongs to
+// the human in SUDO_USER, and that is who must own ~/.ao and run the agents.
+func (c *commandContext) buildSetupVMPlan(domain string) (setupPlan, error) {
+	target, err := setupTargetUser()
+	if err != nil {
+		return setupPlan{}, err
+	}
+	in := setupPlanInput{
+		Domain:      domain,
+		User:        target.Username,
+		Home:        target.HomeDir,
+		DataDir:     os.Getenv("AO_DATA_DIR"),
+		RunFile:     os.Getenv("AO_RUN_FILE"),
+		MachineFile: os.Getenv("AO_MACHINE_FILE"),
+	}
+	if group, err := user.LookupGroupId(target.Gid); err == nil {
+		in.Group = group.Name
+	}
+	plan, err := buildSetupPlan(in)
+	if err != nil {
+		return setupPlan{}, err
+	}
+	// Binding is a later batch: this command only reports whether it has
+	// happened, so the gateway is started rather than left stopped on a machine
+	// that is already bound. It never writes machine.json.
+	if _, err := os.Stat(plan.MachineFile); err == nil {
+		plan.Bound = true
+	}
+	return plan, nil
+}
+
+// setupTargetUser is the unprivileged owner of the machine: SUDO_USER when the
+// command was run through sudo, otherwise whoever is running it.
+func setupTargetUser() (*user.User, error) {
+	if name := strings.TrimSpace(os.Getenv("SUDO_USER")); name != "" && name != "root" {
+		target, err := user.Lookup(name)
+		if err != nil {
+			return nil, fmt.Errorf("look up SUDO_USER %q: %w", name, err)
+		}
+		return target, nil
+	}
+	target, err := user.Current()
+	if err != nil {
+		return nil, fmt.Errorf("look up the current user: %w", err)
+	}
+	return target, nil
+}
+
+// ---------------------------------------------------------------------------
+// install
+// ---------------------------------------------------------------------------
+
+// installSetupVM performs every mutation, in order. It reports whether the
+// gateway ended up running, plus any note the summary has to carry. Each step is
+// skipped when it is already done, so a second run of ao setup-vm changes
+// nothing and restarts nothing.
+func (c *commandContext) installSetupVM(ctx context.Context, out io.Writer, plan setupPlan) (bool, []string, error) {
+	step := func(format string, args ...any) error {
+		_, err := fmt.Fprintf(out, "==> "+format+"\n", args...)
+		return err
+	}
+	var notes []string
+
+	for _, dir := range plan.setupDirs() {
+		if err := c.runSetupPrivileged(ctx, "install", "-d", "-m", "0700", "-o", plan.User, "-g", plan.Group, dir); err != nil {
+			return false, notes, err
+		}
+	}
+	if err := step("state directories ready under %s, owned by %s", plan.AODir, plan.User); err != nil {
+		return false, notes, err
+	}
+
+	if err := c.ensureSetupPackages(ctx, out, plan.Packages); err != nil {
+		return false, notes, err
+	}
+	binaryChanged, err := c.ensureSetupBinary(ctx, out, plan)
+	if err != nil {
+		return false, notes, err
+	}
+
+	daemonChanged, err := c.writeSetupUnit(ctx, out, setupVMDaemonUnit, renderDaemonUnit(plan))
+	if err != nil {
+		return false, notes, err
+	}
+	gatewayChanged, err := c.writeSetupUnit(ctx, out, setupVMGatewayUnit, renderGatewayUnit(plan))
+	if err != nil {
+		return false, notes, err
+	}
+	if daemonChanged || gatewayChanged {
+		if err := c.runSetupPrivileged(ctx, "systemctl", "daemon-reload"); err != nil {
+			return false, notes, err
+		}
+	}
+
+	if err := c.runSetupPrivileged(ctx, "systemctl", "enable", setupVMDaemonUnit, setupVMGatewayUnit); err != nil {
+		return false, notes, err
+	}
+	// Only a changed unit earns a restart: restarting the daemon kills the
+	// agent sessions it is supervising, which a re-run must not do. A new
+	// binary is reported instead of acted on, for the same reason.
+	daemonAction := "start"
+	if daemonChanged {
+		daemonAction = "restart"
+	}
+	if err := c.runSetupPrivileged(ctx, "systemctl", daemonAction, setupVMDaemonUnit); err != nil {
+		return false, notes, err
+	}
+	if err := step("%s enabled and running", setupVMDaemonUnit); err != nil {
+		return false, notes, err
+	}
+	if binaryChanged && daemonAction == "start" {
+		notes = append(notes, fmt.Sprintf(
+			"the ao binary was replaced, but %s was left running on the previous build so live agent"+
+				"\n  sessions were not killed. Restart it when nothing is mid-task: sudo systemctl restart %s",
+			setupVMDaemonUnit, setupVMDaemonUnit))
+	}
+
+	if !plan.Bound {
+		// `ao vm serve` reads machine.json once at startup and cannot serve
+		// without it, so starting it now would only produce a restart loop.
+		return false, notes, step("%s enabled but not started: this machine is not bound yet", setupVMGatewayUnit)
+	}
+	// The gateway holds no session state, so a new binary or unit is safe to
+	// restart into immediately.
+	gatewayAction := "start"
+	if gatewayChanged || binaryChanged {
+		gatewayAction = "restart"
+	}
+	if err := c.runSetupPrivileged(ctx, "systemctl", gatewayAction, setupVMGatewayUnit); err != nil {
+		return false, notes, err
+	}
+	return true, notes, step("%s enabled and running", setupVMGatewayUnit)
+}
+
+func (c *commandContext) ensureSetupPackages(ctx context.Context, out io.Writer, packages []string) error {
+	missing := make([]string, 0, len(packages))
+	for _, pkg := range packages {
+		installed, err := c.deps.CommandOutput(ctx, "dpkg-query", "-W", "-f=${Status}", pkg)
+		if err != nil || !dpkgInstalled(string(installed)) {
+			missing = append(missing, pkg)
+		}
+	}
+	if len(missing) == 0 {
+		_, err := fmt.Fprintf(out, "==> packages already present: %s\n", strings.Join(packages, ", "))
+		return err
+	}
+	if slices.Contains(missing, "gh") {
+		if err := c.ensureGitHubCLIRepo(ctx); err != nil {
+			return err
+		}
+	}
+	if err := c.runSetupPrivileged(ctx, "apt-get", "update"); err != nil {
+		return err
+	}
+	args := append([]string{"DEBIAN_FRONTEND=noninteractive", "apt-get", "install", "-y"}, missing...)
+	if err := c.runSetupPrivileged(ctx, "env", args...); err != nil {
+		return err
+	}
+	_, err := fmt.Fprintf(out, "==> installed: %s\n", strings.Join(missing, ", "))
+	return err
+}
+
+// ensureGitHubCLIRepo adds GitHub's own apt repository, which is where a
+// current gh comes from. Ubuntu LTS either has no gh package at all (22.04) or
+// a years-old one, and gh is what picks up the user's git credentials.
+func (c *commandContext) ensureGitHubCLIRepo(ctx context.Context) error {
+	if _, err := os.Stat(setupVMKeyringPath); err != nil {
+		keyring, err := setupHTTPGet(ctx, c.setupHTTPClient(), setupVMKeyringURL, 1<<20)
+		if err != nil {
+			return fmt.Errorf("download the GitHub CLI signing key: %w", err)
+		}
+		if len(keyring) < 100 {
+			return fmt.Errorf("the GitHub CLI signing key at %s came back empty", setupVMKeyringURL)
+		}
+		if err := c.runSetupPrivileged(ctx, "install", "-d", "-m", "0755", filepath.ToSlash(filepath.Dir(setupVMKeyringPath))); err != nil {
+			return err
+		}
+		if _, err := c.writeSetupFile(ctx, setupVMKeyringPath, "0644", keyring); err != nil {
+			return err
+		}
+	}
+	arch := "amd64"
+	if raw, err := c.deps.CommandOutput(ctx, "dpkg", "--print-architecture"); err == nil {
+		if detected := strings.TrimSpace(firstOutputLine(raw)); detected != "" {
+			arch = detected
+		}
+	}
+	_, err := c.writeSetupFile(ctx, setupVMSourceListPath, "0644", []byte(githubCLISourceList(arch)))
+	return err
+}
+
+// ensureSetupBinary puts the running ao binary at an absolute, stable path,
+// because a systemd unit must never resolve its ExecStart through a PATH. It
+// reports whether the installed binary actually changed.
+func (c *commandContext) ensureSetupBinary(ctx context.Context, out io.Writer, plan setupPlan) (bool, error) {
+	self, err := c.deps.Executable()
+	if err != nil {
+		return false, fmt.Errorf("locate the running ao binary: %w", err)
+	}
+	if resolved, err := filepath.EvalSymlinks(self); err == nil {
+		self = resolved
+	}
+	if filepath.ToSlash(self) == plan.BinaryPath || setupSameFile(self, plan.BinaryPath) {
+		_, err := fmt.Fprintf(out, "==> ao binary already current at %s\n", plan.BinaryPath)
+		return false, err
+	}
+	if err := c.runSetupPrivileged(ctx, "install", "-m", "0755", "-o", "root", "-g", "root", self, plan.BinaryPath); err != nil {
+		return false, err
+	}
+	_, err = fmt.Fprintf(out, "==> installed the ao binary to %s\n", plan.BinaryPath)
+	return true, err
+}
+
+func (c *commandContext) writeSetupUnit(ctx context.Context, out io.Writer, name, content string) (bool, error) {
+	dest := slashPath(setupVMUnitDir, name)
+	changed, err := c.writeSetupFile(ctx, dest, "0644", []byte(content))
+	if err != nil {
+		return false, err
+	}
+	verb := "unchanged"
+	if changed {
+		verb = "written"
+	}
+	if _, err := fmt.Fprintf(out, "==> %s %s\n", dest, verb); err != nil {
+		return changed, err
+	}
+	return changed, nil
+}
+
+// writeSetupFile writes dest only when its content differs, which is what
+// makes re-running safe: no duplicated units and no file that grows on every
+// run. It reports whether anything changed.
+func (c *commandContext) writeSetupFile(ctx context.Context, dest, mode string, content []byte) (bool, error) {
+	if existing, err := os.ReadFile(dest); err == nil && bytes.Equal(existing, content) {
+		return false, nil
+	}
+	tmp, err := os.CreateTemp("", "ao-setup-vm-*")
+	if err != nil {
+		return false, err
+	}
+	tmpPath := tmp.Name()
+	defer func() { _ = os.Remove(tmpPath) }()
+	if _, err := tmp.Write(content); err != nil {
+		_ = tmp.Close()
+		return false, err
+	}
+	if err := tmp.Close(); err != nil {
+		return false, err
+	}
+	if err := c.runSetupPrivileged(ctx, "install", "-m", mode, "-o", "root", "-g", "root", tmpPath, dest); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// runSetupPrivileged is the only place ao setup-vm mutates the machine. It
+// prefixes sudo -n when the process is not already root; preflight has already
+// established that one of the two is true.
+func (c *commandContext) runSetupPrivileged(ctx context.Context, name string, args ...string) error {
+	if os.Getuid() != 0 {
+		args = append([]string{"-n", name}, args...)
+		name = "sudo"
+	}
+	out, err := c.deps.CommandOutput(ctx, name, args...)
+	if err == nil {
+		return nil
+	}
+	detail := strings.TrimSpace(string(out))
+	if detail == "" {
+		return fmt.Errorf("%s %s: %w", name, strings.Join(args, " "), err)
+	}
+	return fmt.Errorf("%s %s: %w: %s", name, strings.Join(args, " "), err, detail)
+}
+
+// setupSameFile reports whether two files have identical content, so an
+// already-current binary is not reinstalled on every run.
+func setupSameFile(a, b string) bool {
+	sumA, err := setupFileSum(a)
+	if err != nil {
+		return false
+	}
+	sumB, err := setupFileSum(b)
+	if err != nil {
+		return false
+	}
+	return sumA == sumB
+}
+
+func setupFileSum(path string) (string, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = file.Close() }()
+	digest := sha256.New()
+	if _, err := io.Copy(digest, file); err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%x", digest.Sum(nil)), nil
+}
+
+func writeSetupText(out io.Writer, text string) error {
+	_, err := io.WriteString(out, text)
+	return err
+}

--- a/backend/internal/cli/setupvm_plan.go
+++ b/backend/internal/cli/setupvm_plan.go
@@ -1,0 +1,1001 @@
+package cli
+
+// This file holds every decision `ao setup-vm` makes: the platform gate, the
+// preflight verdicts, the path plan, the systemd unit text, and the closing
+// summary. Nothing in here shells out, reads the network, or touches the disk,
+// so all of it is unit-testable on macOS and Windows, where `CLI E2E` also
+// runs. The thin privileged layer that executes these decisions lives in
+// setupvm.go.
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"path"
+	"slices"
+	"strconv"
+	"strings"
+)
+
+const (
+	// setupVMBinaryPath is where the ao binary is installed so both systemd
+	// units can name it by absolute path. A unit must never depend on the
+	// invoking shell's PATH.
+	setupVMBinaryPath = "/usr/local/bin/ao"
+	// setupVMUnitDir is the system-wide systemd unit directory. Units go here
+	// rather than under /lib so a distro package upgrade never overwrites them.
+	setupVMUnitDir = "/etc/systemd/system"
+	// setupVMDaemonUnit runs the loopback daemon; setupVMGatewayUnit runs the
+	// public TLS gateway. Two units, two processes, per ADR 0002. They are
+	// never collapsed into one.
+	setupVMDaemonUnit  = "ao-daemon.service"
+	setupVMGatewayUnit = "ao-gateway.service"
+	// setupVMKeyringPath and setupVMSourceListPath are GitHub's documented
+	// apt locations for the gh package, used only when gh is missing.
+	setupVMKeyringPath    = "/etc/apt/keyrings/githubcli-archive-keyring.gpg"
+	setupVMSourceListPath = "/etc/apt/sources.list.d/github-cli.list"
+	setupVMKeyringURL     = "https://cli.github.com/packages/githubcli-archive-keyring.gpg"
+)
+
+// setupVMPackages are the apt packages the VM needs. Agent harnesses are
+// deliberately absent: they have interactive logins and are installed later by
+// `ao vm setup-harness`.
+var setupVMPackages = []string{"tmux", "git", "gh"}
+
+// setupVMPorts are the ports the gateway must be able to bind and be reached
+// on: 80 for the ACME HTTP-01 challenge and the https redirect, 443 for the
+// public TLS listener.
+var setupVMPorts = []int{80, 443}
+
+// ---------------------------------------------------------------------------
+// Platform gate
+// ---------------------------------------------------------------------------
+
+// setupPlatform is what a probe learned about this box's operating system.
+type setupPlatform struct {
+	GOOS         string
+	OSRelease    map[string]string
+	HasSystemctl bool
+	HasAptGet    bool
+}
+
+// errUnsupportedPlatform reports that this box is not an Ubuntu box with
+// systemd and apt. The command prints the manual path and exits without
+// touching anything.
+type errUnsupportedPlatform struct{ reason string }
+
+func (e errUnsupportedPlatform) Error() string {
+	return "ao setup-vm supports Ubuntu LTS with systemd and apt only: " + e.reason
+}
+
+// parseOSRelease parses the shell-assignment format of /etc/os-release. Values
+// may be single- or double-quoted; anything unparseable is skipped rather than
+// failing the whole file, because the gate only needs ID and VERSION.
+func parseOSRelease(content string) map[string]string {
+	out := map[string]string{}
+	for _, line := range strings.Split(content, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		key, value, ok := strings.Cut(line, "=")
+		if !ok {
+			continue
+		}
+		key = strings.TrimSpace(key)
+		value = strings.TrimSpace(value)
+		if len(value) >= 2 && (value[0] == '"' || value[0] == '\'') && value[len(value)-1] == value[0] {
+			value = value[1 : len(value)-1]
+		}
+		if key != "" {
+			out[key] = value
+		}
+	}
+	return out
+}
+
+// platformName renders the best human name available for this box, for the
+// refusal message.
+func (p setupPlatform) platformName() string {
+	if name := p.OSRelease["PRETTY_NAME"]; name != "" {
+		return name
+	}
+	if id := p.OSRelease["ID"]; id != "" {
+		return strings.TrimSpace(id + " " + p.OSRelease["VERSION_ID"])
+	}
+	return p.GOOS
+}
+
+// checkSetupPlatform is the platform gate. It returns an
+// errUnsupportedPlatform for anything that is not Ubuntu with systemd and apt,
+// so the caller can print the manual path instead of half-installing. A
+// non-LTS Ubuntu is a warning rather than a refusal: apt and systemd are
+// there, so every step still works, the release just goes end-of-life sooner.
+func checkSetupPlatform(p setupPlatform) (warnings []string, err error) {
+	if p.GOOS != "linux" {
+		return nil, errUnsupportedPlatform{reason: "this is " + p.GOOS + ", not Linux"}
+	}
+	if id := strings.ToLower(p.OSRelease["ID"]); id != "ubuntu" {
+		return nil, errUnsupportedPlatform{reason: "this box reports " + p.platformName()}
+	}
+	if !p.HasSystemctl {
+		return nil, errUnsupportedPlatform{reason: "systemctl was not found on PATH, so systemd units cannot be installed"}
+	}
+	if !p.HasAptGet {
+		return nil, errUnsupportedPlatform{reason: "apt-get was not found on PATH, so packages cannot be installed"}
+	}
+	if !strings.Contains(strings.ToUpper(p.OSRelease["VERSION"]), "LTS") {
+		warnings = append(warnings, fmt.Sprintf(
+			"%s is not an LTS release. Setup will work, but the release goes end-of-life sooner than an LTS one.",
+			p.platformName()))
+	}
+	return warnings, nil
+}
+
+// renderManualPath is what an unsupported box gets instead of a half-install:
+// the same work, spelled out, for a machine ao setup-vm will not touch.
+func renderManualPath(p setupPlatform, domain string) string {
+	var b strings.Builder
+	b.WriteString("ao setup-vm automates Ubuntu LTS only, because it installs apt packages and\n")
+	fmt.Fprintf(&b, "systemd units. This machine reports %s, so nothing was changed.\n", p.platformName())
+	b.WriteString("\nSet the machine up by hand instead:\n")
+	b.WriteString("\n  1. Install tmux, git, and the GitHub CLI (gh) with this system's package manager.\n")
+	fmt.Fprintf(&b, "  2. Put the ao binary on PATH at an absolute location, for example %s.\n", setupVMBinaryPath)
+	b.WriteString("  3. Run the daemon as your own (non-root) user, with the state directory set\n")
+	b.WriteString("     explicitly to an absolute path:\n")
+	b.WriteString("       AO_DATA_DIR=\"$HOME/.ao/data\" ao daemon\n")
+	b.WriteString("     It listens on 127.0.0.1 only and has no authentication, which is why it must\n")
+	b.WriteString("     never be exposed directly.\n")
+	b.WriteString("  4. Run the gateway as a second, separate process, never the same one:\n")
+	fmt.Fprintf(&b, "       AO_DATA_DIR=\"$HOME/.ao/data\" ao vm serve --domain %s\n", domain)
+	b.WriteString("     It binds :80 and :443, so it needs both ports free, the privilege to bind\n")
+	b.WriteString("     them, and both reachable from the internet for the Let's Encrypt HTTP-01\n")
+	b.WriteString("     challenge.\n")
+	fmt.Fprintf(&b, "  5. Point %s at this machine's public IP with a DNS A record.\n", domain)
+	b.WriteString("  6. Supervise both processes with whatever this system uses, restarting them on\n")
+	b.WriteString("     failure and on boot.\n")
+	b.WriteString("\nThen finish the same way ao setup-vm would:\n")
+	b.WriteString("  ao vm setup-harness claude   (log in to an agent harness in the foreground)\n")
+	b.WriteString("  gh auth login                (git credentials for private repositories)\n")
+	return b.String()
+}
+
+// ---------------------------------------------------------------------------
+// Preflight
+// ---------------------------------------------------------------------------
+
+// setupProblem is one failed preflight check together with the exact steps
+// that fix it. Preflight collects every problem before reporting, so one run
+// tells the user everything they have to do.
+type setupProblem struct {
+	Check       string
+	Detail      string
+	Remediation []string
+}
+
+// setupPortProbe is the result of trying to bind one port on this box, on the
+// loopback interface. Loopback is enough: privilege for ports under 1024 and a
+// conflicting wildcard listener both show up there, and preflight has no
+// business opening a public port of its own.
+type setupPortProbe struct {
+	Port int
+	// Err is the bind error, nil when the port could be bound.
+	Err error
+	// HeldByGateway is true when the port is already held by this machine's
+	// own gateway unit, which is a pass rather than a conflict: it is what a
+	// second run of ao setup-vm on a working machine looks like.
+	HeldByGateway bool
+}
+
+// setupReachability is the outside-in verdict for the public ports.
+type setupReachability struct {
+	// Ran is false when the probe could not be made: no prober answered, or
+	// nothing is listening on this box yet so a closed answer would be
+	// meaningless. Neither is evidence that the ports are closed, so it
+	// downgrades to a warning rather than a failure, with the firewall
+	// remediation printed anyway.
+	Ran bool
+	// Open maps port to whether an off-box prober could connect to it.
+	Open map[int]bool
+	// Err explains why Ran is false.
+	Err error
+}
+
+// setupPreflight is everything observed about the box before anything is
+// mutated. Every field is filled by a probe in setupvm.go; the verdict is
+// computed by evaluatePreflight, which is pure.
+type setupPreflight struct {
+	Domain string
+
+	// UID is this process's user id, 0 when it is already root.
+	UID int
+	// SudoPath is where sudo was found, empty when it is not installed.
+	SudoPath string
+	// SudoPasswordless is true when `sudo -n true` succeeded.
+	SudoPasswordless bool
+
+	// PublicIP is this box's address as seen from the internet.
+	PublicIP    string
+	PublicIPErr error
+	// ResolvedIPs is what Domain resolves to right now.
+	ResolvedIPs []string
+	ResolveErr  error
+
+	Ports []setupPortProbe
+	Reach setupReachability
+	// GatewayActive is whether this machine's own gateway unit is already
+	// running, which is what makes an outside-in probe meaningful.
+	GatewayActive bool
+
+	// Cloud is the provider key detected from DMI, empty when unknown. It only
+	// selects which firewall click-path to print.
+	Cloud string
+}
+
+// evaluatePreflight turns observations into a verdict. Problems mean the run
+// stops before mutating anything; warnings are printed and the run continues.
+func evaluatePreflight(pf setupPreflight) (problems []setupProblem, warnings []string) {
+	if p := checkSetupPrivilege(pf); p != nil {
+		problems = append(problems, *p)
+	}
+	if p := checkSetupDNS(pf); p != nil {
+		problems = append(problems, *p)
+	}
+	portProblems, portWarnings := checkSetupPorts(pf)
+	problems = append(problems, portProblems...)
+	warnings = append(warnings, portWarnings...)
+
+	blocked := blockedSetupPorts(pf.Reach)
+	switch {
+	case len(blocked) > 0:
+		problems = append(problems, setupProblem{
+			Check:       "public reachability",
+			Detail:      fmt.Sprintf("an off-box prober could not connect to %s on %s", portList(blocked), pf.Domain),
+			Remediation: firewallRemediation(pf.Cloud, pf.Domain, blocked),
+		})
+	case !pf.Reach.Ran:
+		warnings = append(warnings, unverifiedReachabilityDetail(pf)+
+			"\n  This is the one thing setup cannot check for you and cannot fix. If the ports are"+
+			"\n  closed, the gateway will never get a certificate."+
+			"\n"+strings.Join(prefixLines(firewallRemediation(pf.Cloud, pf.Domain, setupVMPorts), "  "), "\n"))
+	}
+	return problems, warnings
+}
+
+// unverifiedReachabilityDetail explains why the outside-in check did not
+// produce a verdict. "Not verified" and "closed" are different answers and must
+// never be printed as if they were the same one.
+func unverifiedReachabilityDetail(pf setupPreflight) string {
+	switch {
+	case pf.Reach.Err != nil:
+		return "could not verify " + portList(setupVMPorts) + " from outside: " + pf.Reach.Err.Error()
+	case !pf.GatewayActive:
+		return "nothing is listening on " + portList(setupVMPorts) +
+			" on this machine yet, so an off-box probe cannot tell a blocked firewall from a stopped gateway"
+	default:
+		return "no off-box prober answered, so " + portList(setupVMPorts) + " were not verified from outside"
+	}
+}
+
+func checkSetupPrivilege(pf setupPreflight) *setupProblem {
+	if pf.UID == 0 {
+		return nil
+	}
+	rerun := fmt.Sprintf("sudo ao setup-vm --domain %s", pf.Domain)
+	if pf.SudoPath == "" {
+		return &setupProblem{
+			Check:  "sudo",
+			Detail: "sudo is not installed and this command is not running as root",
+			Remediation: []string{
+				"Installing packages and systemd units needs root. Either log in as root and run:",
+				"  ao setup-vm --domain " + pf.Domain,
+				"or install sudo first:",
+				"  apt-get install -y sudo",
+			},
+		}
+	}
+	if !pf.SudoPasswordless {
+		return &setupProblem{
+			Check:  "sudo",
+			Detail: "sudo needs a password and this command cannot prompt for one mid-install",
+			Remediation: []string{
+				"Run the whole command through sudo instead, so the password is asked once, up front:",
+				"  " + rerun,
+			},
+		}
+	}
+	return nil
+}
+
+func checkSetupDNS(pf setupPreflight) *setupProblem {
+	if pf.PublicIPErr != nil {
+		return &setupProblem{
+			Check:  "public IP",
+			Detail: "could not determine this machine's public IP: " + pf.PublicIPErr.Error(),
+			Remediation: []string{
+				"This machine needs outbound HTTPS to look up its own public address, and it needs it",
+				"anyway to reach Let's Encrypt and the AO control plane. Check outbound connectivity:",
+				"  curl -sS https://api.ipify.org",
+				"If this machine has no outbound access on purpose, pass the address explicitly:",
+				"  ao setup-vm --domain " + pf.Domain + " --public-ip <this machine's public IP>",
+			},
+		}
+	}
+	if pf.ResolveErr != nil {
+		return &setupProblem{
+			Check:       "DNS",
+			Detail:      fmt.Sprintf("%s does not resolve: %s", pf.Domain, pf.ResolveErr.Error()),
+			Remediation: dnsRemediation(pf.Domain, pf.PublicIP, nil),
+		}
+	}
+	for _, ip := range pf.ResolvedIPs {
+		if ip == pf.PublicIP {
+			return nil
+		}
+	}
+	return &setupProblem{
+		Check: "DNS",
+		Detail: fmt.Sprintf("%s resolves to %s, but this machine's public IP is %s",
+			pf.Domain, strings.Join(pf.ResolvedIPs, ", "), pf.PublicIP),
+		Remediation: dnsRemediation(pf.Domain, pf.PublicIP, pf.ResolvedIPs),
+	}
+}
+
+func dnsRemediation(domain, publicIP string, resolved []string) []string {
+	record := "A"
+	if ip := net.ParseIP(publicIP); ip != nil && ip.To4() == nil {
+		record = "AAAA"
+	}
+	lines := []string{}
+	if len(resolved) > 0 {
+		lines = append(lines, fmt.Sprintf("Change the %s record for %s from %s to %s at your DNS provider:",
+			record, domain, strings.Join(resolved, ", "), publicIP))
+	} else {
+		lines = append(lines, fmt.Sprintf("Add this record at your DNS provider, the one that hosts %s:", domain))
+	}
+	lines = append(lines,
+		fmt.Sprintf("  %-24s %-6s %s", domain+".", record, publicIP),
+		"Use a short TTL (60 seconds) while setting up. Then wait for it to propagate and check:",
+		"  dig +short "+domain,
+		"The gateway gets its certificate over ACME, which only succeeds once the domain resolves",
+		"to this machine, so this has to be right before setup can finish.",
+	)
+	return lines
+}
+
+func checkSetupPorts(pf setupPreflight) (problems []setupProblem, warnings []string) {
+	for _, probe := range pf.Ports {
+		if probe.HeldByGateway {
+			warnings = append(warnings, fmt.Sprintf(
+				"port %d is already held by %s, which is this machine's own gateway. Leaving it running.",
+				probe.Port, setupVMGatewayUnit))
+			continue
+		}
+		if probe.Err == nil {
+			continue
+		}
+		problems = append(problems, setupProblem{
+			Check:       fmt.Sprintf("port %d", probe.Port),
+			Detail:      fmt.Sprintf("cannot bind :%d on this machine: %s", probe.Port, probe.Err.Error()),
+			Remediation: portRemediation(probe),
+		})
+	}
+	return problems, warnings
+}
+
+// portRemediation classifies a bind failure by its message rather than by
+// errno, because this function has to compile and be testable on every OS the
+// CLI E2E matrix runs.
+func portRemediation(probe setupPortProbe) []string {
+	msg := strings.ToLower(probe.Err.Error())
+	switch {
+	case strings.Contains(msg, "permission denied"), strings.Contains(msg, "access"):
+		return []string{
+			"Ports below 1024 need privilege. Run the whole command through sudo:",
+			"  sudo ao setup-vm --domain <your domain>",
+			"The gateway unit itself does not run as root: it gets CAP_NET_BIND_SERVICE instead.",
+		}
+	case strings.Contains(msg, "in use"), strings.Contains(msg, "address already"):
+		return []string{
+			fmt.Sprintf("Something else is already listening on :%d. Find it:", probe.Port),
+			fmt.Sprintf("  sudo ss -ltnp 'sport = :%d'", probe.Port),
+			"A default web server is the usual answer. Stop and disable it, then run setup again:",
+			"  sudo systemctl disable --now nginx    # or apache2, caddy, whatever ss reported",
+			"The gateway terminates TLS itself, so this machine needs no other reverse proxy.",
+		}
+	default:
+		return []string{
+			fmt.Sprintf("Make :%d bindable on this machine, then run setup again.", probe.Port),
+		}
+	}
+}
+
+func blockedSetupPorts(reach setupReachability) []int {
+	if !reach.Ran {
+		return nil
+	}
+	blocked := make([]int, 0, len(setupVMPorts))
+	for _, port := range setupVMPorts {
+		if open, ok := reach.Open[port]; ok && !open {
+			blocked = append(blocked, port)
+		}
+	}
+	return blocked
+}
+
+// firewallRemediation prints exactly what the user has to click. The cloud
+// firewall is the one blocker ao setup-vm cannot fix for them, so when the
+// provider is known this narrows to that provider's path instead of a menu.
+func firewallRemediation(cloud, domain string, ports []int) []string {
+	return slices.Concat(
+		[]string{
+			fmt.Sprintf("Open inbound TCP %s to this machine. Two separate layers can block them:", portList(ports)),
+			"",
+			"  1. The host firewall on this box, which you can fix here:",
+			"       sudo ufw status",
+			"       sudo ufw allow 80/tcp && sudo ufw allow 443/tcp",
+			"",
+			"  2. Your cloud provider's firewall, which ao setup-vm cannot change for you:",
+		},
+		cloudFirewallSteps(cloud),
+		[]string{
+			"",
+			"Then verify from a machine that is not this one, for example your laptop:",
+			"  nc -vz " + domain + " 80",
+			"  nc -vz " + domain + " 443",
+		},
+	)
+}
+
+func cloudFirewallSteps(cloud string) []string {
+	switch cloud {
+	case "aws":
+		return []string{
+			"       AWS (this looks like EC2): EC2 console > Instances > this instance > Security >",
+			"       click its security group > Edit inbound rules > Add rule (Type HTTP, Source",
+			"       0.0.0.0/0) > Add rule (Type HTTPS, Source 0.0.0.0/0) > Save rules.",
+		}
+	case "gcp":
+		return []string{
+			"       Google Cloud (this looks like Compute Engine): VPC network > Firewall >",
+			"       Create firewall rule, Direction Ingress, Source 0.0.0.0/0, Protocols and ports",
+			"       tcp:80,tcp:443 > Create. Or from a machine with gcloud:",
+			"         gcloud compute firewall-rules create ao-gateway --direction=INGRESS \\",
+			"           --action=allow --rules=tcp:80,tcp:443 --source-ranges=0.0.0.0/0",
+		}
+	case "azure":
+		return []string{
+			"       Azure (this looks like an Azure VM): Portal > this VM > Networking >",
+			"       Network settings > Add inbound port rule, Destination port ranges 80,443,",
+			"       Protocol TCP, Action Allow > Add. Or from a machine with az:",
+			"         az network nsg rule create -g <resource-group> --nsg-name <nsg> \\",
+			"           -n ao-gateway --priority 300 --destination-port-ranges 80 443 \\",
+			"           --access Allow --protocol Tcp",
+		}
+	case "digitalocean":
+		return []string{
+			"       DigitalOcean (this looks like a Droplet): Networking > Firewalls > the firewall",
+			"       attached to this Droplet > Inbound Rules > Add rule HTTP (80), then HTTPS (443),",
+			"       sources All IPv4 and All IPv6 > Save. A Droplet with no firewall attached needs",
+			"       no change here.",
+		}
+	case "hetzner":
+		return []string{
+			"       Hetzner Cloud (this looks like a Hetzner server): Console > this server >",
+			"       Firewalls > the attached firewall > Rules > Add rule, Inbound, TCP, port 80,",
+			"       any source; repeat for 443 > Save.",
+		}
+	default:
+		return []string{
+			"       AWS: the instance's security group > Edit inbound rules > add HTTP and HTTPS.",
+			"       Google Cloud: VPC network > Firewall > allow ingress tcp:80,tcp:443.",
+			"       Azure: the VM > Networking > Add inbound port rule for ports 80 and 443.",
+			"       DigitalOcean: Networking > Firewalls > add HTTP and HTTPS inbound rules.",
+			"       Hetzner Cloud: the server > Firewalls > add inbound TCP 80 and 443.",
+			"       Anything else: look for a security group, network ACL, or cloud firewall and",
+			"       allow inbound TCP 80 and 443 from anywhere.",
+		}
+	}
+}
+
+// setupCloudFromVendor maps the DMI system vendor string to a provider key. It
+// is only ever used to pick which firewall instructions to print, so an
+// unrecognised vendor is harmless.
+func setupCloudFromVendor(vendor string) string {
+	v := strings.ToLower(strings.TrimSpace(vendor))
+	switch {
+	case v == "":
+		return ""
+	case strings.Contains(v, "amazon"):
+		return "aws"
+	case strings.Contains(v, "google"):
+		return "gcp"
+	case strings.Contains(v, "microsoft"):
+		return "azure"
+	case strings.Contains(v, "digitalocean"):
+		return "digitalocean"
+	case strings.Contains(v, "hetzner"):
+		return "hetzner"
+	default:
+		return ""
+	}
+}
+
+// renderPreflightFailure is the whole output of a failed preflight. It leads
+// with the fact that nothing was changed, because that is the guarantee the
+// user most needs to trust when a setup script stops halfway.
+func renderPreflightFailure(problems []setupProblem) string {
+	var b strings.Builder
+	b.WriteString("Preflight failed. Nothing on this machine was changed.\n")
+	for _, problem := range problems {
+		fmt.Fprintf(&b, "\nFAIL %s: %s\n", problem.Check, problem.Detail)
+		for _, line := range problem.Remediation {
+			if line == "" {
+				b.WriteString("\n")
+				continue
+			}
+			fmt.Fprintf(&b, "  %s\n", line)
+		}
+	}
+	b.WriteString("\nFix the items above and run the same command again. Preflight is re-runnable.\n")
+	return b.String()
+}
+
+// parseSetupReachability reads the prober's answer. The contract is a JSON
+// object of port to open, for example {"ports":{"80":true,"443":false}}; a
+// port the prober did not report is left unknown rather than assumed closed.
+func parseSetupReachability(body []byte, ports []int) (map[int]bool, error) {
+	var payload struct {
+		Ports map[string]bool `json:"ports"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return nil, fmt.Errorf("parse reachability response: %w", err)
+	}
+	if len(payload.Ports) == 0 {
+		return nil, fmt.Errorf("reachability response reported no ports")
+	}
+	open := map[int]bool{}
+	for _, port := range ports {
+		if value, ok := payload.Ports[strconv.Itoa(port)]; ok {
+			open[port] = value
+		}
+	}
+	if len(open) == 0 {
+		return nil, fmt.Errorf("reachability response reported no ports")
+	}
+	return open, nil
+}
+
+// ---------------------------------------------------------------------------
+// The install plan
+// ---------------------------------------------------------------------------
+
+// setupPlan is every absolute path and identity the install needs. It is
+// computed once, up front, so the systemd units and the summary can never
+// disagree about where state lives.
+type setupPlan struct {
+	Domain string
+	// User and Group own every path below and are who both units run as. The
+	// daemon runs agent sessions, git, and gh, so it must not be root.
+	User  string
+	Group string
+	Home  string
+	// AODir is ~/.ao, the only place AO state may live.
+	AODir string
+	// DataDir, RunFile, MachineFile, and CertDir are all absolute. PR #18 made
+	// the control plane require an absolute DATA_DIR because under systemd a
+	// working-directory-relative path is how keys and state silently relocate.
+	// Same discipline here: the units set every path explicitly.
+	DataDir     string
+	RunFile     string
+	MachineFile string
+	CertDir     string
+	BinaryPath  string
+	Packages    []string
+	// Bound is whether machine.json already exists. `ao vm serve` reads it
+	// once at startup, so an unbound machine gets an enabled-but-stopped
+	// gateway and a summary line telling the user to restart it after binding.
+	Bound bool
+}
+
+// setupPlanInput is the raw material for buildSetupPlan: the target user, and
+// whatever AO_* overrides the environment carries.
+type setupPlanInput struct {
+	Domain      string
+	User        string
+	Group       string
+	Home        string
+	DataDir     string
+	RunFile     string
+	MachineFile string
+	Bound       bool
+}
+
+// buildSetupPlan resolves every path to an absolute one. A relative AO_DATA_DIR
+// or AO_RUN_FILE is rejected rather than absolutized: under systemd it would be
+// resolved against the unit's working directory, which is exactly the silent
+// state relocation this command has to prevent.
+func buildSetupPlan(in setupPlanInput) (setupPlan, error) {
+	if strings.TrimSpace(in.User) == "" {
+		return setupPlan{}, fmt.Errorf("no target user for the systemd units")
+	}
+	if !isLinuxAbs(in.Home) {
+		return setupPlan{}, fmt.Errorf("home directory %q for user %s is not an absolute path", in.Home, in.User)
+	}
+	group := in.Group
+	if group == "" {
+		group = in.User
+	}
+	aoDir := slashPath(in.Home, ".ao")
+	plan := setupPlan{
+		Domain:      in.Domain,
+		User:        in.User,
+		Group:       group,
+		Home:        in.Home,
+		AODir:       aoDir,
+		DataDir:     slashPath(aoDir, "data"),
+		RunFile:     slashPath(aoDir, "running.json"),
+		MachineFile: slashPath(aoDir, "machine.json"),
+		BinaryPath:  setupVMBinaryPath,
+		Packages:    setupVMPackages,
+		Bound:       in.Bound,
+	}
+	for _, override := range []struct {
+		name  string
+		value string
+		dest  *string
+	}{
+		{"AO_DATA_DIR", in.DataDir, &plan.DataDir},
+		{"AO_RUN_FILE", in.RunFile, &plan.RunFile},
+		{"AO_MACHINE_FILE", in.MachineFile, &plan.MachineFile},
+	} {
+		value := strings.TrimSpace(override.value)
+		if value == "" {
+			continue
+		}
+		if !isLinuxAbs(value) {
+			return setupPlan{}, fmt.Errorf(
+				"%s=%q is a relative path. A systemd unit resolves it against the unit's working directory, "+
+					"which silently moves state; set it to an absolute path or unset it", override.name, value)
+		}
+		*override.dest = value
+	}
+	// Matches vmgateway's own default so the unit is explicit about a path the
+	// gateway would otherwise derive on its own.
+	plan.CertDir = slashPath(plan.DataDir, "vm-gateway", "certs")
+	return plan, nil
+}
+
+// slashPath joins Linux paths regardless of the OS this command was compiled
+// for, which is why it uses path and not filepath: the units it writes always
+// run on the Ubuntu box, never on the machine a unit test happens to run on.
+func slashPath(parts ...string) string {
+	return path.Join(parts...)
+}
+
+// isLinuxAbs answers the question filepath.IsAbs cannot: these are always Linux
+// paths, and on Windows filepath.IsAbs("/home/ubuntu") is false because it wants
+// a drive letter, which would make the plan reject a perfectly good path when
+// the unit tests run on the Windows leg of the CLI E2E matrix.
+func isLinuxAbs(p string) bool {
+	return strings.HasPrefix(p, "/")
+}
+
+// setupDirs are the directories the install creates, in order, all owned by
+// the target user and none of them outside ~/.ao.
+func (p setupPlan) setupDirs() []string {
+	dirs := []string{p.AODir}
+	for _, dir := range []string{p.DataDir, p.CertDir, path.Dir(p.RunFile)} {
+		if !slices.Contains(dirs, dir) {
+			dirs = append(dirs, dir)
+		}
+	}
+	return dirs
+}
+
+// ---------------------------------------------------------------------------
+// systemd units
+// ---------------------------------------------------------------------------
+
+// systemdUnit is the small subset of unit syntax these two services need.
+type systemdUnit struct {
+	Description string
+	After       []string
+	Wants       []string
+	// User and Group are never root: the daemon runs agent sessions, git, and
+	// gh as the human who owns the machine, and the gateway reaches :80 and
+	// :443 through a capability instead of through privilege.
+	User       string
+	Group      string
+	WorkingDir string
+	Env        [][2]string
+	ExecStart  string
+	// AmbientCaps lets a non-root service bind a privileged port without
+	// running as root.
+	AmbientCaps []string
+	Comment     []string
+}
+
+// renderSystemdUnit writes a unit file. Environment and WorkingDirectory
+// values are always quoted: systemd splits on whitespace otherwise, and a home
+// directory with a space in it would silently produce a broken unit.
+func renderSystemdUnit(u systemdUnit) string {
+	var b strings.Builder
+	for _, line := range u.Comment {
+		fmt.Fprintf(&b, "# %s\n", line)
+	}
+	b.WriteString("# Written by `ao setup-vm`. Re-running that command rewrites this file.\n")
+	b.WriteString("\n[Unit]\n")
+	fmt.Fprintf(&b, "Description=%s\n", u.Description)
+	b.WriteString("Documentation=https://github.com/agentlab-in/hosted-ao\n")
+	if len(u.Wants) > 0 {
+		fmt.Fprintf(&b, "Wants=%s\n", strings.Join(u.Wants, " "))
+	}
+	if len(u.After) > 0 {
+		fmt.Fprintf(&b, "After=%s\n", strings.Join(u.After, " "))
+	}
+
+	b.WriteString("\n[Service]\n")
+	b.WriteString("Type=simple\n")
+	fmt.Fprintf(&b, "User=%s\n", u.User)
+	fmt.Fprintf(&b, "Group=%s\n", u.Group)
+	fmt.Fprintf(&b, "WorkingDirectory=%q\n", u.WorkingDir)
+	for _, kv := range u.Env {
+		fmt.Fprintf(&b, "Environment=%q\n", kv[0]+"="+kv[1])
+	}
+	fmt.Fprintf(&b, "ExecStart=%s\n", u.ExecStart)
+	if len(u.AmbientCaps) > 0 {
+		fmt.Fprintf(&b, "AmbientCapabilities=%s\n", strings.Join(u.AmbientCaps, " "))
+		fmt.Fprintf(&b, "CapabilityBoundingSet=%s\n", strings.Join(u.AmbientCaps, " "))
+		b.WriteString("NoNewPrivileges=yes\n")
+	}
+	b.WriteString("Restart=on-failure\n")
+	b.WriteString("RestartSec=5\n")
+	b.WriteString("KillSignal=SIGTERM\n")
+	b.WriteString("TimeoutStopSec=30\n")
+
+	b.WriteString("\n[Install]\n")
+	b.WriteString("WantedBy=multi-user.target\n")
+	return b.String()
+}
+
+// unitEnvironment is the absolute state paths both units share. Nothing here
+// is relative and nothing is left to be derived from the process working
+// directory: that is how keys and state silently relocate under systemd, which
+// is the hazard PR #18 fixed in the control plane.
+func (p setupPlan) unitEnvironment() [][2]string {
+	return [][2]string{
+		{"HOME", p.Home},
+		{"AO_DATA_DIR", p.DataDir},
+		{"AO_RUN_FILE", p.RunFile},
+	}
+}
+
+// daemonPath puts the user's own bin directories ahead of systemd's default
+// PATH. The daemon spawns tmux, git, gh, and the agent harnesses, and harnesses
+// install into ~/.local/bin or ~/bin; a unit that cannot see them reports a
+// harness as missing when it is installed and working from a login shell.
+func (p setupPlan) daemonPath() string {
+	return strings.Join([]string{
+		slashPath(p.Home, ".local", "bin"),
+		slashPath(p.Home, "bin"),
+		"/usr/local/sbin", "/usr/local/bin", "/usr/sbin", "/usr/bin", "/sbin", "/bin",
+	}, ":")
+}
+
+// renderDaemonUnit renders the loopback daemon's unit. The daemon stays bound
+// to 127.0.0.1 and unauthenticated, per the hard rule in AGENTS.md, so it gets
+// no capabilities and no public port.
+func renderDaemonUnit(p setupPlan) string {
+	return renderSystemdUnit(systemdUnit{
+		Comment: []string{
+			"The AO daemon: loopback only (127.0.0.1) and unauthenticated by design.",
+			"Nothing off this box can reach it. Public traffic arrives through",
+			"ao-gateway.service, a separate process, which authenticates every request",
+			"before proxying it here. See docs/adr/0002-hosted-public-gateway.md.",
+		},
+		Description: "Agent Orchestrator daemon (loopback API)",
+		Wants:       []string{"network-online.target"},
+		After:       []string{"network-online.target"},
+		User:        p.User,
+		Group:       p.Group,
+		WorkingDir:  p.DataDir,
+		Env:         append(p.unitEnvironment(), [2]string{"PATH", p.daemonPath()}),
+		ExecStart:   p.BinaryPath + " daemon",
+	})
+}
+
+// renderGatewayUnit renders the public TLS gateway's unit. Every path is
+// absolute and set here rather than derived from the process working
+// directory, which is how ACME keys and state silently relocate under systemd.
+func renderGatewayUnit(p setupPlan) string {
+	env := append(p.unitEnvironment(),
+		[2]string{"AO_MACHINE_FILE", p.MachineFile},
+		[2]string{"AO_VM_DOMAIN", p.Domain},
+		[2]string{"AO_VM_CERT_DIR", p.CertDir},
+	)
+	return renderSystemdUnit(systemdUnit{
+		Comment: []string{
+			"The AO VM gateway: binds :80 and :443, obtains and renews a Let's Encrypt",
+			"certificate over ACME, verifies the AO access token on every request, and",
+			"reverse-proxies authenticated requests to the loopback daemon.",
+			"It is a separate process from the daemon and must stay one (ADR 0002).",
+			"It reads " + p.MachineFile + " once at startup, so it needs a restart",
+			"after this machine is bound to an AO account.",
+		},
+		Description: "Agent Orchestrator VM gateway (public TLS on :80 and :443)",
+		Wants:       []string{"network-online.target"},
+		After:       []string{"network-online.target", setupVMDaemonUnit},
+		User:        p.User,
+		Group:       p.Group,
+		WorkingDir:  p.DataDir,
+		Env:         env,
+		ExecStart:   p.BinaryPath + " vm serve",
+		AmbientCaps: []string{"CAP_NET_BIND_SERVICE"},
+	})
+}
+
+// ---------------------------------------------------------------------------
+// The closing summary
+// ---------------------------------------------------------------------------
+
+// renderSetupSummary is the last thing ao setup-vm prints. It reports the
+// machine as installed but not ready, and names every remaining step with the
+// exact command, rather than implying the machine is done.
+func renderSetupSummary(p setupPlan, gatewayStarted bool, warnings []string) string {
+	var b strings.Builder
+	b.WriteString("\nao setup-vm finished. This machine is installed, but not yet ready to use.\n")
+
+	b.WriteString("\nInstalled:\n")
+	fmt.Fprintf(&b, "  ao binary        %s\n", p.BinaryPath)
+	fmt.Fprintf(&b, "  packages         %s\n", strings.Join(p.Packages, ", "))
+	fmt.Fprintf(&b, "  state directory  %s (owned by %s)\n", p.AODir, p.User)
+	fmt.Fprintf(&b, "  daemon unit      %s (enabled, running, loopback only)\n", slashPath(setupVMUnitDir, setupVMDaemonUnit))
+	gatewayState := "enabled, not started: this machine is not bound yet"
+	if gatewayStarted {
+		gatewayState = "enabled, running"
+	}
+	fmt.Fprintf(&b, "  gateway unit     %s (%s)\n", slashPath(setupVMUnitDir, setupVMGatewayUnit), gatewayState)
+
+	if len(warnings) > 0 {
+		b.WriteString("\nWarnings from this run:\n")
+		for _, warning := range warnings {
+			fmt.Fprintf(&b, "  %s\n", warning)
+		}
+	}
+
+	b.WriteString("\nStill missing. Nothing below is done for you:\n")
+	step := 0
+	next := func() int { step++; return step }
+
+	if !p.Bound {
+		fmt.Fprintf(&b, "\n  %d. This machine is not bound to an AO account, so the gateway is installed and\n", next())
+		b.WriteString("     enabled but not serving. Binding is not part of this build yet. Once it writes\n")
+		fmt.Fprintf(&b, "     %s, the gateway needs a restart to read it, because\n", p.MachineFile)
+		b.WriteString("     `ao vm serve` reads that file once at startup:\n")
+		fmt.Fprintf(&b, "       sudo systemctl start %s\n", setupVMGatewayUnit)
+	} else {
+		fmt.Fprintf(&b, "\n  %d. This machine is already bound (%s). If you re-bind it, restart\n", next(), p.MachineFile)
+		b.WriteString("     the gateway so it re-reads the file:\n")
+		fmt.Fprintf(&b, "       sudo systemctl restart %s\n", setupVMGatewayUnit)
+	}
+
+	fmt.Fprintf(&b, "\n  %d. No agent harness is configured. ao setup-vm deliberately does not install one,\n", next())
+	b.WriteString("     because the login is interactive. Run it in the foreground and finish the\n")
+	b.WriteString("     harness's own login:\n")
+	b.WriteString("       ao vm setup-harness claude\n")
+
+	fmt.Fprintf(&b, "\n  %d. No git credentials on this machine, so private repositories cannot be cloned.\n", next())
+	b.WriteString("     gh is installed; authenticate it once:\n")
+	b.WriteString("       gh auth login\n")
+
+	b.WriteString("\nCheck this machine at any time:\n")
+	b.WriteString("  ao doctor\n")
+	fmt.Fprintf(&b, "  systemctl status %s %s\n", setupVMDaemonUnit, setupVMGatewayUnit)
+	fmt.Fprintf(&b, "  journalctl -u %s -f\n", setupVMGatewayUnit)
+	return b.String()
+}
+
+// renderSetupDryRun shows the whole plan, including both unit files verbatim,
+// without touching the machine. Preflight has already run at this point, so a
+// dry run is also the way to check DNS, ports, and sudo on a box you are not
+// ready to modify.
+func renderSetupDryRun(p setupPlan, warnings []string) string {
+	var b strings.Builder
+	b.WriteString("Dry run. Nothing on this machine was changed.\n")
+	if len(warnings) > 0 {
+		b.WriteString("\nWarnings:\n")
+		for _, warning := range warnings {
+			fmt.Fprintf(&b, "  %s\n", warning)
+		}
+	}
+	b.WriteString("\nPlan:\n")
+	fmt.Fprintf(&b, "  domain           %s\n", p.Domain)
+	fmt.Fprintf(&b, "  run as           %s:%s\n", p.User, p.Group)
+	fmt.Fprintf(&b, "  state directory  %s\n", p.AODir)
+	fmt.Fprintf(&b, "  data dir         %s\n", p.DataDir)
+	fmt.Fprintf(&b, "  run file         %s\n", p.RunFile)
+	fmt.Fprintf(&b, "  machine file     %s (bound: %t)\n", p.MachineFile, p.Bound)
+	fmt.Fprintf(&b, "  certificate dir  %s\n", p.CertDir)
+	fmt.Fprintf(&b, "  ao binary        %s\n", p.BinaryPath)
+	fmt.Fprintf(&b, "  apt packages     %s\n", strings.Join(p.Packages, ", "))
+
+	for _, unit := range []struct {
+		name    string
+		content string
+	}{
+		{setupVMDaemonUnit, renderDaemonUnit(p)},
+		{setupVMGatewayUnit, renderGatewayUnit(p)},
+	} {
+		fmt.Fprintf(&b, "\n--- %s ---\n", slashPath(setupVMUnitDir, unit.name))
+		b.WriteString(unit.content)
+	}
+	b.WriteString("\nRun the same command without --dry-run to apply this.\n")
+	return b.String()
+}
+
+// ---------------------------------------------------------------------------
+// small shared helpers
+// ---------------------------------------------------------------------------
+
+// normalizeSetupDomain reduces whatever the user passed to the bare hostname a
+// certificate can be issued for. It mirrors vmgateway.Resolve's own
+// normalization so `ao setup-vm --domain https://vm.example.com/` and the
+// gateway agree on what the domain is.
+func normalizeSetupDomain(raw string) (string, error) {
+	domain := strings.TrimSpace(raw)
+	if scheme, rest, ok := strings.Cut(domain, "://"); ok && scheme != "" {
+		domain = rest
+	}
+	domain = strings.TrimSuffix(domain, "/")
+	if domain == "" {
+		return "", fmt.Errorf("--domain is required, for example --domain vm.example.com")
+	}
+	if strings.ContainsAny(domain, ":/ ") || !strings.Contains(domain, ".") {
+		return "", fmt.Errorf("invalid --domain %q: expected a bare hostname you own, like vm.example.com", raw)
+	}
+	if net.ParseIP(domain) != nil {
+		return "", fmt.Errorf("invalid --domain %q: a certificate cannot be issued for a bare IP, so hosted AO needs a hostname", raw)
+	}
+	return domain, nil
+}
+
+// dpkgInstalled reads `dpkg-query -W -f=${Status}` output. Anything other than
+// the fully-installed status means the package still has to be installed.
+func dpkgInstalled(out string) bool {
+	return strings.Contains(out, "install ok installed")
+}
+
+// githubCLISourceList is the apt source GitHub documents for gh, used only
+// when the distro has no gh package. arch comes from `dpkg --print-architecture`.
+func githubCLISourceList(arch string) string {
+	return fmt.Sprintf("deb [arch=%s signed-by=%s] https://cli.github.com/packages stable main\n",
+		arch, setupVMKeyringPath)
+}
+
+func portList(ports []int) string {
+	parts := make([]string, 0, len(ports))
+	for _, port := range ports {
+		parts = append(parts, strconv.Itoa(port))
+	}
+	switch len(parts) {
+	case 0:
+		return "no ports"
+	case 1:
+		return parts[0]
+	default:
+		return strings.Join(parts[:len(parts)-1], ", ") + " and " + parts[len(parts)-1]
+	}
+}
+
+func prefixLines(lines []string, prefix string) []string {
+	out := make([]string, 0, len(lines))
+	for _, line := range lines {
+		if line == "" {
+			out = append(out, "")
+			continue
+		}
+		out = append(out, prefix+line)
+	}
+	return out
+}

--- a/backend/internal/cli/setupvm_plan_test.go
+++ b/backend/internal/cli/setupvm_plan_test.go
@@ -1,0 +1,764 @@
+package cli
+
+// Every decision `ao setup-vm` makes is tested here, with no VM, no apt, and no
+// systemd: the platform gate, the preflight verdicts, the path plan, both unit
+// files, and the closing summary. This file has to pass on macOS and Windows,
+// where CLI E2E also runs, which is exactly why the decisions live in pure
+// functions and not inside the privileged shell-out layer.
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+const ubuntuNobleOSRelease = `PRETTY_NAME="Ubuntu 24.04.2 LTS"
+NAME="Ubuntu"
+VERSION_ID="24.04"
+VERSION="24.04.2 LTS (Noble Numbat)"
+VERSION_CODENAME=noble
+ID=ubuntu
+ID_LIKE=debian
+HOME_URL="https://www.ubuntu.com/"
+`
+
+func ubuntuPlatform() setupPlatform {
+	return setupPlatform{
+		GOOS:         "linux",
+		OSRelease:    parseOSRelease(ubuntuNobleOSRelease),
+		HasSystemctl: true,
+		HasAptGet:    true,
+	}
+}
+
+func TestParseOSRelease(t *testing.T) {
+	got := parseOSRelease(ubuntuNobleOSRelease + "\n# a comment\nBROKEN\nSINGLE='quoted'\n")
+	for key, want := range map[string]string{
+		"ID":          "ubuntu",
+		"VERSION_ID":  "24.04",
+		"VERSION":     "24.04.2 LTS (Noble Numbat)",
+		"PRETTY_NAME": "Ubuntu 24.04.2 LTS",
+		"SINGLE":      "quoted",
+	} {
+		if got[key] != want {
+			t.Errorf("parseOSRelease()[%q] = %q, want %q", key, got[key], want)
+		}
+	}
+	if _, ok := got["BROKEN"]; ok {
+		t.Error("a line with no '=' should be skipped, not stored")
+	}
+}
+
+func TestCheckSetupPlatform(t *testing.T) {
+	tests := []struct {
+		name        string
+		platform    setupPlatform
+		wantErr     bool
+		wantWarning string
+	}{
+		{name: "ubuntu LTS", platform: ubuntuPlatform()},
+		{
+			name: "ubuntu non-LTS warns but proceeds",
+			platform: setupPlatform{
+				GOOS: "linux", HasSystemctl: true, HasAptGet: true,
+				OSRelease: parseOSRelease("ID=ubuntu\nVERSION=\"25.04 (Plucky Puffin)\"\nPRETTY_NAME=\"Ubuntu 25.04\"\n"),
+			},
+			wantWarning: "not an LTS release",
+		},
+		{
+			name: "debian is refused",
+			platform: setupPlatform{
+				GOOS: "linux", HasSystemctl: true, HasAptGet: true,
+				OSRelease: parseOSRelease("ID=debian\nPRETTY_NAME=\"Debian GNU/Linux 12 (bookworm)\"\n"),
+			},
+			wantErr: true,
+		},
+		{name: "macOS is refused", platform: setupPlatform{GOOS: "darwin"}, wantErr: true},
+		{name: "windows is refused", platform: setupPlatform{GOOS: "windows"}, wantErr: true},
+		{
+			name: "ubuntu without systemd is refused",
+			platform: setupPlatform{
+				GOOS: "linux", HasAptGet: true, OSRelease: parseOSRelease(ubuntuNobleOSRelease),
+			},
+			wantErr: true,
+		},
+		{
+			name: "ubuntu without apt is refused",
+			platform: setupPlatform{
+				GOOS: "linux", HasSystemctl: true, OSRelease: parseOSRelease(ubuntuNobleOSRelease),
+			},
+			wantErr: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			warnings, err := checkSetupPlatform(tc.platform)
+			if tc.wantErr {
+				var unsupported errUnsupportedPlatform
+				if !errors.As(err, &unsupported) {
+					t.Fatalf("checkSetupPlatform err = %v, want errUnsupportedPlatform", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("checkSetupPlatform err = %v, want nil", err)
+			}
+			if tc.wantWarning == "" {
+				if len(warnings) != 0 {
+					t.Fatalf("warnings = %v, want none", warnings)
+				}
+				return
+			}
+			if !strings.Contains(strings.Join(warnings, "\n"), tc.wantWarning) {
+				t.Fatalf("warnings = %v, want one containing %q", warnings, tc.wantWarning)
+			}
+		})
+	}
+}
+
+func TestRenderManualPathNamesEveryStep(t *testing.T) {
+	text := renderManualPath(setupPlatform{GOOS: "darwin"}, "vm.example.com")
+	for _, want := range []string{
+		"nothing was changed",
+		"ao daemon",
+		"ao vm serve --domain vm.example.com",
+		"ao vm setup-harness claude",
+		"gh auth login",
+		"AO_DATA_DIR",
+	} {
+		if !strings.Contains(text, want) {
+			t.Errorf("manual path is missing %q:\n%s", want, text)
+		}
+	}
+	assertNoDashes(t, text)
+}
+
+func TestNormalizeSetupDomain(t *testing.T) {
+	tests := []struct {
+		in      string
+		want    string
+		wantErr bool
+	}{
+		{in: "vm.example.com", want: "vm.example.com"},
+		{in: "  vm.example.com  ", want: "vm.example.com"},
+		{in: "https://vm.example.com", want: "vm.example.com"},
+		{in: "https://vm.example.com/", want: "vm.example.com"},
+		{in: "", wantErr: true},
+		{in: "vm.example.com:443", wantErr: true},
+		{in: "localhost", wantErr: true},
+		{in: "203.0.113.10", wantErr: true},
+		{in: "https://203.0.113.10", wantErr: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.in, func(t *testing.T) {
+			got, err := normalizeSetupDomain(tc.in)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("normalizeSetupDomain(%q) = %q, want an error", tc.in, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("normalizeSetupDomain(%q) err = %v", tc.in, err)
+			}
+			if got != tc.want {
+				t.Fatalf("normalizeSetupDomain(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// passingPreflight is a box where every check succeeds: root, DNS pointing
+// here, both ports free, and the gateway not yet running.
+func passingPreflight() setupPreflight {
+	return setupPreflight{
+		Domain:      "vm.example.com",
+		UID:         0,
+		PublicIP:    "203.0.113.10",
+		ResolvedIPs: []string{"203.0.113.10"},
+		Ports:       []setupPortProbe{{Port: 80}, {Port: 443}},
+	}
+}
+
+func TestEvaluatePreflight_Passing(t *testing.T) {
+	problems, warnings := evaluatePreflight(passingPreflight())
+	if len(problems) != 0 {
+		t.Fatalf("problems = %+v, want none", problems)
+	}
+	// Nothing was listening yet, so the outside-in check cannot run and has to
+	// say so loudly rather than silently passing.
+	joined := strings.Join(warnings, "\n")
+	if !strings.Contains(joined, "cannot tell a blocked firewall from a stopped gateway") {
+		t.Fatalf("warnings = %v, want the unverified-reachability warning", warnings)
+	}
+	if !strings.Contains(joined, "sudo ufw allow 80/tcp") || !strings.Contains(joined, "nc -vz vm.example.com 443") {
+		t.Fatalf("the unverified warning must still print the firewall fix and the off-box check:\n%s", joined)
+	}
+}
+
+func TestEvaluatePreflight_SudoProblems(t *testing.T) {
+	t.Run("no sudo and not root", func(t *testing.T) {
+		pf := passingPreflight()
+		pf.UID = 1000
+		problems, _ := evaluatePreflight(pf)
+		assertProblem(t, problems, "sudo", "apt-get install -y sudo")
+	})
+	t.Run("sudo needs a password", func(t *testing.T) {
+		pf := passingPreflight()
+		pf.UID = 1000
+		pf.SudoPath = "/usr/bin/sudo"
+		problems, _ := evaluatePreflight(pf)
+		assertProblem(t, problems, "sudo", "sudo ao setup-vm --domain vm.example.com")
+	})
+	t.Run("passwordless sudo passes", func(t *testing.T) {
+		pf := passingPreflight()
+		pf.UID = 1000
+		pf.SudoPath = "/usr/bin/sudo"
+		pf.SudoPasswordless = true
+		if problems, _ := evaluatePreflight(pf); len(problems) != 0 {
+			t.Fatalf("problems = %+v, want none", problems)
+		}
+	})
+}
+
+func TestEvaluatePreflight_DNSProblems(t *testing.T) {
+	t.Run("domain points somewhere else", func(t *testing.T) {
+		pf := passingPreflight()
+		pf.ResolvedIPs = []string{"198.51.100.7"}
+		problems, _ := evaluatePreflight(pf)
+		problem := assertProblem(t, problems, "DNS", "203.0.113.10")
+		if !strings.Contains(problem.Detail, "198.51.100.7") {
+			t.Errorf("the detail must name what the domain resolves to now: %q", problem.Detail)
+		}
+		if !strings.Contains(strings.Join(problem.Remediation, "\n"), "dig +short vm.example.com") {
+			t.Errorf("remediation must include the verification command: %v", problem.Remediation)
+		}
+	})
+	t.Run("domain does not resolve at all", func(t *testing.T) {
+		pf := passingPreflight()
+		pf.ResolvedIPs = nil
+		pf.ResolveErr = errors.New("no such host")
+		problems, _ := evaluatePreflight(pf)
+		problem := assertProblem(t, problems, "DNS", "Add this record")
+		if !strings.Contains(strings.Join(problem.Remediation, "\n"), "A      203.0.113.10") {
+			t.Errorf("remediation must spell out the exact A record: %v", problem.Remediation)
+		}
+	})
+	t.Run("an IPv6 public address asks for AAAA", func(t *testing.T) {
+		pf := passingPreflight()
+		pf.PublicIP = "2001:db8::1"
+		pf.ResolvedIPs = []string{"203.0.113.10"}
+		problems, _ := evaluatePreflight(pf)
+		problem := assertProblem(t, problems, "DNS", "AAAA")
+		if strings.Contains(strings.Join(problem.Remediation, "\n"), " A ") {
+			t.Errorf("an IPv6 address must not be described as an A record: %v", problem.Remediation)
+		}
+	})
+	t.Run("public IP undiscoverable", func(t *testing.T) {
+		pf := passingPreflight()
+		pf.PublicIP = ""
+		pf.PublicIPErr = errors.New("dial tcp: i/o timeout")
+		problems, _ := evaluatePreflight(pf)
+		assertProblem(t, problems, "public IP", "--public-ip")
+	})
+}
+
+func TestEvaluatePreflight_PortProblems(t *testing.T) {
+	t.Run("another web server holds 80", func(t *testing.T) {
+		pf := passingPreflight()
+		pf.Ports = []setupPortProbe{
+			{Port: 80, Err: errors.New("listen tcp 127.0.0.1:80: bind: address already in use")},
+			{Port: 443},
+		}
+		problems, _ := evaluatePreflight(pf)
+		problem := assertProblem(t, problems, "port 80", "ss -ltnp 'sport = :80'")
+		if !strings.Contains(strings.Join(problem.Remediation, "\n"), "systemctl disable --now nginx") {
+			t.Errorf("remediation must name how to stop the conflicting server: %v", problem.Remediation)
+		}
+	})
+	t.Run("no privilege for a low port", func(t *testing.T) {
+		pf := passingPreflight()
+		pf.Ports = []setupPortProbe{
+			{Port: 80},
+			{Port: 443, Err: errors.New("listen tcp 127.0.0.1:443: bind: permission denied")},
+		}
+		problems, _ := evaluatePreflight(pf)
+		assertProblem(t, problems, "port 443", "sudo ao setup-vm")
+	})
+	t.Run("our own gateway holding the ports is a warning, not a failure", func(t *testing.T) {
+		pf := passingPreflight()
+		pf.GatewayActive = true
+		pf.Ports = []setupPortProbe{
+			{Port: 80, Err: errors.New("bind: address already in use"), HeldByGateway: true},
+			{Port: 443, Err: errors.New("bind: address already in use"), HeldByGateway: true},
+		}
+		problems, warnings := evaluatePreflight(pf)
+		if len(problems) != 0 {
+			t.Fatalf("problems = %+v, want none: a re-run on a working machine must not fail", problems)
+		}
+		if !strings.Contains(strings.Join(warnings, "\n"), "this machine's own gateway") {
+			t.Fatalf("warnings = %v, want one naming the gateway", warnings)
+		}
+	})
+}
+
+func TestEvaluatePreflight_BlockedFirewallIsDetectedAndNamed(t *testing.T) {
+	pf := passingPreflight()
+	pf.Cloud = "aws"
+	pf.GatewayActive = true
+	pf.Reach = setupReachability{Ran: true, Open: map[int]bool{80: true, 443: false}}
+
+	problems, _ := evaluatePreflight(pf)
+	problem := assertProblem(t, problems, "public reachability", "Edit inbound rules")
+	remediation := strings.Join(problem.Remediation, "\n")
+	if !strings.Contains(problem.Detail, "443") || strings.Contains(problem.Detail, "80 and 443") {
+		t.Errorf("only the blocked port should be reported: %q", problem.Detail)
+	}
+	if strings.Contains(remediation, "Hetzner") {
+		t.Errorf("a known cloud must get its own instructions, not the whole menu:\n%s", remediation)
+	}
+	if !strings.Contains(remediation, "nc -vz vm.example.com 443") {
+		t.Errorf("remediation must include the off-box verification: %s", remediation)
+	}
+	assertNoDashes(t, renderPreflightFailure(problems))
+}
+
+func TestFirewallRemediationPerCloud(t *testing.T) {
+	for cloud, want := range map[string]string{
+		"aws":          "security group",
+		"gcp":          "gcloud compute firewall-rules create",
+		"azure":        "az network nsg rule create",
+		"digitalocean": "Droplet",
+		"hetzner":      "Hetzner Cloud",
+		"":             "Anything else",
+	} {
+		lines := strings.Join(firewallRemediation(cloud, "vm.example.com", setupVMPorts), "\n")
+		if !strings.Contains(lines, want) {
+			t.Errorf("firewallRemediation(%q) is missing %q:\n%s", cloud, want, lines)
+		}
+		if !strings.Contains(lines, "ufw allow 443/tcp") {
+			t.Errorf("firewallRemediation(%q) must also cover the host firewall", cloud)
+		}
+	}
+}
+
+func TestSetupCloudFromVendor(t *testing.T) {
+	for vendor, want := range map[string]string{
+		"Amazon EC2":            "aws",
+		"Google":                "gcp",
+		"Microsoft Corporation": "azure",
+		"DigitalOcean":          "digitalocean",
+		"Hetzner":               "hetzner",
+		"QEMU":                  "",
+		"":                      "",
+		"  Amazon EC2\n":        "aws",
+	} {
+		if got := setupCloudFromVendor(vendor); got != want {
+			t.Errorf("setupCloudFromVendor(%q) = %q, want %q", vendor, got, want)
+		}
+	}
+}
+
+func TestRenderPreflightFailureLeadsWithChangedNothing(t *testing.T) {
+	pf := passingPreflight()
+	pf.UID = 1000
+	pf.ResolvedIPs = []string{"198.51.100.7"}
+	problems, _ := evaluatePreflight(pf)
+	if len(problems) < 2 {
+		t.Fatalf("expected every problem to be collected in one pass, got %+v", problems)
+	}
+	text := renderPreflightFailure(problems)
+	if !strings.HasPrefix(text, "Preflight failed. Nothing on this machine was changed.") {
+		t.Fatalf("the first line must be the no-mutation guarantee:\n%s", text)
+	}
+	if !strings.Contains(text, "run the same command again") {
+		t.Errorf("the failure text must say it is re-runnable:\n%s", text)
+	}
+}
+
+func TestParseSetupReachability(t *testing.T) {
+	open, err := parseSetupReachability([]byte(`{"ports":{"80":true,"443":false}}`), setupVMPorts)
+	if err != nil {
+		t.Fatalf("parseSetupReachability err = %v", err)
+	}
+	if !open[80] || open[443] {
+		t.Fatalf("open = %v, want 80 open and 443 closed", open)
+	}
+	if _, err := parseSetupReachability([]byte(`not json`), setupVMPorts); err == nil {
+		t.Error("malformed JSON must be an error, never a silent pass")
+	}
+	if _, err := parseSetupReachability([]byte(`{"ports":{}}`), setupVMPorts); err == nil {
+		t.Error("an empty ports object must be an error, never a silent pass")
+	}
+	// A prober that answers about other ports tells us nothing about ours.
+	if _, err := parseSetupReachability([]byte(`{"ports":{"22":true}}`), setupVMPorts); err == nil {
+		t.Error("a response about unrelated ports must be an error")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// the plan and the units
+// ---------------------------------------------------------------------------
+
+func testSetupPlan(t *testing.T) setupPlan {
+	t.Helper()
+	plan, err := buildSetupPlan(setupPlanInput{
+		Domain: "vm.example.com",
+		User:   "ubuntu",
+		Group:  "ubuntu",
+		Home:   "/home/ubuntu",
+	})
+	if err != nil {
+		t.Fatalf("buildSetupPlan err = %v", err)
+	}
+	return plan
+}
+
+func TestBuildSetupPlan_DefaultsUnderAODir(t *testing.T) {
+	plan := testSetupPlan(t)
+	for name, got := range map[string]string{
+		"AODir":       plan.AODir,
+		"DataDir":     plan.DataDir,
+		"RunFile":     plan.RunFile,
+		"MachineFile": plan.MachineFile,
+		"CertDir":     plan.CertDir,
+	} {
+		if !strings.HasPrefix(got, "/home/ubuntu/.ao") {
+			t.Errorf("%s = %q, want it under /home/ubuntu/.ao: all AO state lives there only", name, got)
+		}
+	}
+	if plan.DataDir != "/home/ubuntu/.ao/data" {
+		t.Errorf("DataDir = %q", plan.DataDir)
+	}
+	if plan.RunFile != "/home/ubuntu/.ao/running.json" {
+		t.Errorf("RunFile = %q", plan.RunFile)
+	}
+	if plan.CertDir != "/home/ubuntu/.ao/data/vm-gateway/certs" {
+		t.Errorf("CertDir = %q, want vmgateway's own default so the unit is explicit about it", plan.CertDir)
+	}
+	if plan.BinaryPath != "/usr/local/bin/ao" {
+		t.Errorf("BinaryPath = %q, want an absolute path a systemd unit can name", plan.BinaryPath)
+	}
+	if plan.Bound {
+		t.Error("a fresh plan must not claim the machine is bound")
+	}
+}
+
+func TestBuildSetupPlan_RejectsRelativeOverrides(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		in   setupPlanInput
+	}{
+		{name: "AO_DATA_DIR", in: setupPlanInput{User: "ubuntu", Home: "/home/ubuntu", DataDir: "data"}},
+		{name: "AO_RUN_FILE", in: setupPlanInput{User: "ubuntu", Home: "/home/ubuntu", RunFile: "running.json"}},
+		{name: "AO_MACHINE_FILE", in: setupPlanInput{User: "ubuntu", Home: "/home/ubuntu", MachineFile: "machine.json"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := buildSetupPlan(tc.in)
+			if err == nil {
+				t.Fatal("a relative override must be rejected, not absolutized: under systemd it silently relocates state")
+			}
+			if !strings.Contains(err.Error(), tc.name) {
+				t.Errorf("the error must name the variable at fault: %v", err)
+			}
+		})
+	}
+}
+
+func TestBuildSetupPlan_HonorsAbsoluteOverrides(t *testing.T) {
+	plan, err := buildSetupPlan(setupPlanInput{
+		Domain: "vm.example.com", User: "ubuntu", Home: "/home/ubuntu",
+		DataDir: "/srv/ao/data", RunFile: "/srv/ao/running.json", MachineFile: "/srv/ao/machine.json",
+	})
+	if err != nil {
+		t.Fatalf("buildSetupPlan err = %v", err)
+	}
+	if plan.DataDir != "/srv/ao/data" || plan.RunFile != "/srv/ao/running.json" || plan.MachineFile != "/srv/ao/machine.json" {
+		t.Fatalf("absolute overrides were not honored: %+v", plan)
+	}
+	if plan.CertDir != "/srv/ao/data/vm-gateway/certs" {
+		t.Errorf("CertDir = %q, want it to follow the overridden data dir", plan.CertDir)
+	}
+}
+
+func TestBuildSetupPlan_RejectsUnusableIdentity(t *testing.T) {
+	if _, err := buildSetupPlan(setupPlanInput{Home: "/home/ubuntu"}); err == nil {
+		t.Error("a plan with no target user must fail: the units would otherwise run as root")
+	}
+	if _, err := buildSetupPlan(setupPlanInput{User: "ubuntu", Home: "relative/home"}); err == nil {
+		t.Error("a relative home directory must fail")
+	}
+	plan, err := buildSetupPlan(setupPlanInput{User: "ubuntu", Home: "/home/ubuntu"})
+	if err != nil {
+		t.Fatalf("buildSetupPlan err = %v", err)
+	}
+	if plan.Group != "ubuntu" {
+		t.Errorf("Group = %q, want it to default to the user's own name", plan.Group)
+	}
+}
+
+func TestSetupDirsAreDeduplicated(t *testing.T) {
+	dirs := testSetupPlan(t).setupDirs()
+	seen := map[string]bool{}
+	for _, dir := range dirs {
+		if seen[dir] {
+			t.Fatalf("setupDirs returned %q twice: %v", dir, dirs)
+		}
+		seen[dir] = true
+	}
+	for _, want := range []string{"/home/ubuntu/.ao", "/home/ubuntu/.ao/data", "/home/ubuntu/.ao/data/vm-gateway/certs"} {
+		if !seen[want] {
+			t.Errorf("setupDirs is missing %q: %v", want, dirs)
+		}
+	}
+}
+
+func TestRenderDaemonUnit(t *testing.T) {
+	unit := renderDaemonUnit(testSetupPlan(t))
+	for _, want := range []string{
+		"[Unit]",
+		"[Service]",
+		"[Install]",
+		"User=ubuntu",
+		"Group=ubuntu",
+		`WorkingDirectory="/home/ubuntu/.ao/data"`,
+		`Environment="AO_DATA_DIR=/home/ubuntu/.ao/data"`,
+		`Environment="AO_RUN_FILE=/home/ubuntu/.ao/running.json"`,
+		`Environment="HOME=/home/ubuntu"`,
+		"ExecStart=/usr/local/bin/ao daemon",
+		"Restart=on-failure",
+		"WantedBy=multi-user.target",
+		// The daemon spawns the harnesses, which install under the user's home.
+		`Environment="PATH=/home/ubuntu/.local/bin:/home/ubuntu/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"`,
+	} {
+		if !strings.Contains(unit, want) {
+			t.Errorf("daemon unit is missing %q:\n%s", want, unit)
+		}
+	}
+	// The daemon is loopback-only and unauthenticated: it must never be handed
+	// the right to bind a public port.
+	for _, unwanted := range []string{"AmbientCapabilities", "CAP_NET_BIND_SERVICE", "AO_VM_DOMAIN", "vm serve"} {
+		if strings.Contains(unit, unwanted) {
+			t.Errorf("daemon unit must not contain %q:\n%s", unwanted, unit)
+		}
+	}
+	assertNoDashes(t, unit)
+}
+
+func TestRenderGatewayUnit(t *testing.T) {
+	unit := renderGatewayUnit(testSetupPlan(t))
+	for _, want := range []string{
+		"User=ubuntu",
+		"Group=ubuntu",
+		`WorkingDirectory="/home/ubuntu/.ao/data"`,
+		`Environment="AO_DATA_DIR=/home/ubuntu/.ao/data"`,
+		`Environment="AO_MACHINE_FILE=/home/ubuntu/.ao/machine.json"`,
+		`Environment="AO_VM_DOMAIN=vm.example.com"`,
+		`Environment="AO_VM_CERT_DIR=/home/ubuntu/.ao/data/vm-gateway/certs"`,
+		"ExecStart=/usr/local/bin/ao vm serve",
+		"AmbientCapabilities=CAP_NET_BIND_SERVICE",
+		"CapabilityBoundingSet=CAP_NET_BIND_SERVICE",
+		// The gateway fronts the daemon, so it starts after it.
+		"After=network-online.target ao-daemon.service",
+	} {
+		if !strings.Contains(unit, want) {
+			t.Errorf("gateway unit is missing %q:\n%s", want, unit)
+		}
+	}
+	if strings.Contains(unit, "ao daemon") {
+		t.Error("the gateway unit must not start the daemon: they are two separate processes (ADR 0002)")
+	}
+	if !strings.Contains(unit, "needs a restart") {
+		t.Error("the gateway unit should record that machine.json is read once at startup")
+	}
+	assertNoDashes(t, unit)
+}
+
+// TestSetupUnitsSetEveryPathAbsolutely is the regression test for the hazard
+// PR #18 fixed in the control plane: a working-directory-relative path under
+// systemd silently relocates keys and state.
+func TestSetupUnitsSetEveryPathAbsolutely(t *testing.T) {
+	plan := testSetupPlan(t)
+	for name, unit := range map[string]string{
+		setupVMDaemonUnit:  renderDaemonUnit(plan),
+		setupVMGatewayUnit: renderGatewayUnit(plan),
+	} {
+		for _, line := range strings.Split(unit, "\n") {
+			directive, value, ok := strings.Cut(line, "=")
+			if !ok {
+				continue
+			}
+			switch directive {
+			case "WorkingDirectory":
+				if !strings.HasPrefix(value, `"/`) {
+					t.Errorf("%s: %s must be absolute, got %q", name, directive, value)
+				}
+			case "ExecStart":
+				if !strings.HasPrefix(value, "/") {
+					t.Errorf("%s: %s must be absolute, got %q", name, directive, value)
+				}
+			case "Environment":
+				key, path, found := strings.Cut(strings.Trim(value, `"`), "=")
+				if !found || !strings.HasPrefix(key, "AO_") || !strings.HasSuffix(key, "DIR") && !strings.HasSuffix(key, "FILE") {
+					continue
+				}
+				if !strings.HasPrefix(path, "/") {
+					t.Errorf("%s: %s=%s must be absolute", name, key, path)
+				}
+			}
+		}
+	}
+}
+
+func TestRenderSetupSummary_Unbound(t *testing.T) {
+	plan := testSetupPlan(t)
+	summary := renderSetupSummary(plan, false, []string{"80 and 443 were not verified from outside"})
+	for _, want := range []string{
+		"installed, but not yet ready",
+		"not bound to an AO account",
+		"sudo systemctl start ao-gateway.service",
+		"ao vm setup-harness claude",
+		"gh auth login",
+		"ao doctor",
+		"/home/ubuntu/.ao/machine.json",
+		"80 and 443 were not verified from outside",
+		"enabled, not started",
+	} {
+		if !strings.Contains(summary, want) {
+			t.Errorf("summary is missing %q:\n%s", want, summary)
+		}
+	}
+	assertNoDashes(t, summary)
+}
+
+func TestRenderSetupSummary_Bound(t *testing.T) {
+	plan := testSetupPlan(t)
+	plan.Bound = true
+	summary := renderSetupSummary(plan, true, nil)
+	if !strings.Contains(summary, "already bound") {
+		t.Errorf("a bound machine's summary must say so:\n%s", summary)
+	}
+	if !strings.Contains(summary, "sudo systemctl restart ao-gateway.service") {
+		t.Errorf("a bound machine still needs the restart command after re-binding:\n%s", summary)
+	}
+	if !strings.Contains(summary, "enabled, running") {
+		t.Errorf("a started gateway must be reported as running:\n%s", summary)
+	}
+	// The two remaining manual steps are never done for the user.
+	for _, want := range []string{"ao vm setup-harness claude", "gh auth login"} {
+		if !strings.Contains(summary, want) {
+			t.Errorf("summary is missing %q:\n%s", want, summary)
+		}
+	}
+}
+
+func TestRenderSetupDryRunShowsBothUnitsAndChangesNothing(t *testing.T) {
+	plan := testSetupPlan(t)
+	text := renderSetupDryRun(plan, nil)
+	if !strings.HasPrefix(text, "Dry run. Nothing on this machine was changed.") {
+		t.Fatalf("dry run must lead with the no-mutation guarantee:\n%s", text)
+	}
+	for _, want := range []string{
+		"/etc/systemd/system/ao-daemon.service",
+		"/etc/systemd/system/ao-gateway.service",
+		"ExecStart=/usr/local/bin/ao daemon",
+		"ExecStart=/usr/local/bin/ao vm serve",
+		"tmux, git, gh",
+		"without --dry-run",
+	} {
+		if !strings.Contains(text, want) {
+			t.Errorf("dry run output is missing %q:\n%s", want, text)
+		}
+	}
+}
+
+func TestSetupPackagesExcludeHarnesses(t *testing.T) {
+	for _, unwanted := range []string{"claude", "codex", "caddy", "nginx"} {
+		for _, pkg := range setupVMPackages {
+			if pkg == unwanted {
+				t.Errorf("setup-vm must not install %q: harnesses have interactive logins and Caddy stays on the control plane", unwanted)
+			}
+		}
+	}
+	for _, want := range []string{"tmux", "git", "gh"} {
+		found := false
+		for _, pkg := range setupVMPackages {
+			if pkg == want {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("setupVMPackages is missing %q", want)
+		}
+	}
+}
+
+func TestDpkgInstalled(t *testing.T) {
+	if !dpkgInstalled("install ok installed") {
+		t.Error("a fully installed package must be recognized")
+	}
+	for _, status := range []string{"deinstall ok config-files", "unknown ok not-installed", ""} {
+		if dpkgInstalled(status) {
+			t.Errorf("dpkgInstalled(%q) = true, want false", status)
+		}
+	}
+}
+
+func TestGitHubCLISourceList(t *testing.T) {
+	line := githubCLISourceList("arm64")
+	want := "deb [arch=arm64 signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main\n"
+	if line != want {
+		t.Fatalf("githubCLISourceList(arm64) = %q, want %q", line, want)
+	}
+}
+
+func TestPortList(t *testing.T) {
+	for _, tc := range []struct {
+		in   []int
+		want string
+	}{
+		{in: nil, want: "no ports"},
+		{in: []int{80}, want: "80"},
+		{in: []int{80, 443}, want: "80 and 443"},
+		{in: []int{80, 443, 8080}, want: "80, 443 and 8080"},
+	} {
+		if got := portList(tc.in); got != tc.want {
+			t.Errorf("portList(%v) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+func assertProblem(t *testing.T, problems []setupProblem, check, wantText string) setupProblem {
+	t.Helper()
+	for _, problem := range problems {
+		if problem.Check != check {
+			continue
+		}
+		haystack := problem.Detail + "\n" + strings.Join(problem.Remediation, "\n")
+		if !strings.Contains(haystack, wantText) {
+			t.Fatalf("problem %q does not mention %q:\n%s", check, wantText, haystack)
+		}
+		if len(problem.Remediation) == 0 {
+			t.Fatalf("problem %q has no remediation: every failure must say exactly what to do", check)
+		}
+		return problem
+	}
+	t.Fatalf("no %q problem in %+v", check, problems)
+	return setupProblem{}
+}
+
+// assertNoDashes enforces the repo's writing rule on user-facing text, where it
+// is easiest to break by accident.
+func assertNoDashes(t *testing.T, text string) {
+	t.Helper()
+	for _, dash := range []string{"\u2014", "\u2013"} {
+		if strings.Contains(text, dash) {
+			t.Errorf("user-facing text contains %s:\n%s", fmt.Sprintf("%q", dash), text)
+		}
+	}
+}

--- a/backend/internal/cli/setupvm_test.go
+++ b/backend/internal/cli/setupvm_test.go
@@ -1,0 +1,139 @@
+package cli
+
+// Command-level tests for `ao setup-vm`. They deliberately never reach the
+// install: the point of these is the two refusal paths, which are the ones that
+// must hold on every platform in the CLI E2E matrix. What the command does
+// after preflight passes is decided by the pure functions in
+// setupvm_plan_test.go.
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// errRoundTripper fails every HTTP request, so a test can never depend on the
+// network being there (or reach out to it by accident).
+type errRoundTripper struct{}
+
+func (errRoundTripper) RoundTrip(*http.Request) (*http.Response, error) {
+	return nil, errors.New("network disabled in tests")
+}
+
+// recordingDeps captures every command the CLI would have run.
+func recordingDeps(t *testing.T) (Deps, func() []string) {
+	t.Helper()
+	var mu sync.Mutex
+	var calls []string
+	deps := Deps{
+		HTTPClient: &http.Client{Transport: errRoundTripper{}},
+		CommandOutput: func(_ context.Context, name string, args ...string) ([]byte, error) {
+			mu.Lock()
+			calls = append(calls, strings.TrimSpace(name+" "+strings.Join(args, " ")))
+			mu.Unlock()
+			return nil, errors.New("command not available in tests")
+		},
+	}
+	return deps, func() []string {
+		mu.Lock()
+		defer mu.Unlock()
+		return append([]string(nil), calls...)
+	}
+}
+
+func TestSetupVM_RequiresADomain(t *testing.T) {
+	deps, calls := recordingDeps(t)
+	_, _, err := executeCLI(t, deps, "setup-vm")
+	if err == nil {
+		t.Fatal("expected an error when --domain is missing")
+	}
+	if got := ExitCode(err); got != 2 {
+		t.Errorf("ExitCode = %d, want 2 (a missing flag is CLI misuse)", got)
+	}
+	assertNoSetupMutation(t, calls())
+}
+
+func TestSetupVM_RejectsADomainThatCannotHoldACertificate(t *testing.T) {
+	for _, domain := range []string{"203.0.113.10", "localhost", "vm.example.com:443"} {
+		t.Run(domain, func(t *testing.T) {
+			deps, calls := recordingDeps(t)
+			_, _, err := executeCLI(t, deps, "setup-vm", "--domain", domain)
+			if err == nil {
+				t.Fatalf("expected --domain %q to be rejected", domain)
+			}
+			if got := ExitCode(err); got != 2 {
+				t.Errorf("ExitCode = %d, want 2", got)
+			}
+			assertNoSetupMutation(t, calls())
+		})
+	}
+}
+
+// TestSetupVM_RefusesNonUbuntuWithTheManualPath is the platform gate seen from
+// the outside: on macOS and Windows the command must print the manual path and
+// exit rather than half-installing anything.
+func TestSetupVM_RefusesNonUbuntuWithTheManualPath(t *testing.T) {
+	if runtime.GOOS == "linux" {
+		t.Skip("the gate only refuses non-Linux hosts here; Linux is covered by checkSetupPlatform's table test")
+	}
+	deps, calls := recordingDeps(t)
+	out, _, err := executeCLI(t, deps, "setup-vm", "--domain", "vm.example.com")
+	if err == nil {
+		t.Fatal("expected ao setup-vm to refuse to run on " + runtime.GOOS)
+	}
+	if got := ExitCode(err); got != 1 {
+		t.Errorf("ExitCode = %d, want 1: an unsupported platform is a runtime refusal, not misuse", got)
+	}
+	var unsupported errUnsupportedPlatform
+	if !errors.As(err, &unsupported) {
+		t.Errorf("err = %v, want errUnsupportedPlatform", err)
+	}
+	for _, want := range []string{"nothing was changed", "ao vm serve --domain vm.example.com", "gh auth login"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("refusal output is missing %q:\n%s", want, out)
+		}
+	}
+	assertNoSetupMutation(t, calls())
+}
+
+// TestSetupVM_FailedPreflightChangesNothing is the guarantee the whole command
+// is built around. The domain cannot resolve (.invalid is reserved for exactly
+// this, RFC 2606), so preflight must stop before any mutation.
+func TestSetupVM_FailedPreflightChangesNothing(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("preflight is only reached on Linux; the platform gate refuses earlier elsewhere")
+	}
+	deps, calls := recordingDeps(t)
+	out, _, err := executeCLI(t, deps,
+		"setup-vm",
+		"--domain", "setup-vm-preflight.invalid",
+		// Supplied so the run never needs to look its own address up over HTTP.
+		"--public-ip", "203.0.113.10",
+		"--reachability-probe-url", "",
+	)
+	if err == nil {
+		t.Fatal("expected preflight to fail for a domain that cannot resolve here")
+	}
+	if !strings.Contains(out, "changed") {
+		t.Errorf("output must state that nothing was changed:\n%s", out)
+	}
+	assertNoSetupMutation(t, calls())
+}
+
+// assertNoSetupMutation fails if the command ran anything that could have
+// modified the machine. Read-only probes are fine; the install verbs are not.
+func assertNoSetupMutation(t *testing.T, calls []string) {
+	t.Helper()
+	mutations := []string{"apt-get", "install ", "systemctl enable", "systemctl start", "systemctl restart", "daemon-reload", "sudo -n install"}
+	for _, call := range calls {
+		for _, mutation := range mutations {
+			if strings.Contains(call, mutation) {
+				t.Errorf("nothing may be mutated on this path, but the command ran: %s", call)
+			}
+		}
+	}
+}

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -34,6 +34,25 @@ Every product command resolves to a daemon HTTP route. Run `ao <command>
 | `ao version` / `ao --version` | Print build metadata.                                                                                                             |
 | `ao daemon`                   | Hidden internal daemon entrypoint used by `ao start`.                                                                             |
 
+### Hosted VM
+
+| Command                             | Purpose                                                                                                                                                                          |
+| ----------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ao setup-vm --domain <host>`       | Prepare a hosted Ubuntu LTS VM: platform gate, preflight (DNS, 80/443, sudo) that mutates nothing on failure, then install `ao`, `tmux`, `git`, `gh`, and two systemd units.       |
+| `ao vm serve`                       | Run the public TLS gateway in front of the loopback daemon. Normally started by the `ao-gateway.service` unit `ao setup-vm` writes, never by hand.                                 |
+
+`ao setup-vm` refuses to run on anything but Ubuntu with systemd and apt, and
+prints the manual path instead. It writes `ao-daemon.service` and
+`ao-gateway.service` as two separate units running two separate processes, per
+`docs/adr/0002-hosted-public-gateway.md`, with `WorkingDirectory` and every
+`AO_*` path set to an absolute value. It is idempotent: a second run rewrites
+nothing that has not changed and restarts nothing that does not need it.
+
+It does not install an agent harness and does not configure git credentials, so
+it ends by printing what is still missing with the exact command for each
+(`ao vm setup-harness claude`, `gh auth login`). Use `--dry-run` to see the plan
+and both unit files without touching the machine.
+
 ### Product commands
 
 | Command                             | Daemon route                                   |


### PR DESCRIPTION
Closes #24

Part one of `ao setup-vm`: platform gate, preflight, dependency install, two systemd units, and the closing summary. Device binding and `machine.json` are task 10 and are deliberately not here, so the command ends at "installed, not yet bound" and says so in its own output.

## What it does

`ao setup-vm --domain vm.example.com`

1. **Platform gate.** Ubuntu with systemd and apt only. Anything else prints the full manual path (install deps, run `ao daemon`, run `ao vm serve` as a second process, DNS, supervise both) and exits 1 without touching the box. A non-LTS Ubuntu warns and proceeds: apt and systemd are both there, the release just goes EOL sooner.
2. **Preflight, before any mutation.**
   - Resolves the domain and confirms it points at this box's public IP (discovered over HTTPS, or supplied with `--public-ip`). A mismatch prints the exact record to change, from what to what, plus `dig +short`.
   - Confirms `:80` and `:443` are bindable. A conflicting nginx prints `ss -ltnp` and the disable command; missing privilege prints the sudo re-run. The ports already held by this machine's own gateway is a pass, not a conflict, which is what a re-run on a working machine looks like.
   - Confirms root or passwordless sudo (it cannot prompt mid-install).
   - Confirms the ports from outside, and prints the cloud firewall click path for the provider detected from DMI (AWS, GCP, Azure, DigitalOcean, Hetzner, or the full menu) plus the host-firewall `ufw` commands and the off-box `nc -vz` check.
   - **Any failure prints exact remediation and changes nothing.** The first line of the failure output is that guarantee.
3. **Install.** `ao` at `/usr/local/bin/ao`, `tmux`, `git`, `gh`, and the two units. No harnesses: their logins are interactive.
4. **Summary** of what is still missing, with the exact command for each: the gateway restart after binding, `ao vm setup-harness claude`, `gh auth login`.

`--dry-run` runs the gate and preflight, prints the plan and both unit files verbatim, and changes nothing.

## The specifics that are easy to get wrong

- **Absolute paths everywhere.** Both units set `WorkingDirectory=` and every `AO_*` path explicitly. A relative `AO_DATA_DIR`/`AO_RUN_FILE`/`AO_MACHINE_FILE` is **rejected**, not absolutized: under systemd it resolves against the unit's working directory, which is exactly the silent state relocation PR #18 fixed in the control plane. `TestSetupUnitsSetEveryPathAbsolutely` walks both rendered units and asserts it directive by directive.
- **Two units, two processes** (ADR 0002). `ao-daemon.service` stays loopback and unauthenticated with no capabilities; only `ao-gateway.service` gets `AmbientCapabilities=CAP_NET_BIND_SERVICE`. Neither runs as root: they run as `SUDO_USER` (or the invoking user), who owns `~/.ao`. Tests assert the daemon unit contains no `CAP_NET_BIND_SERVICE`, no `AO_VM_DOMAIN`, and no `vm serve`.
- **`ao vm serve` reads `machine.json` once at startup.** On an unbound machine the gateway unit is enabled but **not started**, because starting it would only produce a restart loop. The summary says so and gives the start command; on an already-bound machine it starts, and the summary gives the restart command for a re-bind. This command never writes `machine.json`.
- **No Caddy on the user VM.** A test asserts `caddy` and `nginx` are not in the package list, alongside the harnesses.
- **Idempotent.** Files are written only when their content differs (no duplicated units, no file that grows per run), `daemon-reload` runs only when a unit changed, and a unit is restarted only when it changed. A replaced `ao` binary restarts the gateway (stateless) but **not** the daemon, and the summary says the daemon is still on the previous build and how to restart it: a re-run must not kill live agent sessions.

## Testability

CLI E2E runs on ubuntu, macOS, Windows, and a container, so every decision lives in pure functions in `setupvm_plan.go` (platform gate, preflight verdicts, path plan, unit rendering, summary and dry-run text) and is unit-tested with no VM, no apt, and no systemd. `setupvm.go` is the thin privileged half: probe, hand the observation to a pure function, execute what it says. `runSetupPrivileged` is the single place anything is mutated.

39 new tests. Notable ones: `TestSetupVM_FailedPreflightChangesNothing` drives the real command on Linux and asserts no mutating command was executed; `TestSetupVM_RefusesNonUbuntuWithTheManualPath` covers the gate from the outside on macOS and Windows; `assertNoDashes` enforces the repo's no-dash writing rule on the user-facing text.

Windows note: `filepath.IsAbs("/home/ubuntu")` is false on Windows, so the plan uses `path` and an explicit `isLinuxAbs`. These are always Linux paths; the unit tests just happen to run elsewhere.

## Known limitation, stated plainly

The outside-in port check needs an observer that is not this box, since a cloud firewall is invisible from inside it. The prober defaults to `https://ao.agentlab.in/api/v1/reachability` (contract documented at the constant: `?host=&ports=` answers `{"ports":{"80":true,...}}`), which the control plane does not implement yet, and it is only queried when something is already listening, because otherwise a closed answer would mean "no listener" rather than "blocked firewall". So today the check reports **unverified** rather than a false verdict, and prints the full firewall remediation and the off-box verification command anyway. When the endpoint lands, a blocked port becomes a hard preflight failure with no changes here. "Not verified" and "closed" are never printed as if they were the same answer.

Preflight also does not open a public port of its own to be probed: `AGENTS.md` permits exactly one network-facing bind (`ao vm serve`), so bindability is checked on loopback, which catches both real failure modes (privilege for ports under 1024, and a conflicting wildcard listener).

## Verification

- `go build ./...`, and `GOOS=windows go build ./...`
- `go vet -tags e2e ./internal/cli/` on linux, darwin, and windows
- `go test -race ./...`: 2944 passed, 5 failed. The 5 are the pre-existing `TestSpawn*` failures on `develop` (HTTP 404), untouched by this work.
- `golangci-lint v2.12.2 run ./internal/cli/`: 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)