### PR TITLE
feat(cli): ao setup-vm part two, device binding, machine.json, and ao whoami

### DIFF
--- a/backend/internal/cli/root.go
+++ b/backend/internal/cli/root.go
@@ -201,6 +201,7 @@ func NewRootCommand(deps Deps) *cobra.Command {
 	root.AddCommand(newReviewCommand(ctx))
 	root.AddCommand(newVMCommand(ctx))
 	root.AddCommand(newSetupVMCommand(ctx))
+	root.AddCommand(newWhoamiCommand(ctx))
 	root.AddCommand(newCompletionCommand())
 	root.AddCommand(newVersionCommand())
 

--- a/backend/internal/cli/setupvm.go
+++ b/backend/internal/cli/setupvm.go
@@ -51,10 +51,11 @@ const (
 var setupVMPublicIPEndpoints = []string{"https://api.ipify.org", "https://ifconfig.me/ip"}
 
 type setupVMOptions struct {
-	Domain   string
-	PublicIP string
-	ProbeURL string
-	DryRun   bool
+	Domain          string
+	PublicIP        string
+	ProbeURL        string
+	ControlPlaneURL string
+	DryRun          bool
 }
 
 func newSetupVMCommand(ctx *commandContext) *cobra.Command {
@@ -67,9 +68,14 @@ func newSetupVMCommand(ctx *commandContext) *cobra.Command {
 			"anything, then installs the ao binary, tmux, git, and gh, and writes two\n" +
 			"systemd units: one for the loopback daemon and one for the public TLS gateway\n" +
 			"(see docs/adr/0002-hosted-public-gateway.md).\n\n" +
+			"It then binds this machine to an AO account over an RFC 8628 device code: it\n" +
+			"prints a short code and a URL, waits for you to approve the machine in a browser\n" +
+			"on any device, writes ~/.ao/machine.json, and restarts the gateway so it reads\n" +
+			"the new binding.\n\n" +
 			"A failed preflight changes nothing at all: it prints exactly what to fix and\n" +
-			"exits. A successful run is idempotent, so running it again is safe, and it ends\n" +
-			"by listing what is still missing with the exact command for each.\n\n" +
+			"exits. A successful run is idempotent, so running it again is safe; an\n" +
+			"already-bound machine has its current binding printed and is then bound again.\n" +
+			"The run ends by listing what is still missing with the exact command for each.\n\n" +
 			"It does not install an agent harness and does not configure git credentials,\n" +
 			"because both need an interactive login.",
 		Args: noArgs,
@@ -81,6 +87,7 @@ func newSetupVMCommand(ctx *commandContext) *cobra.Command {
 	flags.StringVar(&opts.Domain, "domain", "", "Public hostname you own, with a DNS record pointing at this machine (required)")
 	flags.StringVar(&opts.PublicIP, "public-ip", "", "This machine's public IP, for when it cannot be discovered automatically")
 	flags.StringVar(&opts.ProbeURL, "reachability-probe-url", defaultSetupVMProbeURL, "Off-box prober used to confirm 80 and 443 are reachable from the internet")
+	flags.StringVar(&opts.ControlPlaneURL, "control-plane-url", vmgateway.DefaultIssuer, "AO control plane this machine is bound against")
 	flags.BoolVar(&opts.DryRun, "dry-run", false, "Gate, preflight, print the plan and both unit files, and change nothing")
 	return cmd
 }
@@ -92,6 +99,10 @@ func (c *commandContext) runSetupVM(cmd *cobra.Command, opts setupVMOptions) err
 	domain, err := normalizeSetupDomain(opts.Domain)
 	if err != nil {
 		return usageError{err}
+	}
+	controlPlaneURL := strings.TrimRight(strings.TrimSpace(opts.ControlPlaneURL), "/")
+	if controlPlaneURL == "" {
+		return usageError{errors.New("--control-plane-url is required, for example --control-plane-url " + vmgateway.DefaultIssuer)}
 	}
 
 	platform := c.probeSetupPlatform()
@@ -126,7 +137,22 @@ func (c *commandContext) runSetupVM(cmd *cobra.Command, opts setupVMOptions) err
 	if err != nil {
 		return err
 	}
-	return writeSetupText(out, renderSetupSummary(plan, gatewayStarted, append(warnings, notes...)))
+
+	bindErr := c.bindSetupVM(ctx, out, plan, controlPlaneURL)
+	if bindErr == nil {
+		plan.Bound = true
+		gatewayStarted = true
+	} else {
+		// The install is done and correct; only the binding is missing. The
+		// summary still has to print, because it is what tells the user how to
+		// finish, and it is now the only place that says so.
+		notes = append(notes, "binding did not complete: "+bindErr.Error())
+	}
+
+	if err := writeSetupText(out, renderSetupSummary(plan, gatewayStarted, append(warnings, notes...))); err != nil {
+		return err
+	}
+	return bindErr
 }
 
 // ---------------------------------------------------------------------------
@@ -341,9 +367,10 @@ func (c *commandContext) buildSetupVMPlan(domain string) (setupPlan, error) {
 	if err != nil {
 		return setupPlan{}, err
 	}
-	// Binding is a later batch: this command only reports whether it has
-	// happened, so the gateway is started rather than left stopped on a machine
-	// that is already bound. It never writes machine.json.
+	// Bound describes the machine as the install finds it, before this run
+	// binds anything: it is what decides whether the gateway is started during
+	// install, and whether the binding step prints a previous binding it is
+	// about to replace.
 	if _, err := os.Stat(plan.MachineFile); err == nil {
 		plan.Bound = true
 	}

--- a/backend/internal/cli/setupvm_bind.go
+++ b/backend/internal/cli/setupvm_bind.go
@@ -1,0 +1,406 @@
+package cli
+
+// setupvm_bind.go is the thin half of the binding step: the HTTP calls of the
+// RFC 8628 device flow, the atomic write of machine.json, and the gateway
+// restart that makes a fresh binding take effect. Every decision it makes lives
+// in setupvm_bind_plan.go, which is pure.
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"os/user"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/vmgateway"
+)
+
+const (
+	// devicePathCode and devicePathToken are the control plane's RFC 8628
+	// endpoints (controlplane/internal/device/device.go).
+	devicePathCode  = "/device/code"
+	devicePathToken = "/device/token"
+	// deviceCodeGrantType is the grant type RFC 8628 assigns to the device
+	// access token request.
+	deviceCodeGrantType = "urn:ietf:params:oauth:grant-type:device_code"
+	// deviceMaxTransportFailures bounds consecutive network failures while
+	// polling. One dropped request must not throw away a code a human is in
+	// the middle of approving, but an endpoint that is simply gone must not be
+	// hammered until the code expires either.
+	deviceMaxTransportFailures = 5
+	// deviceMaxFlowRestarts bounds how many expired codes may be replaced in
+	// one run, so an unattended terminal eventually stops asking.
+	deviceMaxFlowRestarts = 2
+	// deviceResponseLimit caps how much of an answer is read. Both bodies are
+	// a few hundred bytes.
+	deviceResponseLimit = 1 << 16
+)
+
+// deviceAuthorization is the RFC 8628 section 3.2 device authorization
+// response.
+//
+// DeviceCode is a bearer secret. It is used to poll with and for nothing else:
+// it is never printed, never put in a URL this command displays, and never
+// written to disk.
+type deviceAuthorization struct {
+	DeviceCode              string `json:"device_code"`
+	UserCode                string `json:"user_code"`
+	VerificationURI         string `json:"verification_uri"`
+	VerificationURIComplete string `json:"verification_uri_complete"`
+	ExpiresIn               int    `json:"expires_in"`
+	Interval                int    `json:"interval"`
+}
+
+// deviceTokenResponse is the approved device access token response, reduced to
+// the machine triple machine.json needs. The access token in the same body is
+// deliberately not decoded: nothing in setup-vm uses it, and a field that is
+// never read cannot be logged or persisted by accident.
+type deviceTokenResponse struct {
+	MachineID string `json:"machine_id"`
+	AccountID string `json:"account_id"`
+	PublicURL string `json:"public_url"`
+}
+
+// deviceHTTPError is a non-200 answer from either device endpoint, carrying the
+// OAuth error code the flow's state machine reads.
+type deviceHTTPError struct {
+	Status      int
+	Code        string
+	Description string
+}
+
+func (e deviceHTTPError) Error() string {
+	switch {
+	case e.Code != "" && e.Description != "":
+		return e.Code + ": " + e.Description
+	case e.Code != "":
+		return e.Code
+	default:
+		return fmt.Sprintf("HTTP %d", e.Status)
+	}
+}
+
+// bindSetupVM binds this machine to an AO account and writes machine.json, then
+// restarts the gateway. `ao vm serve` reads that file once at startup, so a
+// fresh binding changes nothing at all until the unit restarts, which is why
+// the restart is done here rather than left in the closing summary as advice.
+//
+// An already-bound machine is re-bound rather than refused, after printing the
+// binding that is about to be replaced.
+func (c *commandContext) bindSetupVM(ctx context.Context, out io.Writer, plan setupPlan, controlPlaneURL string) error {
+	if plan.Bound {
+		// A machine file too broken to read is not worth reporting in detail
+		// here: it is about to be replaced by a good one.
+		if previous, err := vmgateway.ReadMachineFile(plan.MachineFile); err == nil && previous != nil {
+			if _, err := io.WriteString(out, renderPreviousBinding(plan.MachineFile, *previous)); err != nil {
+				return err
+			}
+		}
+	}
+
+	publicURL := "https://" + plan.Domain
+	binding, err := c.runDeviceFlow(ctx, out, controlPlaneURL, setupMachineName(plan.Domain), publicURL)
+	if err != nil {
+		return err
+	}
+
+	content, err := renderMachineFile(binding, c.deps.Now())
+	if err != nil {
+		return err
+	}
+	owner, err := setupTargetUser()
+	if err != nil {
+		return err
+	}
+	if err := writeMachineFile(plan.MachineFile, content, owner); err != nil {
+		return err
+	}
+	// Read the file back through the gateway's own reader rather than trusting
+	// what was just marshalled: this is the one moment where a machine.json the
+	// gateway cannot parse is still cheap to notice.
+	written, err := vmgateway.ReadMachineFile(plan.MachineFile)
+	if err != nil || written == nil {
+		return fmt.Errorf("wrote %s but could not read it back: %w", plan.MachineFile, err)
+	}
+	if _, err := io.WriteString(out, renderBindingWritten(plan.MachineFile, *written)); err != nil {
+		return err
+	}
+
+	if err := c.runSetupPrivileged(ctx, "systemctl", "restart", setupVMGatewayUnit); err != nil {
+		return fmt.Errorf("restart %s so it reads the new binding: %w", setupVMGatewayUnit, err)
+	}
+	_, err = fmt.Fprintf(out, "==> %s restarted, so it has read the new binding\n", setupVMGatewayUnit)
+	return err
+}
+
+// runDeviceFlow requests a device code, prints what the operator has to do, and
+// polls until the code is approved. An expired code is the one failure it can
+// recover from, by offering a fresh one.
+func (c *commandContext) runDeviceFlow(ctx context.Context, out io.Writer, base, machineName, publicURL string) (vmgateway.MachineFile, error) {
+	for restart := 0; ; restart++ {
+		auth, err := c.requestDeviceCode(ctx, base, machineName, publicURL)
+		if err != nil {
+			return vmgateway.MachineFile{}, err
+		}
+		expiry := deviceFlowExpiry(auth.ExpiresIn)
+		if _, err := io.WriteString(out, renderDeviceInstructions(auth, machineName, publicURL, expiry)); err != nil {
+			return vmgateway.MachineFile{}, err
+		}
+
+		binding, err := c.pollForBinding(ctx, base, auth, expiry)
+		if err == nil {
+			return binding, nil
+		}
+		if !errors.Is(err, errDeviceCodeExpired) || restart >= deviceMaxFlowRestarts {
+			return vmgateway.MachineFile{}, err
+		}
+		if !c.confirmDeviceFlowRestart(out, expiry) {
+			return vmgateway.MachineFile{}, err
+		}
+	}
+}
+
+// pollForBinding polls the token endpoint at the server-supplied interval until
+// the code is approved, denied, or expires.
+func (c *commandContext) pollForBinding(ctx context.Context, base string, auth deviceAuthorization, expiry time.Duration) (vmgateway.MachineFile, error) {
+	interval := devicePollStartInterval(auth.Interval)
+	deadline := c.deps.Now().Add(expiry)
+	transportFailures := 0
+
+	for {
+		// Waiting first is deliberate: a code cannot have been approved in the
+		// instant it was issued, and RFC 8628 section 3.4 has the client wait
+		// the interval before every request, including the first.
+		c.deps.Sleep(interval)
+		if err := ctx.Err(); err != nil {
+			return vmgateway.MachineFile{}, err
+		}
+		if c.deps.Now().After(deadline) {
+			return vmgateway.MachineFile{}, errDeviceCodeExpired
+		}
+
+		binding, err := c.requestDeviceToken(ctx, base, auth.DeviceCode)
+		if err == nil {
+			if invalid := validateMachineFile(binding); invalid != nil {
+				return vmgateway.MachineFile{}, fmt.Errorf("the control plane approved this machine but returned an unusable binding: %w", invalid)
+			}
+			return binding, nil
+		}
+
+		var httpErr deviceHTTPError
+		if !errors.As(err, &httpErr) {
+			transportFailures++
+			if transportFailures >= deviceMaxTransportFailures {
+				return vmgateway.MachineFile{}, fmt.Errorf("lost contact with the AO control plane while waiting for approval: %w", err)
+			}
+			continue
+		}
+		transportFailures = 0
+
+		switch outcome := classifyDevicePollError(httpErr.Code); outcome {
+		case devicePollWait:
+		case devicePollSlowDown:
+			interval = nextDevicePollInterval(interval, outcome)
+		case devicePollExpired:
+			return vmgateway.MachineFile{}, errDeviceCodeExpired
+		case devicePollDenied:
+			return vmgateway.MachineFile{}, errDeviceAccessDenied
+		default:
+			return vmgateway.MachineFile{}, fmt.Errorf("the AO control plane refused the device code: %w", err)
+		}
+	}
+}
+
+// confirmDeviceFlowRestart asks whether to request a fresh code. A closed or
+// exhausted stdin answers no: with nobody at the terminal there is nobody to
+// approve a new code either.
+func (c *commandContext) confirmDeviceFlowRestart(out io.Writer, expiry time.Duration) bool {
+	if _, err := io.WriteString(out, renderDeviceRestartPrompt(expiry)); err != nil {
+		return false
+	}
+	line, err := bufio.NewReader(c.deps.In).ReadString('\n')
+	answer := strings.ToLower(strings.TrimSpace(line))
+	if err != nil && answer == "" {
+		_, _ = io.WriteString(out, "no\n")
+		return false
+	}
+	return answer == "" || answer == "y" || answer == "yes"
+}
+
+// requestDeviceCode is the device authorization request. It sends this
+// machine's name and public URL because the VM is the only party that knows
+// them, and the approval page has to show the operator which box they are about
+// to bind.
+func (c *commandContext) requestDeviceCode(ctx context.Context, base, machineName, publicURL string) (deviceAuthorization, error) {
+	form := url.Values{}
+	form.Set("machine_name", machineName)
+	form.Set("public_url", publicURL)
+
+	var auth deviceAuthorization
+	if err := c.postDeviceForm(ctx, base+devicePathCode, form, &auth); err != nil {
+		return deviceAuthorization{}, fmt.Errorf("ask %s for a device code: %w", base, err)
+	}
+	if strings.TrimSpace(auth.DeviceCode) == "" || strings.TrimSpace(auth.UserCode) == "" {
+		return deviceAuthorization{}, fmt.Errorf("%s returned a device authorization with no code", base)
+	}
+	if strings.TrimSpace(auth.VerificationURI) == "" {
+		return deviceAuthorization{}, fmt.Errorf("%s returned a device authorization with no verification URL", base)
+	}
+	return auth, nil
+}
+
+// requestDeviceToken is one device access token request. It returns the machine
+// triple on approval, or a deviceHTTPError carrying the OAuth code that says
+// what the flow should do next.
+func (c *commandContext) requestDeviceToken(ctx context.Context, base, deviceCode string) (vmgateway.MachineFile, error) {
+	form := url.Values{}
+	form.Set("grant_type", deviceCodeGrantType)
+	form.Set("device_code", deviceCode)
+
+	var token deviceTokenResponse
+	if err := c.postDeviceForm(ctx, base+devicePathToken, form, &token); err != nil {
+		return vmgateway.MachineFile{}, err
+	}
+	// machineId is machines.id, which is also the access token's audience. It
+	// is never the hostname and never the public URL: substituting either makes
+	// the gateway 401 every request with nothing on either side to explain why.
+	return vmgateway.MachineFile{
+		MachineID: token.MachineID,
+		AccountID: token.AccountID,
+		PublicURL: token.PublicURL,
+	}, nil
+}
+
+// postDeviceForm posts a form-encoded body, which is what the OAuth specs use,
+// and decodes either the success body or the OAuth error body. The device code
+// travels in the body rather than the query string so it never reaches an
+// access log or a shell history.
+func (c *commandContext) postDeviceForm(ctx context.Context, endpoint string, form url.Values, into any) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, strings.NewReader(form.Encode()))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", setupVMUserAgent)
+
+	resp, err := c.setupHTTPClient().Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, deviceResponseLimit))
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return decodeDeviceError(resp.StatusCode, body)
+	}
+	if err := json.Unmarshal(body, into); err != nil {
+		return fmt.Errorf("parse the answer from %s: %w", endpoint, err)
+	}
+	return nil
+}
+
+// decodeDeviceError reads the OAuth error envelope both endpoints return. A
+// body that is not that envelope leaves the code empty, which the state machine
+// classifies as fatal rather than as a state of the flow.
+func decodeDeviceError(status int, body []byte) error {
+	var payload struct {
+		Error            string `json:"error"`
+		ErrorDescription string `json:"error_description"`
+	}
+	_ = json.Unmarshal(body, &payload)
+	return deviceHTTPError{Status: status, Code: payload.Error, Description: payload.ErrorDescription}
+}
+
+// setupMachineName is the name the approval page shows. The hostname is what
+// the operator will recognise; the domain is the fallback for a box whose
+// hostname says nothing.
+func setupMachineName(domain string) string {
+	host, err := os.Hostname()
+	host = strings.TrimSpace(host)
+	if err != nil || host == "" || host == "localhost" {
+		return domain
+	}
+	return host
+}
+
+// writeMachineFile writes machine.json mode 0600, atomically.
+//
+// A partial machine.json is worse than none: the gateway treats a missing file
+// as "not bound yet" and starts, but a malformed one fails the unmarshal and
+// stops it dead. So the bytes go to a temp file in the same directory and are
+// renamed into place, which is atomic within a directory; a temp file in /tmp
+// would not be, because rename cannot cross filesystems.
+func writeMachineFile(path string, content []byte, owner *user.User) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("create %s: %w", dir, err)
+	}
+	tmp, err := os.CreateTemp(dir, ".machine.json.*")
+	if err != nil {
+		return fmt.Errorf("create a temporary file next to %s: %w", path, err)
+	}
+	tmpPath := tmp.Name()
+	// Removing an already-renamed file fails harmlessly; an abandoned one is
+	// what this cleans up, so no half-written file is ever left behind.
+	defer func() { _ = os.Remove(tmpPath) }()
+
+	if _, err := tmp.Write(content); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("write %s: %w", path, err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("write %s: %w", path, err)
+	}
+	// os.CreateTemp already creates 0600, but the mode is part of this file's
+	// contract rather than an implementation detail of the standard library:
+	// machine.json names the only account allowed to reach this box.
+	if err := os.Chmod(tmpPath, 0o600); err != nil {
+		return fmt.Errorf("set the mode of %s: %w", path, err)
+	}
+	if err := chownMachineFile(tmpPath, owner); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return fmt.Errorf("move the new machine file into place at %s: %w", path, err)
+	}
+	return nil
+}
+
+// chownMachineFile hands the file to the user the gateway unit runs as. Under
+// sudo this process is root while ao-gateway.service is not, and a 0600 file
+// owned by root is one the gateway cannot read, so it would refuse to start on
+// a machine that had just been bound successfully.
+func chownMachineFile(path string, owner *user.User) error {
+	if owner == nil || os.Getuid() != 0 {
+		return nil
+	}
+	uid, gid := -1, -1
+	if parsed, err := strconv.Atoi(owner.Uid); err == nil {
+		uid = parsed
+	}
+	if parsed, err := strconv.Atoi(owner.Gid); err == nil {
+		gid = parsed
+	}
+	if uid < 0 || gid < 0 {
+		// Non-numeric ids are a Windows user, and this path only ever runs on
+		// the Ubuntu box the platform gate already checked for.
+		return nil
+	}
+	if err := os.Chown(path, uid, gid); err != nil {
+		return fmt.Errorf("give %s to %s: %w", path, owner.Username, err)
+	}
+	return nil
+}

--- a/backend/internal/cli/setupvm_bind_plan.go
+++ b/backend/internal/cli/setupvm_bind_plan.go
@@ -1,0 +1,295 @@
+package cli
+
+// setupvm_bind_plan.go holds every decision the binding half of `ao setup-vm`
+// makes: what one device-flow poll answer means, how far to back off, the exact
+// bytes of machine.json, and every line the binding prints. Nothing in here
+// touches the network or the disk, so all of it is unit-testable on macOS and
+// Windows, where CLI E2E also runs. The thin layer that executes these
+// decisions lives in setupvm_bind.go, the same split setupvm.go and
+// setupvm_plan.go already use.
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/vmgateway"
+)
+
+const (
+	// devicePollDefaultInterval is used only when the device authorization
+	// response carries no interval. The server's own value wins whenever there
+	// is one: it is the authority on how fast it is willing to be polled.
+	devicePollDefaultInterval = 5 * time.Second
+	// deviceSlowDownIncrement is the back-off RFC 8628 section 3.5 prescribes:
+	// on slow_down the client raises its polling interval by 5 seconds. It is
+	// an instruction, not a warning, so it is applied rather than logged.
+	deviceSlowDownIncrement = 5 * time.Second
+	// devicePollMaxInterval caps the back-off, so a server answering slow_down
+	// forever cannot stretch one wait past the device code's own lifetime.
+	devicePollMaxInterval = 60 * time.Second
+	// deviceFlowFallbackExpiry bounds the wait when the device authorization
+	// response omits expires_in, so an unapproved flow always ends.
+	deviceFlowFallbackExpiry = 15 * time.Minute
+)
+
+// The RFC 8628 section 3.5 error codes this client understands, plus the one
+// OAuth code the control plane returns for a device code it has never seen.
+const (
+	deviceErrAuthorizationPending = "authorization_pending"
+	deviceErrSlowDown             = "slow_down"
+	deviceErrAccessDenied         = "access_denied"
+	deviceErrExpiredToken         = "expired_token"
+	deviceErrInvalidGrant         = "invalid_grant"
+)
+
+var (
+	// errDeviceCodeExpired is the one failure the flow can recover from, by
+	// asking for a fresh code.
+	errDeviceCodeExpired = errors.New("the device code expired before anyone approved it")
+	// errDeviceAccessDenied is a human saying no in the browser, which is a
+	// decision rather than a fault, so it is never retried.
+	errDeviceAccessDenied = errors.New("the binding was denied in the browser")
+)
+
+// devicePollOutcome is what one answer from the token endpoint means for the
+// polling loop.
+type devicePollOutcome int
+
+const (
+	// devicePollWait: nobody has approved yet. Poll again, unchanged.
+	devicePollWait devicePollOutcome = iota
+	// devicePollSlowDown: polling too fast. Poll again, after backing off.
+	devicePollSlowDown
+	// devicePollExpired: the code is unusable and only a new one can help.
+	devicePollExpired
+	// devicePollDenied: a human refused this machine.
+	devicePollDenied
+	// devicePollFatal: anything else, which is an outage or a bug rather than
+	// a state of the flow, and must not be retried until the code expires.
+	devicePollFatal
+)
+
+// classifyDevicePollError maps an OAuth error code to what the loop does next.
+func classifyDevicePollError(code string) devicePollOutcome {
+	switch strings.TrimSpace(code) {
+	case deviceErrAuthorizationPending:
+		return devicePollWait
+	case deviceErrSlowDown:
+		return devicePollSlowDown
+	case deviceErrExpiredToken, deviceErrInvalidGrant:
+		// invalid_grant is an unknown device code, which is what an expired one
+		// becomes once the control plane sweeps it. Same remedy either way: the
+		// code cannot be approved, so offer a new one.
+		return devicePollExpired
+	case deviceErrAccessDenied:
+		return devicePollDenied
+	default:
+		return devicePollFatal
+	}
+}
+
+// nextDevicePollInterval applies the back-off. Only slow_down changes the
+// interval; every other outcome keeps polling at the rate the server asked for.
+func nextDevicePollInterval(current time.Duration, outcome devicePollOutcome) time.Duration {
+	if outcome != devicePollSlowDown {
+		return current
+	}
+	if next := current + deviceSlowDownIncrement; next < devicePollMaxInterval {
+		return next
+	}
+	return devicePollMaxInterval
+}
+
+// devicePollStartInterval reads the server-supplied interval, falling back only
+// when it is absent or nonsensical.
+func devicePollStartInterval(seconds int) time.Duration {
+	if seconds <= 0 {
+		return devicePollDefaultInterval
+	}
+	return time.Duration(seconds) * time.Second
+}
+
+// deviceFlowExpiry reads the server-supplied expires_in, with the same
+// fallback discipline.
+func deviceFlowExpiry(seconds int) time.Duration {
+	if seconds <= 0 {
+		return deviceFlowFallbackExpiry
+	}
+	return time.Duration(seconds) * time.Second
+}
+
+// ---------------------------------------------------------------------------
+// machine.json
+// ---------------------------------------------------------------------------
+
+// validateMachineFile rejects a binding that would produce a machine.json the
+// gateway cannot serve from, before anything is written.
+//
+// publicUrl has to be a full origin because `ao vm serve` reduces it with
+// url.Parse and u.Hostname(). A bare hostname parses as a path, leaves the
+// certificate whitelist empty, and fails every TLS handshake while the gateway
+// logs a clean start, so it is caught here instead.
+func validateMachineFile(mf vmgateway.MachineFile) error {
+	for _, field := range [][2]string{
+		{"machineId", mf.MachineID},
+		{"accountId", mf.AccountID},
+		{"publicUrl", mf.PublicURL},
+	} {
+		if strings.TrimSpace(field[1]) == "" {
+			return fmt.Errorf("%s is empty", field[0])
+		}
+	}
+	u, err := url.Parse(mf.PublicURL)
+	if err != nil || u.Scheme == "" || u.Hostname() == "" {
+		return fmt.Errorf("publicUrl %q is not a full origin like https://vm.example.com", mf.PublicURL)
+	}
+	return nil
+}
+
+// renderMachineFile is the exact bytes of ~/.ao/machine.json.
+//
+// It marshals vmgateway.MachineFile, the very type `ao vm serve` unmarshals, so
+// the writer and the reader cannot drift: renaming a field there stops this
+// compiling. machineId is machines.id and becomes the access token's `aud`,
+// compared byte for byte, so it is never the hostname and never the public URL.
+// issuedAt goes out as RFC 3339 because a value that does not parse fails the
+// whole unmarshal and the gateway then refuses to start over a field it never
+// reads.
+func renderMachineFile(mf vmgateway.MachineFile, issuedAt time.Time) ([]byte, error) {
+	mf.IssuedAt = issuedAt.UTC().Truncate(time.Second)
+	if err := validateMachineFile(mf); err != nil {
+		return nil, fmt.Errorf("refusing to write an unusable machine file: %w", err)
+	}
+	data, err := json.MarshalIndent(mf, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("render the machine file: %w", err)
+	}
+	return append(data, '\n'), nil
+}
+
+// ---------------------------------------------------------------------------
+// What the binding prints
+// ---------------------------------------------------------------------------
+
+// renderMachineFields is the one layout every binding readout uses, so
+// ao setup-vm and ao whoami describe the same file the same way.
+func renderMachineFields(indent string, mf vmgateway.MachineFile) string {
+	var b strings.Builder
+	for _, field := range [][2]string{
+		{"machine id", mf.MachineID},
+		{"account id", mf.AccountID},
+		{"public url", mf.PublicURL},
+		{"bound at", mf.IssuedAt.UTC().Format(time.RFC3339)},
+	} {
+		fmt.Fprintf(&b, "%s%-12s  %s\n", indent, field[0], field[1])
+	}
+	return b.String()
+}
+
+// renderPreviousBinding is printed before a re-bind. An already-bound machine
+// is re-bound rather than refused, so the operator has to see what is about to
+// be replaced while there is still time to press Ctrl-C.
+func renderPreviousBinding(path string, mf vmgateway.MachineFile) string {
+	var b strings.Builder
+	b.WriteString("\n==> This machine is already bound. Binding again replaces the entry below.\n\n")
+	b.WriteString(renderMachineFields("      ", mf))
+	fmt.Fprintf(&b, "      %-12s  %s\n", "machine file", path)
+	return b.String()
+}
+
+// renderDeviceInstructions is what the operator reads while the flow waits.
+//
+// The user code is the part meant to be displayed. The device code is a bearer
+// secret and appears nowhere: not here, not in a printed URL, not in a log
+// line, and not on disk. verification_uri_complete carries only the user code,
+// which is why it is safe to print.
+func renderDeviceInstructions(auth deviceAuthorization, machineName, publicURL string, expiry time.Duration) string {
+	var b strings.Builder
+	b.WriteString("\n==> Binding this machine to an AO account.\n\n")
+	b.WriteString("      On any device with a browser, open:\n")
+	fmt.Fprintf(&b, "        %s\n", auth.VerificationURI)
+	b.WriteString("      and enter this code:\n")
+	fmt.Fprintf(&b, "        %s\n", auth.UserCode)
+	if complete := strings.TrimSpace(auth.VerificationURIComplete); complete != "" {
+		b.WriteString("\n      Or open this link, which fills the code in for you:\n")
+		fmt.Fprintf(&b, "        %s\n", complete)
+	}
+	b.WriteString("\n      The approval page will show this machine as:\n")
+	fmt.Fprintf(&b, "        %s (%s)\n", machineName, publicURL)
+	fmt.Fprintf(&b, "\n    Waiting for approval. This code expires in %s. Press Ctrl-C to stop.\n",
+		humanDeviceDuration(expiry))
+	return b.String()
+}
+
+// renderBindingWritten confirms the write, naming the file and its mode because
+// both are part of the contract: the gateway reads that path, and nothing else
+// on the box may read that file.
+func renderBindingWritten(path string, mf vmgateway.MachineFile) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "\n==> Approved. Wrote %s (mode 0600).\n\n", path)
+	b.WriteString(renderMachineFields("      ", mf))
+	return b.String()
+}
+
+// renderDeviceRestartPrompt asks whether to request a fresh code. An expired
+// code is the one device-flow failure that is worth retrying in place: the
+// operator is usually still sitting at the terminal, and the alternative is
+// re-running the whole of setup-vm to get back here.
+func renderDeviceRestartPrompt(expiry time.Duration) string {
+	return fmt.Sprintf("\n    Nobody approved that code within %s, so it expired.\n"+
+		"    Request a new code? [Y/n]: ", humanDeviceDuration(expiry))
+}
+
+// humanDeviceDuration renders a code lifetime the way a person would say it.
+func humanDeviceDuration(d time.Duration) string {
+	switch {
+	case d >= time.Minute && d%time.Minute == 0:
+		minutes := int(d / time.Minute)
+		if minutes == 1 {
+			return "1 minute"
+		}
+		return fmt.Sprintf("%d minutes", minutes)
+	default:
+		return d.Round(time.Second).String()
+	}
+}
+
+// renderWhoami is the whole output of `ao whoami`: the binding `ao vm serve`
+// is running with, or a plain statement that there is none.
+func renderWhoami(mf *vmgateway.MachineFile, path string) string {
+	var b strings.Builder
+	if mf == nil {
+		b.WriteString("This machine is not bound to an AO account.\n")
+		fmt.Fprintf(&b, "There is no machine file at %s.\n", path)
+		b.WriteString("\nBind it by running setup on the machine itself:\n")
+		b.WriteString("  sudo ao setup-vm --domain <the hostname you own>\n")
+		return b.String()
+	}
+
+	problem := validateMachineFile(*mf)
+	if problem != nil {
+		b.WriteString("This machine has a machine file, but it is not usable.\n\n")
+	} else {
+		b.WriteString("This machine is bound to an AO account.\n\n")
+	}
+	b.WriteString(renderMachineFields("  ", *mf))
+	fmt.Fprintf(&b, "  %-12s  %s\n", "machine file", path)
+
+	if problem != nil {
+		fmt.Fprintf(&b, "\nProblem: %s\n", problem)
+		fmt.Fprintf(&b, "`ao vm serve` will not start until that is fixed. Bind this machine again:\n")
+		b.WriteString("  sudo ao setup-vm --domain <the hostname you own>\n")
+		return b.String()
+	}
+
+	b.WriteString("\nA request reaches the daemon on this machine only with an AO access token whose\n")
+	b.WriteString("audience is that machine id and whose subject is that account id. Everything else\n")
+	b.WriteString("gets a 401.\n")
+	fmt.Fprintf(&b, "\n`ao vm serve` reads that file once at startup, so after any change to it:\n"+
+		"  sudo systemctl restart %s\n", setupVMGatewayUnit)
+	return b.String()
+}

--- a/backend/internal/cli/setupvm_bind_test.go
+++ b/backend/internal/cli/setupvm_bind_test.go
@@ -1,0 +1,659 @@
+package cli
+
+// Tests for the binding half of `ao setup-vm`. The highest-value one here is
+// TestMachineFileRoundTripsThroughTheGatewayReader: it writes the file with the
+// real writer and reads it back with vmgateway's real reader, which is what
+// stops the two from ever disagreeing about machine.json.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/vmgateway"
+)
+
+// testMachineID and testAccountID are lowercase hyphenated UUIDs, the shape
+// machines.id and accounts.id actually have. machineId in particular becomes
+// the token audience, so a test that used a hostname here would pass while the
+// real thing 401s.
+const (
+	testMachineID = "6f1b6b0a-6a7f-4f2a-9a2f-1f3d2c4b5a60"
+	testAccountID = "b2c3d4e5-1111-4222-8333-444455556666"
+	testPublicURL = "https://vm.example.com"
+)
+
+// fakeDeviceClock makes the polling loop deterministic: sleeping advances the
+// clock, so a code's expiry is reached by polling rather than by waiting.
+type fakeDeviceClock struct {
+	mu    sync.Mutex
+	now   time.Time
+	slept []time.Duration
+}
+
+func newFakeDeviceClock() *fakeDeviceClock {
+	return &fakeDeviceClock{now: time.Date(2026, 7, 30, 9, 0, 0, 0, time.UTC)}
+}
+
+func (c *fakeDeviceClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.now
+}
+
+func (c *fakeDeviceClock) Sleep(d time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.slept = append(c.slept, d)
+	c.now = c.now.Add(d)
+}
+
+func (c *fakeDeviceClock) sleeps() []time.Duration {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]time.Duration(nil), c.slept...)
+}
+
+// deviceFlowServer is a stand-in control plane. tokenAnswers is walked one
+// entry per poll; the last entry repeats once the list runs out.
+type deviceFlowServer struct {
+	mu           sync.Mutex
+	deviceCode   string
+	codeRequests int
+	tokenPolls   int
+	machineName  string
+	publicURL    string
+	grantType    string
+	presented    []string
+	tokenAnswers []func(w http.ResponseWriter)
+	expiresIn    int
+	interval     int
+}
+
+func (s *deviceFlowServer) start(t *testing.T) string {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /device/code", func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Errorf("device code request body: %v", err)
+		}
+		s.mu.Lock()
+		s.codeRequests++
+		s.machineName = r.PostForm.Get("machine_name")
+		s.publicURL = r.PostForm.Get("public_url")
+		code := s.deviceCode
+		s.mu.Unlock()
+
+		writeTestJSON(w, http.StatusOK, map[string]any{
+			"device_code":               code,
+			"user_code":                 "BCDF-GHJK",
+			"verification_uri":          "https://ao.example.com/device",
+			"verification_uri_complete": "https://ao.example.com/device?user_code=BCDF-GHJK",
+			"expires_in":                s.expiresIn,
+			"interval":                  s.interval,
+		})
+	})
+	mux.HandleFunc("POST /device/token", func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Errorf("device token request body: %v", err)
+		}
+		s.mu.Lock()
+		s.grantType = r.PostForm.Get("grant_type")
+		s.presented = append(s.presented, r.PostForm.Get("device_code"))
+		answer := s.tokenAnswers[min(s.tokenPolls, len(s.tokenAnswers)-1)]
+		s.tokenPolls++
+		s.mu.Unlock()
+		answer(w)
+	})
+
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+	return server.URL
+}
+
+func writeTestJSON(w http.ResponseWriter, status int, body any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(body)
+}
+
+func oauthError(status int, code string) func(http.ResponseWriter) {
+	return func(w http.ResponseWriter) {
+		writeTestJSON(w, status, map[string]string{"error": code, "error_description": "test"})
+	}
+}
+
+func approved(w http.ResponseWriter) {
+	writeTestJSON(w, http.StatusOK, map[string]any{
+		"access_token": "an-access-token-the-cli-must-ignore",
+		"token_type":   "Bearer",
+		"expires_in":   3600,
+		"machine_id":   testMachineID,
+		"account_id":   testAccountID,
+		"public_url":   testPublicURL,
+	})
+}
+
+// ---------------------------------------------------------------------------
+// machine.json: the writer against the gateway's real reader
+// ---------------------------------------------------------------------------
+
+// TestMachineFileRoundTripsThroughTheGatewayReader is the test this whole task
+// hangs on. `ao vm serve` refuses to start on a machine.json it cannot parse,
+// and that only ever shows up on a real VM, so the writer is pinned to the
+// reader here instead.
+func TestMachineFileRoundTripsThroughTheGatewayReader(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".ao", "machine.json")
+	issuedAt := time.Date(2026, 7, 30, 9, 15, 30, 500_000_000, time.UTC)
+
+	content, err := renderMachineFile(vmgateway.MachineFile{
+		MachineID: testMachineID,
+		AccountID: testAccountID,
+		PublicURL: testPublicURL,
+	}, issuedAt)
+	if err != nil {
+		t.Fatalf("renderMachineFile: %v", err)
+	}
+	if err := writeMachineFile(path, content, nil); err != nil {
+		t.Fatalf("writeMachineFile: %v", err)
+	}
+
+	got, err := vmgateway.ReadMachineFile(path)
+	if err != nil {
+		t.Fatalf("the gateway's own reader rejected the file this command wrote: %v\n%s", err, content)
+	}
+	if got == nil {
+		t.Fatal("ReadMachineFile returned no file for one that was just written")
+	}
+	if got.MachineID != testMachineID {
+		t.Errorf("machineId = %q, want %q: it is the token audience, never the hostname", got.MachineID, testMachineID)
+	}
+	if got.AccountID != testAccountID {
+		t.Errorf("accountId = %q, want %q", got.AccountID, testAccountID)
+	}
+	if got.PublicURL != testPublicURL {
+		t.Errorf("publicUrl = %q, want the full origin %q", got.PublicURL, testPublicURL)
+	}
+	if !got.IssuedAt.Equal(issuedAt.Truncate(time.Second)) {
+		t.Errorf("issuedAt = %s, want %s", got.IssuedAt, issuedAt.Truncate(time.Second))
+	}
+
+	// issuedAt is only ever read by encoding/json, so assert the wire form
+	// directly: a value that is not RFC 3339 fails the whole unmarshal and
+	// stops the gateway over a field nobody consumes.
+	var raw struct {
+		IssuedAt string `json:"issuedAt"`
+	}
+	if err := json.Unmarshal(content, &raw); err != nil {
+		t.Fatalf("unmarshal the rendered file: %v", err)
+	}
+	if _, err := time.Parse(time.RFC3339, raw.IssuedAt); err != nil {
+		t.Errorf("issuedAt %q is not RFC 3339: %v", raw.IssuedAt, err)
+	}
+
+	// The whole point of the file: the gateway resolves its configuration from
+	// it and gets a bare hostname for the certificate whitelist.
+	for _, key := range []string{"AO_VM_DOMAIN", "AO_VM_MACHINE_ID", "AO_VM_ACCOUNT_ID", "AO_MACHINE_FILE"} {
+		t.Setenv(key, "")
+	}
+	cfg, err := vmgateway.Resolve(vmgateway.Options{MachineFile: path}, t.TempDir())
+	if err != nil {
+		t.Fatalf("the gateway could not resolve its config from the written file: %v", err)
+	}
+	if cfg.Domain != "vm.example.com" {
+		t.Errorf("resolved domain = %q, want the bare hostname vm.example.com", cfg.Domain)
+	}
+	if cfg.MachineID != testMachineID {
+		t.Errorf("resolved machine id = %q, want %q", cfg.MachineID, testMachineID)
+	}
+}
+
+func TestWriteMachineFileIsAtomicAndPrivate(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "machine.json")
+
+	first, err := renderMachineFile(vmgateway.MachineFile{
+		MachineID: testMachineID, AccountID: testAccountID, PublicURL: testPublicURL,
+	}, time.Now())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := writeMachineFile(path, first, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	// Re-binding replaces the file rather than appending to it or leaving the
+	// old one in place.
+	replacement := "11111111-2222-4333-8444-555566667777"
+	second, err := renderMachineFile(vmgateway.MachineFile{
+		MachineID: replacement, AccountID: testAccountID, PublicURL: testPublicURL,
+	}, time.Now())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := writeMachineFile(path, second, nil); err != nil {
+		t.Fatal(err)
+	}
+	got, err := vmgateway.ReadMachineFile(path)
+	if err != nil || got == nil {
+		t.Fatalf("read back after re-bind: %v", err)
+	}
+	if got.MachineID != replacement {
+		t.Errorf("machineId = %q after re-bind, want %q", got.MachineID, replacement)
+	}
+
+	// No temp file may survive either write: the reader globs nothing, but a
+	// stray half-written sibling is exactly what the rename dance exists to
+	// avoid leaving around.
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 || entries[0].Name() != "machine.json" {
+		names := make([]string, 0, len(entries))
+		for _, entry := range entries {
+			names = append(names, entry.Name())
+		}
+		t.Errorf("directory holds %v, want only machine.json", names)
+	}
+
+	if runtime.GOOS == "windows" {
+		return
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Errorf("machine.json mode = %04o, want 0600", perm)
+	}
+}
+
+func TestRenderMachineFileRefusesAnUnusableBinding(t *testing.T) {
+	for name, mf := range map[string]vmgateway.MachineFile{
+		"no machine id": {AccountID: testAccountID, PublicURL: testPublicURL},
+		"no account id": {MachineID: testMachineID, PublicURL: testPublicURL},
+		"no public url": {MachineID: testMachineID, AccountID: testAccountID},
+		// A bare hostname parses as a path, so the gateway's certificate
+		// whitelist ends up empty and every handshake fails.
+		"bare hostname public url": {MachineID: testMachineID, AccountID: testAccountID, PublicURL: "vm.example.com"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := renderMachineFile(mf, time.Now()); err == nil {
+				t.Fatalf("expected %s to be refused before anything is written", name)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// The device flow state machine
+// ---------------------------------------------------------------------------
+
+func TestClassifyDevicePollError(t *testing.T) {
+	for code, want := range map[string]devicePollOutcome{
+		"authorization_pending": devicePollWait,
+		"slow_down":             devicePollSlowDown,
+		"expired_token":         devicePollExpired,
+		"invalid_grant":         devicePollExpired,
+		"access_denied":         devicePollDenied,
+		"invalid_request":       devicePollFatal,
+		"server_error":          devicePollFatal,
+		"":                      devicePollFatal,
+	} {
+		if got := classifyDevicePollError(code); got != want {
+			t.Errorf("classifyDevicePollError(%q) = %d, want %d", code, got, want)
+		}
+	}
+}
+
+func TestNextDevicePollIntervalBacksOffOnlyOnSlowDown(t *testing.T) {
+	if got := nextDevicePollInterval(5*time.Second, devicePollWait); got != 5*time.Second {
+		t.Errorf("authorization_pending changed the interval to %s, want it unchanged", got)
+	}
+	if got := nextDevicePollInterval(5*time.Second, devicePollSlowDown); got != 10*time.Second {
+		t.Errorf("slow_down interval = %s, want 10s (RFC 8628 adds 5 seconds)", got)
+	}
+	if got := nextDevicePollInterval(devicePollMaxInterval, devicePollSlowDown); got != devicePollMaxInterval {
+		t.Errorf("slow_down past the cap = %s, want it capped at %s", got, devicePollMaxInterval)
+	}
+}
+
+func TestDevicePollStartIntervalPrefersTheServerValue(t *testing.T) {
+	if got := devicePollStartInterval(7); got != 7*time.Second {
+		t.Errorf("interval = %s, want the server's 7s", got)
+	}
+	if got := devicePollStartInterval(0); got != devicePollDefaultInterval {
+		t.Errorf("interval with no server value = %s, want %s", got, devicePollDefaultInterval)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// The device flow against a stand-in control plane
+// ---------------------------------------------------------------------------
+
+func deviceFlowContext(t *testing.T, clock *fakeDeviceClock, stdin string) (*commandContext, *strings.Builder) {
+	t.Helper()
+	out := &strings.Builder{}
+	deps := Deps{
+		In:    strings.NewReader(stdin),
+		Now:   clock.Now,
+		Sleep: clock.Sleep,
+	}
+	return &commandContext{deps: deps.withDefaults()}, out
+}
+
+func TestDeviceFlowPollsAtTheServerIntervalAndBacksOff(t *testing.T) {
+	server := &deviceFlowServer{
+		deviceCode: "device-code-that-must-never-be-printed",
+		expiresIn:  900,
+		interval:   7,
+		tokenAnswers: []func(http.ResponseWriter){
+			oauthError(http.StatusBadRequest, "authorization_pending"),
+			oauthError(http.StatusBadRequest, "authorization_pending"),
+			oauthError(http.StatusBadRequest, "slow_down"),
+			approved,
+		},
+	}
+	base := server.start(t)
+	clock := newFakeDeviceClock()
+	ctx, out := deviceFlowContext(t, clock, "")
+
+	binding, err := ctx.runDeviceFlow(context.Background(), out, base, "vm-01", testPublicURL)
+	if err != nil {
+		t.Fatalf("runDeviceFlow: %v", err)
+	}
+	if binding.MachineID != testMachineID || binding.AccountID != testAccountID || binding.PublicURL != testPublicURL {
+		t.Fatalf("binding = %+v, want the machine triple the token endpoint returned", binding)
+	}
+
+	// Sleep before every poll, at the server's interval, plus 5 seconds after
+	// slow_down. Ignoring slow_down is how a client gets rate limited off the
+	// endpoint entirely, so it has to show up here.
+	want := []time.Duration{7 * time.Second, 7 * time.Second, 7 * time.Second, 12 * time.Second}
+	got := clock.sleeps()
+	if len(got) != len(want) {
+		t.Fatalf("sleeps = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("sleep %d = %s, want %s (full sequence %v)", i, got[i], want[i], got)
+		}
+	}
+
+	if server.grantType != deviceCodeGrantType {
+		t.Errorf("grant_type = %q, want %q", server.grantType, deviceCodeGrantType)
+	}
+	if server.machineName != "vm-01" || server.publicURL != testPublicURL {
+		t.Errorf("device authorization sent name %q and public url %q, want vm-01 and %q",
+			server.machineName, server.publicURL, testPublicURL)
+	}
+	for i, presented := range server.presented {
+		if presented != server.deviceCode {
+			t.Errorf("poll %d presented %q, want the device code from the authorization response", i, presented)
+		}
+	}
+}
+
+// TestDeviceFlowNeverPrintsTheDeviceCode pins the one security property of the
+// printed output: the user code is meant to be shown, the device code is a
+// bearer secret and must not reach the terminal, a URL, or a log.
+func TestDeviceFlowNeverPrintsTheDeviceCode(t *testing.T) {
+	secret := "sup3rsecret-device-code-value"
+	server := &deviceFlowServer{
+		deviceCode:   secret,
+		expiresIn:    900,
+		interval:     1,
+		tokenAnswers: []func(http.ResponseWriter){approved},
+	}
+	base := server.start(t)
+	clock := newFakeDeviceClock()
+	ctx, out := deviceFlowContext(t, clock, "")
+
+	if _, err := ctx.runDeviceFlow(context.Background(), out, base, "vm-01", testPublicURL); err != nil {
+		t.Fatalf("runDeviceFlow: %v", err)
+	}
+	printed := out.String()
+	if strings.Contains(printed, secret) {
+		t.Fatalf("the device code was printed:\n%s", printed)
+	}
+	for _, want := range []string{"BCDF-GHJK", "https://ao.example.com/device", "vm-01", testPublicURL} {
+		if !strings.Contains(printed, want) {
+			t.Errorf("output is missing %q:\n%s", want, printed)
+		}
+	}
+	assertNoDashes(t, printed)
+}
+
+func TestDeviceFlowOffersToRestartAnExpiredCode(t *testing.T) {
+	newServer := func() *deviceFlowServer {
+		return &deviceFlowServer{
+			deviceCode:   "device-code",
+			expiresIn:    900,
+			interval:     1,
+			tokenAnswers: []func(http.ResponseWriter){oauthError(http.StatusBadRequest, "expired_token")},
+		}
+	}
+
+	t.Run("accepted", func(t *testing.T) {
+		server := newServer()
+		base := server.start(t)
+		ctx, out := deviceFlowContext(t, newFakeDeviceClock(), "y\n")
+		_, err := ctx.runDeviceFlow(context.Background(), out, base, "vm-01", testPublicURL)
+		if !errors.Is(err, errDeviceCodeExpired) {
+			t.Fatalf("err = %v, want errDeviceCodeExpired", err)
+		}
+		if server.codeRequests < 2 {
+			t.Errorf("device code requests = %d, want a fresh code after the operator said yes", server.codeRequests)
+		}
+		if !strings.Contains(out.String(), "Request a new code?") {
+			t.Errorf("an expired code must offer to restart the flow:\n%s", out.String())
+		}
+	})
+
+	t.Run("declined", func(t *testing.T) {
+		server := newServer()
+		base := server.start(t)
+		ctx, out := deviceFlowContext(t, newFakeDeviceClock(), "n\n")
+		_, err := ctx.runDeviceFlow(context.Background(), out, base, "vm-01", testPublicURL)
+		if !errors.Is(err, errDeviceCodeExpired) {
+			t.Fatalf("err = %v, want errDeviceCodeExpired", err)
+		}
+		if server.codeRequests != 1 {
+			t.Errorf("device code requests = %d, want 1: a declined restart asks for nothing more", server.codeRequests)
+		}
+	})
+}
+
+func TestDeviceFlowStopsWhenTheApprovalIsDenied(t *testing.T) {
+	server := &deviceFlowServer{
+		deviceCode:   "device-code",
+		expiresIn:    900,
+		interval:     1,
+		tokenAnswers: []func(http.ResponseWriter){oauthError(http.StatusForbidden, "access_denied")},
+	}
+	base := server.start(t)
+	ctx, out := deviceFlowContext(t, newFakeDeviceClock(), "y\n")
+
+	_, err := ctx.runDeviceFlow(context.Background(), out, base, "vm-01", testPublicURL)
+	if !errors.Is(err, errDeviceAccessDenied) {
+		t.Fatalf("err = %v, want errDeviceAccessDenied", err)
+	}
+	if server.codeRequests != 1 {
+		t.Errorf("device code requests = %d, want 1: a refusal is a decision, not something to retry", server.codeRequests)
+	}
+}
+
+// TestDeviceFlowGivesUpWhenTheCodeExpiresUnapproved covers the deadline rather
+// than the server's expired_token: a control plane that simply stops answering
+// must not leave setup-vm polling forever.
+func TestDeviceFlowGivesUpWhenTheCodeExpiresUnapproved(t *testing.T) {
+	server := &deviceFlowServer{
+		deviceCode:   "device-code",
+		expiresIn:    30,
+		interval:     10,
+		tokenAnswers: []func(http.ResponseWriter){oauthError(http.StatusBadRequest, "authorization_pending")},
+	}
+	base := server.start(t)
+	ctx, out := deviceFlowContext(t, newFakeDeviceClock(), "")
+
+	_, err := ctx.runDeviceFlow(context.Background(), out, base, "vm-01", testPublicURL)
+	if !errors.Is(err, errDeviceCodeExpired) {
+		t.Fatalf("err = %v, want errDeviceCodeExpired", err)
+	}
+}
+
+// TestDeviceFlowRejectsABindingItCannotWrite guards the confusion PR #18 was
+// opened for: a control plane that answered with the hostname where machines.id
+// belongs must fail loudly here, not silently produce a machine that 401s
+// every request.
+func TestDeviceFlowRejectsABindingItCannotWrite(t *testing.T) {
+	server := &deviceFlowServer{
+		deviceCode: "device-code",
+		expiresIn:  900,
+		interval:   1,
+		tokenAnswers: []func(http.ResponseWriter){func(w http.ResponseWriter) {
+			writeTestJSON(w, http.StatusOK, map[string]any{
+				"machine_id": "",
+				"account_id": testAccountID,
+				"public_url": testPublicURL,
+			})
+		}},
+	}
+	base := server.start(t)
+	ctx, out := deviceFlowContext(t, newFakeDeviceClock(), "")
+
+	if _, err := ctx.runDeviceFlow(context.Background(), out, base, "vm-01", testPublicURL); err == nil {
+		t.Fatal("expected an approval with no machine id to be refused")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// bindSetupVM end to end
+// ---------------------------------------------------------------------------
+
+func TestBindSetupVMWritesTheFileAndRestartsTheGateway(t *testing.T) {
+	server := &deviceFlowServer{
+		deviceCode:   "device-code",
+		expiresIn:    900,
+		interval:     1,
+		tokenAnswers: []func(http.ResponseWriter){approved},
+	}
+	base := server.start(t)
+
+	dir := t.TempDir()
+	plan := setupPlan{
+		Domain:      "vm.example.com",
+		MachineFile: filepath.Join(dir, "machine.json"),
+	}
+
+	var mu sync.Mutex
+	var calls []string
+	clock := newFakeDeviceClock()
+	deps := Deps{
+		Now:   clock.Now,
+		Sleep: clock.Sleep,
+		CommandOutput: func(_ context.Context, name string, args ...string) ([]byte, error) {
+			mu.Lock()
+			calls = append(calls, strings.TrimSpace(name+" "+strings.Join(args, " ")))
+			mu.Unlock()
+			return nil, nil
+		},
+	}
+	ctx := &commandContext{deps: deps.withDefaults()}
+	out := &strings.Builder{}
+
+	if err := ctx.bindSetupVM(context.Background(), out, plan, base); err != nil {
+		t.Fatalf("bindSetupVM: %v", err)
+	}
+
+	mf, err := vmgateway.ReadMachineFile(plan.MachineFile)
+	if err != nil || mf == nil {
+		t.Fatalf("read the file bindSetupVM wrote: %v", err)
+	}
+	if mf.MachineID != testMachineID {
+		t.Errorf("machineId = %q, want %q", mf.MachineID, testMachineID)
+	}
+	if !mf.IssuedAt.Equal(clock.Now().Truncate(time.Second)) {
+		t.Errorf("issuedAt = %s, want the time of the binding", mf.IssuedAt)
+	}
+
+	// `ao vm serve` reads machine.json once at startup, so a binding that does
+	// not restart the unit is a binding the gateway never notices.
+	restarted := false
+	mu.Lock()
+	for _, call := range calls {
+		if strings.Contains(call, "systemctl restart "+setupVMGatewayUnit) {
+			restarted = true
+		}
+	}
+	mu.Unlock()
+	if !restarted {
+		t.Errorf("%s was never restarted after binding, so the gateway is still unbound. Calls: %v",
+			setupVMGatewayUnit, calls)
+	}
+	assertNoDashes(t, out.String())
+}
+
+// TestBindSetupVMPrintsThePreviousBindingBeforeReplacingIt is the re-bind
+// contract: an already-bound machine is never refused, and the binding about to
+// be replaced is shown while there is still time to stop.
+func TestBindSetupVMPrintsThePreviousBindingBeforeReplacingIt(t *testing.T) {
+	server := &deviceFlowServer{
+		deviceCode:   "device-code",
+		expiresIn:    900,
+		interval:     1,
+		tokenAnswers: []func(http.ResponseWriter){approved},
+	}
+	base := server.start(t)
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "machine.json")
+	previousID := "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee"
+	previous, err := renderMachineFile(vmgateway.MachineFile{
+		MachineID: previousID, AccountID: testAccountID, PublicURL: "https://old.example.com",
+	}, time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := writeMachineFile(path, previous, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	clock := newFakeDeviceClock()
+	deps := Deps{
+		Now:           clock.Now,
+		Sleep:         clock.Sleep,
+		CommandOutput: func(context.Context, string, ...string) ([]byte, error) { return nil, nil },
+	}
+	ctx := &commandContext{deps: deps.withDefaults()}
+	out := &strings.Builder{}
+
+	plan := setupPlan{Domain: "vm.example.com", MachineFile: path, Bound: true}
+	if err := ctx.bindSetupVM(context.Background(), out, plan, base); err != nil {
+		t.Fatalf("bindSetupVM on an already-bound machine: %v", err)
+	}
+
+	printed := out.String()
+	if !strings.Contains(printed, "already bound") || !strings.Contains(printed, previousID) {
+		t.Errorf("a re-bind must print the binding it replaces:\n%s", printed)
+	}
+	mf, err := vmgateway.ReadMachineFile(path)
+	if err != nil || mf == nil {
+		t.Fatalf("read back after re-bind: %v", err)
+	}
+	if mf.MachineID != testMachineID {
+		t.Errorf("machineId = %q after re-bind, want the new %q: the old file must not survive", mf.MachineID, testMachineID)
+	}
+	assertNoDashes(t, printed)
+}

--- a/backend/internal/cli/setupvm_plan.go
+++ b/backend/internal/cli/setupvm_plan.go
@@ -870,13 +870,18 @@ func renderSetupSummary(p setupPlan, gatewayStarted bool, warnings []string) str
 
 	if !p.Bound {
 		fmt.Fprintf(&b, "\n  %d. This machine is not bound to an AO account, so the gateway is installed and\n", next())
-		b.WriteString("     enabled but not serving. Binding is not part of this build yet. Once it writes\n")
-		fmt.Fprintf(&b, "     %s, the gateway needs a restart to read it, because\n", p.MachineFile)
-		b.WriteString("     `ao vm serve` reads that file once at startup:\n")
+		b.WriteString("     enabled but not serving. Run setup again to retry the binding, which is the\n")
+		b.WriteString("     only step still outstanding; everything above it is already done:\n")
+		fmt.Fprintf(&b, "       sudo ao setup-vm --domain %s\n", p.Domain)
+		fmt.Fprintf(&b, "     Once that writes %s, the gateway needs a restart to\n", p.MachineFile)
+		b.WriteString("     read it, because `ao vm serve` reads that file once at startup:\n")
 		fmt.Fprintf(&b, "       sudo systemctl start %s\n", setupVMGatewayUnit)
 	} else {
-		fmt.Fprintf(&b, "\n  %d. This machine is already bound (%s). If you re-bind it, restart\n", next(), p.MachineFile)
-		b.WriteString("     the gateway so it re-reads the file:\n")
+		fmt.Fprintf(&b, "\n  %d. This machine is already bound (%s), and ao setup-vm restarted\n", next(), p.MachineFile)
+		fmt.Fprintf(&b, "     %s so it has read that binding. Check it at any time:\n", setupVMGatewayUnit)
+		b.WriteString("       ao whoami\n")
+		b.WriteString("     If you ever change that file by hand, restart the gateway yourself, because\n")
+		b.WriteString("     `ao vm serve` reads it once at startup:\n")
 		fmt.Fprintf(&b, "       sudo systemctl restart %s\n", setupVMGatewayUnit)
 	}
 
@@ -930,6 +935,9 @@ func renderSetupDryRun(p setupPlan, warnings []string) string {
 		fmt.Fprintf(&b, "\n--- %s ---\n", slashPath(setupVMUnitDir, unit.name))
 		b.WriteString(unit.content)
 	}
+	b.WriteString("\nA real run also binds this machine to an AO account over a device code, which\n")
+	b.WriteString("needs a browser and a human to approve it, and then writes the machine file\n")
+	b.WriteString("above and restarts the gateway so it reads it.\n")
 	b.WriteString("\nRun the same command without --dry-run to apply this.\n")
 	return b.String()
 }

--- a/backend/internal/cli/whoami.go
+++ b/backend/internal/cli/whoami.go
@@ -1,0 +1,69 @@
+package cli
+
+// whoami.go reports the binding this machine currently has: the machine id an
+// access token's audience must match, the one account allowed to reach it, and
+// where that came from. It only ever reads the file. `ao setup-vm` owns writing
+// it, on the machine itself.
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/vmgateway"
+)
+
+func newWhoamiCommand(ctx *commandContext) *cobra.Command {
+	var machineFile string
+	cmd := &cobra.Command{
+		Use:   "whoami",
+		Short: "Show which AO account this machine is bound to",
+		Long: "ao whoami reads ~/.ao/machine.json and reports the binding `ao vm serve` is\n" +
+			"running with: the machine id an access token's audience has to match, the one\n" +
+			"account allowed to reach this machine, and the public URL it was registered\n" +
+			"under.\n\n" +
+			"It reads that file and nothing else, so it answers the same on a machine whose\n" +
+			"gateway is stopped. Binding is done by `ao setup-vm`, on the machine itself.",
+		Args: noArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return ctx.runWhoami(cmd, machineFile)
+		},
+	}
+	cmd.Flags().StringVar(&machineFile, "machine-file", "", "machine.json path (default: AO_MACHINE_FILE, else ~/.ao/machine.json)")
+	return cmd
+}
+
+func (c *commandContext) runWhoami(cmd *cobra.Command, machineFile string) error {
+	path, err := resolveMachineFilePath(machineFile)
+	if err != nil {
+		return err
+	}
+	// The gateway's own reader, so a file this command calls readable is one
+	// the gateway can also start from.
+	mf, err := vmgateway.ReadMachineFile(path)
+	if err != nil {
+		return err
+	}
+	return writeSetupText(cmd.OutOrStdout(), renderWhoami(mf, path))
+}
+
+// resolveMachineFilePath mirrors vmgateway.Resolve exactly: the flag wins, then
+// AO_MACHINE_FILE, then ~/.ao/machine.json. It deliberately does not use the
+// AO_DATA_DIR-resolved data dir, because the reader does not look there either,
+// and the two have to name the same file or this command would confidently
+// report a binding the gateway never sees.
+func resolveMachineFilePath(override string) (string, error) {
+	for _, candidate := range []string{override, os.Getenv("AO_MACHINE_FILE")} {
+		if candidate = strings.TrimSpace(candidate); candidate != "" {
+			return candidate, nil
+		}
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve the machine file path: %w", err)
+	}
+	return filepath.Join(home, ".ao", "machine.json"), nil
+}

--- a/backend/internal/cli/whoami_test.go
+++ b/backend/internal/cli/whoami_test.go
@@ -1,0 +1,116 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/vmgateway"
+)
+
+func TestWhoamiReportsTheBinding(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "machine.json")
+	content, err := renderMachineFile(vmgateway.MachineFile{
+		MachineID: testMachineID, AccountID: testAccountID, PublicURL: testPublicURL,
+	}, time.Date(2026, 7, 30, 9, 15, 30, 0, time.UTC))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := writeMachineFile(path, content, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	out, _, err := executeCLI(t, Deps{}, "whoami", "--machine-file", path)
+	if err != nil {
+		t.Fatalf("ao whoami: %v", err)
+	}
+	for _, want := range []string{
+		"bound to an AO account",
+		testMachineID,
+		testAccountID,
+		testPublicURL,
+		"2026-07-30T09:15:30Z",
+		path,
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("ao whoami output is missing %q:\n%s", want, out)
+		}
+	}
+	assertNoDashes(t, out)
+}
+
+func TestWhoamiOnAnUnboundMachine(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "machine.json")
+
+	out, _, err := executeCLI(t, Deps{}, "whoami", "--machine-file", path)
+	// A missing machine file is the normal not-bound-yet state, the same way
+	// the gateway's reader treats it, so it is reported rather than raised.
+	if err != nil {
+		t.Fatalf("a missing machine file must not be an error: %v", err)
+	}
+	for _, want := range []string{"not bound to an AO account", path, "ao setup-vm --domain"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("ao whoami output is missing %q:\n%s", want, out)
+		}
+	}
+	assertNoDashes(t, out)
+}
+
+// TestWhoamiFlagsAFileTheGatewayCannotUse catches the binding that looks fine
+// until `ao vm serve` starts: a publicUrl that is a bare hostname leaves the
+// certificate whitelist empty, and a machine.json is fatal to the gateway
+// rather than ignored.
+func TestWhoamiFlagsAFileTheGatewayCannotUse(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "machine.json")
+	if err := os.WriteFile(path, []byte(`{"machineId":"`+testMachineID+
+		`","accountId":"`+testAccountID+`","publicUrl":"vm.example.com","issuedAt":"2026-07-30T09:15:30Z"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	out, _, err := executeCLI(t, Deps{}, "whoami", "--machine-file", path)
+	if err != nil {
+		t.Fatalf("ao whoami: %v", err)
+	}
+	if !strings.Contains(out, "not usable") || !strings.Contains(out, "full origin") {
+		t.Errorf("an unusable machine file must be reported as such:\n%s", out)
+	}
+	assertNoDashes(t, out)
+}
+
+func TestResolveMachineFilePathPrecedence(t *testing.T) {
+	t.Setenv("AO_MACHINE_FILE", "/from/env/machine.json")
+
+	got, err := resolveMachineFilePath("/from/flag/machine.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "/from/flag/machine.json" {
+		t.Errorf("path = %q, want the flag to win", got)
+	}
+
+	got, err = resolveMachineFilePath("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "/from/env/machine.json" {
+		t.Errorf("path = %q, want AO_MACHINE_FILE", got)
+	}
+
+	// The default is $HOME/.ao/machine.json, not the AO_DATA_DIR-resolved data
+	// dir, because that is where vmgateway's reader looks. The two have to name
+	// the same file or whoami would report a binding the gateway never sees.
+	t.Setenv("AO_MACHINE_FILE", "")
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skip("no home directory on this machine")
+	}
+	got, err = resolveMachineFilePath("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := filepath.Join(home, ".ao", "machine.json"); got != want {
+		t.Errorf("default path = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
Part two of `ao setup-vm`. Part one (#28) stopped at "installed, not yet bound"; this adds the binding, the machine file, and the command that reports it. It extends part one rather than reworking it: the platform gate, preflight, install, and units are untouched.

Closes #29

## What this adds

- **The RFC 8628 device flow client** against the control plane endpoints from #26. It requests a device code, prints the user code and verification URL, and polls `/device/token` at the **server-supplied** interval. `authorization_pending` keeps waiting, `slow_down` backs off by 5 seconds (capped at 60), `expired_token` reports the expiry and offers a fresh code, `access_denied` stops without retrying.
- **This machine's name and public URL go in the device authorization request.** The VM is the only party that knows its own public URL, and the approval page has to show the operator which box they are approving.
- **`~/.ao/machine.json`, mode 0600**, written via a temp file in the same directory plus a rename. A missing machine file is the normal "not bound yet" state the gateway tolerates; a malformed one fails the unmarshal and stops it dead, so the reader must never see a partial write.
- **Idempotent re-bind.** An already-bound machine has its current binding printed and is then bound again. It is never refused, and the old file is never left in place.
- **`ao-gateway.service` is restarted after the write.** `ao vm serve` reads `machine.json` once at startup, so a fresh binding does nothing at all until the unit restarts.
- **`ao whoami`**, reporting the current binding through the gateway's own reader, and flagging a file the gateway would refuse to start on.

## The machine.json contract

The contract was already fixed by the merged reader, so this matches it rather than deciding it:

- `machineId` is `machines.id` and becomes the token `aud`, compared byte for byte. It is never the hostname and never the public URL. An approval that comes back without one is refused before anything is written.
- `accountId` is `accounts.id` and becomes the expected `sub`.
- `publicUrl` is a full origin. A bare hostname is rejected at write time, because it parses as a path, leaves the certificate whitelist empty, and then fails every TLS handshake while the gateway logs a clean start.
- `issuedAt` is RFC 3339. The gateway never reads the value, but a malformed one fails the whole unmarshal.

The writer marshals `vmgateway.MachineFile` itself, so renaming a field in the reader stops this compiling.

## Ownership and permissions

Under `sudo` the process is root while `ao-gateway.service` is not, so a 0600 root-owned `machine.json` is one the gateway cannot read. The file is handed to the same user part one's state directories are owned by.

## Security

- The `device_code` is a bearer secret. It travels in the POST body only, and is never printed, never placed in a URL this command displays, and never written to disk. `TestDeviceFlowNeverPrintsTheDeviceCode` asserts it does not reach the terminal. The user code is the part meant to be shown.
- The access token that arrives with the approval is deliberately not decoded: nothing here uses it, and a field that is never read cannot be logged or persisted by accident.
- An abandoned or failed binding leaves no partial file. The temp file is removed on every path that does not rename it.

## Testing

- `TestMachineFileRoundTripsThroughTheGatewayReader` is the load-bearing one: it writes with this writer and reads back with the real `vmgateway.ReadMachineFile`, then runs `vmgateway.Resolve` over the result to confirm the gateway can actually configure itself from it. That is what stops the writer and reader from disagreeing somewhere only a real VM would find out.
- The flow state machine, interval back-off, file rendering, re-bind behavior, and `whoami` output are all pure and table-tested, so they hold on every leg of the `CLI E2E` matrix. The network and shell-out layers stay thin, driven in tests by an `httptest` stand-in control plane and a fake clock.
- `go test ./internal/cli/`: 347 passed, plus the 5 `TestSpawn*` failures that are already red on `develop` and unrelated to this change.

## Risks and follow-ups

- Binding is interactive by design, so a re-run of `ao setup-vm` on a working machine now waits for a browser approval. That is what the spec asks for ("on an already-bound machine it prints the previous binding and re-binds"), but it is worth knowing before scripting a re-run.
- `--control-plane-url` defaults to `vmgateway.DefaultIssuer` and exists mainly so the flow can be pointed at a locally-run control plane.
- Not in scope, and untouched: `ao vm setup-harness claude`, `ao doctor`, `controlplane/`, and `backend/internal/vmgateway/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)