### PR TITLE
feat(cli): ao vm setup-harness claude, harness readiness via ao doctor

### DIFF
--- a/backend/internal/cli/doctor.go
+++ b/backend/internal/cli/doctor.go
@@ -35,6 +35,11 @@ type doctorCheck struct {
 	Section string      `json:"section,omitempty"`
 	Name    string      `json:"name"`
 	Message string      `json:"message"`
+	// Remediation is the one command that fixes this check, when a single
+	// command does. It exists so a consumer of `ao doctor --json` (the
+	// desktop's machine card) can show exactly what to run instead of parsing
+	// it back out of Message. Empty when there is no single command to name.
+	Remediation string `json:"remediation,omitempty"`
 }
 
 type doctorReport struct {
@@ -174,8 +179,90 @@ func (c *commandContext) runDoctor(ctx context.Context) []doctorCheck {
 	for _, harness := range doctorHarnesses {
 		checks = append(checks, c.checkHarness(ctx, harness))
 	}
-	checks = append(checks, c.checkCodexLaunchFlags(ctx), c.checkGitHubToken(ctx))
+	checks = append(checks, c.checkClaudeAuth(ctx), c.checkCodexLaunchFlags(ctx), c.checkGitHubToken(ctx))
 	return checks
+}
+
+// checkClaudeAuth reports whether the claude harness has finished its own
+// login on this machine. `claude auth status --json` is the harness's own
+// machine-readable answer, so this reports the harness's state rather than
+// guessing at where its credentials live (a keychain entry on macOS, a file
+// elsewhere, or an environment variable). It is the readiness signal the
+// desktop reads for a machine card: a machine that is registered but has no
+// harness configured shows Remediation instead of failing silently.
+//
+// A missing login is a WARN, never a FAIL: plenty of machines run AO with a
+// different harness, or with none, and `ao doctor` must still exit 0 there.
+func (c *commandContext) checkClaudeAuth(ctx context.Context) doctorCheck {
+	const name = "claude-auth"
+	setupCmd := "ao vm setup-harness " + claudeHarnessName
+	warn := func(message string) doctorCheck {
+		return doctorCheck{
+			Level: doctorWarn, Section: doctorSectionAgents, Name: name,
+			Message: message, Remediation: setupCmd,
+		}
+	}
+
+	path, err := c.deps.LookPath(claudeHarnessName)
+	if err != nil || path == "" {
+		return warn(fmt.Sprintf("claude not found in PATH; install the Claude Code CLI, then run `%s`", setupCmd))
+	}
+	reqCtx, cancel := context.WithTimeout(ctx, probeTimeout)
+	defer cancel()
+	probe := strings.Join(claudeAuthStatusArgs, " ")
+	out, cmdErr := c.deps.CommandOutput(reqCtx, path, claudeAuthStatusArgs...)
+	// `claude auth status` exits non-zero when the harness is not logged in and
+	// still prints its JSON, so the output is what answers the question. A
+	// non-zero exit only matters when there is no parseable answer in it.
+	status, parseErr := parseClaudeAuthStatus(out)
+	if parseErr != nil {
+		reason := parseErr
+		if cmdErr != nil {
+			reason = cmdErr
+		}
+		return warn(fmt.Sprintf("could not read harness auth state (`claude %s`: %v); log in with `%s`", probe, reason, setupCmd))
+	}
+	if !status.LoggedIn {
+		return warn(fmt.Sprintf("%s is installed but not signed in; run `%s`", path, setupCmd))
+	}
+	return doctorCheck{
+		Level: doctorPass, Section: doctorSectionAgents, Name: name,
+		Message: fmt.Sprintf("%s is signed in (%s)", path, status.describe()),
+	}
+}
+
+type claudeAuthStatus struct {
+	LoggedIn    bool   `json:"loggedIn"`
+	AuthMethod  string `json:"authMethod"`
+	APIProvider string `json:"apiProvider"`
+}
+
+func (s claudeAuthStatus) describe() string {
+	method := strings.TrimSpace(s.AuthMethod)
+	if method == "" {
+		method = "unknown"
+	}
+	if provider := strings.TrimSpace(s.APIProvider); provider != "" {
+		return fmt.Sprintf("authMethod=%s apiProvider=%s", method, provider)
+	}
+	return "authMethod=" + method
+}
+
+// parseClaudeAuthStatus reads the JSON object out of `claude auth status
+// --json` output. It slices to the outermost braces first because the probe
+// runs through CombinedOutput, so an unrelated notice on stderr (an update
+// banner, a deprecation warning) would otherwise make valid JSON unparseable.
+func parseClaudeAuthStatus(out []byte) (claudeAuthStatus, error) {
+	clean := ansiRE.ReplaceAllString(string(out), "")
+	start, end := strings.Index(clean, "{"), strings.LastIndex(clean, "}")
+	if start < 0 || end < start {
+		return claudeAuthStatus{}, fmt.Errorf("no JSON object in output %q", strings.TrimSpace(clean))
+	}
+	var status claudeAuthStatus
+	if err := json.Unmarshal([]byte(clean[start:end+1]), &status); err != nil {
+		return claudeAuthStatus{}, err
+	}
+	return status, nil
 }
 
 // checkStore inspects the SQLite store WITHOUT opening or migrating it. The

--- a/backend/internal/cli/doctor_test.go
+++ b/backend/internal/cli/doctor_test.go
@@ -129,6 +129,10 @@ func TestDoctorChecksHarnessVersions(t *testing.T) {
 			if len(args) == 1 && args[0] == "--version" {
 				return []byte(strings.TrimPrefix(name, "/bin/") + " 1.2.3\n"), nil
 			}
+			// The claude-auth readiness check probes the same binary.
+			if name == "/bin/claude" && strings.Join(args, " ") == "auth status --json" {
+				return []byte(`{"loggedIn":true,"authMethod":"claudeai","apiProvider":"firstParty"}`), nil
+			}
 			// The codex launch-flag canary probes the same binary.
 			if name == "/bin/codex" && len(args) > 0 && (args[0] == "--dangerously-bypass-hook-trust" || args[0] == "features") {
 				return []byte("ok\n"), nil
@@ -174,6 +178,153 @@ func TestDoctorWarnsWhenHarnessVersionFails(t *testing.T) {
 	check := findDoctorCheck(t, c.runDoctor(context.Background()), "codex")
 	if check.Level != doctorWarn || !strings.Contains(check.Message, "failed") {
 		t.Fatalf("codex check = %+v, want WARN version failure", check)
+	}
+}
+
+// claudeAuthFake answers the harness version probe and the claude-auth
+// readiness probe against a fake claude at /bin/claude.
+func claudeAuthFake(t *testing.T, statusOutput string, statusErr error) func(context.Context, string, ...string) ([]byte, error) {
+	t.Helper()
+	return func(_ context.Context, name string, args ...string) ([]byte, error) {
+		switch {
+		case name == "/bin/git":
+			return []byte("git version 2.43.0\n"), nil
+		case name == "/bin/claude" && strings.Join(args, " ") == "--version":
+			return []byte("2.1.220 (Claude Code)\n"), nil
+		case name == "/bin/claude" && strings.Join(args, " ") == "auth status --json":
+			return []byte(statusOutput), statusErr
+		default:
+			t.Fatalf("unexpected command: %s %v", name, args)
+			return nil, nil
+		}
+	}
+}
+
+func TestDoctorClaudeAuthPassesWhenSignedIn(t *testing.T) {
+	setConfigEnv(t)
+	c := doctorContext(t, map[string]string{"git": "/bin/git", "claude": "/bin/claude"},
+		claudeAuthFake(t, `{"loggedIn":true,"authMethod":"claudeai","apiProvider":"firstParty"}`, nil))
+
+	check := findDoctorCheck(t, c.runDoctor(context.Background()), "claude-auth")
+	if check.Level != doctorPass {
+		t.Fatalf("claude-auth check = %+v, want PASS", check)
+	}
+	if !strings.Contains(check.Message, "signed in") || !strings.Contains(check.Message, "authMethod=claudeai") {
+		t.Errorf("claude-auth message = %q, want the auth method reported", check.Message)
+	}
+	if check.Remediation != "" {
+		t.Errorf("claude-auth remediation = %q, want empty when the check passes", check.Remediation)
+	}
+}
+
+// TestDoctorClaudeAuthWarnsWhenNotSignedIn is the state the desktop machine
+// card renders: a machine with the harness installed but no login must name
+// the exact command that fixes it rather than failing silently. The non-zero
+// exit is real: `claude auth status --json` exits 1 when not logged in and
+// still prints its JSON, so the output answers the question, not the exit code.
+func TestDoctorClaudeAuthWarnsWhenNotSignedIn(t *testing.T) {
+	setConfigEnv(t)
+	c := doctorContext(t, map[string]string{"git": "/bin/git", "claude": "/bin/claude"},
+		claudeAuthFake(t, `{"loggedIn":false,"authMethod":"none","apiProvider":"firstParty"}`, errors.New("exit status 1")))
+
+	check := findDoctorCheck(t, c.runDoctor(context.Background()), "claude-auth")
+	if check.Level != doctorWarn || !strings.Contains(check.Message, "not signed in") {
+		t.Fatalf("claude-auth check = %+v, want WARN not signed in", check)
+	}
+	if check.Remediation != "ao vm setup-harness claude" {
+		t.Errorf("claude-auth remediation = %q, want the setup-harness command", check.Remediation)
+	}
+}
+
+func TestDoctorClaudeAuthWarnsWhenHarnessMissing(t *testing.T) {
+	setConfigEnv(t)
+	c := doctorContext(t, map[string]string{"git": "/bin/git"}, func(context.Context, string, ...string) ([]byte, error) {
+		return []byte("git version 2.43.0\n"), nil
+	})
+
+	check := findDoctorCheck(t, c.runDoctor(context.Background()), "claude-auth")
+	if check.Level != doctorWarn || !strings.Contains(check.Message, "not found in PATH") {
+		t.Fatalf("claude-auth check = %+v, want WARN missing binary", check)
+	}
+	if check.Remediation != "ao vm setup-harness claude" {
+		t.Errorf("claude-auth remediation = %q, want the setup-harness command", check.Remediation)
+	}
+}
+
+// TestDoctorClaudeAuthWarnsWhenProbeUnusable covers a claude release that no
+// longer answers `claude auth status --json`, and output that is not JSON at
+// all. Neither may crash doctor or be reported as signed in.
+func TestDoctorClaudeAuthWarnsWhenProbeUnusable(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		output string
+		err    error
+	}{
+		{name: "command fails", output: "error: unknown command 'auth'\n", err: errors.New("exit status 1")},
+		{name: "output is not json", output: "Logged in as octocat\n"},
+		{name: "output is empty"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			setConfigEnv(t)
+			c := doctorContext(t, map[string]string{"git": "/bin/git", "claude": "/bin/claude"},
+				claudeAuthFake(t, tc.output, tc.err))
+
+			check := findDoctorCheck(t, c.runDoctor(context.Background()), "claude-auth")
+			if check.Level != doctorWarn || !strings.Contains(check.Message, "could not read harness auth state") {
+				t.Fatalf("claude-auth check = %+v, want WARN unreadable auth state", check)
+			}
+		})
+	}
+}
+
+// TestParseClaudeAuthStatusIgnoresSurroundingNoise pins the reason the probe
+// slices to the outermost braces: it runs through CombinedOutput, so a notice
+// on stderr must not make valid JSON unparseable.
+func TestParseClaudeAuthStatusIgnoresSurroundingNoise(t *testing.T) {
+	out := []byte("\x1b[33mA new version of Claude Code is available.\x1b[0m\n" +
+		`{"loggedIn":true,"authMethod":"apiKey","apiProvider":"firstParty"}` + "\n")
+	status, err := parseClaudeAuthStatus(out)
+	if err != nil {
+		t.Fatalf("parseClaudeAuthStatus: %v", err)
+	}
+	if !status.LoggedIn || status.AuthMethod != "apiKey" {
+		t.Fatalf("status = %+v, want loggedIn with authMethod=apiKey", status)
+	}
+	if got := status.describe(); got != "authMethod=apiKey apiProvider=firstParty" {
+		t.Errorf("describe = %q", got)
+	}
+}
+
+// TestDoctorJSONReportsClaudeAuthRemediation pins the shape the desktop reads:
+// a named check in `ao doctor --json` carrying a level and a remediation
+// command.
+func TestDoctorJSONReportsClaudeAuthRemediation(t *testing.T) {
+	setConfigEnv(t)
+	clearDoctorGitHubEnv(t)
+	deps := Deps{
+		LookPath:     func(string) (string, error) { return "", errors.New("missing") },
+		ProcessAlive: func(int) bool { return false },
+	}
+	stdout, _, _ := executeCLI(t, deps, "doctor", "--json")
+
+	var report doctorReport
+	if err := json.Unmarshal([]byte(stdout), &report); err != nil {
+		t.Fatalf("unmarshal doctor --json: %v (output %q)", err, stdout)
+	}
+	var found *doctorCheck
+	for i := range report.Checks {
+		if report.Checks[i].Name == "claude-auth" {
+			found = &report.Checks[i]
+		}
+	}
+	if found == nil {
+		t.Fatalf("no claude-auth check in %+v", report.Checks)
+	}
+	if found.Level != doctorWarn || found.Remediation != "ao vm setup-harness claude" {
+		t.Fatalf("claude-auth check = %+v, want WARN with the setup-harness remediation", *found)
+	}
+	if found.Section != doctorSectionAgents {
+		t.Errorf("claude-auth section = %q, want %q", found.Section, doctorSectionAgents)
 	}
 }
 

--- a/backend/internal/cli/root.go
+++ b/backend/internal/cli/root.go
@@ -70,6 +70,11 @@ type Deps struct {
 	LookPath           func(file string) (string, error)
 	CommandOutput      func(ctx context.Context, name string, args ...string) ([]byte, error)
 	CommandOutputInDir func(ctx context.Context, dir, name string, args ...string) ([]byte, error)
+	// RunInteractive hands this process's real terminal to another program and
+	// waits for it, rather than capturing its output. ao vm setup-harness needs
+	// it: the harness login prints a URL and waits for a code to be pasted
+	// back, which only works on a terminal a human is sitting at.
+	RunInteractive func(ctx context.Context, name string, args ...string) error
 	// DoctorGitHubRESTBase lets tests point the doctor GitHub token probe at
 	// httptest without mutating package-global state.
 	DoctorGitHubRESTBase string
@@ -90,6 +95,7 @@ func DefaultDeps() Deps {
 		LookPath:             exec.LookPath,
 		CommandOutput:        commandOutput,
 		CommandOutputInDir:   commandOutputInDir,
+		RunInteractive:       runInteractive,
 		DoctorGitHubRESTBase: defaultDoctorGitHubRESTBase,
 		Now:                  time.Now,
 		Sleep:                time.Sleep,
@@ -98,6 +104,18 @@ func DefaultDeps() Deps {
 
 func commandOutput(ctx context.Context, name string, args ...string) ([]byte, error) {
 	return aoprocess.CommandContext(ctx, name, args...).CombinedOutput()
+}
+
+// runInteractive inherits the process's own stdio so the child owns the
+// terminal. It uses os/exec directly rather than the shared process helper
+// because that helper hides the child's window on Windows, which is wrong for
+// a program the user has to interact with.
+func runInteractive(ctx context.Context, name string, args ...string) error {
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
 }
 
 func commandOutputInDir(ctx context.Context, dir, name string, args ...string) ([]byte, error) {
@@ -137,6 +155,9 @@ func (d Deps) withDefaults() Deps {
 	}
 	if d.CommandOutputInDir == nil {
 		d.CommandOutputInDir = def.CommandOutputInDir
+	}
+	if d.RunInteractive == nil {
+		d.RunInteractive = def.RunInteractive
 	}
 	if d.DoctorGitHubRESTBase == "" {
 		d.DoctorGitHubRESTBase = def.DoctorGitHubRESTBase

--- a/backend/internal/cli/vm.go
+++ b/backend/internal/cli/vm.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os/signal"
+	"strings"
 	"syscall"
 
 	"github.com/spf13/cobra"
@@ -13,15 +14,14 @@ import (
 	"github.com/aoagents/agent-orchestrator/backend/internal/vmgateway"
 )
 
-// newVMCommand groups commands that run on a hosted VM gateway machine. It
-// is a plain grouping parent; ao setup-vm and ao vm setup-harness are later
-// batches and not added here yet.
+// newVMCommand groups commands that run on a hosted VM gateway machine.
 func newVMCommand(ctx *commandContext) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "vm",
 		Short: "Commands for a hosted VM gateway machine",
 	}
 	cmd.AddCommand(newVMServeCommand(ctx))
+	cmd.AddCommand(newVMSetupHarnessCommand(ctx))
 	return cmd
 }
 
@@ -102,6 +102,69 @@ func (c *commandContext) runVMServe(cmd *cobra.Command, opts vmgateway.Options) 
 	log.Info("ao vm serve starting",
 		"domain", gwCfg.Domain, "machineId", gwCfg.MachineID, "daemonAddr", gwCfg.DaemonAddr)
 	return srv.Run(ctxSig, cfg.ShutdownTimeout)
+}
+
+// The claude harness is the only one ao vm setup-harness supports in v1. Its
+// login and its readiness probe are two halves of the same `claude auth`
+// surface, so they live together here: if a claude release moves one, doctor's
+// claude-auth check and this command break together and visibly, rather than
+// one of them silently reporting the wrong thing.
+const claudeHarnessName = "claude"
+
+var (
+	claudeLoginArgs      = []string{"auth", "login"}
+	claudeAuthStatusArgs = []string{"auth", "status", "--json"}
+)
+
+func newVMSetupHarnessCommand(ctx *commandContext) *cobra.Command {
+	return &cobra.Command{
+		Use:   "setup-harness " + claudeHarnessName,
+		Short: "Log in to an agent harness on this machine, in the foreground",
+		Long: "ao vm setup-harness runs the harness's own interactive login and hands the\n" +
+			"terminal over to it. The harness prints a URL and then waits for a code to be\n" +
+			"pasted back, so the exchange cannot be scripted or run in the background: run\n" +
+			"this on a real terminal (an SSH session into the VM is fine).\n\n" +
+			"Only the claude harness is supported. `ao doctor` then reports whether the\n" +
+			"harness is signed in as its claude-auth check, which is what the desktop app\n" +
+			"reads for a machine's harness readiness.\n\n" +
+			"Git credentials are separate and are not wrapped by ao: run `gh auth login`\n" +
+			"once, and the daemon picks the credential up on its own.",
+		Args: usageArgs(cobra.ExactArgs(1)),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return ctx.runVMSetupHarness(cmd, args[0])
+		},
+	}
+}
+
+func (c *commandContext) runVMSetupHarness(cmd *cobra.Command, harness string) error {
+	if strings.ToLower(strings.TrimSpace(harness)) != claudeHarnessName {
+		return usageError{fmt.Errorf(
+			"unsupported harness %q: only %q is supported (other harnesses are out of scope for now)",
+			harness, claudeHarnessName)}
+	}
+	path, err := c.deps.LookPath(claudeHarnessName)
+	if err != nil || path == "" {
+		return fmt.Errorf("claude not found in PATH: install the Claude Code CLI on this machine first (ao setup-vm deliberately does not, because the login is interactive), then re-run `ao vm setup-harness %s`", claudeHarnessName)
+	}
+
+	out := cmd.OutOrStdout()
+	login := strings.Join(claudeLoginArgs, " ")
+	if _, err := fmt.Fprintf(out, "Handing the terminal to `%s %s`.\n"+
+		"It prints a URL and then waits for a code to be pasted back, so finish the\n"+
+		"login here rather than trying to script it.\n\n", path, login); err != nil {
+		return err
+	}
+
+	// Everything around it is ao's; the login itself is the harness's. This
+	// hand-off stays deliberately thin, so there is nothing here for a claude
+	// release to break behind our back.
+	if err := c.deps.RunInteractive(cmd.Context(), path, claudeLoginArgs...); err != nil {
+		return fmt.Errorf("`claude %s` did not complete: %w", login, err)
+	}
+
+	_, err = fmt.Fprint(out, "\nHarness login finished. Confirm it with `ao doctor` (the claude-auth check),\n"+
+		"and if this machine still needs git credentials, run `gh auth login`.\n")
+	return err
 }
 
 // discoverDaemonAddr reads the loopback daemon's own running.json handshake

--- a/backend/internal/cli/vm_test.go
+++ b/backend/internal/cli/vm_test.go
@@ -3,7 +3,10 @@ package cli
 import (
 	"bytes"
 	"context"
+	"errors"
+	"fmt"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -88,5 +91,117 @@ func TestVMServe_StartsAndShutsDownCleanly(t *testing.T) {
 		}
 	case <-time.After(5 * time.Second):
 		t.Fatal("ao vm serve did not shut down after context cancellation")
+	}
+}
+
+// setupHarnessDeps builds Deps for ao vm setup-harness with a fake claude on
+// PATH, recording the interactive hand-off instead of performing it. The real
+// hand-off is one exec.Cmd with inherited stdio (see runInteractive): it cannot
+// run in CI because the harness login waits for a human to paste a code, which
+// is exactly why everything else about the command is kept out of it.
+func setupHarnessDeps(claudePath string, runErr error, calls *[][]string) Deps {
+	return Deps{
+		LookPath: func(name string) (string, error) {
+			if name == "claude" && claudePath != "" {
+				return claudePath, nil
+			}
+			return "", fmt.Errorf("%s missing", name)
+		},
+		RunInteractive: func(_ context.Context, name string, args ...string) error {
+			*calls = append(*calls, append([]string{name}, args...))
+			return runErr
+		},
+	}
+}
+
+func TestVMSetupHarnessRunsClaudeLoginInForeground(t *testing.T) {
+	setConfigEnv(t)
+	var calls [][]string
+	stdout, _, err := executeCLI(t, setupHarnessDeps("/bin/claude", nil, &calls), "vm", "setup-harness", "claude")
+	if err != nil {
+		t.Fatalf("ao vm setup-harness claude: %v", err)
+	}
+	if len(calls) != 1 || strings.Join(calls[0], " ") != "/bin/claude auth login" {
+		t.Fatalf("interactive calls = %v, want one `/bin/claude auth login`", calls)
+	}
+	if !strings.Contains(stdout, "ao doctor") {
+		t.Errorf("stdout = %q, want it to point at ao doctor for readiness", stdout)
+	}
+}
+
+// TestVMSetupHarnessRejectsOtherHarnesses pins the deliberate v1 limit: any
+// harness other than claude is refused outright, with the supported name in the
+// message, rather than half-supported.
+func TestVMSetupHarnessRejectsOtherHarnesses(t *testing.T) {
+	setConfigEnv(t)
+	for _, harness := range []string{"codex", "gemini", "Claude Code", ""} {
+		t.Run("harness="+harness, func(t *testing.T) {
+			var calls [][]string
+			_, _, err := executeCLI(t, setupHarnessDeps("/bin/claude", nil, &calls), "vm", "setup-harness", harness)
+			if err == nil {
+				t.Fatalf("expected an error for harness %q", harness)
+			}
+			if got := ExitCode(err); got != 2 {
+				t.Errorf("ExitCode = %d, want 2 (an unsupported harness name is misuse)", got)
+			}
+			if !strings.Contains(err.Error(), `"claude"`) {
+				t.Errorf("error = %q, want it to name the supported harness", err)
+			}
+			if len(calls) != 0 {
+				t.Errorf("interactive calls = %v, want none for an unsupported harness", calls)
+			}
+		})
+	}
+}
+
+func TestVMSetupHarnessCaseAndSpaceInsensitive(t *testing.T) {
+	setConfigEnv(t)
+	var calls [][]string
+	if _, _, err := executeCLI(t, setupHarnessDeps("/bin/claude", nil, &calls), "vm", "setup-harness", " Claude "); err != nil {
+		t.Fatalf("ao vm setup-harness \" Claude \": %v", err)
+	}
+	if len(calls) != 1 {
+		t.Fatalf("interactive calls = %v, want one", calls)
+	}
+}
+
+func TestVMSetupHarnessRequiresExactlyOneHarness(t *testing.T) {
+	setConfigEnv(t)
+	for _, args := range [][]string{{"vm", "setup-harness"}, {"vm", "setup-harness", "claude", "codex"}} {
+		var calls [][]string
+		_, _, err := executeCLI(t, setupHarnessDeps("/bin/claude", nil, &calls), args...)
+		if err == nil {
+			t.Fatalf("expected an error for %v", args)
+		}
+		if got := ExitCode(err); got != 2 {
+			t.Errorf("ExitCode for %v = %d, want 2", args, got)
+		}
+	}
+}
+
+func TestVMSetupHarnessErrorsWhenClaudeMissing(t *testing.T) {
+	setConfigEnv(t)
+	var calls [][]string
+	_, _, err := executeCLI(t, setupHarnessDeps("", nil, &calls), "vm", "setup-harness", "claude")
+	if err == nil || !strings.Contains(err.Error(), "not found in PATH") {
+		t.Fatalf("err = %v, want a not-found-in-PATH failure", err)
+	}
+	if len(calls) != 0 {
+		t.Errorf("interactive calls = %v, want none when claude is missing", calls)
+	}
+}
+
+// TestVMSetupHarnessSurfacesLoginFailure covers the user abandoning the login
+// (Ctrl-C) or the harness exiting non-zero: the command must fail rather than
+// claim the machine is ready.
+func TestVMSetupHarnessSurfacesLoginFailure(t *testing.T) {
+	setConfigEnv(t)
+	var calls [][]string
+	_, _, err := executeCLI(t, setupHarnessDeps("/bin/claude", errors.New("exit status 130"), &calls), "vm", "setup-harness", "claude")
+	if err == nil || !strings.Contains(err.Error(), "exit status 130") {
+		t.Fatalf("err = %v, want the harness exit surfaced", err)
+	}
+	if got := ExitCode(err); got != 1 {
+		t.Errorf("ExitCode = %d, want 1 (a failed login is a runtime failure, not misuse)", got)
 	}
 }

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -29,7 +29,7 @@ Every product command resolves to a daemon HTTP route. Run `ao <command>
 | `ao start`                    | Start the daemon in the background and wait for `/readyz`.                                                                        |
 | `ao stop`                     | Gracefully stop the daemon via loopback `POST /shutdown` after verifying daemon identity.                                         |
 | `ao status` / `--json`        | Report daemon state from `running.json`, process liveness, `/healthz`, and `/readyz`.                                             |
-| `ao doctor` / `--json`        | Check config, data directory, DB-file presence, daemon state, `git`, and (on Darwin/Linux) `tmux`; on Windows conpty is built in. |
+| `ao doctor` / `--json`        | Check config, data directory, DB-file presence, daemon state, `git`, agent-harness presence and sign-in, and (on Darwin/Linux) `tmux`; on Windows conpty is built in. |
 | `ao completion <shell>`       | Generate completions for `bash`, `zsh`, `fish`, or `powershell`.                                                                  |
 | `ao version` / `ao --version` | Print build metadata.                                                                                                             |
 | `ao daemon`                   | Hidden internal daemon entrypoint used by `ao start`.                                                                             |
@@ -40,6 +40,7 @@ Every product command resolves to a daemon HTTP route. Run `ao <command>
 | ----------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `ao setup-vm --domain <host>`       | Prepare a hosted Ubuntu LTS VM: platform gate, preflight (DNS, 80/443, sudo) that mutates nothing on failure, then install `ao`, `tmux`, `git`, `gh`, and two systemd units.       |
 | `ao vm serve`                       | Run the public TLS gateway in front of the loopback daemon. Normally started by the `ao-gateway.service` unit `ao setup-vm` writes, never by hand.                                 |
+| `ao vm setup-harness claude`        | Hand the terminal to the claude harness's own interactive login. Foreground only, and `claude` is the only supported harness.                                                      |
 
 `ao setup-vm` refuses to run on anything but Ubuntu with systemd and apt, and
 prints the manual path instead. It writes `ao-daemon.service` and
@@ -52,6 +53,18 @@ It does not install an agent harness and does not configure git credentials, so
 it ends by printing what is still missing with the exact command for each
 (`ao vm setup-harness claude`, `gh auth login`). Use `--dry-run` to see the plan
 and both unit files without touching the machine.
+
+`ao vm setup-harness claude` runs `claude auth login` with this process's own
+stdio, so the harness owns the terminal: it prints a URL and then waits for a
+code to be pasted back, which cannot be scripted. Git credentials are not
+wrapped by any `ao` command; `gh auth login` once is enough, and the daemon
+reads the credential through `gh auth token`.
+
+Harness readiness is reported by `ao doctor` as its `claude-auth` check, which
+asks the harness itself (`claude auth status --json`) rather than guessing where
+its credentials live. A machine with no harness login is a `WARN`, never a
+`FAIL`, and carries a `remediation` field in `ao doctor --json` naming the exact
+command to run. That is what the desktop machine card reads.
 
 ### Product commands
 


### PR DESCRIPTION
Closes #30

Item 11 of Batch 4: `ao vm setup-harness claude`, plus harness readiness surfaced through the existing `ao doctor` checks so the desktop machine card can show it.

## What this adds

**`ao vm setup-harness claude`** hands this process's real terminal to `claude auth login` and waits for it. Nothing about the login is scraped or driven: the harness prints a URL and then waits for a code to be pasted back, which is precisely why the spec says foreground. The hand-off is one `exec.Cmd` with inherited stdio behind a new `Deps.RunInteractive` seam, so everything worth testing sits outside it.

Only the `claude` harness is supported. Any other name is rejected with exit 2 and a message naming the supported one, rather than half-supported.

Git credentials are untouched by design. `gh auth login` stays manual, and the daemon's existing `gh auth token` path in `backend/internal/daemon/tracker_intake_wiring.go` picks the credential up with no further work. No `ao` command wraps it and nothing prompts for a token.

**Readiness comes from `ao doctor`**, not a parallel mechanism. A new `claude-auth` check in the existing "Agent harnesses" section asks the harness itself (`claude auth status --json`) rather than guessing where its credentials live (macOS keychain, a file elsewhere, an env var). It is a `WARN`, never a `FAIL`, so machines running a different harness or none still exit 0.

## Output shape the desktop consumes (task 12, please read)

`ao doctor --json` gains one check and `doctorCheck` gains one optional field:

```json
{
  "level": "WARN",
  "section": "Agent harnesses",
  "name": "claude-auth",
  "message": "/opt/homebrew/bin/claude is installed but not signed in; run `ao vm setup-harness claude`",
  "remediation": "ao vm setup-harness claude"
}
```

- `name` is stable: `claude-auth`.
- `level` is `PASS` when signed in (message reports `authMethod` and `apiProvider`), `WARN` otherwise: not installed, not signed in, or the probe was unreadable.
- `remediation` is new and optional (`omitempty`). It carries the one command that fixes a check, so the machine card can show exactly what to run instead of parsing it out of `message`. It is set only on this check today; every other check omits it. Existing fields are unchanged and nothing else in the JSON moved.
- Text output is unchanged: the command is already in `message`, so `remediation` would only be duplicated there.

One thing worth flagging: there is no HTTP route for doctor. `ao doctor --json` is a local CLI surface, so a *remote* machine card cannot read this over the gateway yet. Adding a daemon route would mean `httpd` + DTO + `openapi.yaml` + `schema.ts`, which is outside this task's stated boundary (`vm.go` plus the doctor files, `root.go` minimally). Calling it out rather than silently half-building it.

## Notable behavior found while building

`claude auth status --json` **exits 1 when not signed in and still prints valid JSON**. The check therefore trusts the output and only falls back to the exit status when there is no parseable answer in it, otherwise every unauthenticated machine would report "could not read auth state" instead of "not signed in". Verified against claude 2.1.220. The probe runs through `CombinedOutput`, so it slices to the outermost braces before unmarshalling: an update banner on stderr must not make valid JSON unparseable.

## Tests

The interactive login cannot run in CI, and this does not pretend otherwise. What is covered:

- `ao vm setup-harness claude` invokes exactly `claude auth login` through the interactive seam, and points at `ao doctor` afterwards.
- Rejection of `codex`, `gemini`, `Claude Code`, and `""` with exit 2, and no hand-off attempted.
- Arg count (zero and two harnesses both exit 2); case and whitespace tolerance.
- Missing `claude` on PATH, and an abandoned or non-zero login surfaced as a runtime failure (exit 1), never as success.
- `claude-auth`: signed in, not signed in (with the real non-zero exit), harness missing, probe failing, non-JSON output, empty output.
- The `--json` shape end to end through the real command, including `remediation` and `section`.
- `parseClaudeAuthStatus` against ANSI-coloured banner noise around the JSON.

Also verified by hand end to end with a fake `claude` earlier on PATH: stdin really is inherited by the child, exit codes are 0 / 1 / 2 as intended.

## Verification

- `go build ./...`, `go vet ./...`, `gofmt -l .` clean.
- `go test ./...` (backend): 2967 passed, 5 failed. The 5 are the documented pre-existing `TestSpawn*` failures on develop, unrelated to this change.
- `go test -race` on the touched package: 52 passed.
- `go test -tags e2e ./internal/cli/...`: `TestE2E_DoctorDoesNotTouchTheStore` passes; the new check keeps `doctor --json` at `"ok": true` because it can only WARN.
- `golangci-lint v2.12.2 run ./internal/cli/...`: 0 issues.
- No API contract change, so no `npm run api` regeneration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)