### PR TITLE
feat(desktop): machine list, picker, and switching

### DIFF
--- a/docs/desktop-login-contract.md
+++ b/docs/desktop-login-contract.md
@@ -72,29 +72,31 @@ verifier, and a mismatched `redirect_uri`.
 **No access token is issued here.** Login yields identity plus the refresh token and
 nothing else; every access token comes from a later exchange at the token endpoint.
 
-## Two token audiences, deliberately not interchangeable
+## Which token the desktop uses where
 
-Decided by the orchestrator after `controlplane/TOKEN_CONTRACT.md` merged, because
-that file only covered machine-audience tokens and said nothing about how a desktop
-install authenticates to the control plane itself, which it must do before it has
-picked any machine. `hosted-ao-17` is implementing the token endpoint and adding a
-section to `TOKEN_CONTRACT.md` defining both audiences; that file wins once it does.
+The two access token audiences, how each is obtained, and where a refresh token
+may be presented are defined in
+[`controlplane/TOKEN_CONTRACT.md`](../controlplane/TOKEN_CONTRACT.md), "The two
+audiences". That file is authoritative; this section only records which of them
+the desktop reaches for, and when.
 
-- **Control-plane audience.** `aud` is the control plane origin
-  (`https://ao.agentlab.in`). This is what authenticates control-plane API calls
-  such as `GET /api/v1/machines`. Obtained by exchanging the refresh token at the
-  token endpoint.
-- **Machine audience.** `aud` is a `machines.id`, verified by that machine's
-  gateway. Obtained per machine, and only after one is chosen. Task 13 in batch 5.
+| Desktop step | Credential |
+| --- | --- |
+| Sign in (above) | none, PKCE plus `state` |
+| `GET /api/v1/machines` | control-plane-audience access token, from `POST /api/v1/token` |
+| Talking to a chosen machine | machine-audience access token (task 13, batch 5) |
 
-The refresh token goes **only** to the control plane's token endpoint. It is never a
-Bearer credential on a resource route, never in a URL, and never in a log line. An
-access token of one audience is never sent to the other.
+Two consequences the desktop side owns:
 
-Neither exchange is implemented here: this task ends at "a refresh token is stored".
-When task 13 adds a cached control-plane access token, **sign-out must discard that
-cache as well as the stored refresh token.** Today there is nothing cached to
-discard, so deleting the file is the whole of sign-out.
+- **Sign-out discards every cached token, not just the file.**
+  `frontend/src/main/ao-control-token.ts` caches a control-plane-audience access
+  token in memory, and `aoAccount:signOut` clears it alongside deleting
+  `ao-account.json`. When task 13 caches a machine-audience token, it clears there
+  too.
+- **Every refresh exchange persists the rotated refresh token** through
+  `writeStoredAccount`, before the access token it came with is handed to a caller.
+  The presented token is already revoked by then, so losing the replacement would
+  lock the install out.
 
 ## What the desktop stores
 
@@ -114,3 +116,11 @@ Because refresh tokens rotate on every use, the refresh exchange must persist ea
 replacement through `writeStoredAccount` in
 `frontend/src/main/ao-account-store.ts` or the next refresh replays a revoked
 token.
+
+`~/.ao/ao-machine.json`, mode 0600, records which machine is active, and is
+absent when this computer is. It holds no credential: an id, a name, the
+machine's public origin, and the last-seen the control plane reported. It stores
+the whole record rather than just the id so a launch knows it is pointed at a
+remote machine before it can reach the control plane, which is what stops the
+app spawning a local daemon on a remote machine's behalf. See
+`frontend/src/main/ao-machines.ts`.

--- a/frontend/e2e/support/fake-bridge.ts
+++ b/frontend/e2e/support/fake-bridge.ts
@@ -44,6 +44,25 @@ export async function installFakeBridge(page: Page, opts: FakeBridgeOptions = {}
 		({ version, daemonState, daemonPort }) => {
 			const unsubscribe = () => () => undefined;
 			const signedOutAoAccount = { status: "signed-out" as const, controlPlaneUrl: "https://ao.agentlab.in" };
+			// This computer is machine zero and stays selectable with no account,
+			// which is what the renderer smoke suite sees.
+			const signedOutAoMachines = {
+				status: "signed-out" as const,
+				activeMachineId: "local",
+				machines: [
+					{
+						id: "local",
+						name: "This Mac",
+						baseUrl: "",
+						local: true,
+						createdAt: null,
+						lastSeen: null,
+						reachability: "online" as const,
+						harness: "unknown" as const,
+						harnessCommand: null,
+					},
+				],
+			};
 			const status: DaemonStatus =
 				daemonState === "ready" ? { state: "ready", port: daemonPort } : { state: daemonState };
 			const navState = (viewId: string) => ({
@@ -149,6 +168,11 @@ export async function installFakeBridge(page: Page, opts: FakeBridgeOptions = {}
 					getState: async () => signedOutAoAccount,
 					signIn: async () => signedOutAoAccount,
 					signOut: async () => signedOutAoAccount,
+				},
+				machines: {
+					getState: async () => signedOutAoMachines,
+					refresh: async () => signedOutAoMachines,
+					select: async () => signedOutAoMachines,
 				},
 			} satisfies AoBridge;
 			(window as unknown as { ao: unknown }).ao = ao;
@@ -416,6 +440,25 @@ export async function installFakeAgent(page: Page, opts: FakeAgentOptions = {}):
 
 			const unsubscribe = () => () => undefined;
 			const signedOutAoAccount = { status: "signed-out" as const, controlPlaneUrl: "https://ao.agentlab.in" };
+			// This computer is machine zero and stays selectable with no account,
+			// which is what the renderer smoke suite sees.
+			const signedOutAoMachines = {
+				status: "signed-out" as const,
+				activeMachineId: "local",
+				machines: [
+					{
+						id: "local",
+						name: "This Mac",
+						baseUrl: "",
+						local: true,
+						createdAt: null,
+						lastSeen: null,
+						reachability: "online" as const,
+						harness: "unknown" as const,
+						harnessCommand: null,
+					},
+				],
+			};
 			const status: DaemonStatus = { state: "ready", port: daemonPort };
 			const navState = (viewId: string, url = "", error?: string) => ({
 				viewId,
@@ -507,6 +550,11 @@ export async function installFakeAgent(page: Page, opts: FakeAgentOptions = {}):
 					getState: async () => signedOutAoAccount,
 					signIn: async () => signedOutAoAccount,
 					signOut: async () => signedOutAoAccount,
+				},
+				machines: {
+					getState: async () => signedOutAoMachines,
+					refresh: async () => signedOutAoMachines,
+					select: async () => signedOutAoMachines,
 				},
 			} satisfies AoBridge;
 			(window as unknown as { ao: unknown }).ao = ao;

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -60,9 +60,11 @@ import { connectSupervisor, type SupervisorLinkHandle } from "./main/supervisor-
 import { keepDaemonAlive, shouldLinkOnAttach } from "./main/daemon-owner";
 import { readMigrationState, updateMigration, writeAppStateMarker, type MigrationState } from "./main/app-state";
 import { createAoAccountController } from "./main/ao-account";
+import { createAoMachinesController } from "./main/ao-machines";
+import type { AoMachine } from "./shared/ao-machines";
 import { isAllowedAppExternalURL, openAllowedAppExternalURL } from "./main/external-open";
 import { buildWindowsAppMenuTemplate } from "./main/menu";
-import { createRemoteDaemonLifecycle } from "./main/remote-daemon";
+import { createRemoteDaemonLifecycle, machineDaemonStatus } from "./main/remote-daemon";
 
 // Globals injected at compile time by @electron-forge/plugin-vite.
 declare const MAIN_WINDOW_VITE_DEV_SERVER_URL: string | undefined;
@@ -117,7 +119,16 @@ const remoteDaemonConfig: RemoteDaemonConfig | null = (() => {
 		return null;
 	}
 })();
-const remoteDaemonLifecycle = createRemoteDaemonLifecycle(remoteDaemonConfig, remoteDaemonConfigurationFailureStatus);
+// The active registered machine's status, or null when this computer is the
+// active machine. Held here rather than read from the machines controller so
+// the lifecycle can be built before the state dir is resolved, and so a remote
+// machine restored at boot is in force before the first startDaemon() call.
+let activeMachineStatus: DaemonStatus | null = null;
+const remoteDaemonLifecycle = createRemoteDaemonLifecycle(
+	remoteDaemonConfig,
+	remoteDaemonConfigurationFailureStatus,
+	() => activeMachineStatus,
+);
 let daemonStatus: DaemonStatus = remoteDaemonLifecycle.currentStatus() ?? { state: "stopped" };
 let daemonOutput = "";
 let browserViewHost: BrowserViewHost | null = null;
@@ -1428,7 +1439,50 @@ function aoAccount(): ReturnType<typeof createAoAccountController> {
 
 ipcMain.handle("aoAccount:getState", () => aoAccount().getState());
 ipcMain.handle("aoAccount:signIn", () => aoAccount().signIn());
-ipcMain.handle("aoAccount:signOut", () => aoAccount().signOut());
+ipcMain.handle("aoAccount:signOut", async () => {
+	const state = await aoAccount().signOut();
+	// Signing out removes the only credential that can reach a registered
+	// machine, so the app falls back to this computer, which needs no account.
+	await aoMachines().reset();
+	return state;
+});
+
+// The machine list and which machine is active. This computer is machine zero
+// and is always offered; everything below is only about reaching a machine the
+// account has registered.
+let aoMachinesController: ReturnType<typeof createAoMachinesController> | null = null;
+function aoMachines(): ReturnType<typeof createAoMachinesController> {
+	if (aoMachinesController) return aoMachinesController;
+	const runFile = runFilePath();
+	aoMachinesController = createAoMachinesController({
+		stateDir: runFile ? path.dirname(runFile) : null,
+		env: process.env,
+		safeStorage,
+		// "This Mac" on macOS, per the spec. The other platforms get a label that
+		// is not wrong for them.
+		localMachineName: process.platform === "darwin" ? "This Mac" : "This computer",
+		onActiveChange: applyActiveMachine,
+	});
+	return aoMachinesController;
+}
+
+/**
+ * Re-point the app at the machine that just became active.
+ *
+ * A remote machine sets activeMachineStatus, which is what makes the remote
+ * lifecycle own the app's daemon state: from here on startDaemon() returns that
+ * status and the local start function is never called, whether the machine is
+ * up or down. Selecting this computer clears it, and startDaemon() attaches to
+ * or spawns the local daemon exactly as it always has.
+ */
+function applyActiveMachine(machine: AoMachine | null): void {
+	activeMachineStatus = machine ? machineDaemonStatus(machine) : null;
+	void startDaemon();
+}
+
+ipcMain.handle("aoMachines:getState", () => aoMachines().getState());
+ipcMain.handle("aoMachines:refresh", () => aoMachines().refresh());
+ipcMain.handle("aoMachines:select", (_event, machineId: string) => aoMachines().select(machineId));
 
 ipcMain.handle("updates:getStatus", (): UpdateStatus => getUpdateStatus());
 ipcMain.handle("updates:check", async (_event, options?: UpdateCheckOptions) => {
@@ -1564,8 +1618,22 @@ app.whenReady().then(async () => {
 			setDaemonStatus(remoteStatus);
 		}
 	}
+	// Before the first startDaemon(): a machine chosen in a previous run must be
+	// active by the time anything can start a daemon, or the app would spawn a
+	// local one on behalf of a remote machine. restore() reads the remembered
+	// machine off disk, so it needs no network and cannot be beaten by one.
+	try {
+		await aoMachines().restore();
+	} catch (err) {
+		console.error("failed to restore the active machine:", err);
+	}
+
 	createWindow();
 	void startDaemon();
+	// Fills in the real list and each machine's reachability once the window is
+	// up. Failure here leaves the remembered machine in place; it never falls
+	// back to the local daemon.
+	if (activeMachineStatus) void aoMachines().refresh();
 	initAutoUpdates();
 
 	app.on("activate", () => {

--- a/frontend/src/main/ao-control-token.test.ts
+++ b/frontend/src/main/ao-control-token.test.ts
@@ -1,0 +1,133 @@
+// @vitest-environment node
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+import { readStoredAccount, writeStoredAccount, type SafeStorageLike } from "./ao-account-store";
+import { createControlPlaneTokenSource } from "./ao-control-token";
+
+// Same stand-in as ao-account-store.test.ts: reversible, and different from the
+// plaintext, which is all these tests need from it.
+const safeStorage: SafeStorageLike = {
+	isEncryptionAvailable: () => true,
+	encryptString: (plain) => Buffer.from(Array.from(Buffer.from(plain, "utf8"), (b) => b ^ 0x5a)),
+	decryptString: (cipher) => Buffer.from(Array.from(cipher, (b) => b ^ 0x5a)).toString("utf8"),
+};
+
+const account = { id: "acct_1", email: "dev@example.com" };
+const CONTROL_PLANE = "https://ao.agentlab.in";
+
+let stateDir = "";
+
+beforeEach(async () => {
+	stateDir = await mkdtemp(path.join(os.tmpdir(), "ao-control-token-"));
+});
+afterEach(async () => {
+	await rm(stateDir, { recursive: true, force: true });
+});
+
+function tokenResponse(body: Record<string, unknown>, status = 200) {
+	return new Response(JSON.stringify(body), { status, headers: { "Content-Type": "application/json" } });
+}
+
+function source(fetchImpl: typeof fetch, now = () => 0) {
+	return createControlPlaneTokenSource({ stateDir, controlPlaneUrl: CONTROL_PLANE, safeStorage, fetchImpl, now });
+}
+
+test("exchanges the refresh token at the token endpoint, and nowhere else", async () => {
+	await writeStoredAccount(stateDir, safeStorage, { account, refreshToken: "rt_1" });
+	const fetchImpl = vi.fn(async () => tokenResponse({ access_token: "at_1", expires_in: 900, refresh_token: "rt_2" }));
+
+	await expect(source(fetchImpl as unknown as typeof fetch).get()).resolves.toBe("at_1");
+
+	expect(fetchImpl).toHaveBeenCalledTimes(1);
+	const [url, init] = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
+	expect(url).toBe("https://ao.agentlab.in/api/v1/token");
+	expect(init.method).toBe("POST");
+	// The refresh token is a body parameter of the token endpoint. It is never a
+	// Bearer credential and never in the URL (controlplane/TOKEN_CONTRACT.md).
+	expect(new URLSearchParams(init.body as string).get("refresh_token")).toBe("rt_1");
+	expect(new URLSearchParams(init.body as string).get("grant_type")).toBe("refresh_token");
+	expect(JSON.stringify(init.headers)).not.toContain("rt_1");
+	expect(url).not.toContain("rt_1");
+});
+
+test("persists the rotated refresh token, because the presented one is already revoked", async () => {
+	await writeStoredAccount(stateDir, safeStorage, { account, refreshToken: "rt_1" });
+	const fetchImpl = vi.fn(async () => tokenResponse({ access_token: "at_1", expires_in: 900, refresh_token: "rt_2" }));
+
+	await source(fetchImpl as unknown as typeof fetch).get();
+
+	const stored = await readStoredAccount(stateDir, safeStorage);
+	expect(stored?.refreshToken).toBe("rt_2");
+	expect(stored?.account).toEqual(account);
+});
+
+test("caches the access token until it is close to expiry", async () => {
+	await writeStoredAccount(stateDir, safeStorage, { account, refreshToken: "rt_1" });
+	let now = 0;
+	let issued = 0;
+	const fetchImpl = vi.fn(async () => {
+		issued += 1;
+		return tokenResponse({ access_token: `at_${issued}`, expires_in: 900, refresh_token: "rt_next" });
+	});
+	const tokens = source(fetchImpl as unknown as typeof fetch, () => now);
+
+	await expect(tokens.get()).resolves.toBe("at_1");
+	now = 800_000;
+	await expect(tokens.get()).resolves.toBe("at_1");
+	expect(fetchImpl).toHaveBeenCalledTimes(1);
+
+	// Inside the 60s skew window, so a fresh exchange rather than a token that
+	// would expire mid-request.
+	now = 860_000;
+	await expect(tokens.get()).resolves.toBe("at_2");
+	expect(fetchImpl).toHaveBeenCalledTimes(2);
+});
+
+test("concurrent callers share one exchange, so neither replays a rotated token", async () => {
+	await writeStoredAccount(stateDir, safeStorage, { account, refreshToken: "rt_1" });
+	const fetchImpl = vi.fn(async () => tokenResponse({ access_token: "at_1", expires_in: 900, refresh_token: "rt_2" }));
+	const tokens = source(fetchImpl as unknown as typeof fetch);
+
+	await expect(Promise.all([tokens.get(), tokens.get(), tokens.get()])).resolves.toEqual(["at_1", "at_1", "at_1"]);
+	expect(fetchImpl).toHaveBeenCalledTimes(1);
+});
+
+test("signed out returns no token and never calls the control plane", async () => {
+	const fetchImpl = vi.fn();
+	await expect(source(fetchImpl as unknown as typeof fetch).get()).resolves.toBeNull();
+	expect(fetchImpl).not.toHaveBeenCalled();
+});
+
+test("a revoked or replayed refresh token says to sign in again", async () => {
+	await writeStoredAccount(stateDir, safeStorage, { account, refreshToken: "rt_1" });
+	const fetchImpl = vi.fn(async () =>
+		tokenResponse({ error: "invalid_grant", error_description: "the refresh token is not valid" }, 400),
+	);
+
+	await expect(source(fetchImpl as unknown as typeof fetch).get()).rejects.toThrow(/Sign in again/);
+});
+
+test("a response missing either token is a failure, not a half-applied rotation", async () => {
+	await writeStoredAccount(stateDir, safeStorage, { account, refreshToken: "rt_1" });
+
+	const noAccess = vi.fn(async () => tokenResponse({ refresh_token: "rt_2" }));
+	await expect(source(noAccess as unknown as typeof fetch).get()).rejects.toThrow(/did not return an access token/);
+
+	const noRotation = vi.fn(async () => tokenResponse({ access_token: "at_1" }));
+	await expect(source(noRotation as unknown as typeof fetch).get()).rejects.toThrow(/replacement refresh token/);
+	// The refresh token on disk is untouched, so the next attempt can retry it.
+	await expect(readStoredAccount(stateDir, safeStorage)).resolves.toMatchObject({ refreshToken: "rt_1" });
+});
+
+test("clear drops the cached token, so sign-out leaves nothing behind", async () => {
+	await writeStoredAccount(stateDir, safeStorage, { account, refreshToken: "rt_1" });
+	const fetchImpl = vi.fn(async () => tokenResponse({ access_token: "at_1", expires_in: 900, refresh_token: "rt_2" }));
+	const tokens = source(fetchImpl as unknown as typeof fetch);
+
+	await tokens.get();
+	tokens.clear();
+	await tokens.get();
+	expect(fetchImpl).toHaveBeenCalledTimes(2);
+});

--- a/frontend/src/main/ao-control-token.ts
+++ b/frontend/src/main/ao-control-token.ts
@@ -1,0 +1,135 @@
+import { readStoredAccount, writeStoredAccount, type SafeStorageLike } from "./ao-account-store";
+
+/**
+ * The desktop install's control-plane-audience access token.
+ *
+ * `GET /api/v1/machines` and every other control plane API route accept exactly
+ * one credential: an access token whose `aud` is the control plane's own origin
+ * (controlplane/TOKEN_CONTRACT.md, "The two audiences"). A machine-audience
+ * token, the browser session cookie, and the refresh token itself are each
+ * rejected there. So the refresh token is presented here, at
+ * `POST /api/v1/token`, and nowhere else: it is long-lived and high-value, and
+ * sending it on a resource route would spread ninety days of account access
+ * across logs and proxies where a fifteen minute token would have leaked
+ * fifteen minutes.
+ *
+ * Refresh tokens rotate on use, so exchanging one revokes it in the same
+ * transaction that issues its replacement. Two consequences shape this module:
+ * the replacement is persisted before the access token is handed out, and
+ * concurrent callers share one exchange rather than racing two, where the
+ * loser would have presented an already-revoked token.
+ *
+ * Not in scope here: the machine-audience token, the Bearer header on the
+ * daemon's REST and SSE routes, the `/mux` cookie, and silent background
+ * refresh. That is the remote transport, task 13.
+ */
+
+/** Refreshed this early before expiry, so a token never expires mid-request. */
+const EXPIRY_SKEW_MS = 60_000;
+
+/** Fallback when the token endpoint omits `expires_in`; the contract's default. */
+const DEFAULT_TTL_SECONDS = 15 * 60;
+
+export type ControlPlaneTokenDeps = {
+	/** The ~/.ao state dir, where the encrypted refresh token lives. */
+	stateDir: string;
+	/** Origin of the control plane this install trusts, no trailing slash. */
+	controlPlaneUrl: string;
+	safeStorage: SafeStorageLike;
+	fetchImpl?: typeof fetch;
+	now?: () => number;
+};
+
+export type ControlPlaneTokenSource = {
+	/** A usable access token, or null when this install is not signed in. */
+	get: () => Promise<string | null>;
+	/** Drop the cached token. Called on sign-out: nothing survives it. */
+	clear: () => void;
+};
+
+type TokenResponse = {
+	access_token?: unknown;
+	expires_in?: unknown;
+	refresh_token?: unknown;
+};
+
+function exchangeFailure(status: number, body: unknown): Error {
+	const envelope = (body ?? {}) as { error?: unknown; error_description?: unknown };
+	const code = typeof envelope.error === "string" ? envelope.error : "";
+	const description = typeof envelope.error_description === "string" ? envelope.error_description : "";
+	if (code === "invalid_grant") {
+		return new Error("This computer's AO sign-in is no longer valid. Sign in again.");
+	}
+	return new Error(description || code || `The control plane returned ${status}.`);
+}
+
+export function createControlPlaneTokenSource(deps: ControlPlaneTokenDeps): ControlPlaneTokenSource {
+	const fetchImpl = deps.fetchImpl ?? fetch;
+	const now = deps.now ?? Date.now;
+
+	let cached: { token: string; expiresAt: number } | null = null;
+	let inFlight: Promise<string | null> | null = null;
+
+	async function exchange(): Promise<string | null> {
+		const stored = await readStoredAccount(deps.stateDir, deps.safeStorage);
+		if (!stored) return null;
+
+		const response = await fetchImpl(`${deps.controlPlaneUrl}/api/v1/token`, {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/x-www-form-urlencoded",
+				Accept: "application/json",
+			},
+			body: new URLSearchParams({
+				grant_type: "refresh_token",
+				refresh_token: stored.refreshToken,
+			}).toString(),
+		});
+
+		// Bodies here carry a refresh token, so nothing about them is logged.
+		let body: unknown = null;
+		try {
+			body = await response.json();
+		} catch {
+			body = null;
+		}
+		if (!response.ok) throw exchangeFailure(response.status, body);
+
+		const { access_token: accessToken, expires_in: expiresIn, refresh_token: rotated } = (body ?? {}) as TokenResponse;
+		if (typeof accessToken !== "string" || !accessToken) {
+			throw new Error("The control plane did not return an access token.");
+		}
+		if (typeof rotated !== "string" || !rotated) {
+			throw new Error("The control plane did not return a replacement refresh token.");
+		}
+
+		// Persisted before the access token is handed out: the presented refresh
+		// token is already revoked, so losing the replacement here would lock this
+		// install out until the user signs in again.
+		await writeStoredAccount(deps.stateDir, deps.safeStorage, { account: stored.account, refreshToken: rotated });
+
+		const ttlSeconds = typeof expiresIn === "number" && expiresIn > 0 ? expiresIn : DEFAULT_TTL_SECONDS;
+		cached = { token: accessToken, expiresAt: now() + ttlSeconds * 1000 };
+		return accessToken;
+	}
+
+	return {
+		async get(): Promise<string | null> {
+			if (cached && cached.expiresAt - EXPIRY_SKEW_MS > now()) return cached.token;
+			// One exchange at a time. A second concurrent exchange would present a
+			// refresh token the first one had already rotated away.
+			if (inFlight) return inFlight;
+			const attempt = Promise.resolve()
+				.then(exchange)
+				.finally(() => {
+					inFlight = null;
+				});
+			inFlight = attempt;
+			return attempt;
+		},
+
+		clear(): void {
+			cached = null;
+		},
+	};
+}

--- a/frontend/src/main/ao-machines.test.ts
+++ b/frontend/src/main/ao-machines.test.ts
@@ -1,0 +1,239 @@
+// @vitest-environment node
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+import { LOCAL_MACHINE_ID, type AoMachine } from "../shared/ao-machines";
+import { AO_MACHINE_FILE_NAME, createAoMachinesController } from "./ao-machines";
+import type { ControlPlaneTokenSource } from "./ao-control-token";
+import type { SafeStorageLike } from "./ao-account-store";
+
+const safeStorage: SafeStorageLike = {
+	isEncryptionAvailable: () => true,
+	encryptString: (plain) => Buffer.from(plain, "utf8"),
+	decryptString: (cipher) => cipher.toString("utf8"),
+};
+
+const signedIn: ControlPlaneTokenSource = { get: async () => "cp_access_token", clear: () => undefined };
+const signedOut: ControlPlaneTokenSource = { get: async () => null, clear: () => undefined };
+
+const machineRow = (extra: Record<string, unknown> = {}) => ({
+	id: "mch_1",
+	name: "ao-build-01",
+	public_url: "https://vm.example.com",
+	created_at: "2026-07-01T10:00:00Z",
+	last_seen: "2026-07-30T09:00:00Z",
+	...extra,
+});
+
+const listResponse = (...rows: Array<Record<string, unknown>>) =>
+	new Response(JSON.stringify({ machines: rows }), { status: 200, headers: { "Content-Type": "application/json" } });
+
+/**
+ * A fetch that answers the control plane's list route from `rows`, and answers
+ * a machine's own origin according to `up`. Anything not in `up` throws, which
+ * is what an unreachable machine looks like to fetch.
+ */
+function fakeFetch(rows: Array<Record<string, unknown>>, up: Record<string, boolean> = {}) {
+	return vi.fn(async (input: string, init?: RequestInit) => {
+		const url = String(input);
+		if (url.endsWith("/api/v1/machines")) {
+			expect(new Headers(init?.headers).get("Authorization")).toBe("Bearer cp_access_token");
+			return listResponse(...rows);
+		}
+		const origin = new URL(url).origin;
+		if (up[origin]) return new Response("not found", { status: 404 });
+		throw new Error("connect ECONNREFUSED");
+	});
+}
+
+let stateDir = "";
+let active: Array<AoMachine | null> = [];
+
+beforeEach(async () => {
+	stateDir = await mkdtemp(path.join(os.tmpdir(), "ao-machines-"));
+	active = [];
+});
+afterEach(async () => {
+	await rm(stateDir, { recursive: true, force: true });
+});
+
+function controller(fetchImpl: ReturnType<typeof fakeFetch>, tokenSource: ControlPlaneTokenSource = signedIn) {
+	return createAoMachinesController({
+		stateDir,
+		env: {},
+		safeStorage,
+		localMachineName: "This Mac",
+		onActiveChange: (machine) => active.push(machine),
+		fetchImpl: fetchImpl as unknown as typeof fetch,
+		probeTimeoutMs: 50,
+		tokenSource,
+	});
+}
+
+test("this computer is machine zero, and it is there before anything is listed", () => {
+	const state = controller(fakeFetch([])).getState();
+	expect(state.machines[0]).toMatchObject({ id: LOCAL_MACHINE_ID, name: "This Mac", local: true });
+	expect(state.activeMachineId).toBe(LOCAL_MACHINE_ID);
+});
+
+test("signed out still offers this computer: local use never requires an account", async () => {
+	const fetchImpl = fakeFetch([machineRow()]);
+	const state = await controller(fetchImpl, signedOut).refresh();
+
+	expect(state.status).toBe("signed-out");
+	expect(state.machines.map((machine) => machine.id)).toEqual([LOCAL_MACHINE_ID]);
+	expect(fetchImpl).not.toHaveBeenCalled();
+});
+
+test("lists the account's machines with a control-plane-audience bearer token", async () => {
+	const fetchImpl = fakeFetch([machineRow()], { "https://vm.example.com": true });
+	const state = await controller(fetchImpl).refresh();
+
+	expect(state.status).toBe("ready");
+	expect(state.machines.map((machine) => machine.id)).toEqual([LOCAL_MACHINE_ID, "mch_1"]);
+	expect(state.machines[1]).toMatchObject({ reachability: "online", baseUrl: "https://vm.example.com" });
+	// The Authorization header is asserted inside fakeFetch; this pins the route.
+	expect(String(fetchImpl.mock.calls[0][0])).toBe("https://ao.agentlab.in/api/v1/machines");
+});
+
+test("a machine that does not answer is offline, with the last-seen the control plane reported", async () => {
+	const state = await controller(fakeFetch([machineRow()])).refresh();
+	expect(state.machines[1]).toMatchObject({ reachability: "offline", lastSeen: "2026-07-30T09:00:00Z" });
+});
+
+test("the liveness probe sends no credential of any kind", async () => {
+	const fetchImpl = fakeFetch([machineRow()], { "https://vm.example.com": true });
+	await controller(fetchImpl).refresh();
+
+	const probe = fetchImpl.mock.calls.find(([url]) => String(url).startsWith("https://vm.example.com"));
+	expect(probe).toBeDefined();
+	const headers = new Headers((probe?.[1] as RequestInit | undefined)?.headers);
+	expect(headers.get("Authorization")).toBeNull();
+	expect(headers.get("Cookie")).toBeNull();
+});
+
+test("selecting a machine re-points the app and survives a restart", async () => {
+	const fetchImpl = fakeFetch([machineRow()], { "https://vm.example.com": true });
+	const machines = controller(fetchImpl);
+	await machines.refresh();
+
+	const state = await machines.select("mch_1");
+	expect(state.activeMachineId).toBe("mch_1");
+	expect(active.at(-1)).toMatchObject({ id: "mch_1", baseUrl: "https://vm.example.com" });
+
+	// The whole record is on disk, not just the id, so the next launch knows it
+	// is pointed at a remote machine before it can reach the control plane.
+	const onDisk = JSON.parse(await readFile(path.join(stateDir, AO_MACHINE_FILE_NAME), "utf8"));
+	expect(onDisk.machine).toMatchObject({ id: "mch_1", baseUrl: "https://vm.example.com" });
+
+	active = [];
+	const relaunched = controller(fakeFetch([machineRow()]));
+	await expect(relaunched.restore()).resolves.toMatchObject({ id: "mch_1", baseUrl: "https://vm.example.com" });
+	expect(active).toHaveLength(1);
+});
+
+test("switching back to this computer leaves no machine on disk", async () => {
+	const machines = controller(fakeFetch([machineRow()], { "https://vm.example.com": true }));
+	await machines.refresh();
+	await machines.select("mch_1");
+
+	const state = await machines.select(LOCAL_MACHINE_ID);
+	expect(state.activeMachineId).toBe(LOCAL_MACHINE_ID);
+	expect(active.at(-1)).toBeNull();
+	await expect(readFile(path.join(stateDir, AO_MACHINE_FILE_NAME), "utf8")).rejects.toThrow();
+});
+
+test("an id that is not in the list is refused rather than guessed at", async () => {
+	const machines = controller(fakeFetch([machineRow()], { "https://vm.example.com": true }));
+	await machines.refresh();
+
+	const state = await machines.select("mch_someone_elses");
+	expect(state.activeMachineId).toBe(LOCAL_MACHINE_ID);
+	expect(state.error).toMatch(/no longer in this account's list/);
+});
+
+test("a revoked machine drops out of the list and the app falls back to this computer", async () => {
+	const machines = controller(fakeFetch([machineRow()], { "https://vm.example.com": true }));
+	await machines.refresh();
+	await machines.select("mch_1");
+
+	const revoked = createAoMachinesController({
+		stateDir,
+		env: {},
+		safeStorage,
+		localMachineName: "This Mac",
+		onActiveChange: (machine) => active.push(machine),
+		fetchImpl: fakeFetch([]) as unknown as typeof fetch,
+		probeTimeoutMs: 50,
+		tokenSource: signedIn,
+	});
+	await revoked.restore();
+	const state = await revoked.refresh();
+
+	expect(state.activeMachineId).toBe(LOCAL_MACHINE_ID);
+	expect(state.machines.map((machine) => machine.id)).toEqual([LOCAL_MACHINE_ID]);
+});
+
+test("a control-plane outage keeps the active machine and still reports whether it is up", async () => {
+	const machines = controller(fakeFetch([machineRow()], { "https://vm.example.com": true }));
+	await machines.refresh();
+	await machines.select("mch_1");
+
+	const offline = createAoMachinesController({
+		stateDir,
+		env: {},
+		safeStorage,
+		localMachineName: "This Mac",
+		onActiveChange: (machine) => active.push(machine),
+		fetchImpl: (async (input: string) => {
+			if (String(input).endsWith("/api/v1/machines")) throw new Error("getaddrinfo ENOTFOUND ao.agentlab.in");
+			return new Response("not found", { status: 404 });
+		}) as unknown as typeof fetch,
+		probeTimeoutMs: 50,
+		tokenSource: signedIn,
+	});
+	await offline.restore();
+	const state = await offline.refresh();
+
+	expect(state.status).toBe("error");
+	expect(state.error).toMatch(/ENOTFOUND/);
+	expect(state.activeMachineId).toBe("mch_1");
+	expect(state.machines[1]).toMatchObject({ id: "mch_1", reachability: "online" });
+});
+
+test("signing out forgets the token and falls back to this computer", async () => {
+	const clear = vi.fn();
+	const machines = createAoMachinesController({
+		stateDir,
+		env: {},
+		safeStorage,
+		localMachineName: "This Mac",
+		onActiveChange: (machine) => active.push(machine),
+		fetchImpl: fakeFetch([machineRow()], { "https://vm.example.com": true }) as unknown as typeof fetch,
+		probeTimeoutMs: 50,
+		tokenSource: { get: async () => "cp_access_token", clear },
+	});
+	await machines.refresh();
+	await machines.select("mch_1");
+
+	await machines.reset();
+
+	expect(clear).toHaveBeenCalledTimes(1);
+	expect(machines.getState()).toMatchObject({ status: "signed-out", activeMachineId: LOCAL_MACHINE_ID });
+	expect(active.at(-1)).toBeNull();
+});
+
+test("a bad AO_CONTROL_URL is reported, never a silent fall back to production", async () => {
+	const machines = createAoMachinesController({
+		stateDir,
+		env: { AO_CONTROL_URL: "not a url" },
+		safeStorage,
+		localMachineName: "This Mac",
+		onActiveChange: (machine) => active.push(machine),
+		fetchImpl: fakeFetch([machineRow()]) as unknown as typeof fetch,
+	});
+	const state = await machines.refresh();
+	expect(state.status).toBe("error");
+	expect(state.error).toMatch(/AO_CONTROL_URL/);
+});

--- a/frontend/src/main/ao-machines.ts
+++ b/frontend/src/main/ao-machines.ts
@@ -1,0 +1,338 @@
+import { mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+import {
+	LOCAL_MACHINE_ID,
+	localMachine,
+	parseMachineOrigin,
+	parseMachinesResponse,
+	type AoMachine,
+	type AoMachineReachability,
+	type AoMachinesState,
+	type AoMachinesStatus,
+} from "../shared/ao-machines";
+import { readControlPlaneUrl } from "../shared/control-plane";
+import { createControlPlaneTokenSource, type ControlPlaneTokenSource } from "./ao-control-token";
+import type { SafeStorageLike } from "./ao-account-store";
+
+/**
+ * Main-process owner of the machine list and of which machine is active.
+ *
+ * One machine is active at a time. Switching re-points the renderer at that
+ * machine's base URL; running two machines side by side is out of scope and
+ * nothing here is built toward it.
+ *
+ * The local machine is machine zero and is always in the list, signed in or
+ * not. Nothing in this module gates it behind an account.
+ *
+ * The credential for the list is a control-plane-audience access token, from
+ * ao-control-token.ts. See controlplane/TOKEN_CONTRACT.md, "The two audiences".
+ */
+
+/** Active machine, beside the other ~/.ao state files. Absent means local. */
+export const AO_MACHINE_FILE_NAME = "ao-machine.json";
+
+const SCHEMA_VERSION = 1;
+
+/** A machine that has not answered within this is reported offline. */
+const DEFAULT_PROBE_TIMEOUT_MS = 4000;
+
+/**
+ * What is persisted about the active machine.
+ *
+ * The whole record is stored rather than just the id, and that is load
+ * bearing. At the next launch the app must know it is pointed at a remote
+ * machine BEFORE it can list machines, because listing needs a token exchange
+ * over the network. With only an id, that window would look exactly like "no
+ * machine is active", and the app would spawn a local daemon for a remote
+ * machine. See restore() and the lifecycle wiring in main.ts.
+ */
+type PersistedMachine = {
+	id: string;
+	name: string;
+	baseUrl: string;
+	lastSeen: string | null;
+};
+
+type MachineFile = {
+	version: number;
+	machine: PersistedMachine | null;
+};
+
+export type AoMachinesControllerDeps = {
+	/** The ~/.ao state dir, or null when the home dir is unresolvable. */
+	stateDir: string | null;
+	env: Record<string, string | undefined>;
+	safeStorage: SafeStorageLike;
+	/** Display name for machine zero, for example "This Mac". */
+	localMachineName: string;
+	/**
+	 * Called whenever the active machine changes, with null for the local
+	 * machine. The main process turns this into the renderer's base URL.
+	 */
+	onActiveChange: (machine: AoMachine | null) => void;
+	fetchImpl?: typeof fetch;
+	probeTimeoutMs?: number;
+	/** Test seam, so a controller can be driven without a real token exchange. */
+	tokenSource?: ControlPlaneTokenSource;
+};
+
+export type AoMachinesController = {
+	/** Current known state. No network: the renderer can poll this freely. */
+	getState: () => AoMachinesState;
+	/** List from the control plane and probe every machine's reachability. */
+	refresh: () => Promise<AoMachinesState>;
+	/** Make one machine active. Unknown ids are rejected rather than guessed. */
+	select: (machineId: string) => Promise<AoMachinesState>;
+	/** Boot: re-apply the machine chosen in a previous run, before any daemon start. */
+	restore: () => Promise<AoMachine | null>;
+	/** Sign-out: forget the token and fall back to the local machine. */
+	reset: () => Promise<void>;
+};
+
+const errorMessage = (err: unknown): string => (err instanceof Error ? err.message : String(err));
+
+function machineFilePath(stateDir: string): string {
+	return path.join(stateDir, AO_MACHINE_FILE_NAME);
+}
+
+async function readPersisted(stateDir: string): Promise<PersistedMachine | null> {
+	let raw: string;
+	try {
+		raw = await readFile(machineFilePath(stateDir), "utf8");
+	} catch {
+		return null;
+	}
+	let parsed: Partial<MachineFile>;
+	try {
+		parsed = JSON.parse(raw) as Partial<MachineFile>;
+	} catch {
+		return null;
+	}
+	if (parsed.version !== SCHEMA_VERSION || !parsed.machine) return null;
+	const { id, name, baseUrl, lastSeen } = parsed.machine;
+	const origin = parseMachineOrigin(baseUrl);
+	if (typeof id !== "string" || !id || id === LOCAL_MACHINE_ID || !origin) return null;
+	return {
+		id,
+		name: typeof name === "string" && name ? name : origin,
+		baseUrl: origin,
+		lastSeen: typeof lastSeen === "string" ? lastSeen : null,
+	};
+}
+
+async function writePersisted(stateDir: string, machine: PersistedMachine | null): Promise<void> {
+	if (!machine) {
+		// Local is the absence of a file, so a fresh install and a switch back to
+		// this computer leave exactly the same state on disk.
+		await rm(machineFilePath(stateDir), { force: true });
+		return;
+	}
+	const file: MachineFile = { version: SCHEMA_VERSION, machine };
+	// Atomic write, mirroring app-state.json and ao-account.json.
+	await mkdir(stateDir, { recursive: true, mode: 0o750 });
+	const tmp = path.join(stateDir, `.ao-machine-${process.pid}.json`);
+	await writeFile(tmp, `${JSON.stringify(file, null, 2)}\n`, { mode: 0o600 });
+	await rename(tmp, machineFilePath(stateDir));
+}
+
+/** The remembered machine as a list entry, before the control plane is reached. */
+function machineFromPersisted(persisted: PersistedMachine): AoMachine {
+	return {
+		id: persisted.id,
+		name: persisted.name,
+		baseUrl: persisted.baseUrl,
+		local: false,
+		createdAt: null,
+		lastSeen: persisted.lastSeen,
+		reachability: "unknown",
+		harness: "unknown",
+		harnessCommand: null,
+	};
+}
+
+export function createAoMachinesController(deps: AoMachinesControllerDeps): AoMachinesController {
+	const fetchImpl = deps.fetchImpl ?? fetch;
+	const probeTimeoutMs = deps.probeTimeoutMs ?? DEFAULT_PROBE_TIMEOUT_MS;
+
+	// Resolved once, like the account controller: a bad AO_CONTROL_URL must be
+	// visible rather than silently falling back to the production control plane.
+	let configError: string | null = null;
+	let controlPlaneUrl = "";
+	try {
+		controlPlaneUrl = readControlPlaneUrl(deps.env);
+	} catch (err) {
+		configError = errorMessage(err);
+	}
+
+	const tokenSource =
+		deps.tokenSource ??
+		(deps.stateDir && !configError
+			? createControlPlaneTokenSource({
+					stateDir: deps.stateDir,
+					controlPlaneUrl,
+					safeStorage: deps.safeStorage,
+					fetchImpl,
+				})
+			: null);
+
+	/** Registered machines from the last successful list, or the remembered one. */
+	let remote: AoMachine[] = [];
+	let active: AoMachine | null = null;
+	let status: AoMachinesStatus = "signed-out";
+	let lastError: string | null = null;
+
+	function currentState(): AoMachinesState {
+		const local = localMachine(deps.localMachineName);
+		return {
+			status,
+			machines: [local, ...remote],
+			activeMachineId: active?.id ?? LOCAL_MACHINE_ID,
+			...(lastError ? { error: lastError } : {}),
+		};
+	}
+
+	async function setActive(machine: AoMachine | null): Promise<void> {
+		const sameMachine = (active?.id ?? null) === (machine?.id ?? null);
+		const sameUrl = (active?.baseUrl ?? "") === (machine?.baseUrl ?? "");
+		active = machine;
+		if (deps.stateDir) {
+			await writePersisted(
+				deps.stateDir,
+				machine ? { id: machine.id, name: machine.name, baseUrl: machine.baseUrl, lastSeen: machine.lastSeen } : null,
+			);
+		}
+		// Re-point the renderer only when the target actually moved, so a periodic
+		// refresh does not churn every long-lived connection.
+		if (!sameMachine || !sameUrl) deps.onActiveChange(machine);
+	}
+
+	async function fetchMachines(token: string): Promise<AoMachine[]> {
+		const response = await fetchImpl(`${controlPlaneUrl}/api/v1/machines`, {
+			headers: { Authorization: `Bearer ${token}`, Accept: "application/json" },
+		});
+		if (response.status === 401) {
+			throw new Error("The control plane rejected this computer's sign-in. Sign in again.");
+		}
+		if (!response.ok) {
+			throw new Error(`The control plane returned ${response.status} listing machines.`);
+		}
+		return parseMachinesResponse(await response.json());
+	}
+
+	/**
+	 * Liveness probe, with no credential of any kind.
+	 *
+	 * The gateway answers an unauthenticated request for a route it does not
+	 * proxy with a 404 before auth runs, so any HTTP answer at all proves the
+	 * machine is up. Only a transport failure or a timeout is offline. Nothing
+	 * about this result can reach the local daemon path: an offline machine is a
+	 * status, not an absence, so the remote lifecycle still owns the app's
+	 * daemon state and the local start function is never called. See main.ts.
+	 */
+	async function probe(machine: AoMachine): Promise<AoMachineReachability> {
+		const controller = new AbortController();
+		const timer = setTimeout(() => controller.abort(), probeTimeoutMs);
+		try {
+			await fetchImpl(`${machine.baseUrl}/`, { method: "GET", signal: controller.signal, redirect: "manual" });
+			return "online";
+		} catch {
+			return "offline";
+		} finally {
+			clearTimeout(timer);
+		}
+	}
+
+	async function probeAll(): Promise<void> {
+		const results = await Promise.all(remote.map(probe));
+		remote = remote.map((machine, index) => ({ ...machine, reachability: results[index] }));
+		if (!active) return;
+		const refreshed = remote.find((machine) => machine.id === active?.id);
+		if (!refreshed) return;
+		// Reachability is the whole reason the renderer is or is not pointed at
+		// this machine, so a change in it is a change of target.
+		const moved = refreshed.reachability !== active.reachability;
+		active = refreshed;
+		if (moved) deps.onActiveChange(refreshed);
+	}
+
+	async function refresh(): Promise<AoMachinesState> {
+		if (configError) {
+			status = "error";
+			lastError = configError;
+			return currentState();
+		}
+		if (!deps.stateDir || !tokenSource) {
+			status = "error";
+			lastError = "Could not resolve the ~/.ao state directory, so machines cannot be listed.";
+			return currentState();
+		}
+
+		lastError = null;
+		try {
+			const token = await tokenSource.get();
+			if (!token) {
+				// Signed out. There is no way to reach a registered machine without an
+				// account, so fall back to this computer, which needs none.
+				status = "signed-out";
+				remote = [];
+				await setActive(null);
+				return currentState();
+			}
+			remote = await fetchMachines(token);
+			status = "ready";
+			const stillRegistered = active ? (remote.find((machine) => machine.id === active?.id) ?? null) : null;
+			// A revoked machine is absent from the list. Falling back to this
+			// computer beats staying pointed at something the account no longer owns.
+			if (active && !stillRegistered) await setActive(null);
+			else if (stillRegistered) await setActive(stillRegistered);
+		} catch (err) {
+			// The control plane is unreachable or refused the token. Keep the machine
+			// that is already active and let the probe below say whether it is up:
+			// a control-plane outage does not make a working machine unusable.
+			status = "error";
+			lastError = errorMessage(err);
+			if (active && !remote.some((machine) => machine.id === active?.id)) remote = [active];
+		}
+
+		await probeAll();
+		return currentState();
+	}
+
+	return {
+		getState: currentState,
+		refresh,
+
+		async select(machineId: string): Promise<AoMachinesState> {
+			if (machineId === LOCAL_MACHINE_ID) {
+				await setActive(null);
+				return currentState();
+			}
+			const machine = remote.find((candidate) => candidate.id === machineId);
+			if (!machine) {
+				lastError = "That machine is no longer in this account's list.";
+				return currentState();
+			}
+			await setActive(machine);
+			return currentState();
+		},
+
+		async restore(): Promise<AoMachine | null> {
+			if (!deps.stateDir) return null;
+			const persisted = await readPersisted(deps.stateDir);
+			if (!persisted) return null;
+			const machine = machineFromPersisted(persisted);
+			remote = [machine];
+			active = machine;
+			deps.onActiveChange(machine);
+			return machine;
+		},
+
+		async reset(): Promise<void> {
+			tokenSource?.clear();
+			remote = [];
+			status = "signed-out";
+			lastError = null;
+			await setActive(null);
+		},
+	};
+}

--- a/frontend/src/main/remote-daemon.test.ts
+++ b/frontend/src/main/remote-daemon.test.ts
@@ -1,5 +1,24 @@
 import { describe, expect, it, vi } from "vitest";
-import { createRemoteDaemonLifecycle, installRemoteDaemonCookie, remoteDaemonReadyStatus } from "./remote-daemon";
+import type { AoMachine } from "../shared/ao-machines";
+import {
+	createRemoteDaemonLifecycle,
+	installRemoteDaemonCookie,
+	machineDaemonStatus,
+	remoteDaemonReadyStatus,
+} from "./remote-daemon";
+
+const machine = (extra: Partial<AoMachine> = {}): AoMachine => ({
+	id: "mch_1",
+	name: "ao-build-01",
+	baseUrl: "https://vm.example.com",
+	local: false,
+	createdAt: null,
+	lastSeen: null,
+	reachability: "online",
+	harness: "unknown",
+	harnessCommand: null,
+	...extra,
+});
 
 describe("installRemoteDaemonCookie", () => {
 	it("installs the pairing secret as a secure HttpOnly remote-origin cookie", async () => {
@@ -110,6 +129,90 @@ describe("createRemoteDaemonLifecycle", () => {
 		expect(localRefresh).not.toHaveBeenCalled();
 		expect(localStart).not.toHaveBeenCalled();
 		expect(localStop).not.toHaveBeenCalled();
+	});
+});
+
+describe("an active registered machine", () => {
+	const localCalls = () => {
+		const spawnLocalDaemon = vi.fn();
+		return {
+			spawnLocalDaemon,
+			localRefresh: vi.fn(async () => {
+				spawnLocalDaemon();
+				return { state: "stopped" as const };
+			}),
+			localStart: vi.fn(async () => {
+				spawnLocalDaemon();
+				return { state: "stopped" as const };
+			}),
+			localStop: vi.fn(() => ({ state: "stopped" as const })),
+		};
+	};
+
+	it("re-points the app at that machine's base URL", async () => {
+		const lifecycle = createRemoteDaemonLifecycle(null, null, () => machineDaemonStatus(machine()));
+		const { localStart } = localCalls();
+
+		await expect(lifecycle.start(localStart, vi.fn())).resolves.toEqual({
+			state: "ready",
+			baseUrl: "https://vm.example.com",
+			message: "Connected to ao-build-01",
+		});
+		expect(localStart).not.toHaveBeenCalled();
+	});
+
+	// The hazard this guards: the app spawns a local daemon when it cannot reach
+	// one, and doing that because a remote machine is down would be wrong. The
+	// local functions are arguments the lifecycle simply never calls while a
+	// machine is active, so being down cannot reach them by any path.
+	it("never spawns a local daemon when it is unreachable", async () => {
+		const down = machine({ reachability: "offline", lastSeen: "2026-07-30T09:00:00Z" });
+		const lifecycle = createRemoteDaemonLifecycle(null, null, () => machineDaemonStatus(down));
+		const { localRefresh, localStart, localStop, spawnLocalDaemon } = localCalls();
+		const setStatus = vi.fn();
+
+		const offline = {
+			state: "error",
+			code: "daemon_unreachable",
+			message: expect.stringContaining("ao-build-01 is not reachable. Last seen"),
+		};
+		await expect(lifecycle.refresh(localRefresh, setStatus)).resolves.toMatchObject(offline);
+		await expect(lifecycle.start(localStart, setStatus)).resolves.toMatchObject(offline);
+		expect(lifecycle.stop(localStop, setStatus)).toMatchObject(offline);
+
+		expect(localRefresh).not.toHaveBeenCalled();
+		expect(localStart).not.toHaveBeenCalled();
+		expect(localStop).not.toHaveBeenCalled();
+		expect(spawnLocalDaemon).not.toHaveBeenCalled();
+	});
+
+	it("hands back to the local daemon only when this computer is the active machine", async () => {
+		const lifecycle = createRemoteDaemonLifecycle(null, null, () => null);
+		const { localStart } = localCalls();
+
+		await expect(lifecycle.start(localStart, vi.fn())).resolves.toEqual({ state: "stopped" });
+		expect(localStart).toHaveBeenCalledTimes(1);
+	});
+
+	it("does not displace AO_REMOTE_URL, which keeps behaving exactly as before", async () => {
+		const config = { baseUrl: "https://api.ao.agentlab.in", token: "dGVzdF9wYWlyaW5nLXNlY3JldA" };
+		const lifecycle = createRemoteDaemonLifecycle(config, null, () => machineDaemonStatus(machine()));
+
+		await expect(lifecycle.start(vi.fn(), vi.fn())).resolves.toEqual(remoteDaemonReadyStatus(config));
+	});
+});
+
+describe("machineDaemonStatus", () => {
+	it("says when a machine was last seen, or that it never has been", () => {
+		expect(machineDaemonStatus(machine({ reachability: "offline" })).message).toContain("never connected");
+		expect(machineDaemonStatus(machine({ reachability: "offline", lastSeen: "2020-01-01T09:00:00Z" })).message)
+			.toMatch(/Last seen .+ ago\./);
+	});
+
+	it("is connecting, not ready, before the machine has answered", () => {
+		expect(machineDaemonStatus(machine({ reachability: "unknown" }))).toMatchObject({ state: "starting" });
+		// Nothing is pointed at a machine that has not answered yet.
+		expect(machineDaemonStatus(machine({ reachability: "unknown" })).baseUrl).toBeUndefined();
 	});
 });
 

--- a/frontend/src/main/remote-daemon.ts
+++ b/frontend/src/main/remote-daemon.ts
@@ -1,4 +1,5 @@
 import { REMOTE_PAIRING_COOKIE_NAME, type RemoteDaemonConfig } from "../shared/remote-daemon";
+import { formatLastSeen, type AoMachine } from "../shared/ao-machines";
 import type { DaemonStatus } from "../shared/daemon-status";
 
 type CookieStore = {
@@ -29,13 +30,44 @@ export function remoteDaemonReadyStatus(config: RemoteDaemonConfig): DaemonStatu
 	return { state: "ready", baseUrl: config.baseUrl, message: "Connected to remote daemon" };
 }
 
+/**
+ * The app's daemon status while a registered machine is the active one.
+ *
+ * An unreachable machine is an error status, not the absence of one, and that
+ * is the whole point: createRemoteDaemonLifecycle only falls through to the
+ * local daemon when there is no status here at all. A remote machine being
+ * down therefore cannot spawn a local daemon, because the code path that
+ * spawns one is never reached rather than being skipped by a condition.
+ */
+export function machineDaemonStatus(machine: AoMachine): DaemonStatus {
+	if (machine.reachability === "offline") {
+		const seen = formatLastSeen(machine.lastSeen);
+		return {
+			state: "error",
+			code: "daemon_unreachable",
+			message: seen
+				? `${machine.name} is not reachable. Last seen ${seen}.`
+				: `${machine.name} is not reachable, and has never connected to AO.`,
+		};
+	}
+	if (machine.reachability === "unknown") {
+		return { state: "starting", message: `Connecting to ${machine.name}…` };
+	}
+	return { state: "ready", baseUrl: machine.baseUrl, message: `Connected to ${machine.name}` };
+}
+
 export function createRemoteDaemonLifecycle(
 	config: RemoteDaemonConfig | null,
 	initialFailureStatus: DaemonStatus | null = null,
+	// The active registered machine's status, or null when this computer is the
+	// active machine. AO_REMOTE_URL is checked first so the env pairing hatch
+	// keeps behaving exactly as it did before machines existed.
+	activeMachineStatus: () => DaemonStatus | null = () => null,
 ) {
 	let failureStatus = initialFailureStatus;
 
-	const currentStatus = (): DaemonStatus | null => failureStatus ?? (config ? remoteDaemonReadyStatus(config) : null);
+	const currentStatus = (): DaemonStatus | null =>
+		failureStatus ?? (config ? remoteDaemonReadyStatus(config) : activeMachineStatus());
 	const applyRemoteStatus = (setStatus: SetDaemonStatus): DaemonStatus | null => {
 		const status = currentStatus();
 		if (status) setStatus(status);

--- a/frontend/src/preload.ts
+++ b/frontend/src/preload.ts
@@ -2,6 +2,7 @@ import { contextBridge, ipcRenderer } from "electron";
 import { FOCUS_TERMINAL_SHORTCUT_CHANNEL, KEYBOARD_SHORTCUTS_HELP_CHANNEL, NEXT_SESSION_SHORTCUT_CHANNEL, NEW_SESSION_SHORTCUT_CHANNEL, NEW_SHELL_TERMINAL_SHORTCUT_CHANNEL, OPEN_SETTINGS_SHORTCUT_CHANNEL, PREVIOUS_SESSION_SHORTCUT_CHANNEL } from "./shared/shortcuts";
 import type { BrowserNavState, BrowserRect } from "./main/browser-view-host";
 import type { AoAccountState } from "./shared/ao-account";
+import type { AoMachinesState } from "./shared/ao-machines";
 import type { DaemonStatus } from "./shared/daemon-status";
 import type { TelemetryBootstrap } from "./shared/telemetry";
 import type { MigrationState } from "./main/app-state";
@@ -232,6 +233,14 @@ const api = {
 		getState: () => ipcRenderer.invoke("aoAccount:getState") as Promise<AoAccountState>,
 		signIn: () => ipcRenderer.invoke("aoAccount:signIn") as Promise<AoAccountState>,
 		signOut: () => ipcRenderer.invoke("aoAccount:signOut") as Promise<AoAccountState>,
+	},
+	// The machine list and the picker. No URL and no token is ever typed into
+	// the app, so there is nothing here that takes either: the renderer picks an
+	// id out of a list the main process fetched.
+	machines: {
+		getState: () => ipcRenderer.invoke("aoMachines:getState") as Promise<AoMachinesState>,
+		refresh: () => ipcRenderer.invoke("aoMachines:refresh") as Promise<AoMachinesState>,
+		select: (machineId: string) => ipcRenderer.invoke("aoMachines:select", machineId) as Promise<AoMachinesState>,
 	},
 };
 

--- a/frontend/src/renderer/components/GlobalSettingsForm.tsx
+++ b/frontend/src/renderer/components/GlobalSettingsForm.tsx
@@ -5,6 +5,7 @@ import { ConnectMobileModal } from "./ConnectMobileModal";
 import { AccountSection } from "./settings/AccountSection";
 import { DeveloperModeSection } from "./settings/DeveloperModeSection";
 import { GeneralSettingsSection } from "./settings/GeneralSettingsSection";
+import { MachinesSection } from "./settings/MachinesSection";
 import { ReportProblemDialog } from "./settings/ReportProblemDialog";
 import { SettingsLinkRow } from "./settings/SettingsRow";
 import { SettingsPageShell } from "./settings/SettingsPageShell";
@@ -23,6 +24,7 @@ export function GlobalSettingsForm() {
 				<SettingsPanel onClose={() => navigate({ to: "/" })}>
 					<GeneralSettingsSection onConnectMobile={() => setMobileOpen(true)} />
 					<AccountSection />
+					<MachinesSection />
 					<UpdatesSection />
 					<DeveloperModeSection />
 					<SettingsSection title="Get help">

--- a/frontend/src/renderer/components/settings/MachinesSection.test.tsx
+++ b/frontend/src/renderer/components/settings/MachinesSection.test.tsx
@@ -1,0 +1,140 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, expect, test, vi } from "vitest";
+import { HARNESS_SETUP_COMMAND, LOCAL_MACHINE_ID, localMachine, type AoMachine, type AoMachinesState } from "../../../shared/ao-machines";
+import { MachinesSection } from "./MachinesSection";
+
+const { refresh, select, writeText } = vi.hoisted(() => ({
+	refresh: vi.fn(),
+	select: vi.fn(),
+	writeText: vi.fn(),
+}));
+
+vi.mock("../../lib/bridge", () => ({
+	aoBridge: { machines: { refresh, select }, clipboard: { writeText } },
+}));
+
+const remote = (extra: Partial<AoMachine> & Pick<AoMachine, "id" | "name" | "baseUrl">): AoMachine => ({
+	local: false,
+	createdAt: null,
+	lastSeen: null,
+	reachability: "online",
+	harness: "unknown",
+	harnessCommand: null,
+	...extra,
+});
+
+const ONLINE = remote({ id: "mch_1", name: "ao-build-01", baseUrl: "https://vm.example.com", harness: "ready" });
+const NO_HARNESS = remote({
+	id: "mch_2",
+	name: "ao-scratch",
+	baseUrl: "https://scratch.example.com",
+	harness: "missing",
+	harnessCommand: HARNESS_SETUP_COMMAND,
+});
+const OFFLINE = remote({
+	id: "mch_3",
+	name: "ao-eu-west",
+	baseUrl: "https://eu-west.example.com",
+	reachability: "offline",
+	lastSeen: "2020-01-01T09:00:00Z",
+});
+
+const READY: AoMachinesState = {
+	status: "ready",
+	machines: [localMachine("This Mac"), ONLINE, NO_HARNESS, OFFLINE],
+	activeMachineId: LOCAL_MACHINE_ID,
+};
+
+function renderSection() {
+	const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+	return render(
+		<QueryClientProvider client={client}>
+			<MachinesSection />
+		</QueryClientProvider>,
+	);
+}
+
+const machineRow = (id: string) => screen.getAllByTestId("ao-machine").find((row) => row.dataset.machineId === id)!;
+
+beforeEach(() => {
+	refresh.mockReset().mockResolvedValue(READY);
+	select.mockReset().mockResolvedValue({ ...READY, activeMachineId: "mch_1" });
+	writeText.mockReset().mockResolvedValue(undefined);
+});
+
+test("this computer is machine zero, listed first and active by default", async () => {
+	renderSection();
+	const rows = await screen.findAllByTestId("ao-machine");
+	expect(rows[0].dataset.machineId).toBe(LOCAL_MACHINE_ID);
+	expect(within(rows[0]).getByText("This Mac")).toBeInTheDocument();
+	expect(within(rows[0]).getByText("Active")).toBeInTheDocument();
+});
+
+test("signed out still lists this computer and says an account is only for remote machines", async () => {
+	refresh.mockResolvedValue({
+		status: "signed-out",
+		machines: [localMachine("This Mac")],
+		activeMachineId: LOCAL_MACHINE_ID,
+	} satisfies AoMachinesState);
+	renderSection();
+
+	expect(await screen.findByText("This Mac")).toBeInTheDocument();
+	expect(screen.getByText(/works without an account/i)).toBeInTheDocument();
+});
+
+test("an unreachable machine says it is offline and when it was last seen", async () => {
+	renderSection();
+	await screen.findAllByTestId("ao-machine");
+	const row = machineRow("mch_3");
+
+	expect(within(row).getByText("Offline")).toBeInTheDocument();
+	expect(within(row).getByText(/Offline, last seen .+ ago/)).toBeInTheDocument();
+});
+
+test("a machine with no harness shows exactly which command to run, and copies it", async () => {
+	renderSection();
+	await screen.findAllByTestId("ao-machine");
+	const row = machineRow("mch_2");
+
+	const hint = within(row).getByTestId("ao-machine-harness-hint");
+	expect(hint).toHaveTextContent(`No agent harness on ao-scratch. Run ${HARNESS_SETUP_COMMAND} on that machine.`);
+
+	await userEvent.click(within(hint).getByRole("button", { name: /copy/i }));
+	expect(writeText).toHaveBeenCalledWith(HARNESS_SETUP_COMMAND);
+});
+
+test("a machine that is up and set up carries no state badge at all", async () => {
+	renderSection();
+	await screen.findAllByTestId("ao-machine");
+	const row = machineRow("mch_1");
+
+	expect(within(row).queryByText("Offline")).not.toBeInTheDocument();
+	expect(within(row).queryByText("No harness")).not.toBeInTheDocument();
+	expect(within(row).queryByTestId("ao-machine-harness-hint")).not.toBeInTheDocument();
+});
+
+test("picking a machine switches to it, and the active one cannot be re-picked", async () => {
+	renderSection();
+	await screen.findAllByTestId("ao-machine");
+
+	await userEvent.click(within(machineRow("mch_1")).getByRole("button"));
+	expect(select).toHaveBeenCalledWith("mch_1");
+
+	expect(await within(machineRow("mch_1")).findByText("Active")).toBeInTheDocument();
+	expect(within(machineRow("mch_1")).getByRole("button")).toBeDisabled();
+});
+
+test("a failure to list is shown, and this computer stays available", async () => {
+	refresh.mockResolvedValue({
+		status: "error",
+		machines: [localMachine("This Mac")],
+		activeMachineId: LOCAL_MACHINE_ID,
+		error: "The control plane returned 503 listing machines.",
+	} satisfies AoMachinesState);
+	renderSection();
+
+	expect(await screen.findByTestId("ao-machines-error")).toHaveTextContent(/503 listing machines/);
+	expect(within(machineRow(LOCAL_MACHINE_ID)).getByText("This Mac")).toBeInTheDocument();
+});

--- a/frontend/src/renderer/components/settings/MachinesSection.test.tsx
+++ b/frontend/src/renderer/components/settings/MachinesSection.test.tsx
@@ -105,6 +105,31 @@ test("a machine with no harness shows exactly which command to run, and copies i
 	expect(writeText).toHaveBeenCalledWith(HARNESS_SETUP_COMMAND);
 });
 
+test("readiness that is not reported is said once, not badged on every machine", async () => {
+	refresh.mockResolvedValue({
+		...READY,
+		machines: [localMachine("This Mac"), remote({ id: "mch_9", name: "ao-unknown", baseUrl: "https://u.example.com" })],
+	} satisfies AoMachinesState);
+	renderSection();
+
+	expect(await screen.findByTestId("ao-machines-harness-unknown")).toHaveTextContent(
+		/not reported for remote machines/,
+	);
+	expect(within(machineRow("mch_9")).queryByText("No harness")).not.toBeInTheDocument();
+	expect(within(machineRow("mch_9")).queryByTestId("ao-machine-harness-hint")).not.toBeInTheDocument();
+});
+
+test("nothing is said about readiness once every machine has reported", async () => {
+	refresh.mockResolvedValue({
+		...READY,
+		machines: [localMachine("This Mac"), ONLINE, NO_HARNESS],
+	} satisfies AoMachinesState);
+	renderSection();
+
+	await screen.findAllByTestId("ao-machine");
+	expect(screen.queryByTestId("ao-machines-harness-unknown")).not.toBeInTheDocument();
+});
+
 test("a machine that is up and set up carries no state badge at all", async () => {
 	renderSection();
 	await screen.findAllByTestId("ao-machine");

--- a/frontend/src/renderer/components/settings/MachinesSection.tsx
+++ b/frontend/src/renderer/components/settings/MachinesSection.tsx
@@ -1,0 +1,158 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { AlertTriangle, Check, Copy, Laptop, Loader2, Server } from "lucide-react";
+import { useState } from "react";
+import { aoBridge } from "../../lib/bridge";
+import { formatLastSeen, type AoMachine, type AoMachinesState } from "../../../shared/ao-machines";
+import { Badge } from "../ui/badge";
+import { Button } from "../ui/button";
+import { SettingsSection } from "./SettingsSection";
+
+export const aoMachinesQueryKey = ["ao-machines"] as const;
+
+/**
+ * The machine picker. One machine is active at a time, and switching re-points
+ * the app at that machine's base URL.
+ *
+ * This computer is machine zero: it is always in the list, it is always
+ * selectable, and it never needs an account. Everything below it is a machine
+ * registered with `ao setup-vm`, which is the only way one gets here. No URL
+ * and no token is ever typed into this app.
+ */
+export function MachinesSection() {
+	const queryClient = useQueryClient();
+	const query = useQuery({ queryKey: aoMachinesQueryKey, queryFn: () => aoBridge.machines.refresh() });
+	const apply = (next: AoMachinesState) => queryClient.setQueryData(aoMachinesQueryKey, next);
+
+	const select = useMutation({
+		mutationFn: (machineId: string) => aoBridge.machines.select(machineId),
+		onSuccess: apply,
+	});
+
+	const state = query.data;
+	const machines = state?.machines ?? [];
+	const activeMachineId = state?.activeMachineId ?? "";
+	const mutationError = select.error instanceof Error ? select.error.message : null;
+	const error = state?.error ?? mutationError;
+
+	return (
+		<SettingsSection title="Machines" sectionId="machines">
+			{machines.map((machine) => (
+				<MachineRow
+					key={machine.id}
+					machine={machine}
+					active={machine.id === activeMachineId}
+					busy={select.isPending}
+					onSelect={() => select.mutate(machine.id)}
+				/>
+			))}
+
+			{query.isLoading ? (
+				<p className="flex items-center gap-2 px-1 text-xs leading-row text-settings-muted">
+					<Loader2 className="size-icon-sm animate-spin" aria-hidden="true" />
+					Looking for machines registered to your account…
+				</p>
+			) : null}
+
+			<p className="px-1 text-xs leading-row text-settings-muted">
+				{state?.status === "signed-out"
+					? "Sign in to reach a machine you registered with `ao setup-vm`. This computer works without an account."
+					: "One machine is active at a time. Switching points this app at that machine."}
+			</p>
+
+			{error ? (
+				<p className="flex items-start gap-2 px-1 text-xs leading-row text-error" data-testid="ao-machines-error">
+					<AlertTriangle className="mt-0.5 size-icon-sm shrink-0" aria-hidden="true" />
+					<span>{error}</span>
+				</p>
+			) : null}
+		</SettingsSection>
+	);
+}
+
+function MachineRow({
+	machine,
+	active,
+	busy,
+	onSelect,
+}: {
+	machine: AoMachine;
+	active: boolean;
+	busy: boolean;
+	onSelect: () => void;
+}) {
+	const Icon = machine.local ? Laptop : Server;
+	const offline = machine.reachability === "offline";
+	const lastSeen = formatLastSeen(machine.lastSeen);
+	const detail = machine.local
+		? "Runs on this computer"
+		: offline
+			? lastSeen
+				? `Offline, last seen ${lastSeen}`
+				: "Offline, has never connected"
+			: new URL(machine.baseUrl).host;
+
+	return (
+		<div className="flex w-full flex-col gap-1.5" data-testid="ao-machine" data-machine-id={machine.id}>
+			<button
+				type="button"
+				onClick={onSelect}
+				disabled={busy || active}
+				aria-pressed={active}
+				className="settings-row-bar w-full text-left transition-colors hover:bg-settings-menu-selected disabled:hover:bg-transparent"
+			>
+				<div className="flex shrink-0 items-center gap-(--size-settings-row-icon-gap)">
+					<Icon className="size-icon-lg shrink-0 text-settings-muted" aria-hidden="true" />
+					<span className="whitespace-nowrap text-sm leading-5 text-settings-label">{machine.name}</span>
+				</div>
+				<div className="flex min-w-0 flex-1 items-center justify-end gap-2">
+					<span className="min-w-0 truncate text-control text-settings-muted">{detail}</span>
+					{offline ? <Badge variant="error">Offline</Badge> : null}
+					{machine.harness === "missing" ? <Badge variant="warning">No harness</Badge> : null}
+					{active ? (
+						<Badge variant="accent">
+							<Check className="size-3" aria-hidden="true" />
+							Active
+						</Badge>
+					) : null}
+				</div>
+			</button>
+
+			{machine.harness === "missing" && machine.harnessCommand ? (
+				<HarnessHint machineName={machine.name} command={machine.harnessCommand} />
+			) : null}
+		</div>
+	);
+}
+
+/**
+ * A registered machine with no agent harness cannot run an agent, so it says
+ * exactly which command to run on it rather than failing later with nothing to
+ * act on. The command runs on that machine, over SSH, not here.
+ */
+function HarnessHint({ machineName, command }: { machineName: string; command: string }) {
+	const [copied, setCopied] = useState(false);
+
+	return (
+		<div
+			className="flex items-center gap-2 rounded-md bg-raised px-3 py-2 text-xs leading-row text-settings-muted"
+			data-testid="ao-machine-harness-hint"
+		>
+			<span className="min-w-0 flex-1">
+				No agent harness on {machineName}. Run <code className="font-mono text-foreground">{command}</code> on that
+				machine.
+			</span>
+			<Button
+				type="button"
+				variant="ghost"
+				size="sm"
+				onClick={async () => {
+					await aoBridge.clipboard.writeText(command);
+					setCopied(true);
+				}}
+			>
+				{copied ? <Check className="size-icon-sm" aria-hidden="true" /> : <Copy className="size-icon-sm" aria-hidden="true" />}
+				{copied ? "Copied" : "Copy"}
+			</Button>
+		</div>
+	);
+}

--- a/frontend/src/renderer/components/settings/MachinesSection.tsx
+++ b/frontend/src/renderer/components/settings/MachinesSection.tsx
@@ -59,6 +59,16 @@ export function MachinesSection() {
 					: "One machine is active at a time. Switching points this app at that machine."}
 			</p>
 
+			{/* `ao doctor` is a local command with no HTTP route yet, so nothing
+			    carries a registered machine's readiness here. Saying so once beats
+			    a badge on every machine that would only mean "not asked". */}
+			{machines.some((machine) => !machine.local && machine.harness === "unknown") ? (
+				<p className="px-1 text-xs leading-row text-settings-muted" data-testid="ao-machines-harness-unknown">
+					Agent-harness readiness is not reported for remote machines yet. Run{" "}
+					<code className="font-mono">ao doctor</code> on the machine to check it.
+				</p>
+			) : null}
+
 			{error ? (
 				<p className="flex items-start gap-2 px-1 text-xs leading-row text-error" data-testid="ao-machines-error">
 					<AlertTriangle className="mt-0.5 size-icon-sm shrink-0" aria-hidden="true" />

--- a/frontend/src/renderer/lib/bridge.ts
+++ b/frontend/src/renderer/lib/bridge.ts
@@ -1,5 +1,12 @@
 import type { AoBridge } from "../../preload";
 import type { AoAccountState } from "../../shared/ao-account";
+import {
+	HARNESS_SETUP_COMMAND,
+	LOCAL_MACHINE_ID,
+	localMachine,
+	type AoMachine,
+	type AoMachinesState,
+} from "../../shared/ao-machines";
 import { DEFAULT_CONTROL_PLANE_URL } from "../../shared/control-plane";
 export type { FeatureBuild } from "../../main/feature-builds";
 
@@ -8,6 +15,52 @@ const BROWSER_PREVIEW_ACCOUNT_STATE: AoAccountState = {
 	controlPlaneUrl: DEFAULT_CONTROL_PLANE_URL,
 	error: "Signing in needs the desktop app; it is not available in browser preview.",
 };
+
+// Browser preview has no main process, so the machine list cannot be fetched.
+// These stand in for it, and they are also what `ao preview` renders when the
+// machine picker is being reviewed: this computer, a registered machine with no
+// agent harness, and a machine that is down.
+const previewRemoteMachine = (machine: Partial<AoMachine> & Pick<AoMachine, "id" | "name" | "baseUrl">): AoMachine => ({
+	local: false,
+	createdAt: null,
+	lastSeen: null,
+	reachability: "online",
+	harness: "unknown",
+	harnessCommand: null,
+	...machine,
+});
+
+const BROWSER_PREVIEW_MACHINES: AoMachine[] = [
+	localMachine("This Mac"),
+	previewRemoteMachine({
+		id: "mch_ready",
+		name: "ao-build-01",
+		baseUrl: "https://vm.example.com",
+		harness: "ready",
+	}),
+	previewRemoteMachine({
+		id: "mch_no_harness",
+		name: "ao-scratch",
+		baseUrl: "https://scratch.example.com",
+		harness: "missing",
+		harnessCommand: HARNESS_SETUP_COMMAND,
+	}),
+	previewRemoteMachine({
+		id: "mch_offline",
+		name: "ao-eu-west",
+		baseUrl: "https://eu-west.example.com",
+		reachability: "offline",
+		lastSeen: new Date(Date.now() - 3 * 60 * 60 * 1000).toISOString(),
+	}),
+];
+
+let previewActiveMachineId = LOCAL_MACHINE_ID;
+
+const browserPreviewMachinesState = (): AoMachinesState => ({
+	status: "ready",
+	machines: BROWSER_PREVIEW_MACHINES,
+	activeMachineId: previewActiveMachineId,
+});
 
 export const aoBridge: AoBridge =
 	window.ao ??
@@ -158,5 +211,13 @@ export const aoBridge: AoBridge =
 			getState: async () => BROWSER_PREVIEW_ACCOUNT_STATE,
 			signIn: async () => BROWSER_PREVIEW_ACCOUNT_STATE,
 			signOut: async () => BROWSER_PREVIEW_ACCOUNT_STATE,
+		},
+		machines: {
+			getState: async () => browserPreviewMachinesState(),
+			refresh: async () => browserPreviewMachinesState(),
+			select: async (machineId: string) => {
+				previewActiveMachineId = machineId;
+				return browserPreviewMachinesState();
+			},
 		},
 	} satisfies AoBridge);

--- a/frontend/src/renderer/test/setup.ts
+++ b/frontend/src/renderer/test/setup.ts
@@ -1,8 +1,17 @@
 import "@testing-library/jest-dom/vitest";
 import type { AoAccountState } from "../../shared/ao-account";
+import { LOCAL_MACHINE_ID, localMachine, type AoMachinesState } from "../../shared/ao-machines";
 import { DEFAULT_CONTROL_PLANE_URL } from "../../shared/control-plane";
 
 const signedOutAoAccount: AoAccountState = { status: "signed-out", controlPlaneUrl: DEFAULT_CONTROL_PLANE_URL };
+
+// Signed out is the default everywhere in tests, and this computer is still the
+// active machine: local use never requires an account.
+const signedOutAoMachines: AoMachinesState = {
+	status: "signed-out",
+	machines: [localMachine("This Mac")],
+	activeMachineId: LOCAL_MACHINE_ID,
+};
 
 // Guard: src/main/** tests run in the Node.js environment (no DOM). vitest still
 // routes setupFiles here, so only install the DOM stubs when a DOM exists.
@@ -194,6 +203,11 @@ if (typeof window !== "undefined") {
 			getState: async () => signedOutAoAccount,
 			signIn: async () => signedOutAoAccount,
 			signOut: async () => signedOutAoAccount,
+		},
+		machines: {
+			getState: async () => signedOutAoMachines,
+			refresh: async () => signedOutAoMachines,
+			select: async () => signedOutAoMachines,
 		},
 	};
 } // end if (typeof window !== "undefined")

--- a/frontend/src/shared/ao-machines.test.ts
+++ b/frontend/src/shared/ao-machines.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "vitest";
 import {
 	HARNESS_SETUP_COMMAND,
 	LOCAL_MACHINE_ID,
+	harnessFromDoctorChecks,
 	formatLastSeen,
 	localMachine,
 	parseMachineOrigin,
@@ -34,29 +35,41 @@ describe("parseMachinesResponse", () => {
 		]);
 	});
 
-	test("a machine with no harness reports the exact command to run", () => {
-		const [machine] = parseMachinesResponse({ machines: [row({ harness: { ready: false } })] });
-		expect(machine.harness).toBe("missing");
-		expect(machine.harnessCommand).toBe(HARNESS_SETUP_COMMAND);
-	});
-
-	test("a harness command the control plane supplies wins over the default", () => {
+	test("a machine with no harness reports the command the doctor check names", () => {
 		const [machine] = parseMachinesResponse({
-			machines: [row({ harness: { ready: false, command: "ao vm setup-harness codex" } })],
+			machines: [
+				row({
+					doctor: {
+						checks: [
+							{ level: "PASS", section: "Core", name: "daemon" },
+							{
+								level: "WARN",
+								section: "Agent harnesses",
+								name: "claude-auth",
+								message: "claude is installed but not signed in",
+								remediation: "ao vm setup-harness claude",
+							},
+						],
+					},
+				}),
+			],
 		});
-		expect(machine.harnessCommand).toBe("ao vm setup-harness codex");
+		expect(machine.harness).toBe("missing");
+		expect(machine.harnessCommand).toBe("ao vm setup-harness claude");
 	});
 
-	test("a ready harness carries no command", () => {
-		const [machine] = parseMachinesResponse({ machines: [row({ harness: { ready: true } })] });
+	test("a signed-in harness is ready and carries no command", () => {
+		const [machine] = parseMachinesResponse({
+			machines: [row({ doctor: { checks: [{ level: "PASS", name: "claude-auth" }] } })],
+		});
 		expect(machine).toMatchObject({ harness: "ready", harnessCommand: null });
 	});
 
-	// Readiness comes from task 11's `ao doctor` surfacing, which may not be on
-	// this route yet. Absent must never be read as "missing" or as "ready".
-	test("an absent harness field degrades to unknown rather than claiming either state", () => {
-		for (const harness of [undefined, null, {}, "ready", { ready: "yes" }]) {
-			const [machine] = parseMachinesResponse({ machines: [row({ harness })] });
+	// `ao doctor` has no HTTP route yet, so this is what every registered
+	// machine looks like today. Absent must never read as "missing" or "ready".
+	test("readiness that is simply not available degrades to unknown", () => {
+		for (const doctor of [undefined, null, {}, { checks: [] }, { checks: [{ level: "PASS", name: "codex" }] }]) {
+			const [machine] = parseMachinesResponse({ machines: [row({ doctor })] });
 			expect(machine).toMatchObject({ harness: "unknown", harnessCommand: null });
 		}
 	});
@@ -132,5 +145,36 @@ describe("formatLastSeen", () => {
 	test("has nothing to say about a machine that has never been seen", () => {
 		expect(formatLastSeen(null, now)).toBeNull();
 		expect(formatLastSeen("not a date", now)).toBeNull();
+	});
+});
+
+describe("harnessFromDoctorChecks", () => {
+	const warn = (extra: Record<string, unknown> = {}) => [
+		{ level: "WARN", section: "Agent harnesses", name: "claude-auth", ...extra },
+	];
+
+	test("every non-PASS level is a missing harness, since the check never fails", () => {
+		// The check emits WARN for a missing binary, a missing login, and an
+		// unreadable answer alike, and deliberately never FAIL.
+		expect(harnessFromDoctorChecks(warn())).toMatchObject({ harness: "missing" });
+		expect(harnessFromDoctorChecks([{ level: "FAIL", name: "claude-auth" }])).toMatchObject({ harness: "missing" });
+	});
+
+	test("falls back to the documented command only when the check names none", () => {
+		expect(harnessFromDoctorChecks(warn({ remediation: "  " })).harnessCommand).toBe(HARNESS_SETUP_COMMAND);
+		expect(harnessFromDoctorChecks(warn({ remediation: "ao vm setup-harness claude --force" })).harnessCommand).toBe(
+			"ao vm setup-harness claude --force",
+		);
+	});
+
+	test("accepts a bare checks array as well as the whole doctor report", () => {
+		expect(harnessFromDoctorChecks(warn())).toMatchObject({ harness: "missing" });
+		expect(harnessFromDoctorChecks({ ok: true, failures: 0, checks: warn() })).toMatchObject({ harness: "missing" });
+	});
+
+	test("says nothing when there is no report to read", () => {
+		for (const raw of [undefined, null, "PASS", 7, { checks: "nope" }]) {
+			expect(harnessFromDoctorChecks(raw)).toMatchObject({ harness: "unknown", harnessCommand: null });
+		}
 	});
 });

--- a/frontend/src/shared/ao-machines.test.ts
+++ b/frontend/src/shared/ao-machines.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, test } from "vitest";
+import {
+	HARNESS_SETUP_COMMAND,
+	LOCAL_MACHINE_ID,
+	formatLastSeen,
+	localMachine,
+	parseMachineOrigin,
+	parseMachinesResponse,
+} from "./ao-machines";
+
+const row = (extra: Record<string, unknown> = {}) => ({
+	id: "mch_1",
+	name: "ao-build-01",
+	public_url: "https://vm.example.com",
+	created_at: "2026-07-01T10:00:00Z",
+	last_seen: "2026-07-30T09:00:00Z",
+	...extra,
+});
+
+describe("parseMachinesResponse", () => {
+	test("reads the control plane's list shape", () => {
+		expect(parseMachinesResponse({ machines: [row()] })).toEqual([
+			{
+				id: "mch_1",
+				name: "ao-build-01",
+				baseUrl: "https://vm.example.com",
+				local: false,
+				createdAt: "2026-07-01T10:00:00Z",
+				lastSeen: "2026-07-30T09:00:00Z",
+				reachability: "unknown",
+				harness: "unknown",
+				harnessCommand: null,
+			},
+		]);
+	});
+
+	test("a machine with no harness reports the exact command to run", () => {
+		const [machine] = parseMachinesResponse({ machines: [row({ harness: { ready: false } })] });
+		expect(machine.harness).toBe("missing");
+		expect(machine.harnessCommand).toBe(HARNESS_SETUP_COMMAND);
+	});
+
+	test("a harness command the control plane supplies wins over the default", () => {
+		const [machine] = parseMachinesResponse({
+			machines: [row({ harness: { ready: false, command: "ao vm setup-harness codex" } })],
+		});
+		expect(machine.harnessCommand).toBe("ao vm setup-harness codex");
+	});
+
+	test("a ready harness carries no command", () => {
+		const [machine] = parseMachinesResponse({ machines: [row({ harness: { ready: true } })] });
+		expect(machine).toMatchObject({ harness: "ready", harnessCommand: null });
+	});
+
+	// Readiness comes from task 11's `ao doctor` surfacing, which may not be on
+	// this route yet. Absent must never be read as "missing" or as "ready".
+	test("an absent harness field degrades to unknown rather than claiming either state", () => {
+		for (const harness of [undefined, null, {}, "ready", { ready: "yes" }]) {
+			const [machine] = parseMachinesResponse({ machines: [row({ harness })] });
+			expect(machine).toMatchObject({ harness: "unknown", harnessCommand: null });
+		}
+	});
+
+	test("last_seen is optional, and a machine that has never connected reports null", () => {
+		const [machine] = parseMachinesResponse({ machines: [row({ last_seen: null })] });
+		expect(machine.lastSeen).toBeNull();
+	});
+
+	test("falls back to the host when the control plane has no name for a machine", () => {
+		const [machine] = parseMachinesResponse({ machines: [row({ name: "  " })] });
+		expect(machine.name).toBe("vm.example.com");
+	});
+
+	test("drops rows the app could not point itself at, keeping the rest", () => {
+		const body = {
+			machines: [
+				row({ id: "mch_ok" }),
+				row({ id: "", public_url: "https://a.example.com" }),
+				row({ id: "mch_path", public_url: "https://b.example.com/api" }),
+				row({ id: "mch_scheme", public_url: "ftp://c.example.com" }),
+				row({ id: "mch_creds", public_url: "https://user:pw@d.example.com" }),
+				// "local" is machine zero's id and can never come from the network.
+				row({ id: LOCAL_MACHINE_ID, public_url: "https://e.example.com" }),
+				"not an object",
+			],
+		};
+		expect(parseMachinesResponse(body).map((machine) => machine.id)).toEqual(["mch_ok"]);
+	});
+
+	test("a body without a machines array is an empty list, not a throw", () => {
+		for (const body of [null, undefined, {}, { machines: null }, { machines: "nope" }]) {
+			expect(parseMachinesResponse(body)).toEqual([]);
+		}
+	});
+});
+
+describe("parseMachineOrigin", () => {
+	test("accepts a bare host and an origin, and strips a trailing slash", () => {
+		expect(parseMachineOrigin("vm.example.com")).toBe("https://vm.example.com");
+		expect(parseMachineOrigin("https://vm.example.com/")).toBe("https://vm.example.com");
+		expect(parseMachineOrigin(" https://vm.example.com ")).toBe("https://vm.example.com");
+	});
+
+	test("rejects anything that is not a bare origin", () => {
+		for (const raw of ["", "   ", "https://vm.example.com/api", "https://vm.example.com?x=1", "ftp://vm", 7, null]) {
+			expect(parseMachineOrigin(raw)).toBeNull();
+		}
+	});
+});
+
+describe("localMachine", () => {
+	test("is machine zero, needs no account, and is reachable by definition", () => {
+		expect(localMachine("This Mac")).toMatchObject({
+			id: LOCAL_MACHINE_ID,
+			name: "This Mac",
+			local: true,
+			baseUrl: "",
+			reachability: "online",
+		});
+	});
+});
+
+describe("formatLastSeen", () => {
+	const now = Date.parse("2026-07-30T12:00:00Z");
+
+	test("reports how long ago the control plane last saw the machine", () => {
+		expect(formatLastSeen("2026-07-30T11:57:00Z", now)).toMatch(/3 minutes ago/);
+		expect(formatLastSeen("2026-07-30T09:00:00Z", now)).toMatch(/3 hours ago/);
+		expect(formatLastSeen("2026-07-26T12:00:00Z", now)).toMatch(/4 days ago/);
+	});
+
+	test("has nothing to say about a machine that has never been seen", () => {
+		expect(formatLastSeen(null, now)).toBeNull();
+		expect(formatLastSeen("not a date", now)).toBeNull();
+	});
+});

--- a/frontend/src/shared/ao-machines.ts
+++ b/frontend/src/shared/ao-machines.ts
@@ -99,26 +99,59 @@ function optionalIso(raw: unknown): string | null {
 	return Number.isNaN(Date.parse(raw)) ? null : raw;
 }
 
+/** One check from `ao doctor --json` (backend/internal/cli/doctor.go). */
+export type DoctorCheck = {
+	level?: unknown;
+	section?: unknown;
+	name?: unknown;
+	message?: unknown;
+	/** The one command that fixes this check, when a single command does. */
+	remediation?: unknown;
+};
+
+/** The check that answers whether an agent harness is set up on a machine. */
+export const HARNESS_DOCTOR_CHECK = "claude-auth";
+
+type HarnessReadiness = Pick<AoMachine, "harness" | "harnessCommand">;
+
+const HARNESS_UNKNOWN: HarnessReadiness = { harness: "unknown", harnessCommand: null };
+
 /**
- * Harness readiness for one machine, from an optional `harness` object on the
- * row: `{"ready": false, "command": "ao vm setup-harness claude"}`.
+ * Harness readiness from a machine's `ao doctor --json` checks.
  *
- * Readiness itself is produced by the machine's own `ao doctor` checks, which
- * task 11 (issue #30) is adding in parallel; how the control plane will carry
- * that summary on this route is not settled yet. So the field is read when it
- * is there and the state is "unknown" when it is not. Unknown deliberately
- * claims nothing: it neither tells a user to run a command they may not need,
- * nor reports a harness as ready without having checked.
+ * The `claude-auth` check is the whole signal: it asks the harness itself
+ * rather than guessing where its credentials live. PASS is signed in; anything
+ * else is a WARN, which the check emits for a missing binary, a missing login,
+ * and an unreadable answer alike. It never returns FAIL, so nothing here
+ * branches on FAIL. The command shown comes from the check's `remediation`
+ * field, which exists precisely so this does not have to hardcode one.
  */
-function parseHarness(raw: unknown): Pick<AoMachine, "harness" | "harnessCommand"> {
-	if (!raw || typeof raw !== "object") return { harness: "unknown", harnessCommand: null };
-	const { ready, command } = raw as { ready?: unknown; command?: unknown };
-	if (typeof ready !== "boolean") return { harness: "unknown", harnessCommand: null };
-	if (ready) return { harness: "ready", harnessCommand: null };
-	return {
-		harness: "missing",
-		harnessCommand: typeof command === "string" && command.trim() ? command.trim() : HARNESS_SETUP_COMMAND,
-	};
+export function harnessFromDoctorChecks(raw: unknown): HarnessReadiness {
+	const checks = Array.isArray(raw) ? raw : (raw as { checks?: unknown } | null | undefined)?.checks;
+	if (!Array.isArray(checks)) return HARNESS_UNKNOWN;
+	const check = checks.find(
+		(candidate): candidate is DoctorCheck =>
+			!!candidate && typeof candidate === "object" && (candidate as DoctorCheck).name === HARNESS_DOCTOR_CHECK,
+	);
+	if (!check || typeof check.level !== "string") return HARNESS_UNKNOWN;
+	if (check.level === "PASS") return { harness: "ready", harnessCommand: null };
+	const remediation = typeof check.remediation === "string" ? check.remediation.trim() : "";
+	return { harness: "missing", harnessCommand: remediation || HARNESS_SETUP_COMMAND };
+}
+
+/**
+ * Where a machine's harness readiness comes from. The one seam to change when
+ * the data source moves.
+ *
+ * Today `ao doctor` is a local CLI surface with no HTTP route, so nothing
+ * carries a registered machine's checks to this app and this is "unknown" for
+ * every one of them. Unknown deliberately claims nothing: it neither tells a
+ * user to run a command they may not need, nor reports a harness as ready
+ * without having checked. When the daemon route lands, read the checks here;
+ * no caller and nothing in the UI changes.
+ */
+export function readMachineHarness(row: { doctor?: unknown }): HarnessReadiness {
+	return harnessFromDoctorChecks(row.doctor);
 }
 
 function parseMachine(raw: unknown): AoMachine | null {
@@ -140,7 +173,7 @@ function parseMachine(raw: unknown): AoMachine | null {
 		lastSeen: optionalIso(row.last_seen),
 		// Filled in by the liveness probe; the control plane does not know.
 		reachability: "unknown",
-		...parseHarness(row.harness),
+		...readMachineHarness(row),
 	};
 }
 

--- a/frontend/src/shared/ao-machines.ts
+++ b/frontend/src/shared/ao-machines.ts
@@ -1,0 +1,181 @@
+/**
+ * The machines the desktop app can point itself at: this computer, plus the
+ * machines the signed-in account has registered with the control plane.
+ *
+ * The registered ones come from `GET /api/v1/machines`, which accepts only a
+ * control-plane-audience access token (see controlplane/TOKEN_CONTRACT.md,
+ * "The two audiences"). This module is the pure part: shapes and parsing, no
+ * I/O, so the main process owns the fetch and the renderer owns the rendering.
+ */
+
+/** Machine zero. Never comes from the control plane and never needs an account. */
+export const LOCAL_MACHINE_ID = "local";
+
+/** What a user runs on the machine itself when no agent harness is set up. */
+export const HARNESS_SETUP_COMMAND = "ao vm setup-harness claude";
+
+/** Whether the machine answered a liveness probe on this refresh. */
+export type AoMachineReachability = "unknown" | "online" | "offline";
+
+/** Whether an agent harness is set up on the machine. */
+export type AoMachineHarness = "ready" | "missing" | "unknown";
+
+export type AoMachine = {
+	id: string;
+	name: string;
+	/** HTTPS origin of the machine's gateway, with no trailing slash. Empty for the local machine. */
+	baseUrl: string;
+	/** True only for machine zero, which is this computer. */
+	local: boolean;
+	/** ISO 8601, or null when the control plane did not report one. */
+	createdAt: string | null;
+	/** ISO 8601 of the last contact the control plane recorded, or null for never. */
+	lastSeen: string | null;
+	reachability: AoMachineReachability;
+	harness: AoMachineHarness;
+	/** The exact command to run on the machine. Set when `harness` is "missing". */
+	harnessCommand: string | null;
+};
+
+export type AoMachinesStatus =
+	// No account, so there is nothing to list. The local machine is still offered.
+	| "signed-out"
+	| "loading"
+	| "ready"
+	// The list could not be fetched. `error` says why; the local machine still works.
+	| "error";
+
+export type AoMachinesState = {
+	status: AoMachinesStatus;
+	/** Always non-empty: the local machine is index zero, signed in or not. */
+	machines: AoMachine[];
+	activeMachineId: string;
+	/** Last failure listing machines. Never contains a token. */
+	error?: string;
+};
+
+/** Machine zero, always present. Local use never requires an account. */
+export function localMachine(name: string): AoMachine {
+	return {
+		id: LOCAL_MACHINE_ID,
+		name,
+		baseUrl: "",
+		local: true,
+		createdAt: null,
+		lastSeen: null,
+		// This computer is reachable by definition: the app is running on it.
+		reachability: "online",
+		// Local harness state is already covered by `ao doctor` on this machine
+		// and by the agent pickers, so the machine list does not restate it.
+		harness: "unknown",
+		harnessCommand: null,
+	};
+}
+
+/**
+ * Normalize a machine's public URL to a bare origin.
+ *
+ * The control plane already stores it normalized (its `normalizePublicURL`), so
+ * this mostly guards against a row that predates that or was written by hand: a
+ * value with a path, credentials, or a scheme the renderer cannot talk to is
+ * rejected rather than turned into a base URL the app would then point at.
+ */
+export function parseMachineOrigin(raw: unknown): string | null {
+	if (typeof raw !== "string" || !raw.trim()) return null;
+	const candidate = raw.trim();
+	let url: URL;
+	try {
+		url = new URL(candidate.includes("://") ? candidate : `https://${candidate}`);
+	} catch {
+		return null;
+	}
+	if (url.protocol !== "https:" && url.protocol !== "http:") return null;
+	if (url.pathname !== "/" || url.search || url.hash || url.username || url.password) return null;
+	return url.origin;
+}
+
+function optionalIso(raw: unknown): string | null {
+	if (typeof raw !== "string" || !raw.trim()) return null;
+	return Number.isNaN(Date.parse(raw)) ? null : raw;
+}
+
+/**
+ * Harness readiness for one machine, from an optional `harness` object on the
+ * row: `{"ready": false, "command": "ao vm setup-harness claude"}`.
+ *
+ * Readiness itself is produced by the machine's own `ao doctor` checks, which
+ * task 11 (issue #30) is adding in parallel; how the control plane will carry
+ * that summary on this route is not settled yet. So the field is read when it
+ * is there and the state is "unknown" when it is not. Unknown deliberately
+ * claims nothing: it neither tells a user to run a command they may not need,
+ * nor reports a harness as ready without having checked.
+ */
+function parseHarness(raw: unknown): Pick<AoMachine, "harness" | "harnessCommand"> {
+	if (!raw || typeof raw !== "object") return { harness: "unknown", harnessCommand: null };
+	const { ready, command } = raw as { ready?: unknown; command?: unknown };
+	if (typeof ready !== "boolean") return { harness: "unknown", harnessCommand: null };
+	if (ready) return { harness: "ready", harnessCommand: null };
+	return {
+		harness: "missing",
+		harnessCommand: typeof command === "string" && command.trim() ? command.trim() : HARNESS_SETUP_COMMAND,
+	};
+}
+
+function parseMachine(raw: unknown): AoMachine | null {
+	if (!raw || typeof raw !== "object") return null;
+	const row = raw as Record<string, unknown>;
+	const id = typeof row.id === "string" ? row.id.trim() : "";
+	if (!id || id === LOCAL_MACHINE_ID) return null;
+	const baseUrl = parseMachineOrigin(row.public_url);
+	// A row the app cannot point itself at is not offerable, and offering it
+	// would mean a picker entry that silently does nothing when clicked.
+	if (!baseUrl) return null;
+	const name = typeof row.name === "string" && row.name.trim() ? row.name.trim() : new URL(baseUrl).hostname;
+	return {
+		id,
+		name,
+		baseUrl,
+		local: false,
+		createdAt: optionalIso(row.created_at),
+		lastSeen: optionalIso(row.last_seen),
+		// Filled in by the liveness probe; the control plane does not know.
+		reachability: "unknown",
+		...parseHarness(row.harness),
+	};
+}
+
+/**
+ * Parse the `GET /api/v1/machines` body. Unusable rows are dropped rather than
+ * failing the whole list, so one malformed registration does not hide every
+ * other machine the account owns.
+ */
+export function parseMachinesResponse(body: unknown): AoMachine[] {
+	const rows = (body as { machines?: unknown } | null | undefined)?.machines;
+	if (!Array.isArray(rows)) return [];
+	return rows.map(parseMachine).filter((machine): machine is AoMachine => machine !== null);
+}
+
+const SECOND_MS = 1000;
+const MINUTE_MS = 60 * SECOND_MS;
+const HOUR_MS = 60 * MINUTE_MS;
+const DAY_MS = 24 * HOUR_MS;
+
+// unit, its length in ms, and how many of it before the next unit reads better.
+const RELATIVE_UNITS: Array<[Intl.RelativeTimeFormatUnit, number, number]> = [
+	["second", SECOND_MS, 60],
+	["minute", MINUTE_MS, 60],
+	["hour", HOUR_MS, 24],
+];
+
+/** "3 minutes ago", or null when the machine has never been seen. */
+export function formatLastSeen(lastSeen: string | null, now = Date.now()): string | null {
+	if (!lastSeen) return null;
+	const at = Date.parse(lastSeen);
+	if (Number.isNaN(at)) return null;
+	const elapsed = Math.max(0, now - at);
+	const format = new Intl.RelativeTimeFormat(undefined, { numeric: "auto" });
+	for (const [unit, ms, limit] of RELATIVE_UNITS) {
+		if (elapsed < ms * limit) return format.format(-Math.round(elapsed / ms), unit);
+	}
+	return format.format(-Math.round(elapsed / DAY_MS), "day");
+}


### PR DESCRIPTION
Closes #31. Batch 4, task 12.

Lists the account's registered machines after login and lets the user pick one, from Settings → Machines.

## What this does

- **Lists the account's machines** from `GET /api/v1/machines` and offers them as a picker. No URL and no token is ever typed into the app.
- **"This Mac" is machine zero**, always present, always selectable, never gated behind sign-in. Signing out falls the app back to it rather than leaving it pointed at a machine it can no longer authenticate to.
- **One active machine at a time.** Switching re-points the renderer's base URL through the existing daemon-status handshake. Nothing is built toward two machines side by side.
- **An unreachable machine shows offline with its last-seen**, and cannot spawn a local daemon.
- **A machine with no harness shows the exact command to run**, with a copy button.

## The contract rule

`GET /api/v1/machines` takes a control-plane-audience access token and nothing else. `frontend/src/main/ao-control-token.ts` obtains one by exchanging the refresh token at `POST /api/v1/token`, per `controlplane/TOKEN_CONTRACT.md` → "The two audiences". Three properties are pinned by tests:

- The refresh token goes to the token endpoint and nowhere else: never a Bearer credential, never in a URL, never logged.
- The rotated replacement is persisted through `writeStoredAccount` **before** the access token is handed to a caller. The presented one is already revoked by then.
- Concurrent callers share one exchange, so a second caller cannot present a token the first already rotated away.

The liveness probe that decides offline sends no credential of any kind, which is also asserted.

## Why an offline machine structurally cannot spawn a local daemon

The app spawns a local daemon when it cannot reach one, so doing that because a remote VM is down would be wrong. This is not guarded by a conditional:

- `createRemoteDaemonLifecycle` takes the local start/refresh/stop functions as **arguments** and calls them only when it has no status of its own. An offline machine is an `error` status, not the absence of one, so the local path is never reached rather than being skipped by a check.
- The active machine's **whole record** is persisted to `~/.ao/ao-machine.json`, not just its id, and `restore()` runs **before the first `startDaemon()`**. With only an id, the window between launch and the first control-plane call would look exactly like "no machine is active", and the app would spawn a local daemon on a remote machine's behalf.

`frontend/src/main/remote-daemon.test.ts` asserts that refresh, start, and stop all return the offline status without calling any local function.

## Harness readiness, and what I assumed

Readiness is read from the `claude-auth` check that PR #33 added to `ao doctor --json`, using its `remediation` field as the command shown, with the documented `ao vm setup-harness claude` only as a fallback when the check names none. PASS is signed in; every other level is a missing harness, since that check deliberately never returns FAIL.

**`ao doctor` has no HTTP route today**, so nothing carries a registered machine's checks to this app and readiness is `unknown` for every remote machine right now. Unknown claims nothing in either direction: it does not tell a user to run a command they may not need, and it does not report a harness as ready without having checked. The section says so once, rather than badging every machine with what would only mean "not asked".

`readMachineHarness` in `frontend/src/shared/ao-machines.ts` is the single seam. When the daemon route lands, it reads the checks from there and no caller and nothing in the UI changes.

## Left alone deliberately

- **`AO_REMOTE_URL` and `AO_REMOTE_TOKEN` are untouched and still take precedence** over a selected machine, with a test pinning that. They are removed in batch 5, not here.
- **No authenticated remote transport.** No Bearer on the daemon's REST or SSE, no `/mux` cookie, no silent background refresh. That is task 13, and until it lands a selected remote machine will 401 on daemon calls. Related, and worth flagging for task 13: the packaged renderer's CSP pins `connect-src` to `127.0.0.1`, so a remote origin needs a CSP decision there. That is pre-existing for the `AO_REMOTE_URL` path, which is why it is dev-only today.
- `controlplane/` and `backend/` are untouched. No HTTP surface changed, so `openapi.yaml` and `schema.ts` are unchanged.

## Docs cleanup

`docs/desktop-login-contract.md` duplicated the two-audience contract that `controlplane/TOKEN_CONTRACT.md` now owns. Collapsed to a pointer plus a table of which token the desktop uses where, keeping only the desktop-specific parts, and documenting `ao-machine.json`. `TOKEN_CONTRACT.md` is unchanged; it is the document that describes the contract.

## Verification

- `npm --prefix frontend run typecheck`, `typecheck:e2e`: clean.
- `npm --prefix frontend test`: 99 files, 1204 tests passing (46 new).
- Rendered through `ao preview http://localhost:5173/#/settings`. The list shows This Mac active, a ready machine, a no-harness machine with its command and copy button, and an offline machine with "Offline, last seen 3 hours ago"; clicking a machine moves the Active pill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)