### PR TITLE
feat(httpd): expose the ao doctor checks at GET /api/v1/doctor

### DIFF
--- a/backend/internal/cli/doctor.go
+++ b/backend/internal/cli/doctor.go
@@ -2,71 +2,20 @@ package cli
 
 import (
 	"context"
-	"encoding/json"
-	"errors"
 	"fmt"
-	"io"
-	"io/fs"
-	"net/http"
-	"os"
-	"path/filepath"
-	"regexp"
-	"runtime"
-	"strconv"
-	"strings"
-	"time"
 
 	"github.com/spf13/cobra"
 
-	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/codex"
-	"github.com/aoagents/agent-orchestrator/backend/internal/config"
+	"github.com/aoagents/agent-orchestrator/backend/internal/doctor"
 )
 
-type doctorLevel string
-
-const (
-	doctorPass doctorLevel = "PASS"
-	doctorWarn doctorLevel = "WARN"
-	doctorFail doctorLevel = "FAIL"
-)
-
-type doctorCheck struct {
-	Level   doctorLevel `json:"level"`
-	Section string      `json:"section,omitempty"`
-	Name    string      `json:"name"`
-	Message string      `json:"message"`
-	// Remediation is the one command that fixes this check, when a single
-	// command does. It exists so a consumer of `ao doctor --json` (the
-	// desktop's machine card) can show exactly what to run instead of parsing
-	// it back out of Message. Empty when there is no single command to name.
-	Remediation string `json:"remediation,omitempty"`
-}
-
+// doctorReport is the `ao doctor --json` document. The checks themselves come
+// from internal/doctor, which the daemon's GET /api/v1/doctor also calls; only
+// the framing (ok/failures counts, text grouping) is the CLI's.
 type doctorReport struct {
-	OK       bool          `json:"ok"`
-	Failures int           `json:"failures"`
-	Checks   []doctorCheck `json:"checks"`
-}
-
-const (
-	doctorSectionCore           = "Core"
-	doctorSectionTools          = "Tools"
-	doctorSectionAgents         = "Agent harnesses"
-	doctorSectionGitHub         = "GitHub"
-	minGitVersion               = "2.25.0"
-	githubDoctorUserAgent       = "ao-agent-orchestrator/doctor"
-	defaultDoctorGitHubRESTBase = "https://api.github.com"
-)
-
-type harnessProbe struct {
-	Name       string
-	BinaryName string
-	VersionArg string
-}
-
-var doctorHarnesses = []harnessProbe{
-	{Name: "claude-code", BinaryName: "claude", VersionArg: "--version"},
-	{Name: "codex", BinaryName: "codex", VersionArg: "--version"},
+	OK       bool           `json:"ok"`
+	Failures int            `json:"failures"`
+	Checks   []doctor.Check `json:"checks"`
 }
 
 func newDoctorCommand(ctx *commandContext) *cobra.Command {
@@ -79,7 +28,7 @@ func newDoctorCommand(ctx *commandContext) *cobra.Command {
 			checks := ctx.runDoctor(cmd.Context())
 			failures := 0
 			for _, check := range checks {
-				if check.Level == doctorFail {
+				if check.Level == doctor.Fail {
 					failures++
 				}
 			}
@@ -106,7 +55,7 @@ func newDoctorCommand(ctx *commandContext) *cobra.Command {
 	return cmd
 }
 
-func writeDoctorText(cmd *cobra.Command, checks []doctorCheck) error {
+func writeDoctorText(cmd *cobra.Command, checks []doctor.Check) error {
 	var lastSection string
 	for _, check := range checks {
 		if check.Section != "" && check.Section != lastSection {
@@ -127,529 +76,50 @@ func writeDoctorText(cmd *cobra.Command, checks []doctorCheck) error {
 	return nil
 }
 
-func (c *commandContext) runDoctor(ctx context.Context) []doctorCheck {
-	checks := []doctorCheck{}
+func (c *commandContext) runDoctor(ctx context.Context) []doctor.Check {
+	return doctor.Run(ctx, c.doctorDeps())
+}
 
-	cfg, err := config.Load()
-	if err != nil {
-		return append(checks, doctorCheck{Level: doctorFail, Section: doctorSectionCore, Name: "config", Message: err.Error()})
+// doctorDeps hands the shared check runner the CLI's own injectable side
+// effects, so `ao doctor` stays testable through Deps and the checks stay in
+// one place.
+func (c *commandContext) doctorDeps() doctor.Deps {
+	return doctor.Deps{
+		LookPath:       c.deps.LookPath,
+		CommandOutput:  c.deps.CommandOutput,
+		Executable:     c.deps.Executable,
+		HTTPClient:     c.deps.HTTPClient,
+		GitHubRESTBase: c.deps.DoctorGitHubRESTBase,
+		DaemonCheck:    c.doctorDaemonCheck,
 	}
-	checks = append(checks, doctorCheck{
-		Level: doctorPass, Section: doctorSectionCore, Name: "config",
-		Message: fmt.Sprintf("runFile=%s dataDir=%s port=%d", cfg.RunFilePath, cfg.DataDir, cfg.Port),
-	})
+}
 
-	if err := os.MkdirAll(cfg.DataDir, 0o750); err != nil {
-		checks = append(checks, doctorCheck{Level: doctorFail, Section: doctorSectionCore, Name: "data-dir", Message: err.Error()})
-	} else {
-		checks = append(checks,
-			doctorCheck{Level: doctorPass, Section: doctorSectionCore, Name: "data-dir", Message: cfg.DataDir},
-			checkDataDirWritable(cfg.DataDir),
-		)
-	}
-
-	checks = append(checks, checkStore(cfg.DataDir), checkHooksLog(cfg.DataDir, time.Now()))
-
+// doctorDaemonCheck is the CLI's answer to "is the daemon up": the same
+// run-file plus health-probe inspection `ao status` reports. The daemon's own
+// HTTP route answers this differently, which is why the check is injected
+// rather than living in internal/doctor.
+func (c *commandContext) doctorDaemonCheck(ctx context.Context) doctor.Check {
 	st, err := c.inspectDaemon(ctx)
 	if err != nil {
-		checks = append(checks, doctorCheck{Level: doctorFail, Section: doctorSectionCore, Name: "daemon", Message: err.Error()})
-	} else {
-		level := doctorPass
-		switch st.State {
-		case stateStale, stateNotReady:
-			level = doctorWarn
-		case stateUnhealthy:
-			level = doctorFail
-		}
-		msg := string(st.State)
-		if st.PID != 0 {
-			msg = fmt.Sprintf("%s pid=%d port=%d", msg, st.PID, st.Port)
-		}
-		if st.Error != "" {
-			msg += " (" + st.Error + ")"
-		}
-		checks = append(checks, doctorCheck{Level: level, Section: doctorSectionCore, Name: "daemon", Message: msg})
+		return doctor.Check{Level: doctor.Fail, Section: doctor.SectionCore, Name: "daemon", Message: err.Error()}
 	}
-
-	checks = append(checks,
-		c.checkGit(ctx),
-		c.checkTerminalRuntime(ctx),
-		c.checkAOBinary(),
-	)
-	for _, harness := range doctorHarnesses {
-		checks = append(checks, c.checkHarness(ctx, harness))
+	level := doctor.Pass
+	switch st.State {
+	case stateStale, stateNotReady:
+		level = doctor.Warn
+	case stateUnhealthy:
+		level = doctor.Fail
 	}
-	checks = append(checks, c.checkClaudeAuth(ctx), c.checkCodexLaunchFlags(ctx), c.checkGitHubToken(ctx))
-	return checks
+	msg := string(st.State)
+	if st.PID != 0 {
+		msg = fmt.Sprintf("%s pid=%d port=%d", msg, st.PID, st.Port)
+	}
+	if st.Error != "" {
+		msg += " (" + st.Error + ")"
+	}
+	return doctor.Check{Level: level, Section: doctor.SectionCore, Name: "daemon", Message: msg}
 }
 
-// checkClaudeAuth reports whether the claude harness has finished its own
-// login on this machine. `claude auth status --json` is the harness's own
-// machine-readable answer, so this reports the harness's state rather than
-// guessing at where its credentials live (a keychain entry on macOS, a file
-// elsewhere, or an environment variable). It is the readiness signal the
-// desktop reads for a machine card: a machine that is registered but has no
-// harness configured shows Remediation instead of failing silently.
-//
-// A missing login is a WARN, never a FAIL: plenty of machines run AO with a
-// different harness, or with none, and `ao doctor` must still exit 0 there.
-func (c *commandContext) checkClaudeAuth(ctx context.Context) doctorCheck {
-	const name = "claude-auth"
-	setupCmd := "ao vm setup-harness " + claudeHarnessName
-	warn := func(message string) doctorCheck {
-		return doctorCheck{
-			Level: doctorWarn, Section: doctorSectionAgents, Name: name,
-			Message: message, Remediation: setupCmd,
-		}
-	}
-
-	path, err := c.deps.LookPath(claudeHarnessName)
-	if err != nil || path == "" {
-		return warn(fmt.Sprintf("claude not found in PATH; install the Claude Code CLI, then run `%s`", setupCmd))
-	}
-	reqCtx, cancel := context.WithTimeout(ctx, probeTimeout)
-	defer cancel()
-	probe := strings.Join(claudeAuthStatusArgs, " ")
-	out, cmdErr := c.deps.CommandOutput(reqCtx, path, claudeAuthStatusArgs...)
-	// `claude auth status` exits non-zero when the harness is not logged in and
-	// still prints its JSON, so the output is what answers the question. A
-	// non-zero exit only matters when there is no parseable answer in it.
-	status, parseErr := parseClaudeAuthStatus(out)
-	if parseErr != nil {
-		reason := parseErr
-		if cmdErr != nil {
-			reason = cmdErr
-		}
-		return warn(fmt.Sprintf("could not read harness auth state (`claude %s`: %v); log in with `%s`", probe, reason, setupCmd))
-	}
-	if !status.LoggedIn {
-		return warn(fmt.Sprintf("%s is installed but not signed in; run `%s`", path, setupCmd))
-	}
-	return doctorCheck{
-		Level: doctorPass, Section: doctorSectionAgents, Name: name,
-		Message: fmt.Sprintf("%s is signed in (%s)", path, status.describe()),
-	}
-}
-
-type claudeAuthStatus struct {
-	LoggedIn    bool   `json:"loggedIn"`
-	AuthMethod  string `json:"authMethod"`
-	APIProvider string `json:"apiProvider"`
-}
-
-func (s claudeAuthStatus) describe() string {
-	method := strings.TrimSpace(s.AuthMethod)
-	if method == "" {
-		method = "unknown"
-	}
-	if provider := strings.TrimSpace(s.APIProvider); provider != "" {
-		return fmt.Sprintf("authMethod=%s apiProvider=%s", method, provider)
-	}
-	return "authMethod=" + method
-}
-
-// parseClaudeAuthStatus reads the JSON object out of `claude auth status
-// --json` output. It slices to the outermost braces first because the probe
-// runs through CombinedOutput, so an unrelated notice on stderr (an update
-// banner, a deprecation warning) would otherwise make valid JSON unparseable.
-func parseClaudeAuthStatus(out []byte) (claudeAuthStatus, error) {
-	clean := ansiRE.ReplaceAllString(string(out), "")
-	start, end := strings.Index(clean, "{"), strings.LastIndex(clean, "}")
-	if start < 0 || end < start {
-		return claudeAuthStatus{}, fmt.Errorf("no JSON object in output %q", strings.TrimSpace(clean))
-	}
-	var status claudeAuthStatus
-	if err := json.Unmarshal([]byte(clean[start:end+1]), &status); err != nil {
-		return claudeAuthStatus{}, err
-	}
-	return status, nil
-}
-
-// checkStore inspects the SQLite store WITHOUT opening or migrating it. The
-// daemon is the sole writer and migrator of the database (architecture.md §7);
-// the CLI must never run migrations or open a second writer against a database
-// a live daemon may already own. Migrations are validated by the daemon at
-// startup and surfaced through /readyz, so doctor only confirms whether the
-// database file exists yet.
-func checkStore(dataDir string) doctorCheck {
-	dbPath := filepath.Join(dataDir, "ao.db")
-	info, err := os.Stat(dbPath)
-	switch {
-	case err == nil:
-		return doctorCheck{
-			Level: doctorPass, Section: doctorSectionCore, Name: "sqlite",
-			Message: fmt.Sprintf("%s (%d bytes); migrations are applied by the daemon at startup", dbPath, info.Size()),
-		}
-	case errors.Is(err, fs.ErrNotExist):
-		return doctorCheck{
-			Level: doctorWarn, Section: doctorSectionCore, Name: "sqlite",
-			Message: "database not created yet; run `ao start` to initialize and migrate it",
-		}
-	default:
-		return doctorCheck{Level: doctorFail, Section: doctorSectionCore, Name: "sqlite", Message: err.Error()}
-	}
-}
-
-func checkDataDirWritable(dataDir string) doctorCheck {
-	f, err := os.CreateTemp(dataDir, ".ao-doctor-write-*")
-	if err != nil {
-		return doctorCheck{Level: doctorFail, Section: doctorSectionCore, Name: "data-dir-write", Message: err.Error()}
-	}
-	name := f.Name()
-	if _, err := f.WriteString("ok\n"); err != nil {
-		_ = f.Close()
-		_ = os.Remove(name)
-		return doctorCheck{Level: doctorFail, Section: doctorSectionCore, Name: "data-dir-write", Message: err.Error()}
-	}
-	if err := f.Close(); err != nil {
-		_ = os.Remove(name)
-		return doctorCheck{Level: doctorFail, Section: doctorSectionCore, Name: "data-dir-write", Message: err.Error()}
-	}
-	if err := os.Remove(name); err != nil {
-		return doctorCheck{Level: doctorWarn, Section: doctorSectionCore, Name: "data-dir-write", Message: fmt.Sprintf("write probe succeeded but cleanup failed: %v", err)}
-	}
-	return doctorCheck{Level: doctorPass, Section: doctorSectionCore, Name: "data-dir-write", Message: "write probe succeeded"}
-}
-
-// checkAOBinary verifies the `ao` that workspace hooks would invoke. Agent
-// adapters install hook commands as a bare `ao hooks <agent> <event>`, so an
-// `ao` earlier on PATH that is not this binary (e.g. a legacy CLI without the
-// hooks command) fails every callback and silently kills activity tracking.
-// The daemon pins PATH inside the sessions it spawns, so a mismatch here is a
-// warning about every other context (manual runs, foreign panes), not a hard
-// failure.
-func (c *commandContext) checkAOBinary() doctorCheck {
-	const name = "ao-binary"
-	self, err := c.deps.Executable()
-	if err != nil {
-		return doctorCheck{Level: doctorWarn, Section: doctorSectionTools, Name: name, Message: fmt.Sprintf("could not resolve the running executable: %v", err)}
-	}
-	onPath, err := c.deps.LookPath("ao")
-	if err != nil || onPath == "" {
-		return doctorCheck{
-			Level: doctorWarn, Section: doctorSectionTools, Name: name,
-			Message: "ao not found in PATH; workspace hooks invoke `ao hooks <agent> <event>` (daemon-spawned sessions pin PATH to the daemon binary and are unaffected)",
-		}
-	}
-	if sameBinary(self, onPath) {
-		return doctorCheck{Level: doctorPass, Section: doctorSectionTools, Name: name, Message: fmt.Sprintf("ao in PATH is this binary (%s)", onPath)}
-	}
-	return doctorCheck{
-		Level: doctorWarn, Section: doctorSectionTools, Name: name,
-		Message: fmt.Sprintf("ao in PATH is %s, not this binary (%s); workspace hooks run `ao hooks` and a foreign ao breaks activity tracking outside daemon-spawned sessions", onPath, self),
-	}
-}
-
-// sameBinary reports whether two paths name the same file, tolerating symlinks
-// via os.SameFile and falling back to cleaned-path equality when either stat
-// fails.
-func sameBinary(a, b string) bool {
-	ai, aErr := os.Stat(a)
-	bi, bErr := os.Stat(b)
-	if aErr == nil && bErr == nil {
-		return os.SameFile(ai, bi)
-	}
-	return filepath.Clean(a) == filepath.Clean(b)
-}
-
-func (c *commandContext) checkGit(ctx context.Context) doctorCheck {
-	path, err := c.deps.LookPath("git")
-	if err != nil || path == "" {
-		return doctorCheck{Level: doctorFail, Section: doctorSectionTools, Name: "git", Message: "not found in PATH"}
-	}
-	reqCtx, cancel := context.WithTimeout(ctx, probeTimeout)
-	defer cancel()
-	out, err := c.deps.CommandOutput(reqCtx, path, "--version")
-	if err != nil {
-		return doctorCheck{Level: doctorFail, Section: doctorSectionTools, Name: "git", Message: fmt.Sprintf("%s: %v", path, err)}
-	}
-	version, err := parseGitVersion(string(out))
-	if err != nil {
-		return doctorCheck{Level: doctorWarn, Section: doctorSectionTools, Name: "git", Message: fmt.Sprintf("%s (version unknown: %s)", path, firstOutputLine(out))}
-	}
-	cmp, err := compareDottedVersion(version, minGitVersion)
-	if err != nil {
-		return doctorCheck{Level: doctorWarn, Section: doctorSectionTools, Name: "git", Message: fmt.Sprintf("%s (version unknown: %s)", path, firstOutputLine(out))}
-	}
-	if cmp < 0 {
-		return doctorCheck{Level: doctorWarn, Section: doctorSectionTools, Name: "git", Message: fmt.Sprintf("%s (version %s; AO expects >= %s for worktrees)", path, version, minGitVersion)}
-	}
-	return doctorCheck{Level: doctorPass, Section: doctorSectionTools, Name: "git", Message: fmt.Sprintf("%s (version %s; supports worktrees)", path, version)}
-}
-
-// checkTerminalRuntime checks the runtime multiplexer used on this platform:
-// tmux on Darwin/Linux, ConPTY (built-in) on Windows.
-func (c *commandContext) checkTerminalRuntime(ctx context.Context) doctorCheck {
-	if runtime.GOOS == "windows" {
-		return doctorCheck{
-			Level:   doctorPass,
-			Section: doctorSectionTools,
-			Name:    "conpty",
-			Message: "ConPTY (built-in): no external terminal multiplexer required on Windows",
-		}
-	}
-	return c.checkTmux(ctx)
-}
-
-func (c *commandContext) checkTmux(ctx context.Context) doctorCheck {
-	path, err := c.deps.LookPath("tmux")
-	if err != nil || path == "" {
-		return doctorCheck{Level: doctorWarn, Section: doctorSectionTools, Name: "tmux", Message: "not found in PATH; required on macOS/Linux to start sessions"}
-	}
-	reqCtx, cancel := context.WithTimeout(ctx, probeTimeout)
-	defer cancel()
-	out, err := c.deps.CommandOutput(reqCtx, path, "-V")
-	if err != nil {
-		return doctorCheck{Level: doctorFail, Section: doctorSectionTools, Name: "tmux", Message: fmt.Sprintf("%s: %v", path, err)}
-	}
-	version := firstOutputLine(out)
-	if version == "" {
-		version = "version unknown"
-	}
-	return doctorCheck{Level: doctorPass, Section: doctorSectionTools, Name: "tmux", Message: fmt.Sprintf("%s (%s)", path, version)}
-}
-
-// checkHooksLog surfaces recent agent hook delivery failures. `ao hooks`
-// callbacks deliberately swallow errors (a hook must never break the user's
-// agent), so $AO_DATA_DIR/hooks.log is the only place a dead activity feed
-// becomes visible. Lines start with an RFC3339 timestamp (see appendHooksLog).
-func checkHooksLog(dataDir string, now time.Time) doctorCheck {
-	const name = "hooks-log"
-	path := filepath.Join(dataDir, hooksLogName)
-	data, err := os.ReadFile(path) //nolint:gosec // path rooted in AO's own data dir
-	if errors.Is(err, fs.ErrNotExist) {
-		return doctorCheck{Level: doctorPass, Section: doctorSectionCore, Name: name, Message: "no hook delivery failures recorded"}
-	}
-	if err != nil {
-		return doctorCheck{Level: doctorWarn, Section: doctorSectionCore, Name: name, Message: err.Error()}
-	}
-
-	recent := 0
-	latest := ""
-	for line := range strings.SplitSeq(string(data), "\n") {
-		line = strings.TrimSpace(line)
-		if line == "" {
-			continue
-		}
-		stamp, _, ok := strings.Cut(line, " ")
-		if !ok {
-			continue
-		}
-		ts, err := time.Parse(time.RFC3339, stamp)
-		if err != nil || now.Sub(ts) > 24*time.Hour {
-			continue
-		}
-		recent++
-		latest = line
-	}
-	if recent == 0 {
-		return doctorCheck{Level: doctorPass, Section: doctorSectionCore, Name: name, Message: fmt.Sprintf("no hook delivery failures in the last 24h (%s)", path)}
-	}
-	return doctorCheck{
-		Level: doctorWarn, Section: doctorSectionCore, Name: name,
-		Message: fmt.Sprintf("%d hook delivery failure(s) in the last 24h — activity tracking may be degraded; latest: %s (full log: %s)", recent, latest, path),
-	}
-}
-
-func (c *commandContext) checkHarness(ctx context.Context, harness harnessProbe) doctorCheck {
-	path, err := c.deps.LookPath(harness.BinaryName)
-	if err != nil || path == "" {
-		return doctorCheck{
-			Level: doctorWarn, Section: doctorSectionAgents, Name: harness.Name,
-			Message: fmt.Sprintf("%s not found in PATH", harness.BinaryName),
-		}
-	}
-	if harness.VersionArg == "" {
-		return doctorCheck{Level: doctorPass, Section: doctorSectionAgents, Name: harness.Name, Message: fmt.Sprintf("%s resolves to %s", harness.BinaryName, path)}
-	}
-	reqCtx, cancel := context.WithTimeout(ctx, probeTimeout)
-	defer cancel()
-	out, err := c.deps.CommandOutput(reqCtx, path, harness.VersionArg)
-	if err != nil {
-		return doctorCheck{
-			Level: doctorWarn, Section: doctorSectionAgents, Name: harness.Name,
-			Message: fmt.Sprintf("%s resolves to %s, but `%s %s` failed: %v", harness.BinaryName, path, harness.BinaryName, harness.VersionArg, err),
-		}
-	}
-	version := firstOutputLine(out)
-	if version == "" {
-		version = "version output was empty"
-	}
-	return doctorCheck{Level: doctorPass, Section: doctorSectionAgents, Name: harness.Name, Message: fmt.Sprintf("%s resolves to %s (%s)", harness.BinaryName, path, version)}
-}
-
-// checkCodexLaunchFlags smoke-tests AO's codex launch surface against the
-// installed binary: the hook-trust bypass flag and the `-c` session-flag
-// config AO injects at spawn (activity hooks, worktree trust, nudge
-// suppression). Codex has no stable hook-config contract, so a codex upgrade
-// can silently break activity tracking; this canary turns that breakage into
-// a doctor warning. The probes come from the codex adapter itself so they
-// cannot drift from the real spawn argv.
-func (c *commandContext) checkCodexLaunchFlags(ctx context.Context) doctorCheck {
-	const name = "codex-launch-flags"
-	path, err := c.deps.LookPath("codex")
-	if err != nil || path == "" {
-		return doctorCheck{Level: doctorPass, Section: doctorSectionAgents, Name: name, Message: "skipped: codex not found in PATH"}
-	}
-	for _, probe := range codex.DoctorLaunchProbes() {
-		reqCtx, cancel := context.WithTimeout(ctx, probeTimeout)
-		out, err := c.deps.CommandOutput(reqCtx, path, probe...)
-		cancel()
-		if err != nil {
-			return doctorCheck{
-				Level: doctorWarn, Section: doctorSectionAgents, Name: name,
-				Message: fmt.Sprintf("codex rejected AO's launch flags (`codex %s`: %v) — codex sessions may spawn without activity hooks; a codex CLI update likely changed its flag/config surface", strings.Join(probe, " "), err),
-			}
-		}
-		if strings.Contains(string(out), "unknown configuration field") {
-			return doctorCheck{
-				Level: doctorWarn, Section: doctorSectionAgents, Name: name,
-				Message: fmt.Sprintf("codex no longer recognizes one of AO's config overrides (%s) — codex sessions may spawn without activity hooks", firstOutputLine(out)),
-			}
-		}
-	}
-	return doctorCheck{Level: doctorPass, Section: doctorSectionAgents, Name: name, Message: "codex accepts AO's hook/trust launch flags"}
-}
-
-func (c *commandContext) checkGitHubToken(ctx context.Context) doctorCheck {
-	token, source, err := c.githubToken(ctx)
-	if err != nil {
-		return doctorCheck{Level: doctorWarn, Section: doctorSectionGitHub, Name: "github-token", Message: err.Error()}
-	}
-
-	reqCtx, cancel := context.WithTimeout(ctx, probeTimeout)
-	defer cancel()
-	req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, strings.TrimRight(c.deps.DoctorGitHubRESTBase, "/")+"/user", http.NoBody)
-	if err != nil {
-		return doctorCheck{Level: doctorFail, Section: doctorSectionGitHub, Name: "github-token", Message: err.Error()}
-	}
-	req.Header.Set("Accept", "application/vnd.github+json")
-	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
-	req.Header.Set("User-Agent", githubDoctorUserAgent)
-	req.Header.Set("Authorization", "Bearer "+token)
-	resp, err := c.deps.HTTPClient.Do(req)
-	if err != nil {
-		return doctorCheck{Level: doctorFail, Section: doctorSectionGitHub, Name: "github-token", Message: fmt.Sprintf("%s token validation failed: %v", source, err)}
-	}
-	defer func() {
-		_, _ = io.Copy(io.Discard, resp.Body)
-		_ = resp.Body.Close()
-	}()
-
-	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
-		return doctorCheck{Level: doctorFail, Section: doctorSectionGitHub, Name: "github-token", Message: fmt.Sprintf("%s token rejected by GitHub (HTTP %d)", source, resp.StatusCode)}
-	}
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return doctorCheck{Level: doctorWarn, Section: doctorSectionGitHub, Name: "github-token", Message: fmt.Sprintf("%s token probe returned HTTP %d", source, resp.StatusCode)}
-	}
-
-	var user struct {
-		Login string `json:"login"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&user); err != nil {
-		return doctorCheck{Level: doctorFail, Section: doctorSectionGitHub, Name: "github-token", Message: fmt.Sprintf("%s token probe decode failed: %v", source, err)}
-	}
-	login := user.Login
-	if login == "" {
-		login = "unknown user"
-	}
-	scopes := strings.TrimSpace(resp.Header.Get("X-OAuth-Scopes"))
-	scopeMsg := "scopes unavailable"
-	if scopes != "" {
-		scopeMsg = "scopes: " + scopes
-	}
-	return doctorCheck{Level: doctorPass, Section: doctorSectionGitHub, Name: "github-token", Message: fmt.Sprintf("%s token valid for %s (%s)", source, login, scopeMsg)}
-}
-
-func (c *commandContext) githubToken(ctx context.Context) (token, source string, err error) {
-	for _, name := range []string{"AO_GITHUB_TOKEN", "GITHUB_TOKEN"} {
-		if v := strings.TrimSpace(os.Getenv(name)); v != "" {
-			return v, name, nil
-		}
-	}
-	path, lookErr := c.deps.LookPath("gh")
-	if lookErr != nil || path == "" {
-		return "", "", errors.New("no GitHub token found (set AO_GITHUB_TOKEN/GITHUB_TOKEN or run `gh auth login`)")
-	}
-	reqCtx, cancel := context.WithTimeout(ctx, probeTimeout)
-	defer cancel()
-	out, cmdErr := c.deps.CommandOutput(reqCtx, path, "auth", "token")
-	if cmdErr != nil {
-		return "", "", fmt.Errorf("gh is installed but no token was available (`gh auth token` failed: %w)", cmdErr)
-	}
-	token = strings.TrimSpace(string(out))
-	if token == "" {
-		return "", "", errors.New("gh is installed but returned an empty auth token")
-	}
-	return token, "gh", nil
-}
-
-var (
-	ansiRE       = regexp.MustCompile(`\x1b\[[0-9;]*[A-Za-z]`)
-	gitVersionRE = regexp.MustCompile(`(?i)\bgit version\s+(\d+(?:\.\d+){1,3})`)
-)
-
-func parseGitVersion(out string) (string, error) {
-	clean := ansiRE.ReplaceAllString(out, "")
-	m := gitVersionRE.FindStringSubmatch(clean)
-	if len(m) < 2 {
-		return "", fmt.Errorf("parse git version from %q", strings.TrimSpace(clean))
-	}
-	return m[1], nil
-}
-
-func firstOutputLine(out []byte) string {
-	clean := strings.TrimSpace(ansiRE.ReplaceAllString(string(out), ""))
-	if clean == "" {
-		return ""
-	}
-	line := strings.SplitN(clean, "\n", 2)[0]
-	return strings.TrimSpace(line)
-}
-
-func compareDottedVersion(a, b string) (int, error) {
-	ap, err := dottedVersionParts(a)
-	if err != nil {
-		return 0, err
-	}
-	bp, err := dottedVersionParts(b)
-	if err != nil {
-		return 0, err
-	}
-	maxLen := len(ap)
-	if len(bp) > maxLen {
-		maxLen = len(bp)
-	}
-	for i := 0; i < maxLen; i++ {
-		var av, bv int
-		if i < len(ap) {
-			av = ap[i]
-		}
-		if i < len(bp) {
-			bv = bp[i]
-		}
-		switch {
-		case av < bv:
-			return -1, nil
-		case av > bv:
-			return 1, nil
-		}
-	}
-	return 0, nil
-}
-
-func dottedVersionParts(s string) ([]int, error) {
-	raw := strings.Split(s, ".")
-	parts := make([]int, 0, len(raw))
-	for _, part := range raw {
-		if part == "" {
-			return nil, fmt.Errorf("empty version segment in %q", s)
-		}
-		n, err := strconv.Atoi(part)
-		if err != nil {
-			return nil, fmt.Errorf("parse version segment %q in %q: %w", part, s, err)
-		}
-		parts = append(parts, n)
-	}
-	return parts, nil
-}
+// firstOutputLine is the shared version-probe formatter, kept under its
+// original CLI name for the VM preflight that also uses it.
+func firstOutputLine(out []byte) string { return doctor.FirstOutputLine(out) }

--- a/backend/internal/cli/doctor_test.go
+++ b/backend/internal/cli/doctor_test.go
@@ -4,296 +4,15 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
-	"io"
-	"net/http"
-	"net/http/httptest"
-	"os"
-	"path/filepath"
-	"runtime"
 	"strings"
 	"testing"
-	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/doctor"
 )
 
-func TestDoctorChecksGitVersion(t *testing.T) {
-	setConfigEnv(t)
-	c := doctorContext(t, map[string]string{"git": "/bin/git"}, func(_ context.Context, name string, args ...string) ([]byte, error) {
-		if name != "/bin/git" || len(args) != 1 || args[0] != "--version" {
-			t.Fatalf("unexpected command: %s %v", name, args)
-		}
-		return []byte("git version 2.43.0\n"), nil
-	})
-
-	check := findDoctorCheck(t, c.runDoctor(context.Background()), "git")
-	if check.Level != doctorPass || !strings.Contains(check.Message, "2.43.0") || !strings.Contains(check.Message, "supports worktrees") {
-		t.Fatalf("git check = %+v, want PASS with version", check)
-	}
-}
-
-func TestDoctorWarnsOnUnsupportedGitVersion(t *testing.T) {
-	setConfigEnv(t)
-	c := doctorContext(t, map[string]string{"git": "/bin/git"}, func(context.Context, string, ...string) ([]byte, error) {
-		return []byte("git version 2.24.9\n"), nil
-	})
-
-	check := findDoctorCheck(t, c.runDoctor(context.Background()), "git")
-	if check.Level != doctorWarn || !strings.Contains(check.Message, ">= 2.25.0") {
-		t.Fatalf("git check = %+v, want WARN with minimum version", check)
-	}
-}
-
-func TestDoctorFailsWhenGitMissing(t *testing.T) {
-	setConfigEnv(t)
-	c := doctorContext(t, map[string]string{}, nil)
-
-	check := findDoctorCheck(t, c.runDoctor(context.Background()), "git")
-	if check.Level != doctorFail {
-		t.Fatalf("git check = %+v, want FAIL", check)
-	}
-}
-
-func TestDoctorChecksTmuxVersion(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("ao doctor emits a conpty check on Windows, not tmux")
-	}
-	setConfigEnv(t)
-	c := doctorContext(t, map[string]string{"git": "/bin/git", "tmux": "/bin/tmux"}, func(_ context.Context, name string, args ...string) ([]byte, error) {
-		switch name {
-		case "/bin/git":
-			return []byte("git version 2.43.0\n"), nil
-		case "/bin/tmux":
-			if len(args) != 1 || args[0] != "-V" {
-				t.Fatalf("unexpected tmux command: %s %v", name, args)
-			}
-			return []byte("tmux 3.3a\n"), nil
-		default:
-			t.Fatalf("unexpected command: %s %v", name, args)
-			return nil, nil
-		}
-	})
-
-	check := findDoctorCheck(t, c.runDoctor(context.Background()), "tmux")
-	if check.Level != doctorPass || !strings.Contains(check.Message, "3.3a") {
-		t.Fatalf("tmux check = %+v, want PASS with version", check)
-	}
-}
-
-// TestDoctorChecksTmuxVersionFailsOnError covers the case where tmux is found
-// but the version command fails.
-func TestDoctorChecksTmuxVersionFailsOnError(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("ao doctor emits a conpty check on Windows, not tmux")
-	}
-	setConfigEnv(t)
-	c := doctorContext(t, map[string]string{"git": "/bin/git", "tmux": "/bin/tmux"}, func(_ context.Context, name string, _ ...string) ([]byte, error) {
-		if name == "/bin/git" {
-			return []byte("git version 2.43.0\n"), nil
-		}
-		return nil, errors.New("exec: tmux: not found")
-	})
-
-	check := findDoctorCheck(t, c.runDoctor(context.Background()), "tmux")
-	if check.Level != doctorFail {
-		t.Fatalf("tmux check = %+v, want FAIL on version error", check)
-	}
-}
-
-func TestDoctorWarnsWhenTmuxMissing(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("ao doctor emits a conpty check on Windows, not tmux")
-	}
-	setConfigEnv(t)
-	c := doctorContext(t, map[string]string{"git": "/bin/git"}, func(context.Context, string, ...string) ([]byte, error) {
-		return []byte("git version 2.43.0\n"), nil
-	})
-
-	check := findDoctorCheck(t, c.runDoctor(context.Background()), "tmux")
-	if check.Level != doctorWarn {
-		t.Fatalf("tmux check = %+v, want WARN", check)
-	}
-}
-
-func TestDoctorChecksHarnessVersions(t *testing.T) {
-	setConfigEnv(t)
-	cmdPath := map[string]string{
-		"git":    "/bin/git",
-		"claude": "/bin/claude",
-		"codex":  "/bin/codex",
-	}
-	c := doctorContext(t, cmdPath, func(_ context.Context, name string, args ...string) ([]byte, error) {
-		switch name {
-		case "/bin/git":
-			return []byte("git version 2.43.0\n"), nil
-		case "/bin/claude", "/bin/codex":
-			if len(args) == 1 && args[0] == "--version" {
-				return []byte(strings.TrimPrefix(name, "/bin/") + " 1.2.3\n"), nil
-			}
-			// The claude-auth readiness check probes the same binary.
-			if name == "/bin/claude" && strings.Join(args, " ") == "auth status --json" {
-				return []byte(`{"loggedIn":true,"authMethod":"claudeai","apiProvider":"firstParty"}`), nil
-			}
-			// The codex launch-flag canary probes the same binary.
-			if name == "/bin/codex" && len(args) > 0 && (args[0] == "--dangerously-bypass-hook-trust" || args[0] == "features") {
-				return []byte("ok\n"), nil
-			}
-			t.Fatalf("unexpected harness command: %s %v", name, args)
-			return nil, nil
-		default:
-			t.Fatalf("unexpected command: %s %v", name, args)
-			return nil, nil
-		}
-	})
-
-	checks := c.runDoctor(context.Background())
-	for _, name := range []string{"claude-code", "codex"} {
-		check := findDoctorCheck(t, checks, name)
-		if check.Level != doctorPass || !strings.Contains(check.Message, "resolves to") {
-			t.Fatalf("%s check = %+v, want PASS with path/version", name, check)
-		}
-	}
-}
-
-func TestDoctorWarnsWhenHarnessMissing(t *testing.T) {
-	setConfigEnv(t)
-	c := doctorContext(t, map[string]string{"git": "/bin/git"}, func(context.Context, string, ...string) ([]byte, error) {
-		return []byte("git version 2.43.0\n"), nil
-	})
-
-	check := findDoctorCheck(t, c.runDoctor(context.Background()), "codex")
-	if check.Level != doctorWarn || !strings.Contains(check.Message, "not found in PATH") {
-		t.Fatalf("codex check = %+v, want WARN missing binary", check)
-	}
-}
-
-func TestDoctorWarnsWhenHarnessVersionFails(t *testing.T) {
-	setConfigEnv(t)
-	c := doctorContext(t, map[string]string{"git": "/bin/git", "codex": "/bin/codex"}, func(_ context.Context, name string, _ ...string) ([]byte, error) {
-		if name == "/bin/git" {
-			return []byte("git version 2.43.0\n"), nil
-		}
-		return nil, errors.New("boom")
-	})
-
-	check := findDoctorCheck(t, c.runDoctor(context.Background()), "codex")
-	if check.Level != doctorWarn || !strings.Contains(check.Message, "failed") {
-		t.Fatalf("codex check = %+v, want WARN version failure", check)
-	}
-}
-
-// claudeAuthFake answers the harness version probe and the claude-auth
-// readiness probe against a fake claude at /bin/claude.
-func claudeAuthFake(t *testing.T, statusOutput string, statusErr error) func(context.Context, string, ...string) ([]byte, error) {
-	t.Helper()
-	return func(_ context.Context, name string, args ...string) ([]byte, error) {
-		switch {
-		case name == "/bin/git":
-			return []byte("git version 2.43.0\n"), nil
-		case name == "/bin/claude" && strings.Join(args, " ") == "--version":
-			return []byte("2.1.220 (Claude Code)\n"), nil
-		case name == "/bin/claude" && strings.Join(args, " ") == "auth status --json":
-			return []byte(statusOutput), statusErr
-		default:
-			t.Fatalf("unexpected command: %s %v", name, args)
-			return nil, nil
-		}
-	}
-}
-
-func TestDoctorClaudeAuthPassesWhenSignedIn(t *testing.T) {
-	setConfigEnv(t)
-	c := doctorContext(t, map[string]string{"git": "/bin/git", "claude": "/bin/claude"},
-		claudeAuthFake(t, `{"loggedIn":true,"authMethod":"claudeai","apiProvider":"firstParty"}`, nil))
-
-	check := findDoctorCheck(t, c.runDoctor(context.Background()), "claude-auth")
-	if check.Level != doctorPass {
-		t.Fatalf("claude-auth check = %+v, want PASS", check)
-	}
-	if !strings.Contains(check.Message, "signed in") || !strings.Contains(check.Message, "authMethod=claudeai") {
-		t.Errorf("claude-auth message = %q, want the auth method reported", check.Message)
-	}
-	if check.Remediation != "" {
-		t.Errorf("claude-auth remediation = %q, want empty when the check passes", check.Remediation)
-	}
-}
-
-// TestDoctorClaudeAuthWarnsWhenNotSignedIn is the state the desktop machine
-// card renders: a machine with the harness installed but no login must name
-// the exact command that fixes it rather than failing silently. The non-zero
-// exit is real: `claude auth status --json` exits 1 when not logged in and
-// still prints its JSON, so the output answers the question, not the exit code.
-func TestDoctorClaudeAuthWarnsWhenNotSignedIn(t *testing.T) {
-	setConfigEnv(t)
-	c := doctorContext(t, map[string]string{"git": "/bin/git", "claude": "/bin/claude"},
-		claudeAuthFake(t, `{"loggedIn":false,"authMethod":"none","apiProvider":"firstParty"}`, errors.New("exit status 1")))
-
-	check := findDoctorCheck(t, c.runDoctor(context.Background()), "claude-auth")
-	if check.Level != doctorWarn || !strings.Contains(check.Message, "not signed in") {
-		t.Fatalf("claude-auth check = %+v, want WARN not signed in", check)
-	}
-	if check.Remediation != "ao vm setup-harness claude" {
-		t.Errorf("claude-auth remediation = %q, want the setup-harness command", check.Remediation)
-	}
-}
-
-func TestDoctorClaudeAuthWarnsWhenHarnessMissing(t *testing.T) {
-	setConfigEnv(t)
-	c := doctorContext(t, map[string]string{"git": "/bin/git"}, func(context.Context, string, ...string) ([]byte, error) {
-		return []byte("git version 2.43.0\n"), nil
-	})
-
-	check := findDoctorCheck(t, c.runDoctor(context.Background()), "claude-auth")
-	if check.Level != doctorWarn || !strings.Contains(check.Message, "not found in PATH") {
-		t.Fatalf("claude-auth check = %+v, want WARN missing binary", check)
-	}
-	if check.Remediation != "ao vm setup-harness claude" {
-		t.Errorf("claude-auth remediation = %q, want the setup-harness command", check.Remediation)
-	}
-}
-
-// TestDoctorClaudeAuthWarnsWhenProbeUnusable covers a claude release that no
-// longer answers `claude auth status --json`, and output that is not JSON at
-// all. Neither may crash doctor or be reported as signed in.
-func TestDoctorClaudeAuthWarnsWhenProbeUnusable(t *testing.T) {
-	for _, tc := range []struct {
-		name   string
-		output string
-		err    error
-	}{
-		{name: "command fails", output: "error: unknown command 'auth'\n", err: errors.New("exit status 1")},
-		{name: "output is not json", output: "Logged in as octocat\n"},
-		{name: "output is empty"},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			setConfigEnv(t)
-			c := doctorContext(t, map[string]string{"git": "/bin/git", "claude": "/bin/claude"},
-				claudeAuthFake(t, tc.output, tc.err))
-
-			check := findDoctorCheck(t, c.runDoctor(context.Background()), "claude-auth")
-			if check.Level != doctorWarn || !strings.Contains(check.Message, "could not read harness auth state") {
-				t.Fatalf("claude-auth check = %+v, want WARN unreadable auth state", check)
-			}
-		})
-	}
-}
-
-// TestParseClaudeAuthStatusIgnoresSurroundingNoise pins the reason the probe
-// slices to the outermost braces: it runs through CombinedOutput, so a notice
-// on stderr must not make valid JSON unparseable.
-func TestParseClaudeAuthStatusIgnoresSurroundingNoise(t *testing.T) {
-	out := []byte("\x1b[33mA new version of Claude Code is available.\x1b[0m\n" +
-		`{"loggedIn":true,"authMethod":"apiKey","apiProvider":"firstParty"}` + "\n")
-	status, err := parseClaudeAuthStatus(out)
-	if err != nil {
-		t.Fatalf("parseClaudeAuthStatus: %v", err)
-	}
-	if !status.LoggedIn || status.AuthMethod != "apiKey" {
-		t.Fatalf("status = %+v, want loggedIn with authMethod=apiKey", status)
-	}
-	if got := status.describe(); got != "authMethod=apiKey apiProvider=firstParty" {
-		t.Errorf("describe = %q", got)
-	}
-}
+// The checks themselves are tested in internal/doctor, which owns them. What
+// is left here is the `ao doctor` output contract: the text grouping and the
+// --json document the desktop machine card reads.
 
 // TestDoctorJSONReportsClaudeAuthRemediation pins the shape the desktop reads:
 // a named check in `ao doctor --json` carrying a level and a remediation
@@ -311,7 +30,7 @@ func TestDoctorJSONReportsClaudeAuthRemediation(t *testing.T) {
 	if err := json.Unmarshal([]byte(stdout), &report); err != nil {
 		t.Fatalf("unmarshal doctor --json: %v (output %q)", err, stdout)
 	}
-	var found *doctorCheck
+	var found *doctor.Check
 	for i := range report.Checks {
 		if report.Checks[i].Name == "claude-auth" {
 			found = &report.Checks[i]
@@ -320,100 +39,18 @@ func TestDoctorJSONReportsClaudeAuthRemediation(t *testing.T) {
 	if found == nil {
 		t.Fatalf("no claude-auth check in %+v", report.Checks)
 	}
-	if found.Level != doctorWarn || found.Remediation != "ao vm setup-harness claude" {
+	if found.Level != doctor.Warn || found.Remediation != "ao vm setup-harness claude" {
 		t.Fatalf("claude-auth check = %+v, want WARN with the setup-harness remediation", *found)
 	}
-	if found.Section != doctorSectionAgents {
-		t.Errorf("claude-auth section = %q, want %q", found.Section, doctorSectionAgents)
-	}
-}
-
-func TestDoctorChecksGitHubTokenFromEnv(t *testing.T) {
-	setConfigEnv(t)
-	srv := githubDoctorServer(t, http.StatusOK, `{"login":"octocat"}`, "repo, read:org")
-	c := doctorContext(t, map[string]string{"git": "/bin/git"}, func(context.Context, string, ...string) ([]byte, error) {
-		return []byte("git version 2.43.0\n"), nil
-	})
-	t.Setenv("AO_GITHUB_TOKEN", "env-token")
-	c.deps.HTTPClient = srv.Client()
-	c.deps.DoctorGitHubRESTBase = srv.URL
-
-	check := findDoctorCheck(t, c.runDoctor(context.Background()), "github-token")
-	if check.Level != doctorPass || !strings.Contains(check.Message, "AO_GITHUB_TOKEN") || !strings.Contains(check.Message, "repo, read:org") {
-		t.Fatalf("github-token check = %+v, want PASS with source and scopes", check)
-	}
-}
-
-func TestDoctorChecksGitHubTokenFromGHCLI(t *testing.T) {
-	setConfigEnv(t)
-	srv := githubDoctorServer(t, http.StatusOK, `{"login":"octocat"}`, "")
-	c := doctorContext(t, map[string]string{"git": "/bin/git", "gh": "/bin/gh"}, func(_ context.Context, name string, args ...string) ([]byte, error) {
-		if name == "/bin/gh" {
-			if len(args) != 2 || args[0] != "auth" || args[1] != "token" {
-				t.Fatalf("unexpected gh command: %s %v", name, args)
-			}
-			return []byte("gh-token\n"), nil
-		}
-		return []byte("git version 2.43.0\n"), nil
-	})
-	c.deps.HTTPClient = srv.Client()
-	c.deps.DoctorGitHubRESTBase = srv.URL
-
-	check := findDoctorCheck(t, c.runDoctor(context.Background()), "github-token")
-	if check.Level != doctorPass || !strings.Contains(check.Message, "gh token valid") {
-		t.Fatalf("github-token check = %+v, want PASS from gh", check)
-	}
-}
-
-func TestDoctorWarnsWhenGitHubTokenMissing(t *testing.T) {
-	setConfigEnv(t)
-	c := doctorContext(t, map[string]string{"git": "/bin/git"}, func(context.Context, string, ...string) ([]byte, error) {
-		return []byte("git version 2.43.0\n"), nil
-	})
-
-	check := findDoctorCheck(t, c.runDoctor(context.Background()), "github-token")
-	if check.Level != doctorWarn || !strings.Contains(check.Message, "no GitHub token found") {
-		t.Fatalf("github-token check = %+v, want WARN missing token", check)
-	}
-}
-
-func TestDoctorFailsExpiredGitHubToken(t *testing.T) {
-	setConfigEnv(t)
-	srv := githubDoctorServer(t, http.StatusUnauthorized, `{"message":"Bad credentials"}`, "")
-	c := doctorContext(t, map[string]string{"git": "/bin/git"}, func(context.Context, string, ...string) ([]byte, error) {
-		return []byte("git version 2.43.0\n"), nil
-	})
-	t.Setenv("GITHUB_TOKEN", "expired-token")
-	c.deps.HTTPClient = srv.Client()
-	c.deps.DoctorGitHubRESTBase = srv.URL
-
-	check := findDoctorCheck(t, c.runDoctor(context.Background()), "github-token")
-	if check.Level != doctorFail || !strings.Contains(check.Message, "HTTP 401") {
-		t.Fatalf("github-token check = %+v, want FAIL rejected token", check)
+	if found.Section != doctor.SectionAgents {
+		t.Errorf("claude-auth section = %q, want %q", found.Section, doctor.SectionAgents)
 	}
 }
 
 func TestDoctorJSONOutputIsDecodable(t *testing.T) {
 	setConfigEnv(t)
 	clearDoctorGitHubEnv(t)
-	out, errOut, err := executeCLI(t, Deps{
-		LookPath: func(name string) (string, error) {
-			switch name {
-			case "git":
-				return "/bin/git", nil
-			case "tmux":
-				return "/bin/tmux", nil
-			}
-			return "", errors.New("missing")
-		},
-		CommandOutput: func(_ context.Context, name string, _ ...string) ([]byte, error) {
-			if name == "/bin/tmux" {
-				return []byte("tmux 3.3a\n"), nil
-			}
-			return []byte("git version 2.43.0\n"), nil
-		},
-		ProcessAlive: func(int) bool { return false },
-	}, "doctor", "--json")
+	out, errOut, err := executeCLI(t, doctorCLIDeps(), "doctor", "--json")
 	if err != nil {
 		t.Fatalf("doctor --json failed: %v\nstderr=%s\nstdout=%s", err, errOut, out)
 	}
@@ -424,7 +61,7 @@ func TestDoctorJSONOutputIsDecodable(t *testing.T) {
 	if !got.OK || len(got.Checks) == 0 {
 		t.Fatalf("doctor json = %#v, want ok with checks", got)
 	}
-	if findDoctorCheck(t, got.Checks, "git").Section != doctorSectionTools {
+	if findDoctorCheck(t, got.Checks, "git").Section != doctor.SectionTools {
 		t.Fatalf("git json check missing section: %#v", findDoctorCheck(t, got.Checks, "git"))
 	}
 }
@@ -432,7 +69,33 @@ func TestDoctorJSONOutputIsDecodable(t *testing.T) {
 func TestDoctorTextOutputIsGrouped(t *testing.T) {
 	setConfigEnv(t)
 	clearDoctorGitHubEnv(t)
-	out, errOut, err := executeCLI(t, Deps{
+	out, errOut, err := executeCLI(t, doctorCLIDeps(), "doctor")
+	if err != nil {
+		t.Fatalf("doctor failed: %v\nstderr=%s\nstdout=%s", err, errOut, out)
+	}
+	for _, want := range []string{"Core:\nPASS config:", "Tools:\nPASS git:", "Agent harnesses:\nWARN claude-code:", "WARN codex:", "GitHub:\nWARN github-token:"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("doctor output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+// TestDoctorReportsDaemonState covers the one check the CLI supplies itself:
+// internal/doctor cannot know how a caller learns the daemon's state, so
+// `ao doctor` injects the same run-file inspection `ao status` reports.
+func TestDoctorReportsDaemonState(t *testing.T) {
+	setConfigEnv(t)
+	clearDoctorGitHubEnv(t)
+	c := &commandContext{deps: doctorCLIDeps().withDefaults()}
+
+	check := findDoctorCheck(t, c.runDoctor(context.Background()), "daemon")
+	if check.Level != doctor.Pass || check.Message != string(stateStopped) {
+		t.Fatalf("daemon check = %+v, want PASS %q", check, stateStopped)
+	}
+}
+
+func doctorCLIDeps() Deps {
+	return Deps{
 		LookPath: func(name string) (string, error) {
 			switch name {
 			case "git":
@@ -449,14 +112,6 @@ func TestDoctorTextOutputIsGrouped(t *testing.T) {
 			return []byte("git version 2.43.0\n"), nil
 		},
 		ProcessAlive: func(int) bool { return false },
-	}, "doctor")
-	if err != nil {
-		t.Fatalf("doctor failed: %v\nstderr=%s\nstdout=%s", err, errOut, out)
-	}
-	for _, want := range []string{"Core:\nPASS config:", "Tools:\nPASS git:", "Agent harnesses:\nWARN claude-code:", "WARN codex:", "GitHub:\nWARN github-token:"} {
-		if !strings.Contains(out, want) {
-			t.Fatalf("doctor output missing %q:\n%s", want, out)
-		}
 	}
 }
 
@@ -467,108 +122,7 @@ func clearDoctorGitHubEnv(t *testing.T) {
 	t.Setenv("GH_TOKEN", "")
 }
 
-// TestDoctorChecksAOBinaryIdentity covers the `ao-binary` check: workspace
-// hooks invoke a bare `ao hooks <agent> <event>`, so doctor must surface when
-// the `ao` on PATH is not the running binary (e.g. a legacy CLI without the
-// hooks command shadowing the Go one).
-func TestDoctorChecksAOBinaryIdentity(t *testing.T) {
-	dir := t.TempDir()
-	self := filepath.Join(dir, "ao")
-	other := filepath.Join(dir, "ao-legacy")
-	for _, p := range []string{self, other} {
-		if err := os.WriteFile(p, []byte("#!/bin/sh\n"), 0o755); err != nil { //nolint:gosec // test fixture must be executable-shaped
-			t.Fatal(err)
-		}
-	}
-	selfExe := func() (string, error) { return self, nil }
-
-	cases := []struct {
-		name       string
-		executable func() (string, error)
-		paths      map[string]string
-		wantLevel  doctorLevel
-		wantIn     string
-	}{
-		{"ao in PATH is this binary", selfExe, map[string]string{"ao": self}, doctorPass, "this binary"},
-		{"ao in PATH is a different binary", selfExe, map[string]string{"ao": other}, doctorWarn, "not this binary"},
-		{"ao missing from PATH", selfExe, map[string]string{}, doctorWarn, "not found in PATH"},
-		{"running executable unresolvable", func() (string, error) { return "", errors.New("no exe") }, map[string]string{"ao": self}, doctorWarn, "could not resolve"},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			deps := Deps{
-				Executable: tc.executable,
-				LookPath: func(name string) (string, error) {
-					path, ok := tc.paths[name]
-					if !ok || path == "" {
-						return "", fmt.Errorf("%s missing", name)
-					}
-					return path, nil
-				},
-				ProcessAlive: func(int) bool { return false },
-			}
-			c := &commandContext{deps: deps.withDefaults()}
-			check := c.checkAOBinary()
-			if check.Level != tc.wantLevel || !strings.Contains(check.Message, tc.wantIn) {
-				t.Fatalf("ao-binary check = %+v, want level %s with %q", check, tc.wantLevel, tc.wantIn)
-			}
-		})
-	}
-}
-
-// TestDoctorIncludesAOBinaryCheck asserts runDoctor actually surfaces the
-// ao-binary check, so the identity probe cannot silently fall out of the report.
-func TestDoctorIncludesAOBinaryCheck(t *testing.T) {
-	setConfigEnv(t)
-	c := doctorContext(t, map[string]string{"git": "/bin/git"}, func(context.Context, string, ...string) ([]byte, error) {
-		return []byte("git version 2.43.0\n"), nil
-	})
-
-	// doctorContext's LookPath has no "ao", so the check lands as a WARN.
-	check := findDoctorCheck(t, c.runDoctor(context.Background()), "ao-binary")
-	if check.Level != doctorWarn || !strings.Contains(check.Message, "not found in PATH") {
-		t.Fatalf("ao-binary check = %+v, want WARN for missing ao", check)
-	}
-}
-
-func doctorContext(t *testing.T, paths map[string]string, commandOutput func(context.Context, string, ...string) ([]byte, error)) *commandContext {
-	t.Helper()
-	clearDoctorGitHubEnv(t)
-	deps := Deps{
-		LookPath: func(name string) (string, error) {
-			path, ok := paths[name]
-			if !ok || path == "" {
-				return "", fmt.Errorf("%s missing", name)
-			}
-			return path, nil
-		},
-		ProcessAlive: func(int) bool { return false },
-	}
-	if commandOutput != nil {
-		deps.CommandOutput = commandOutput
-	}
-	return &commandContext{deps: deps.withDefaults()}
-}
-
-func githubDoctorServer(t *testing.T, status int, body, scopes string) *httptest.Server {
-	t.Helper()
-	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodGet || r.URL.Path != "/user" {
-			t.Fatalf("unexpected github probe: %s %s", r.Method, r.URL.Path)
-		}
-		if got := r.Header.Get("Authorization"); !strings.HasPrefix(got, "Bearer ") {
-			t.Fatalf("missing bearer auth header: %q", got)
-		}
-		if scopes != "" {
-			w.Header().Set("X-OAuth-Scopes", scopes)
-		}
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(status)
-		_, _ = io.WriteString(w, body)
-	}))
-}
-
-func findDoctorCheck(t *testing.T, checks []doctorCheck, name string) doctorCheck {
+func findDoctorCheck(t *testing.T, checks []doctor.Check, name string) doctor.Check {
 	t.Helper()
 	for _, check := range checks {
 		if check.Name == name {
@@ -576,117 +130,5 @@ func findDoctorCheck(t *testing.T, checks []doctorCheck, name string) doctorChec
 		}
 	}
 	t.Fatalf("doctor check %q not found in %+v", name, checks)
-	return doctorCheck{}
-}
-
-func codexCanaryFake(t *testing.T, probeOutput string, probeErr error) func(context.Context, string, ...string) ([]byte, error) {
-	t.Helper()
-	return func(_ context.Context, name string, args ...string) ([]byte, error) {
-		switch {
-		case name == "/bin/git":
-			return []byte("git version 2.43.0\n"), nil
-		case name == "/bin/codex" && len(args) == 1 && args[0] == "--version":
-			return []byte("codex-cli 0.136.0\n"), nil
-		case name == "/bin/codex":
-			return []byte(probeOutput), probeErr
-		default:
-			t.Fatalf("unexpected command: %s %v", name, args)
-			return nil, nil
-		}
-	}
-}
-
-func TestDoctorCodexLaunchFlagsPass(t *testing.T) {
-	setConfigEnv(t)
-	c := doctorContext(t, map[string]string{"git": "/bin/git", "codex": "/bin/codex"}, codexCanaryFake(t, "ok\n", nil))
-
-	check := findDoctorCheck(t, c.runDoctor(context.Background()), "codex-launch-flags")
-	if check.Level != doctorPass || !strings.Contains(check.Message, "accepts") {
-		t.Fatalf("canary = %+v, want PASS accepts", check)
-	}
-}
-
-func TestDoctorCodexLaunchFlagsWarnOnRejectedFlag(t *testing.T) {
-	setConfigEnv(t)
-	c := doctorContext(t, map[string]string{"git": "/bin/git", "codex": "/bin/codex"},
-		codexCanaryFake(t, "error: unexpected argument '--dangerously-bypass-hook-trust' found\n", errors.New("exit status 2")))
-
-	check := findDoctorCheck(t, c.runDoctor(context.Background()), "codex-launch-flags")
-	if check.Level != doctorWarn || !strings.Contains(check.Message, "rejected AO's launch flags") {
-		t.Fatalf("canary = %+v, want WARN rejected flags", check)
-	}
-}
-
-func TestDoctorCodexLaunchFlagsWarnOnUnknownConfigField(t *testing.T) {
-	setConfigEnv(t)
-	c := doctorContext(t, map[string]string{"git": "/bin/git", "codex": "/bin/codex"},
-		codexCanaryFake(t, "unknown configuration field `hooks` in -c/--config override\n", nil))
-
-	check := findDoctorCheck(t, c.runDoctor(context.Background()), "codex-launch-flags")
-	if check.Level != doctorWarn || !strings.Contains(check.Message, "no longer recognizes") {
-		t.Fatalf("canary = %+v, want WARN unknown config field", check)
-	}
-}
-
-func TestDoctorCodexLaunchFlagsSkippedWithoutCodex(t *testing.T) {
-	setConfigEnv(t)
-	c := doctorContext(t, map[string]string{"git": "/bin/git"}, func(context.Context, string, ...string) ([]byte, error) {
-		return []byte("git version 2.43.0\n"), nil
-	})
-
-	check := findDoctorCheck(t, c.runDoctor(context.Background()), "codex-launch-flags")
-	if check.Level != doctorPass || !strings.Contains(check.Message, "skipped") {
-		t.Fatalf("canary = %+v, want skipped PASS", check)
-	}
-}
-
-func TestDoctorHooksLogStates(t *testing.T) {
-	gitOnly := func(context.Context, string, ...string) ([]byte, error) {
-		return []byte("git version 2.43.0\n"), nil
-	}
-
-	t.Run("missing log passes", func(t *testing.T) {
-		setConfigEnv(t)
-		c := doctorContext(t, map[string]string{"git": "/bin/git"}, gitOnly)
-		check := findDoctorCheck(t, c.runDoctor(context.Background()), "hooks-log")
-		if check.Level != doctorPass || !strings.Contains(check.Message, "no hook delivery failures") {
-			t.Fatalf("hooks-log = %+v, want PASS no failures", check)
-		}
-	})
-
-	t.Run("recent failures warn", func(t *testing.T) {
-		cfg := setConfigEnv(t)
-		writeHooksLogLines(t, cfg.dataDir,
-			time.Now().Add(-48*time.Hour).UTC().Format(time.RFC3339)+" session=old ao hooks codex stop: stale",
-			time.Now().Add(-time.Hour).UTC().Format(time.RFC3339)+" session=mer-1 ao hooks codex stop: connection refused",
-		)
-		c := doctorContext(t, map[string]string{"git": "/bin/git"}, gitOnly)
-		check := findDoctorCheck(t, c.runDoctor(context.Background()), "hooks-log")
-		if check.Level != doctorWarn || !strings.Contains(check.Message, "1 hook delivery failure") || !strings.Contains(check.Message, "connection refused") {
-			t.Fatalf("hooks-log = %+v, want WARN with recent count and latest line", check)
-		}
-	})
-
-	t.Run("only stale failures pass", func(t *testing.T) {
-		cfg := setConfigEnv(t)
-		writeHooksLogLines(t, cfg.dataDir,
-			time.Now().Add(-72*time.Hour).UTC().Format(time.RFC3339)+" session=old ao hooks codex stop: stale",
-		)
-		c := doctorContext(t, map[string]string{"git": "/bin/git"}, gitOnly)
-		check := findDoctorCheck(t, c.runDoctor(context.Background()), "hooks-log")
-		if check.Level != doctorPass || !strings.Contains(check.Message, "last 24h") {
-			t.Fatalf("hooks-log = %+v, want PASS stale-only", check)
-		}
-	})
-}
-
-func writeHooksLogLines(t *testing.T, dataDir string, lines ...string) {
-	t.Helper()
-	if err := os.MkdirAll(dataDir, 0o750); err != nil {
-		t.Fatal(err)
-	}
-	content := strings.Join(lines, "\n") + "\n"
-	if err := os.WriteFile(filepath.Join(dataDir, hooksLogName), []byte(content), 0o600); err != nil {
-		t.Fatal(err)
-	}
+	return doctor.Check{}
 }

--- a/backend/internal/cli/hooks.go
+++ b/backend/internal/cli/hooks.go
@@ -15,6 +15,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/activitydispatch"
+	"github.com/aoagents/agent-orchestrator/backend/internal/doctor"
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 )
 
@@ -27,7 +28,9 @@ const (
 	// hooksLogName is the file under AO_DATA_DIR where hook delivery failures
 	// are appended. Agent hook runners swallow stderr, so without a durable
 	// sink a dead activity feed (e.g. an unreachable daemon) stays invisible.
-	hooksLogName = "hooks.log"
+	// The name lives in internal/doctor because doctor's hooks-log check reads
+	// this file and must never drift from the writer.
+	hooksLogName = doctor.HooksLogName
 	// maxHooksLogBytes caps hooks.log: an append against a file already past
 	// the cap truncates it first, so a persistently failing hook cannot grow
 	// the file without bound.

--- a/backend/internal/cli/root.go
+++ b/backend/internal/cli/root.go
@@ -15,6 +15,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/daemon"
+	"github.com/aoagents/agent-orchestrator/backend/internal/doctor"
 	aoprocess "github.com/aoagents/agent-orchestrator/backend/internal/process"
 	"github.com/aoagents/agent-orchestrator/backend/internal/processalive"
 )
@@ -96,7 +97,7 @@ func DefaultDeps() Deps {
 		CommandOutput:        commandOutput,
 		CommandOutputInDir:   commandOutputInDir,
 		RunInteractive:       runInteractive,
-		DoctorGitHubRESTBase: defaultDoctorGitHubRESTBase,
+		DoctorGitHubRESTBase: doctor.DefaultGitHubRESTBase,
 		Now:                  time.Now,
 		Sleep:                time.Sleep,
 	}

--- a/backend/internal/cli/vm.go
+++ b/backend/internal/cli/vm.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/config"
+	"github.com/aoagents/agent-orchestrator/backend/internal/doctor"
 	"github.com/aoagents/agent-orchestrator/backend/internal/runfile"
 	"github.com/aoagents/agent-orchestrator/backend/internal/vmgateway"
 )
@@ -106,15 +107,14 @@ func (c *commandContext) runVMServe(cmd *cobra.Command, opts vmgateway.Options) 
 
 // The claude harness is the only one ao vm setup-harness supports in v1. Its
 // login and its readiness probe are two halves of the same `claude auth`
-// surface, so they live together here: if a claude release moves one, doctor's
+// surface, so they stay pinned to one another: the harness name and the status
+// probe live in internal/doctor, which owns the claude-auth check, and this
+// command reads the name from there. If a claude release moves one, doctor's
 // claude-auth check and this command break together and visibly, rather than
 // one of them silently reporting the wrong thing.
-const claudeHarnessName = "claude"
+const claudeHarnessName = doctor.ClaudeHarnessName
 
-var (
-	claudeLoginArgs      = []string{"auth", "login"}
-	claudeAuthStatusArgs = []string{"auth", "status", "--json"}
-)
+var claudeLoginArgs = []string{"auth", "login"}
 
 func newVMSetupHarnessCommand(ctx *commandContext) *cobra.Command {
 	return &cobra.Command{

--- a/backend/internal/doctor/doctor.go
+++ b/backend/internal/doctor/doctor.go
@@ -1,0 +1,668 @@
+// Package doctor runs AO's local health checks: the data dir, the tooling, the
+// agent harnesses, and the credentials a machine needs before it can run
+// sessions.
+//
+// It is the single implementation behind both `ao doctor` and the daemon's
+// GET /api/v1/doctor, so a machine's readiness reads the same locally and
+// remotely. The CLI formats the checks as text or JSON; the HTTP controller
+// projects them onto a wire DTO. Neither owns the logic.
+package doctor
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/codex"
+	"github.com/aoagents/agent-orchestrator/backend/internal/config"
+	aoprocess "github.com/aoagents/agent-orchestrator/backend/internal/process"
+)
+
+// Level is a check outcome. FAIL is reserved for a broken machine: `ao doctor`
+// exits non-zero on one, so a merely degraded state (a missing optional tool,
+// a harness that is not signed in) is a WARN.
+type Level string
+
+// The three outcomes a check can report.
+const (
+	Pass Level = "PASS"
+	Warn Level = "WARN"
+	Fail Level = "FAIL"
+)
+
+// Check is one health check outcome. The JSON tags are the wire shape of
+// `ao doctor --json`; the daemon's HTTP route projects this onto its own DTO
+// rather than serializing it directly.
+type Check struct {
+	Level   Level  `json:"level"`
+	Section string `json:"section,omitempty"`
+	Name    string `json:"name"`
+	Message string `json:"message"`
+	// Remediation is the one command that fixes this check, when a single
+	// command does. It exists so a consumer of `ao doctor --json` (the
+	// desktop's machine card) can show exactly what to run instead of parsing
+	// it back out of Message. Empty when there is no single command to name.
+	Remediation string `json:"remediation,omitempty"`
+}
+
+// Section names group the checks in a report, and the names and probe
+// arguments the CLI and this package must agree on.
+const (
+	SectionCore   = "Core"
+	SectionTools  = "Tools"
+	SectionAgents = "Agent harnesses"
+	SectionGitHub = "GitHub"
+
+	// ClaudeHarnessName is the harness whose login `ao vm setup-harness` runs
+	// and whose readiness the claude-auth check reports. Both halves read it
+	// from here so they cannot drift apart.
+	ClaudeHarnessName = "claude"
+
+	// HooksLogName is the file under the data dir where the CLI appends hook
+	// delivery failures (see cli.appendHooksLog). The writer and the
+	// hooks-log check below must agree on the name, and the CLI imports this
+	// package, so the name lives here.
+	HooksLogName = "hooks.log"
+
+	// DefaultGitHubRESTBase is the API root the github-token check probes.
+	DefaultGitHubRESTBase = "https://api.github.com"
+
+	minGitVersion         = "2.25.0"
+	githubDoctorUserAgent = "ao-agent-orchestrator/doctor"
+	probeTimeout          = 2 * time.Second
+)
+
+// ClaudeAuthStatusArgs is the harness's own machine-readable answer to "is
+// this machine signed in", and the only probe the claude-auth check runs.
+var ClaudeAuthStatusArgs = []string{"auth", "status", "--json"}
+
+type harnessProbe struct {
+	Name       string
+	BinaryName string
+	VersionArg string
+}
+
+var harnesses = []harnessProbe{
+	{Name: "claude-code", BinaryName: ClaudeHarnessName, VersionArg: "--version"},
+	{Name: "codex", BinaryName: "codex", VersionArg: "--version"},
+}
+
+// Deps holds the side effects the checks need, so both callers can inject
+// fakes instead of reaching into process-global state.
+type Deps struct {
+	LookPath      func(file string) (string, error)
+	CommandOutput func(ctx context.Context, name string, args ...string) ([]byte, error)
+	Executable    func() (string, error)
+	HTTPClient    *http.Client
+	// GitHubRESTBase lets tests point the github-token probe at httptest.
+	GitHubRESTBase string
+	// DaemonCheck reports the daemon's own state. It is caller-supplied
+	// because the answer differs by vantage point: the CLI inspects the run
+	// file and probes the loopback health endpoints, while the daemon answers
+	// for itself. A nil DaemonCheck omits the check entirely.
+	DaemonCheck func(ctx context.Context) Check
+}
+
+// DefaultDeps returns production dependencies.
+func DefaultDeps() Deps {
+	return Deps{
+		LookPath:       exec.LookPath,
+		CommandOutput:  commandOutput,
+		Executable:     os.Executable,
+		HTTPClient:     &http.Client{Timeout: probeTimeout},
+		GitHubRESTBase: DefaultGitHubRESTBase,
+	}
+}
+
+func commandOutput(ctx context.Context, name string, args ...string) ([]byte, error) {
+	return aoprocess.CommandContext(ctx, name, args...).CombinedOutput()
+}
+
+func (d Deps) withDefaults() Deps {
+	def := DefaultDeps()
+	if d.LookPath == nil {
+		d.LookPath = def.LookPath
+	}
+	if d.CommandOutput == nil {
+		d.CommandOutput = def.CommandOutput
+	}
+	if d.Executable == nil {
+		d.Executable = def.Executable
+	}
+	if d.HTTPClient == nil {
+		d.HTTPClient = def.HTTPClient
+	}
+	if d.GitHubRESTBase == "" {
+		d.GitHubRESTBase = def.GitHubRESTBase
+	}
+	return d
+}
+
+// Run executes every check and returns them in report order. It never returns
+// an error: a check that cannot run reports itself as a failing check, which
+// is the whole point of a doctor.
+func Run(ctx context.Context, deps Deps) []Check {
+	d := deps.withDefaults()
+	checks := []Check{}
+
+	cfg, err := config.Load()
+	if err != nil {
+		return append(checks, Check{Level: Fail, Section: SectionCore, Name: "config", Message: err.Error()})
+	}
+	checks = append(checks, Check{
+		Level: Pass, Section: SectionCore, Name: "config",
+		Message: fmt.Sprintf("runFile=%s dataDir=%s port=%d", cfg.RunFilePath, cfg.DataDir, cfg.Port),
+	})
+
+	if err := os.MkdirAll(cfg.DataDir, 0o750); err != nil {
+		checks = append(checks, Check{Level: Fail, Section: SectionCore, Name: "data-dir", Message: err.Error()})
+	} else {
+		checks = append(checks,
+			Check{Level: Pass, Section: SectionCore, Name: "data-dir", Message: cfg.DataDir},
+			checkDataDirWritable(cfg.DataDir),
+		)
+	}
+
+	checks = append(checks, checkStore(cfg.DataDir), checkHooksLog(cfg.DataDir, time.Now()))
+
+	if d.DaemonCheck != nil {
+		checks = append(checks, d.DaemonCheck(ctx))
+	}
+
+	checks = append(checks,
+		d.checkGit(ctx),
+		d.checkTerminalRuntime(ctx),
+		d.checkAOBinary(),
+	)
+	for _, harness := range harnesses {
+		checks = append(checks, d.checkHarness(ctx, harness))
+	}
+	checks = append(checks, d.checkClaudeAuth(ctx), d.checkCodexLaunchFlags(ctx), d.checkGitHubToken(ctx))
+	return checks
+}
+
+// checkClaudeAuth reports whether the claude harness has finished its own
+// login on this machine. `claude auth status --json` is the harness's own
+// machine-readable answer, so this reports the harness's state rather than
+// guessing at where its credentials live (a keychain entry on macOS, a file
+// elsewhere, or an environment variable). It is the readiness signal the
+// desktop reads for a machine card: a machine that is registered but has no
+// harness configured shows Remediation instead of failing silently.
+//
+// A missing login is a WARN, never a FAIL: plenty of machines run AO with a
+// different harness, or with none, and `ao doctor` must still exit 0 there.
+func (d Deps) checkClaudeAuth(ctx context.Context) Check {
+	const name = "claude-auth"
+	setupCmd := "ao vm setup-harness " + ClaudeHarnessName
+	warn := func(message string) Check {
+		return Check{
+			Level: Warn, Section: SectionAgents, Name: name,
+			Message: message, Remediation: setupCmd,
+		}
+	}
+
+	path, err := d.LookPath(ClaudeHarnessName)
+	if err != nil || path == "" {
+		return warn(fmt.Sprintf("claude not found in PATH; install the Claude Code CLI, then run `%s`", setupCmd))
+	}
+	reqCtx, cancel := context.WithTimeout(ctx, probeTimeout)
+	defer cancel()
+	probe := strings.Join(ClaudeAuthStatusArgs, " ")
+	out, cmdErr := d.CommandOutput(reqCtx, path, ClaudeAuthStatusArgs...)
+	// `claude auth status` exits non-zero when the harness is not logged in and
+	// still prints its JSON, so the output is what answers the question. A
+	// non-zero exit only matters when there is no parseable answer in it.
+	status, parseErr := parseClaudeAuthStatus(out)
+	if parseErr != nil {
+		reason := parseErr
+		if cmdErr != nil {
+			reason = cmdErr
+		}
+		return warn(fmt.Sprintf("could not read harness auth state (`claude %s`: %v); log in with `%s`", probe, reason, setupCmd))
+	}
+	if !status.LoggedIn {
+		return warn(fmt.Sprintf("%s is installed but not signed in; run `%s`", path, setupCmd))
+	}
+	return Check{
+		Level: Pass, Section: SectionAgents, Name: name,
+		Message: fmt.Sprintf("%s is signed in (%s)", path, status.describe()),
+	}
+}
+
+type claudeAuthStatus struct {
+	LoggedIn    bool   `json:"loggedIn"`
+	AuthMethod  string `json:"authMethod"`
+	APIProvider string `json:"apiProvider"`
+}
+
+func (s claudeAuthStatus) describe() string {
+	method := strings.TrimSpace(s.AuthMethod)
+	if method == "" {
+		method = "unknown"
+	}
+	if provider := strings.TrimSpace(s.APIProvider); provider != "" {
+		return fmt.Sprintf("authMethod=%s apiProvider=%s", method, provider)
+	}
+	return "authMethod=" + method
+}
+
+// parseClaudeAuthStatus reads the JSON object out of `claude auth status
+// --json` output. It slices to the outermost braces first because the probe
+// runs through CombinedOutput, so an unrelated notice on stderr (an update
+// banner, a deprecation warning) would otherwise make valid JSON unparseable.
+func parseClaudeAuthStatus(out []byte) (claudeAuthStatus, error) {
+	clean := ansiRE.ReplaceAllString(string(out), "")
+	start, end := strings.Index(clean, "{"), strings.LastIndex(clean, "}")
+	if start < 0 || end < start {
+		return claudeAuthStatus{}, fmt.Errorf("no JSON object in output %q", strings.TrimSpace(clean))
+	}
+	var status claudeAuthStatus
+	if err := json.Unmarshal([]byte(clean[start:end+1]), &status); err != nil {
+		return claudeAuthStatus{}, err
+	}
+	return status, nil
+}
+
+// checkStore inspects the SQLite store WITHOUT opening or migrating it. The
+// daemon is the sole writer and migrator of the database (architecture.md §7);
+// the CLI must never run migrations or open a second writer against a database
+// a live daemon may already own. Migrations are validated by the daemon at
+// startup and surfaced through /readyz, so doctor only confirms whether the
+// database file exists yet.
+func checkStore(dataDir string) Check {
+	dbPath := filepath.Join(dataDir, "ao.db")
+	info, err := os.Stat(dbPath)
+	switch {
+	case err == nil:
+		return Check{
+			Level: Pass, Section: SectionCore, Name: "sqlite",
+			Message: fmt.Sprintf("%s (%d bytes); migrations are applied by the daemon at startup", dbPath, info.Size()),
+		}
+	case errors.Is(err, fs.ErrNotExist):
+		return Check{
+			Level: Warn, Section: SectionCore, Name: "sqlite",
+			Message: "database not created yet; run `ao start` to initialize and migrate it",
+		}
+	default:
+		return Check{Level: Fail, Section: SectionCore, Name: "sqlite", Message: err.Error()}
+	}
+}
+
+func checkDataDirWritable(dataDir string) Check {
+	f, err := os.CreateTemp(dataDir, ".ao-doctor-write-*")
+	if err != nil {
+		return Check{Level: Fail, Section: SectionCore, Name: "data-dir-write", Message: err.Error()}
+	}
+	name := f.Name()
+	if _, err := f.WriteString("ok\n"); err != nil {
+		_ = f.Close()
+		_ = os.Remove(name)
+		return Check{Level: Fail, Section: SectionCore, Name: "data-dir-write", Message: err.Error()}
+	}
+	if err := f.Close(); err != nil {
+		_ = os.Remove(name)
+		return Check{Level: Fail, Section: SectionCore, Name: "data-dir-write", Message: err.Error()}
+	}
+	if err := os.Remove(name); err != nil {
+		return Check{Level: Warn, Section: SectionCore, Name: "data-dir-write", Message: fmt.Sprintf("write probe succeeded but cleanup failed: %v", err)}
+	}
+	return Check{Level: Pass, Section: SectionCore, Name: "data-dir-write", Message: "write probe succeeded"}
+}
+
+// checkAOBinary verifies the `ao` that workspace hooks would invoke. Agent
+// adapters install hook commands as a bare `ao hooks <agent> <event>`, so an
+// `ao` earlier on PATH that is not this binary (e.g. a legacy CLI without the
+// hooks command) fails every callback and silently kills activity tracking.
+// The daemon pins PATH inside the sessions it spawns, so a mismatch here is a
+// warning about every other context (manual runs, foreign panes), not a hard
+// failure.
+func (d Deps) checkAOBinary() Check {
+	const name = "ao-binary"
+	self, err := d.Executable()
+	if err != nil {
+		return Check{Level: Warn, Section: SectionTools, Name: name, Message: fmt.Sprintf("could not resolve the running executable: %v", err)}
+	}
+	onPath, err := d.LookPath("ao")
+	if err != nil || onPath == "" {
+		return Check{
+			Level: Warn, Section: SectionTools, Name: name,
+			Message: "ao not found in PATH; workspace hooks invoke `ao hooks <agent> <event>` (daemon-spawned sessions pin PATH to the daemon binary and are unaffected)",
+		}
+	}
+	if sameBinary(self, onPath) {
+		return Check{Level: Pass, Section: SectionTools, Name: name, Message: fmt.Sprintf("ao in PATH is this binary (%s)", onPath)}
+	}
+	return Check{
+		Level: Warn, Section: SectionTools, Name: name,
+		Message: fmt.Sprintf("ao in PATH is %s, not this binary (%s); workspace hooks run `ao hooks` and a foreign ao breaks activity tracking outside daemon-spawned sessions", onPath, self),
+	}
+}
+
+// sameBinary reports whether two paths name the same file, tolerating symlinks
+// via os.SameFile and falling back to cleaned-path equality when either stat
+// fails.
+func sameBinary(a, b string) bool {
+	ai, aErr := os.Stat(a)
+	bi, bErr := os.Stat(b)
+	if aErr == nil && bErr == nil {
+		return os.SameFile(ai, bi)
+	}
+	return filepath.Clean(a) == filepath.Clean(b)
+}
+
+func (d Deps) checkGit(ctx context.Context) Check {
+	path, err := d.LookPath("git")
+	if err != nil || path == "" {
+		return Check{Level: Fail, Section: SectionTools, Name: "git", Message: "not found in PATH"}
+	}
+	reqCtx, cancel := context.WithTimeout(ctx, probeTimeout)
+	defer cancel()
+	out, err := d.CommandOutput(reqCtx, path, "--version")
+	if err != nil {
+		return Check{Level: Fail, Section: SectionTools, Name: "git", Message: fmt.Sprintf("%s: %v", path, err)}
+	}
+	version, err := parseGitVersion(string(out))
+	if err != nil {
+		return Check{Level: Warn, Section: SectionTools, Name: "git", Message: fmt.Sprintf("%s (version unknown: %s)", path, FirstOutputLine(out))}
+	}
+	cmp, err := compareDottedVersion(version, minGitVersion)
+	if err != nil {
+		return Check{Level: Warn, Section: SectionTools, Name: "git", Message: fmt.Sprintf("%s (version unknown: %s)", path, FirstOutputLine(out))}
+	}
+	if cmp < 0 {
+		return Check{Level: Warn, Section: SectionTools, Name: "git", Message: fmt.Sprintf("%s (version %s; AO expects >= %s for worktrees)", path, version, minGitVersion)}
+	}
+	return Check{Level: Pass, Section: SectionTools, Name: "git", Message: fmt.Sprintf("%s (version %s; supports worktrees)", path, version)}
+}
+
+// checkTerminalRuntime checks the runtime multiplexer used on this platform:
+// tmux on Darwin/Linux, ConPTY (built-in) on Windows.
+func (d Deps) checkTerminalRuntime(ctx context.Context) Check {
+	if runtime.GOOS == "windows" {
+		return Check{
+			Level:   Pass,
+			Section: SectionTools,
+			Name:    "conpty",
+			Message: "ConPTY (built-in): no external terminal multiplexer required on Windows",
+		}
+	}
+	return d.checkTmux(ctx)
+}
+
+func (d Deps) checkTmux(ctx context.Context) Check {
+	path, err := d.LookPath("tmux")
+	if err != nil || path == "" {
+		return Check{Level: Warn, Section: SectionTools, Name: "tmux", Message: "not found in PATH; required on macOS/Linux to start sessions"}
+	}
+	reqCtx, cancel := context.WithTimeout(ctx, probeTimeout)
+	defer cancel()
+	out, err := d.CommandOutput(reqCtx, path, "-V")
+	if err != nil {
+		return Check{Level: Fail, Section: SectionTools, Name: "tmux", Message: fmt.Sprintf("%s: %v", path, err)}
+	}
+	version := FirstOutputLine(out)
+	if version == "" {
+		version = "version unknown"
+	}
+	return Check{Level: Pass, Section: SectionTools, Name: "tmux", Message: fmt.Sprintf("%s (%s)", path, version)}
+}
+
+// checkHooksLog surfaces recent agent hook delivery failures. `ao hooks`
+// callbacks deliberately swallow errors (a hook must never break the user's
+// agent), so $AO_DATA_DIR/hooks.log is the only place a dead activity feed
+// becomes visible. Lines start with an RFC3339 timestamp (see appendHooksLog).
+func checkHooksLog(dataDir string, now time.Time) Check {
+	const name = "hooks-log"
+	path := filepath.Join(dataDir, HooksLogName)
+	data, err := os.ReadFile(path) //nolint:gosec // path rooted in AO's own data dir
+	if errors.Is(err, fs.ErrNotExist) {
+		return Check{Level: Pass, Section: SectionCore, Name: name, Message: "no hook delivery failures recorded"}
+	}
+	if err != nil {
+		return Check{Level: Warn, Section: SectionCore, Name: name, Message: err.Error()}
+	}
+
+	recent := 0
+	latest := ""
+	for line := range strings.SplitSeq(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		stamp, _, ok := strings.Cut(line, " ")
+		if !ok {
+			continue
+		}
+		ts, err := time.Parse(time.RFC3339, stamp)
+		if err != nil || now.Sub(ts) > 24*time.Hour {
+			continue
+		}
+		recent++
+		latest = line
+	}
+	if recent == 0 {
+		return Check{Level: Pass, Section: SectionCore, Name: name, Message: fmt.Sprintf("no hook delivery failures in the last 24h (%s)", path)}
+	}
+	return Check{
+		Level: Warn, Section: SectionCore, Name: name,
+		Message: fmt.Sprintf("%d hook delivery failure(s) in the last 24h — activity tracking may be degraded; latest: %s (full log: %s)", recent, latest, path),
+	}
+}
+
+func (d Deps) checkHarness(ctx context.Context, harness harnessProbe) Check {
+	path, err := d.LookPath(harness.BinaryName)
+	if err != nil || path == "" {
+		return Check{
+			Level: Warn, Section: SectionAgents, Name: harness.Name,
+			Message: fmt.Sprintf("%s not found in PATH", harness.BinaryName),
+		}
+	}
+	if harness.VersionArg == "" {
+		return Check{Level: Pass, Section: SectionAgents, Name: harness.Name, Message: fmt.Sprintf("%s resolves to %s", harness.BinaryName, path)}
+	}
+	reqCtx, cancel := context.WithTimeout(ctx, probeTimeout)
+	defer cancel()
+	out, err := d.CommandOutput(reqCtx, path, harness.VersionArg)
+	if err != nil {
+		return Check{
+			Level: Warn, Section: SectionAgents, Name: harness.Name,
+			Message: fmt.Sprintf("%s resolves to %s, but `%s %s` failed: %v", harness.BinaryName, path, harness.BinaryName, harness.VersionArg, err),
+		}
+	}
+	version := FirstOutputLine(out)
+	if version == "" {
+		version = "version output was empty"
+	}
+	return Check{Level: Pass, Section: SectionAgents, Name: harness.Name, Message: fmt.Sprintf("%s resolves to %s (%s)", harness.BinaryName, path, version)}
+}
+
+// checkCodexLaunchFlags smoke-tests AO's codex launch surface against the
+// installed binary: the hook-trust bypass flag and the `-c` session-flag
+// config AO injects at spawn (activity hooks, worktree trust, nudge
+// suppression). Codex has no stable hook-config contract, so a codex upgrade
+// can silently break activity tracking; this canary turns that breakage into
+// a doctor warning. The probes come from the codex adapter itself so they
+// cannot drift from the real spawn argv.
+func (d Deps) checkCodexLaunchFlags(ctx context.Context) Check {
+	const name = "codex-launch-flags"
+	path, err := d.LookPath("codex")
+	if err != nil || path == "" {
+		return Check{Level: Pass, Section: SectionAgents, Name: name, Message: "skipped: codex not found in PATH"}
+	}
+	for _, probe := range codex.DoctorLaunchProbes() {
+		reqCtx, cancel := context.WithTimeout(ctx, probeTimeout)
+		out, err := d.CommandOutput(reqCtx, path, probe...)
+		cancel()
+		if err != nil {
+			return Check{
+				Level: Warn, Section: SectionAgents, Name: name,
+				Message: fmt.Sprintf("codex rejected AO's launch flags (`codex %s`: %v) — codex sessions may spawn without activity hooks; a codex CLI update likely changed its flag/config surface", strings.Join(probe, " "), err),
+			}
+		}
+		if strings.Contains(string(out), "unknown configuration field") {
+			return Check{
+				Level: Warn, Section: SectionAgents, Name: name,
+				Message: fmt.Sprintf("codex no longer recognizes one of AO's config overrides (%s) — codex sessions may spawn without activity hooks", FirstOutputLine(out)),
+			}
+		}
+	}
+	return Check{Level: Pass, Section: SectionAgents, Name: name, Message: "codex accepts AO's hook/trust launch flags"}
+}
+
+func (d Deps) checkGitHubToken(ctx context.Context) Check {
+	token, source, err := d.githubToken(ctx)
+	if err != nil {
+		return Check{Level: Warn, Section: SectionGitHub, Name: "github-token", Message: err.Error()}
+	}
+
+	reqCtx, cancel := context.WithTimeout(ctx, probeTimeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, strings.TrimRight(d.GitHubRESTBase, "/")+"/user", http.NoBody)
+	if err != nil {
+		return Check{Level: Fail, Section: SectionGitHub, Name: "github-token", Message: err.Error()}
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+	req.Header.Set("User-Agent", githubDoctorUserAgent)
+	req.Header.Set("Authorization", "Bearer "+token)
+	resp, err := d.HTTPClient.Do(req)
+	if err != nil {
+		return Check{Level: Fail, Section: SectionGitHub, Name: "github-token", Message: fmt.Sprintf("%s token validation failed: %v", source, err)}
+	}
+	defer func() {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+	}()
+
+	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+		return Check{Level: Fail, Section: SectionGitHub, Name: "github-token", Message: fmt.Sprintf("%s token rejected by GitHub (HTTP %d)", source, resp.StatusCode)}
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return Check{Level: Warn, Section: SectionGitHub, Name: "github-token", Message: fmt.Sprintf("%s token probe returned HTTP %d", source, resp.StatusCode)}
+	}
+
+	var user struct {
+		Login string `json:"login"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&user); err != nil {
+		return Check{Level: Fail, Section: SectionGitHub, Name: "github-token", Message: fmt.Sprintf("%s token probe decode failed: %v", source, err)}
+	}
+	login := user.Login
+	if login == "" {
+		login = "unknown user"
+	}
+	scopes := strings.TrimSpace(resp.Header.Get("X-OAuth-Scopes"))
+	scopeMsg := "scopes unavailable"
+	if scopes != "" {
+		scopeMsg = "scopes: " + scopes
+	}
+	return Check{Level: Pass, Section: SectionGitHub, Name: "github-token", Message: fmt.Sprintf("%s token valid for %s (%s)", source, login, scopeMsg)}
+}
+
+func (d Deps) githubToken(ctx context.Context) (token, source string, err error) {
+	for _, name := range []string{"AO_GITHUB_TOKEN", "GITHUB_TOKEN"} {
+		if v := strings.TrimSpace(os.Getenv(name)); v != "" {
+			return v, name, nil
+		}
+	}
+	path, lookErr := d.LookPath("gh")
+	if lookErr != nil || path == "" {
+		return "", "", errors.New("no GitHub token found (set AO_GITHUB_TOKEN/GITHUB_TOKEN or run `gh auth login`)")
+	}
+	reqCtx, cancel := context.WithTimeout(ctx, probeTimeout)
+	defer cancel()
+	out, cmdErr := d.CommandOutput(reqCtx, path, "auth", "token")
+	if cmdErr != nil {
+		return "", "", fmt.Errorf("gh is installed but no token was available (`gh auth token` failed: %w)", cmdErr)
+	}
+	token = strings.TrimSpace(string(out))
+	if token == "" {
+		return "", "", errors.New("gh is installed but returned an empty auth token")
+	}
+	return token, "gh", nil
+}
+
+var (
+	ansiRE       = regexp.MustCompile(`\x1b\[[0-9;]*[A-Za-z]`)
+	gitVersionRE = regexp.MustCompile(`(?i)\bgit version\s+(\d+(?:\.\d+){1,3})`)
+)
+
+func parseGitVersion(out string) (string, error) {
+	clean := ansiRE.ReplaceAllString(out, "")
+	m := gitVersionRE.FindStringSubmatch(clean)
+	if len(m) < 2 {
+		return "", fmt.Errorf("parse git version from %q", strings.TrimSpace(clean))
+	}
+	return m[1], nil
+}
+
+// FirstOutputLine returns the first non-empty line of command output with ANSI
+// escapes stripped. It is exported because the CLI's VM preflight reports
+// probed tool versions the same way.
+func FirstOutputLine(out []byte) string {
+	clean := strings.TrimSpace(ansiRE.ReplaceAllString(string(out), ""))
+	if clean == "" {
+		return ""
+	}
+	line := strings.SplitN(clean, "\n", 2)[0]
+	return strings.TrimSpace(line)
+}
+
+func compareDottedVersion(a, b string) (int, error) {
+	ap, err := dottedVersionParts(a)
+	if err != nil {
+		return 0, err
+	}
+	bp, err := dottedVersionParts(b)
+	if err != nil {
+		return 0, err
+	}
+	maxLen := len(ap)
+	if len(bp) > maxLen {
+		maxLen = len(bp)
+	}
+	for i := 0; i < maxLen; i++ {
+		var av, bv int
+		if i < len(ap) {
+			av = ap[i]
+		}
+		if i < len(bp) {
+			bv = bp[i]
+		}
+		switch {
+		case av < bv:
+			return -1, nil
+		case av > bv:
+			return 1, nil
+		}
+	}
+	return 0, nil
+}
+
+func dottedVersionParts(s string) ([]int, error) {
+	raw := strings.Split(s, ".")
+	parts := make([]int, 0, len(raw))
+	for _, part := range raw {
+		if part == "" {
+			return nil, fmt.Errorf("empty version segment in %q", s)
+		}
+		n, err := strconv.Atoi(part)
+		if err != nil {
+			return nil, fmt.Errorf("parse version segment %q in %q: %w", part, s, err)
+		}
+		parts = append(parts, n)
+	}
+	return parts, nil
+}

--- a/backend/internal/doctor/doctor_test.go
+++ b/backend/internal/doctor/doctor_test.go
@@ -1,0 +1,592 @@
+package doctor
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestChecksGitVersion(t *testing.T) {
+	setConfigEnv(t)
+	deps := testDeps(t, map[string]string{"git": "/bin/git"}, func(_ context.Context, name string, args ...string) ([]byte, error) {
+		if name != "/bin/git" || len(args) != 1 || args[0] != "--version" {
+			t.Fatalf("unexpected command: %s %v", name, args)
+		}
+		return []byte("git version 2.43.0\n"), nil
+	})
+
+	check := findCheck(t, Run(context.Background(), deps), "git")
+	if check.Level != Pass || !strings.Contains(check.Message, "2.43.0") || !strings.Contains(check.Message, "supports worktrees") {
+		t.Fatalf("git check = %+v, want PASS with version", check)
+	}
+}
+
+func TestWarnsOnUnsupportedGitVersion(t *testing.T) {
+	setConfigEnv(t)
+	deps := testDeps(t, map[string]string{"git": "/bin/git"}, func(context.Context, string, ...string) ([]byte, error) {
+		return []byte("git version 2.24.9\n"), nil
+	})
+
+	check := findCheck(t, Run(context.Background(), deps), "git")
+	if check.Level != Warn || !strings.Contains(check.Message, ">= 2.25.0") {
+		t.Fatalf("git check = %+v, want WARN with minimum version", check)
+	}
+}
+
+func TestFailsWhenGitMissing(t *testing.T) {
+	setConfigEnv(t)
+	deps := testDeps(t, map[string]string{}, nil)
+
+	check := findCheck(t, Run(context.Background(), deps), "git")
+	if check.Level != Fail {
+		t.Fatalf("git check = %+v, want FAIL", check)
+	}
+}
+
+func TestChecksTmuxVersion(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("doctor emits a conpty check on Windows, not tmux")
+	}
+	setConfigEnv(t)
+	deps := testDeps(t, map[string]string{"git": "/bin/git", "tmux": "/bin/tmux"}, func(_ context.Context, name string, args ...string) ([]byte, error) {
+		switch name {
+		case "/bin/git":
+			return []byte("git version 2.43.0\n"), nil
+		case "/bin/tmux":
+			if len(args) != 1 || args[0] != "-V" {
+				t.Fatalf("unexpected tmux command: %s %v", name, args)
+			}
+			return []byte("tmux 3.3a\n"), nil
+		default:
+			t.Fatalf("unexpected command: %s %v", name, args)
+			return nil, nil
+		}
+	})
+
+	check := findCheck(t, Run(context.Background(), deps), "tmux")
+	if check.Level != Pass || !strings.Contains(check.Message, "3.3a") {
+		t.Fatalf("tmux check = %+v, want PASS with version", check)
+	}
+}
+
+// TestChecksTmuxVersionFailsOnError covers the case where tmux is found but
+// the version command fails.
+func TestChecksTmuxVersionFailsOnError(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("doctor emits a conpty check on Windows, not tmux")
+	}
+	setConfigEnv(t)
+	deps := testDeps(t, map[string]string{"git": "/bin/git", "tmux": "/bin/tmux"}, func(_ context.Context, name string, _ ...string) ([]byte, error) {
+		if name == "/bin/git" {
+			return []byte("git version 2.43.0\n"), nil
+		}
+		return nil, errors.New("exec: tmux: not found")
+	})
+
+	check := findCheck(t, Run(context.Background(), deps), "tmux")
+	if check.Level != Fail {
+		t.Fatalf("tmux check = %+v, want FAIL on version error", check)
+	}
+}
+
+func TestWarnsWhenTmuxMissing(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("doctor emits a conpty check on Windows, not tmux")
+	}
+	setConfigEnv(t)
+	deps := testDeps(t, map[string]string{"git": "/bin/git"}, gitOnly)
+
+	check := findCheck(t, Run(context.Background(), deps), "tmux")
+	if check.Level != Warn {
+		t.Fatalf("tmux check = %+v, want WARN", check)
+	}
+}
+
+func TestChecksHarnessVersions(t *testing.T) {
+	setConfigEnv(t)
+	cmdPath := map[string]string{
+		"git":    "/bin/git",
+		"claude": "/bin/claude",
+		"codex":  "/bin/codex",
+	}
+	deps := testDeps(t, cmdPath, func(_ context.Context, name string, args ...string) ([]byte, error) {
+		switch name {
+		case "/bin/git":
+			return []byte("git version 2.43.0\n"), nil
+		case "/bin/claude", "/bin/codex":
+			if len(args) == 1 && args[0] == "--version" {
+				return []byte(strings.TrimPrefix(name, "/bin/") + " 1.2.3\n"), nil
+			}
+			// The claude-auth readiness check probes the same binary.
+			if name == "/bin/claude" && strings.Join(args, " ") == "auth status --json" {
+				return []byte(`{"loggedIn":true,"authMethod":"claudeai","apiProvider":"firstParty"}`), nil
+			}
+			// The codex launch-flag canary probes the same binary.
+			if name == "/bin/codex" && len(args) > 0 && (args[0] == "--dangerously-bypass-hook-trust" || args[0] == "features") {
+				return []byte("ok\n"), nil
+			}
+			t.Fatalf("unexpected harness command: %s %v", name, args)
+			return nil, nil
+		default:
+			t.Fatalf("unexpected command: %s %v", name, args)
+			return nil, nil
+		}
+	})
+
+	checks := Run(context.Background(), deps)
+	for _, name := range []string{"claude-code", "codex"} {
+		check := findCheck(t, checks, name)
+		if check.Level != Pass || !strings.Contains(check.Message, "resolves to") {
+			t.Fatalf("%s check = %+v, want PASS with path/version", name, check)
+		}
+	}
+}
+
+func TestWarnsWhenHarnessMissing(t *testing.T) {
+	setConfigEnv(t)
+	deps := testDeps(t, map[string]string{"git": "/bin/git"}, gitOnly)
+
+	check := findCheck(t, Run(context.Background(), deps), "codex")
+	if check.Level != Warn || !strings.Contains(check.Message, "not found in PATH") {
+		t.Fatalf("codex check = %+v, want WARN missing binary", check)
+	}
+}
+
+func TestWarnsWhenHarnessVersionFails(t *testing.T) {
+	setConfigEnv(t)
+	deps := testDeps(t, map[string]string{"git": "/bin/git", "codex": "/bin/codex"}, func(_ context.Context, name string, _ ...string) ([]byte, error) {
+		if name == "/bin/git" {
+			return []byte("git version 2.43.0\n"), nil
+		}
+		return nil, errors.New("boom")
+	})
+
+	check := findCheck(t, Run(context.Background(), deps), "codex")
+	if check.Level != Warn || !strings.Contains(check.Message, "failed") {
+		t.Fatalf("codex check = %+v, want WARN version failure", check)
+	}
+}
+
+// claudeAuthFake answers the harness version probe and the claude-auth
+// readiness probe against a fake claude at /bin/claude.
+func claudeAuthFake(t *testing.T, statusOutput string, statusErr error) func(context.Context, string, ...string) ([]byte, error) {
+	t.Helper()
+	return func(_ context.Context, name string, args ...string) ([]byte, error) {
+		switch {
+		case name == "/bin/git":
+			return []byte("git version 2.43.0\n"), nil
+		case name == "/bin/claude" && strings.Join(args, " ") == "--version":
+			return []byte("2.1.220 (Claude Code)\n"), nil
+		case name == "/bin/claude" && strings.Join(args, " ") == "auth status --json":
+			return []byte(statusOutput), statusErr
+		default:
+			t.Fatalf("unexpected command: %s %v", name, args)
+			return nil, nil
+		}
+	}
+}
+
+func TestClaudeAuthPassesWhenSignedIn(t *testing.T) {
+	setConfigEnv(t)
+	deps := testDeps(t, map[string]string{"git": "/bin/git", "claude": "/bin/claude"},
+		claudeAuthFake(t, `{"loggedIn":true,"authMethod":"claudeai","apiProvider":"firstParty"}`, nil))
+
+	check := findCheck(t, Run(context.Background(), deps), "claude-auth")
+	if check.Level != Pass {
+		t.Fatalf("claude-auth check = %+v, want PASS", check)
+	}
+	if !strings.Contains(check.Message, "signed in") || !strings.Contains(check.Message, "authMethod=claudeai") {
+		t.Errorf("claude-auth message = %q, want the auth method reported", check.Message)
+	}
+	if check.Remediation != "" {
+		t.Errorf("claude-auth remediation = %q, want empty when the check passes", check.Remediation)
+	}
+}
+
+// TestClaudeAuthWarnsWhenNotSignedIn is the state the desktop machine card
+// renders: a machine with the harness installed but no login must name the
+// exact command that fixes it rather than failing silently. The non-zero exit
+// is real: `claude auth status --json` exits 1 when not logged in and still
+// prints its JSON, so the output answers the question, not the exit code.
+func TestClaudeAuthWarnsWhenNotSignedIn(t *testing.T) {
+	setConfigEnv(t)
+	deps := testDeps(t, map[string]string{"git": "/bin/git", "claude": "/bin/claude"},
+		claudeAuthFake(t, `{"loggedIn":false,"authMethod":"none","apiProvider":"firstParty"}`, errors.New("exit status 1")))
+
+	check := findCheck(t, Run(context.Background(), deps), "claude-auth")
+	if check.Level != Warn || !strings.Contains(check.Message, "not signed in") {
+		t.Fatalf("claude-auth check = %+v, want WARN not signed in", check)
+	}
+	if check.Remediation != "ao vm setup-harness claude" {
+		t.Errorf("claude-auth remediation = %q, want the setup-harness command", check.Remediation)
+	}
+}
+
+func TestClaudeAuthWarnsWhenHarnessMissing(t *testing.T) {
+	setConfigEnv(t)
+	deps := testDeps(t, map[string]string{"git": "/bin/git"}, gitOnly)
+
+	check := findCheck(t, Run(context.Background(), deps), "claude-auth")
+	if check.Level != Warn || !strings.Contains(check.Message, "not found in PATH") {
+		t.Fatalf("claude-auth check = %+v, want WARN missing binary", check)
+	}
+	if check.Remediation != "ao vm setup-harness claude" {
+		t.Errorf("claude-auth remediation = %q, want the setup-harness command", check.Remediation)
+	}
+}
+
+// TestClaudeAuthWarnsWhenProbeUnusable covers a claude release that no longer
+// answers `claude auth status --json`, and output that is not JSON at all.
+// Neither may crash doctor or be reported as signed in.
+func TestClaudeAuthWarnsWhenProbeUnusable(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		output string
+		err    error
+	}{
+		{name: "command fails", output: "error: unknown command 'auth'\n", err: errors.New("exit status 1")},
+		{name: "output is not json", output: "Logged in as octocat\n"},
+		{name: "output is empty"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			setConfigEnv(t)
+			deps := testDeps(t, map[string]string{"git": "/bin/git", "claude": "/bin/claude"},
+				claudeAuthFake(t, tc.output, tc.err))
+
+			check := findCheck(t, Run(context.Background(), deps), "claude-auth")
+			if check.Level != Warn || !strings.Contains(check.Message, "could not read harness auth state") {
+				t.Fatalf("claude-auth check = %+v, want WARN unreadable auth state", check)
+			}
+		})
+	}
+}
+
+// TestParseClaudeAuthStatusIgnoresSurroundingNoise pins the reason the probe
+// slices to the outermost braces: it runs through CombinedOutput, so a notice
+// on stderr must not make valid JSON unparseable.
+func TestParseClaudeAuthStatusIgnoresSurroundingNoise(t *testing.T) {
+	out := []byte("\x1b[33mA new version of Claude Code is available.\x1b[0m\n" +
+		`{"loggedIn":true,"authMethod":"apiKey","apiProvider":"firstParty"}` + "\n")
+	status, err := parseClaudeAuthStatus(out)
+	if err != nil {
+		t.Fatalf("parseClaudeAuthStatus: %v", err)
+	}
+	if !status.LoggedIn || status.AuthMethod != "apiKey" {
+		t.Fatalf("status = %+v, want loggedIn with authMethod=apiKey", status)
+	}
+	if got := status.describe(); got != "authMethod=apiKey apiProvider=firstParty" {
+		t.Errorf("describe = %q", got)
+	}
+}
+
+func TestChecksGitHubTokenFromEnv(t *testing.T) {
+	setConfigEnv(t)
+	srv := githubServer(t, http.StatusOK, `{"login":"octocat"}`, "repo, read:org")
+	deps := testDeps(t, map[string]string{"git": "/bin/git"}, gitOnly)
+	t.Setenv("AO_GITHUB_TOKEN", "env-token")
+	deps.HTTPClient = srv.Client()
+	deps.GitHubRESTBase = srv.URL
+
+	check := findCheck(t, Run(context.Background(), deps), "github-token")
+	if check.Level != Pass || !strings.Contains(check.Message, "AO_GITHUB_TOKEN") || !strings.Contains(check.Message, "repo, read:org") {
+		t.Fatalf("github-token check = %+v, want PASS with source and scopes", check)
+	}
+}
+
+func TestChecksGitHubTokenFromGHCLI(t *testing.T) {
+	setConfigEnv(t)
+	srv := githubServer(t, http.StatusOK, `{"login":"octocat"}`, "")
+	deps := testDeps(t, map[string]string{"git": "/bin/git", "gh": "/bin/gh"}, func(_ context.Context, name string, args ...string) ([]byte, error) {
+		if name == "/bin/gh" {
+			if len(args) != 2 || args[0] != "auth" || args[1] != "token" {
+				t.Fatalf("unexpected gh command: %s %v", name, args)
+			}
+			return []byte("gh-token\n"), nil
+		}
+		return []byte("git version 2.43.0\n"), nil
+	})
+	deps.HTTPClient = srv.Client()
+	deps.GitHubRESTBase = srv.URL
+
+	check := findCheck(t, Run(context.Background(), deps), "github-token")
+	if check.Level != Pass || !strings.Contains(check.Message, "gh token valid") {
+		t.Fatalf("github-token check = %+v, want PASS from gh", check)
+	}
+}
+
+func TestWarnsWhenGitHubTokenMissing(t *testing.T) {
+	setConfigEnv(t)
+	deps := testDeps(t, map[string]string{"git": "/bin/git"}, gitOnly)
+
+	check := findCheck(t, Run(context.Background(), deps), "github-token")
+	if check.Level != Warn || !strings.Contains(check.Message, "no GitHub token found") {
+		t.Fatalf("github-token check = %+v, want WARN missing token", check)
+	}
+}
+
+func TestFailsExpiredGitHubToken(t *testing.T) {
+	setConfigEnv(t)
+	srv := githubServer(t, http.StatusUnauthorized, `{"message":"Bad credentials"}`, "")
+	deps := testDeps(t, map[string]string{"git": "/bin/git"}, gitOnly)
+	t.Setenv("GITHUB_TOKEN", "expired-token")
+	deps.HTTPClient = srv.Client()
+	deps.GitHubRESTBase = srv.URL
+
+	check := findCheck(t, Run(context.Background(), deps), "github-token")
+	if check.Level != Fail || !strings.Contains(check.Message, "HTTP 401") {
+		t.Fatalf("github-token check = %+v, want FAIL rejected token", check)
+	}
+}
+
+// TestChecksAOBinaryIdentity covers the `ao-binary` check: workspace hooks
+// invoke a bare `ao hooks <agent> <event>`, so doctor must surface when the
+// `ao` on PATH is not the running binary (e.g. a legacy CLI without the hooks
+// command shadowing the Go one).
+func TestChecksAOBinaryIdentity(t *testing.T) {
+	dir := t.TempDir()
+	self := filepath.Join(dir, "ao")
+	other := filepath.Join(dir, "ao-legacy")
+	for _, p := range []string{self, other} {
+		if err := os.WriteFile(p, []byte("#!/bin/sh\n"), 0o755); err != nil { //nolint:gosec // test fixture must be executable-shaped
+			t.Fatal(err)
+		}
+	}
+	selfExe := func() (string, error) { return self, nil }
+
+	cases := []struct {
+		name       string
+		executable func() (string, error)
+		paths      map[string]string
+		wantLevel  Level
+		wantIn     string
+	}{
+		{"ao in PATH is this binary", selfExe, map[string]string{"ao": self}, Pass, "this binary"},
+		{"ao in PATH is a different binary", selfExe, map[string]string{"ao": other}, Warn, "not this binary"},
+		{"ao missing from PATH", selfExe, map[string]string{}, Warn, "not found in PATH"},
+		{"running executable unresolvable", func() (string, error) { return "", errors.New("no exe") }, map[string]string{"ao": self}, Warn, "could not resolve"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			deps := Deps{Executable: tc.executable, LookPath: lookPathIn(tc.paths)}.withDefaults()
+			check := deps.checkAOBinary()
+			if check.Level != tc.wantLevel || !strings.Contains(check.Message, tc.wantIn) {
+				t.Fatalf("ao-binary check = %+v, want level %s with %q", check, tc.wantLevel, tc.wantIn)
+			}
+		})
+	}
+}
+
+// TestIncludesAOBinaryCheck asserts Run actually surfaces the ao-binary check,
+// so the identity probe cannot silently fall out of the report.
+func TestIncludesAOBinaryCheck(t *testing.T) {
+	setConfigEnv(t)
+	deps := testDeps(t, map[string]string{"git": "/bin/git"}, gitOnly)
+
+	// testDeps' LookPath has no "ao", so the check lands as a WARN.
+	check := findCheck(t, Run(context.Background(), deps), "ao-binary")
+	if check.Level != Warn || !strings.Contains(check.Message, "not found in PATH") {
+		t.Fatalf("ao-binary check = %+v, want WARN for missing ao", check)
+	}
+}
+
+func codexCanaryFake(t *testing.T, probeOutput string, probeErr error) func(context.Context, string, ...string) ([]byte, error) {
+	t.Helper()
+	return func(_ context.Context, name string, args ...string) ([]byte, error) {
+		switch {
+		case name == "/bin/git":
+			return []byte("git version 2.43.0\n"), nil
+		case name == "/bin/codex" && len(args) == 1 && args[0] == "--version":
+			return []byte("codex-cli 0.136.0\n"), nil
+		case name == "/bin/codex":
+			return []byte(probeOutput), probeErr
+		default:
+			t.Fatalf("unexpected command: %s %v", name, args)
+			return nil, nil
+		}
+	}
+}
+
+func TestCodexLaunchFlagsPass(t *testing.T) {
+	setConfigEnv(t)
+	deps := testDeps(t, map[string]string{"git": "/bin/git", "codex": "/bin/codex"}, codexCanaryFake(t, "ok\n", nil))
+
+	check := findCheck(t, Run(context.Background(), deps), "codex-launch-flags")
+	if check.Level != Pass || !strings.Contains(check.Message, "accepts") {
+		t.Fatalf("canary = %+v, want PASS accepts", check)
+	}
+}
+
+func TestCodexLaunchFlagsWarnOnRejectedFlag(t *testing.T) {
+	setConfigEnv(t)
+	deps := testDeps(t, map[string]string{"git": "/bin/git", "codex": "/bin/codex"},
+		codexCanaryFake(t, "error: unexpected argument '--dangerously-bypass-hook-trust' found\n", errors.New("exit status 2")))
+
+	check := findCheck(t, Run(context.Background(), deps), "codex-launch-flags")
+	if check.Level != Warn || !strings.Contains(check.Message, "rejected AO's launch flags") {
+		t.Fatalf("canary = %+v, want WARN rejected flags", check)
+	}
+}
+
+func TestCodexLaunchFlagsWarnOnUnknownConfigField(t *testing.T) {
+	setConfigEnv(t)
+	deps := testDeps(t, map[string]string{"git": "/bin/git", "codex": "/bin/codex"},
+		codexCanaryFake(t, "unknown configuration field `hooks` in -c/--config override\n", nil))
+
+	check := findCheck(t, Run(context.Background(), deps), "codex-launch-flags")
+	if check.Level != Warn || !strings.Contains(check.Message, "no longer recognizes") {
+		t.Fatalf("canary = %+v, want WARN unknown config field", check)
+	}
+}
+
+func TestCodexLaunchFlagsSkippedWithoutCodex(t *testing.T) {
+	setConfigEnv(t)
+	deps := testDeps(t, map[string]string{"git": "/bin/git"}, gitOnly)
+
+	check := findCheck(t, Run(context.Background(), deps), "codex-launch-flags")
+	if check.Level != Pass || !strings.Contains(check.Message, "skipped") {
+		t.Fatalf("canary = %+v, want skipped PASS", check)
+	}
+}
+
+func TestHooksLogStates(t *testing.T) {
+	t.Run("missing log passes", func(t *testing.T) {
+		setConfigEnv(t)
+		deps := testDeps(t, map[string]string{"git": "/bin/git"}, gitOnly)
+		check := findCheck(t, Run(context.Background(), deps), "hooks-log")
+		if check.Level != Pass || !strings.Contains(check.Message, "no hook delivery failures") {
+			t.Fatalf("hooks-log = %+v, want PASS no failures", check)
+		}
+	})
+
+	t.Run("recent failures warn", func(t *testing.T) {
+		dataDir := setConfigEnv(t)
+		writeHooksLogLines(t, dataDir,
+			time.Now().Add(-48*time.Hour).UTC().Format(time.RFC3339)+" session=old ao hooks codex stop: stale",
+			time.Now().Add(-time.Hour).UTC().Format(time.RFC3339)+" session=mer-1 ao hooks codex stop: connection refused",
+		)
+		deps := testDeps(t, map[string]string{"git": "/bin/git"}, gitOnly)
+		check := findCheck(t, Run(context.Background(), deps), "hooks-log")
+		if check.Level != Warn || !strings.Contains(check.Message, "1 hook delivery failure") || !strings.Contains(check.Message, "connection refused") {
+			t.Fatalf("hooks-log = %+v, want WARN with recent count and latest line", check)
+		}
+	})
+
+	t.Run("only stale failures pass", func(t *testing.T) {
+		dataDir := setConfigEnv(t)
+		writeHooksLogLines(t, dataDir,
+			time.Now().Add(-72*time.Hour).UTC().Format(time.RFC3339)+" session=old ao hooks codex stop: stale",
+		)
+		deps := testDeps(t, map[string]string{"git": "/bin/git"}, gitOnly)
+		check := findCheck(t, Run(context.Background(), deps), "hooks-log")
+		if check.Level != Pass || !strings.Contains(check.Message, "last 24h") {
+			t.Fatalf("hooks-log = %+v, want PASS stale-only", check)
+		}
+	})
+}
+
+// TestDaemonCheckIsInjected pins the one point the two callers differ on: the
+// CLI supplies its run-file inspection, the daemon answers for itself, and a
+// caller that supplies neither gets no daemon check rather than a wrong one.
+func TestDaemonCheckIsInjected(t *testing.T) {
+	setConfigEnv(t)
+	deps := testDeps(t, map[string]string{"git": "/bin/git"}, gitOnly)
+	for _, check := range Run(context.Background(), deps) {
+		if check.Name == "daemon" {
+			t.Fatalf("daemon check reported with no DaemonCheck injected: %+v", check)
+		}
+	}
+
+	deps.DaemonCheck = func(context.Context) Check {
+		return Check{Level: Pass, Section: SectionCore, Name: "daemon", Message: "injected"}
+	}
+	check := findCheck(t, Run(context.Background(), deps), "daemon")
+	if check.Message != "injected" {
+		t.Fatalf("daemon check = %+v, want the injected one", check)
+	}
+}
+
+func gitOnly(context.Context, string, ...string) ([]byte, error) {
+	return []byte("git version 2.43.0\n"), nil
+}
+
+// setConfigEnv points config.Load at a temp data dir and returns it, so the
+// filesystem checks never touch the developer's real ~/.ao.
+func setConfigEnv(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	dataDir := filepath.Join(dir, "data")
+	t.Setenv("AO_RUN_FILE", filepath.Join(dir, "running.json"))
+	t.Setenv("AO_DATA_DIR", dataDir)
+	t.Setenv("AO_PORT", "3001")
+	t.Setenv("AO_REQUEST_TIMEOUT", "")
+	t.Setenv("AO_SHUTDOWN_TIMEOUT", "")
+	return dataDir
+}
+
+func lookPathIn(paths map[string]string) func(string) (string, error) {
+	return func(name string) (string, error) {
+		path, ok := paths[name]
+		if !ok || path == "" {
+			return "", fmt.Errorf("%s missing", name)
+		}
+		return path, nil
+	}
+}
+
+func testDeps(t *testing.T, paths map[string]string, commandOutput func(context.Context, string, ...string) ([]byte, error)) Deps {
+	t.Helper()
+	t.Setenv("AO_GITHUB_TOKEN", "")
+	t.Setenv("GITHUB_TOKEN", "")
+	t.Setenv("GH_TOKEN", "")
+	deps := Deps{LookPath: lookPathIn(paths), CommandOutput: commandOutput}
+	return deps.withDefaults()
+}
+
+func githubServer(t *testing.T, status int, body, scopes string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/user" {
+			t.Fatalf("unexpected github probe: %s %s", r.Method, r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); !strings.HasPrefix(got, "Bearer ") {
+			t.Fatalf("missing bearer auth header: %q", got)
+		}
+		if scopes != "" {
+			w.Header().Set("X-OAuth-Scopes", scopes)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		_, _ = io.WriteString(w, body)
+	}))
+}
+
+func findCheck(t *testing.T, checks []Check, name string) Check {
+	t.Helper()
+	for _, check := range checks {
+		if check.Name == name {
+			return check
+		}
+	}
+	t.Fatalf("doctor check %q not found in %+v", name, checks)
+	return Check{}
+}
+
+func writeHooksLogLines(t *testing.T, dataDir string, lines ...string) {
+	t.Helper()
+	if err := os.MkdirAll(dataDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	content := strings.Join(lines, "\n") + "\n"
+	if err := os.WriteFile(filepath.Join(dataDir, HooksLogName), []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/backend/internal/httpd/api.go
+++ b/backend/internal/httpd/api.go
@@ -51,6 +51,7 @@ type API struct {
 	imports       *controllers.ImportController
 	shellTerms    *controllers.ShellTerminalsController
 	dev           *controllers.DevController
+	doctor        *controllers.DoctorController
 	events        *EventsController
 }
 
@@ -77,7 +78,11 @@ func NewAPI(cfg config.Config, deps APIDeps) *API {
 		imports:       &controllers.ImportController{Svc: deps.Import},
 		shellTerms:    &controllers.ShellTerminalsController{Svc: deps.ShellTerminals},
 		dev:           &controllers.DevController{Import: deps.DevImport},
-		events:        &EventsController{Source: deps.CDC, Live: deps.Events},
+		// The doctor route has no service behind it: it probes the machine
+		// this daemon runs on, so it is always available rather than 501 on a
+		// missing dependency.
+		doctor: &controllers.DoctorController{},
+		events: &EventsController{Source: deps.CDC, Live: deps.Events},
 	}
 }
 
@@ -105,6 +110,7 @@ func (a *API) Register(root chi.Router) {
 			a.imports.Register(r)
 			a.shellTerms.Register(r)
 			a.dev.Register(r)
+			a.doctor.Register(r)
 			// Sibling REST controllers plug in here.
 		})
 		// Long-lived streams intentionally bypass the REST timeout middleware.

--- a/backend/internal/httpd/apispec/openapi.yaml
+++ b/backend/internal/httpd/apispec/openapi.yaml
@@ -134,6 +134,25 @@ paths:
       summary: Run the developer project-registry import through the daemon store
       tags:
       - dev
+  /api/v1/doctor:
+    get:
+      operationId: getDoctorReport
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DoctorReportResponse'
+          description: OK
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+          description: Internal Server Error
+      summary: Run this machine's health checks and return the report
+      tags:
+      - doctor
   /api/v1/events:
     get:
       operationId: streamEvents
@@ -2519,6 +2538,53 @@ components:
       required:
       - report
       type: object
+    DoctorCheckResponse:
+      properties:
+        level:
+          description: Check outcome. FAIL means the machine is broken; WARN means
+            degraded.
+          enum:
+          - PASS
+          - WARN
+          - FAIL
+          type: string
+        message:
+          description: Human-readable outcome for this check.
+          type: string
+        name:
+          description: Stable check id, e.g. claude-auth.
+          type: string
+        remediation:
+          description: The single command that fixes this check, e.g. ao vm setup-harness
+            claude. Empty when no single command applies.
+          type: string
+        section:
+          description: Report grouping, e.g. Core, Tools, Agent harnesses, GitHub.
+          type: string
+      required:
+      - level
+      - name
+      - message
+      type: object
+    DoctorReportResponse:
+      properties:
+        checks:
+          description: Every check, in report order.
+          items:
+            $ref: '#/components/schemas/DoctorCheckResponse'
+          type: array
+        failures:
+          description: Number of FAIL checks.
+          type: integer
+        ok:
+          description: True when no check failed. WARN checks (a missing optional
+            tool, a harness that is not signed in) do not clear it.
+          type: boolean
+      required:
+      - ok
+      - failures
+      - checks
+      type: object
     DomainActivity:
       properties:
         lastActivityAt:
@@ -3937,3 +4003,5 @@ tags:
   name: dev
 - description: Connect Mobile LAN bridge control (loopback/desktop only)
   name: mobile
+- description: Machine health checks (the `ao doctor` checks, read remotely)
+  name: doctor

--- a/backend/internal/httpd/apispec/specgen/build.go
+++ b/backend/internal/httpd/apispec/specgen/build.go
@@ -77,6 +77,8 @@ func Build() ([]byte, error) {
 			"Developer-only maintenance operations"),
 		*(&openapi31.Tag{Name: "mobile"}).WithDescription(
 			"Connect Mobile LAN bridge control (loopback/desktop only)"),
+		*(&openapi31.Tag{Name: "doctor"}).WithDescription(
+			"Machine health checks (the `ao doctor` checks, read remotely)"),
 	}
 
 	for _, op := range operations() {
@@ -229,6 +231,9 @@ var schemaNames = map[string]string{
 	"ControllersDevImportProjectsResponse": "DevImportProjectsResponse",
 	// httpd/controllers: mobile wire envelopes
 	"ControllersMobileStatusResponse": "MobileStatusResponse",
+	// httpd/controllers: doctor wire envelopes
+	"ControllersDoctorReportResponse": "DoctorReportResponse",
+	"ControllersDoctorCheckResponse":  "DoctorCheckResponse",
 	// devimport report
 	"DevimportReport":   "DevImportProjectsReport",
 	"DevimportConflict": "DevImportProjectsConflict",
@@ -336,7 +341,24 @@ func operations() []operation {
 	ops = append(ops, devOperations()...)
 	ops = append(ops, mobileOperations()...)
 	ops = append(ops, shellTerminalOperations()...)
+	ops = append(ops, doctorOperations()...)
 	return ops
+}
+
+// doctorOperations describes the machine-readiness surface: the same checks
+// `ao doctor` runs, served under /api/v1 so the VM gateway forwards them and
+// the desktop can read a remote machine's readiness.
+func doctorOperations() []operation {
+	return []operation{
+		{
+			method: http.MethodGet, path: "/api/v1/doctor", id: "getDoctorReport", tag: "doctor",
+			summary: "Run this machine's health checks and return the report",
+			resps: []respUnit{
+				{http.StatusOK, controllers.DoctorReportResponse{}},
+				{http.StatusInternalServerError, envelope.APIError{}},
+			},
+		},
+	}
 }
 
 // shellTerminalOperations describes the standalone shell terminal surface:

--- a/backend/internal/httpd/controllers/doctor.go
+++ b/backend/internal/httpd/controllers/doctor.go
@@ -1,0 +1,98 @@
+package controllers
+
+import (
+	"context"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/doctor"
+	"github.com/aoagents/agent-orchestrator/backend/internal/httpd/envelope"
+)
+
+// DoctorController owns GET /api/v1/doctor: the health checks `ao doctor`
+// runs, served so the desktop can read a remote machine's readiness. It sits
+// under /api/v1 because that is what the VM gateway proxies (see
+// isProxyablePath in internal/vmgateway); a doctor route anywhere else would
+// be unreachable from the app.
+//
+// The route carries no auth of its own, like every other daemon route: the
+// daemon is loopback-bound, and the gateway verifies an AO token on every
+// request before proxying (ADR 0002). A second token check here would
+// duplicate the gateway and diverge from it.
+type DoctorController struct {
+	// Checks runs the health checks. Nil runs the production set; tests
+	// inject fakes rather than spawning real probes.
+	Checks func(ctx context.Context) []doctor.Check
+}
+
+// Register mounts the doctor route on the supplied router.
+func (c *DoctorController) Register(r chi.Router) {
+	r.Get("/doctor", c.report)
+}
+
+func (c *DoctorController) report(w http.ResponseWriter, r *http.Request) {
+	run := c.Checks
+	if run == nil {
+		run = runDoctorChecks
+	}
+	envelope.WriteJSON(w, http.StatusOK, doctorReport(run(r.Context())))
+}
+
+// runDoctorChecks runs the production check set. The daemon answers the daemon
+// check itself: it is the process serving this request, so the CLI's run-file
+// and health-probe inspection would be a roundabout way of asking whether it
+// is awake.
+func runDoctorChecks(ctx context.Context) []doctor.Check {
+	deps := doctor.DefaultDeps()
+	deps.DaemonCheck = func(context.Context) doctor.Check {
+		return doctor.Check{
+			Level: doctor.Pass, Section: doctor.SectionCore, Name: "daemon",
+			Message: "serving this request",
+		}
+	}
+	return doctor.Run(ctx, deps)
+}
+
+// doctorReport projects the checks onto the wire shape, counting failures the
+// same way `ao doctor` does.
+func doctorReport(checks []doctor.Check) DoctorReportResponse {
+	home, _ := os.UserHomeDir()
+	report := DoctorReportResponse{Checks: make([]DoctorCheckResponse, 0, len(checks))}
+	for _, check := range checks {
+		if check.Level == doctor.Fail {
+			report.Failures++
+		}
+		report.Checks = append(report.Checks, DoctorCheckResponse{
+			Level:       string(check.Level),
+			Section:     check.Section,
+			Name:        check.Name,
+			Message:     redactHomePaths(check.Message, home),
+			Remediation: redactHomePaths(check.Remediation, home),
+		})
+	}
+	report.OK = report.Failures == 0
+	return report
+}
+
+// redactHomePaths rewrites paths under the machine's home directory to "~", so
+// a report that crosses the network does not hand out the home layout: the
+// account name, and the directory names under it. Paths outside home (which
+// git a machine resolves, where the ao binary lives) stay whole, because there
+// the path is the diagnostic and it is not private.
+//
+// It only rewrites home as a directory prefix, never a bare mention of it, so
+// a sibling account whose name merely starts with the same letters is not
+// mangled. A data dir moved outside home with AO_DATA_DIR is reported in full;
+// at that point the path is the finding.
+func redactHomePaths(message, home string) string {
+	sep := string(filepath.Separator)
+	home = strings.TrimSuffix(home, sep)
+	if home == "" || home == sep {
+		return message
+	}
+	return strings.ReplaceAll(message, home+sep, "~"+sep)
+}

--- a/backend/internal/httpd/controllers/doctor_test.go
+++ b/backend/internal/httpd/controllers/doctor_test.go
@@ -1,0 +1,126 @@
+package controllers
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/doctor"
+)
+
+func doctorResponse(t *testing.T, checks []doctor.Check) (DoctorReportResponse, string) {
+	t.Helper()
+	r := chi.NewRouter()
+	(&DoctorController{Checks: func(context.Context) []doctor.Check { return checks }}).Register(r)
+
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/doctor", http.NoBody))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /doctor = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	var report DoctorReportResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &report); err != nil {
+		t.Fatalf("decode doctor report: %v (body %s)", err, rec.Body.String())
+	}
+	return report, rec.Body.String()
+}
+
+// TestDoctorReportCarriesRemediation pins what the desktop machine card reads:
+// a named check, its level, and the exact command that fixes it, all intact
+// across the HTTP boundary.
+func TestDoctorReportCarriesRemediation(t *testing.T) {
+	report, body := doctorResponse(t, []doctor.Check{
+		{Level: doctor.Pass, Section: doctor.SectionTools, Name: "git", Message: "/usr/bin/git (version 2.43.0; supports worktrees)"},
+		{
+			Level: doctor.Warn, Section: doctor.SectionAgents, Name: "claude-auth",
+			Message:     "claude not found in PATH; install the Claude Code CLI, then run `ao vm setup-harness claude`",
+			Remediation: "ao vm setup-harness claude",
+		},
+	})
+
+	if !report.OK || report.Failures != 0 {
+		t.Fatalf("report = %+v, want ok with no failures (a WARN is not a failure)", report)
+	}
+	if len(report.Checks) != 2 {
+		t.Fatalf("checks = %+v, want 2", report.Checks)
+	}
+	auth := report.Checks[1]
+	if auth.Name != "claude-auth" || auth.Level != "WARN" || auth.Section != doctor.SectionAgents {
+		t.Errorf("claude-auth check = %+v", auth)
+	}
+	if auth.Remediation != "ao vm setup-harness claude" {
+		t.Errorf("remediation = %q, want the setup-harness command", auth.Remediation)
+	}
+	// A path outside the home directory is the diagnostic itself, so it stays.
+	if !strings.Contains(body, "/usr/bin/git") {
+		t.Errorf("body dropped the resolved git path: %s", body)
+	}
+}
+
+// TestDoctorReportCountsFailures asserts a broken machine is still a readable
+// report: the failure count is the caller's signal, not an HTTP error.
+func TestDoctorReportCountsFailures(t *testing.T) {
+	report, _ := doctorResponse(t, []doctor.Check{
+		{Level: doctor.Fail, Section: doctor.SectionTools, Name: "git", Message: "not found in PATH"},
+		{Level: doctor.Warn, Section: doctor.SectionTools, Name: "tmux", Message: "not found in PATH"},
+		{Level: doctor.Pass, Section: doctor.SectionCore, Name: "daemon", Message: "serving this request"},
+	})
+	if report.OK || report.Failures != 1 {
+		t.Fatalf("report = %+v, want not-ok with 1 failure", report)
+	}
+}
+
+// TestDoctorReportHidesHomeLayout is the privacy property of this route: the
+// body crosses the network to a desktop client, so it must not hand out the
+// machine's home directory layout (the account name, the directories under
+// it). The check messages are full of such paths locally.
+func TestDoctorReportHidesHomeLayout(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		t.Skip("no home directory on this machine")
+	}
+	dataDir := filepath.Join(home, ".ao")
+	_, body := doctorResponse(t, []doctor.Check{
+		{Level: doctor.Pass, Section: doctor.SectionCore, Name: "config", Message: "runFile=" + filepath.Join(dataDir, "running.json") + " dataDir=" + dataDir + " port=3001"},
+		{Level: doctor.Pass, Section: doctor.SectionCore, Name: "sqlite", Message: filepath.Join(dataDir, "ao.db") + " (4096 bytes)"},
+	})
+
+	if strings.Contains(body, home) {
+		t.Fatalf("response leaks the home directory %q: %s", home, body)
+	}
+	if !strings.Contains(body, "~") {
+		t.Fatalf("response dropped the redacted paths entirely: %s", body)
+	}
+}
+
+func TestRedactHomePaths(t *testing.T) {
+	sep := string(filepath.Separator)
+	home := filepath.Join(sep+"home", "ubuntu")
+	cases := []struct {
+		name    string
+		message string
+		home    string
+		want    string
+	}{
+		{"path under home", filepath.Join(home, ".ao", "ao.db"), home, "~" + sep + filepath.Join(".ao", "ao.db")},
+		{"trailing separator on home", filepath.Join(home, ".ao"), home + sep, "~" + sep + ".ao"},
+		{"path outside home", filepath.Join(sep+"usr", "bin", "git"), home, filepath.Join(sep+"usr", "bin", "git")},
+		{"sibling account is not mangled", filepath.Join(sep+"home", "ubuntu2", "x"), home, filepath.Join(sep+"home", "ubuntu2", "x")},
+		{"unknown home leaves the message alone", filepath.Join(home, ".ao"), "", filepath.Join(home, ".ao")},
+		{"root home leaves the message alone", filepath.Join(sep+"etc", "ao"), sep, filepath.Join(sep+"etc", "ao")},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := redactHomePaths(tc.message, tc.home); got != tc.want {
+				t.Errorf("redactHomePaths(%q, %q) = %q, want %q", tc.message, tc.home, got, tc.want)
+			}
+		})
+	}
+}

--- a/backend/internal/httpd/controllers/dto.go
+++ b/backend/internal/httpd/controllers/dto.go
@@ -775,3 +775,25 @@ type UnregisterPushDeviceResponse struct {
 	Token   string `json:"token"`
 	Deleted bool   `json:"deleted"`
 }
+
+// DoctorReportResponse is the body of GET /api/v1/doctor: the same health
+// checks `ao doctor` runs, so the desktop can read a remote machine's
+// readiness through the VM gateway.
+type DoctorReportResponse struct {
+	OK       bool                  `json:"ok" description:"True when no check failed. WARN checks (a missing optional tool, a harness that is not signed in) do not clear it."`
+	Failures int                   `json:"failures" description:"Number of FAIL checks."`
+	Checks   []DoctorCheckResponse `json:"checks" description:"Every check, in report order."`
+}
+
+// DoctorCheckResponse is one check in a doctor report. It is a deliberate
+// projection of the internal check rather than that type serialized directly:
+// this body crosses the network to a desktop client, so it carries check
+// names, outcomes, and fix commands, and messages are rewritten to hide the
+// machine's home directory layout (see redactHomePaths).
+type DoctorCheckResponse struct {
+	Level       string `json:"level" enum:"PASS,WARN,FAIL" description:"Check outcome. FAIL means the machine is broken; WARN means degraded."`
+	Section     string `json:"section,omitempty" description:"Report grouping, e.g. Core, Tools, Agent harnesses, GitHub."`
+	Name        string `json:"name" description:"Stable check id, e.g. claude-auth."`
+	Message     string `json:"message" description:"Human-readable outcome for this check."`
+	Remediation string `json:"remediation,omitempty" description:"The single command that fixes this check, e.g. ao vm setup-harness claude. Empty when no single command applies."`
+}

--- a/backend/internal/httpd/doctor_route_test.go
+++ b/backend/internal/httpd/doctor_route_test.go
@@ -1,0 +1,79 @@
+package httpd
+
+import (
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/config"
+	"github.com/aoagents/agent-orchestrator/backend/internal/vmgateway"
+)
+
+// mountedDoctorRoutes returns the doctor routes the daemon actually mounts,
+// so the assertions below are pinned to the router rather than to a path
+// literal that could drift from it.
+func mountedDoctorRoutes(t *testing.T) []string {
+	t.Helper()
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	router := NewRouterWithControl(config.Config{}, log, nil, APIDeps{}, ControlDeps{})
+
+	var routes []string
+	err := chi.Walk(router, func(method, route string, _ http.Handler, _ ...func(http.Handler) http.Handler) error {
+		if strings.Contains(route, "doctor") {
+			routes = append(routes, strings.ToUpper(method)+" "+route)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk routes: %v", err)
+	}
+	return routes
+}
+
+func TestDoctorRouteIsMounted(t *testing.T) {
+	routes := mountedDoctorRoutes(t)
+	if len(routes) != 1 || routes[0] != "GET /api/v1/doctor" {
+		t.Fatalf("doctor routes = %v, want exactly [GET /api/v1/doctor]", routes)
+	}
+}
+
+// TestDoctorRouteIsGatewayProxyable covers the one failure mode no other test
+// would catch. The desktop reaches a machine through the VM gateway, which
+// forwards /api/v1 and below except the loopback-only mobile and dev
+// prefixes; a doctor route mounted anywhere else would pass every daemon test
+// and still be unreachable from the app, making the whole route pointless.
+//
+// The gateway answers 404 for a path outside its allowlist, before auth runs,
+// and 401 for one inside it, so an unauthenticated probe tells the two apart
+// without needing a signed token or a JWKS endpoint.
+func TestDoctorRouteIsGatewayProxyable(t *testing.T) {
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	// The daemon address is never dialled: every request here stops at the
+	// gateway's path allowlist or its token check, well before the proxy.
+	gateway, err := vmgateway.NewHandler("127.0.0.1:1", nil, vmgateway.VerifyOptions{}, nil, log)
+	if err != nil {
+		t.Fatalf("build gateway handler: %v", err)
+	}
+
+	for _, route := range mountedDoctorRoutes(t) {
+		method, path, _ := strings.Cut(route, " ")
+		rec := httptest.NewRecorder()
+		gateway.ServeHTTP(rec, httptest.NewRequest(method, path, http.NoBody))
+		if rec.Code != http.StatusUnauthorized {
+			t.Fatalf("gateway %s = %d, want 401 (404 means the gateway refuses to forward this path)", route, rec.Code)
+		}
+	}
+
+	// Control: a route the gateway deliberately blocks answers 404, so the
+	// assertion above is really distinguishing allowed from blocked.
+	rec := httptest.NewRecorder()
+	gateway.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/v1/mobile/status", http.NoBody))
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("gateway GET /api/v1/mobile/status = %d, want 404", rec.Code)
+	}
+}

--- a/frontend/src/api/schema.ts
+++ b/frontend/src/api/schema.ts
@@ -72,6 +72,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/doctor": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Run this machine's health checks and return the report */
+        get: operations["getDoctorReport"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/events": {
         parameters: {
             query?: never;
@@ -915,6 +932,29 @@ export interface components {
         DevImportProjectsResponse: {
             report: components["schemas"]["DevImportProjectsReport"];
         };
+        DoctorCheckResponse: {
+            /**
+             * @description Check outcome. FAIL means the machine is broken; WARN means degraded.
+             * @enum {string}
+             */
+            level: "PASS" | "WARN" | "FAIL";
+            /** @description Human-readable outcome for this check. */
+            message: string;
+            /** @description Stable check id, e.g. claude-auth. */
+            name: string;
+            /** @description The single command that fixes this check, e.g. ao vm setup-harness claude. Empty when no single command applies. */
+            remediation?: string;
+            /** @description Report grouping, e.g. Core, Tools, Agent harnesses, GitHub. */
+            section?: string;
+        };
+        DoctorReportResponse: {
+            /** @description Every check, in report order. */
+            checks: components["schemas"]["DoctorCheckResponse"][];
+            /** @description Number of FAIL checks. */
+            failures: number;
+            /** @description True when no check failed. WARN checks (a missing optional tool, a harness that is not signed in) do not clear it. */
+            ok: boolean;
+        };
         DomainActivity: {
             /** Format: date-time */
             lastActivityAt: string;
@@ -1638,6 +1678,35 @@ export interface operations {
             };
             /** @description Not Implemented */
             501: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["APIError"];
+                };
+            };
+        };
+    };
+    getDoctorReport: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DoctorReportResponse"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
                 headers: {
                     [name: string]: unknown;
                 };


### PR DESCRIPTION
Closes #34

## Why

The desktop reads a remote machine's readiness over the VM gateway, and the gateway only proxies `/api/v1` and below (minus the loopback-only `mobile` and `dev` prefixes). Doctor had no HTTP route at all, so the machine card could not show readiness, nor the exact command that fixes a machine with no harness.

## What

- **New package `backend/internal/doctor`** holding the check logic extracted from `backend/internal/cli/doctor.go`. One implementation, two callers: the handler does not duplicate it and does not shell out to the `ao` binary.
- **`GET /api/v1/doctor`** (`DoctorController`), mounted inside the gateway's allowlist.
- **`ao doctor` output is unchanged**, text and `--json`. The check functions, their order, and every message string moved verbatim; the CLI keeps the `ok`/`failures` framing and the text grouping.
- DTO in `controllers/dto.go`, operation in `apispec/specgen/build.go`, regenerated `openapi.yaml` and `frontend/src/api/schema.ts`.

The one check the two callers cannot share is injected (`Deps.DaemonCheck`): the CLI supplies the run-file plus health-probe inspection `ao status` reports, the daemon answers for itself ("serving this request"), and a caller supplying neither gets no daemon check rather than a wrong one.

## Response body

It crosses the network, so it is a deliberate projection of the internal check type rather than that type serialized directly. It carries check names, levels, sections, messages, and remediation commands. Paths under the machine's home directory are rewritten to `~`, so a report does not hand out the home layout (the account name and the directories under it). Paths outside home (`/usr/bin/git`, where `ao` resolves) stay whole, because there the path is the diagnostic and it is not private. No tokens, credentials, or environment dumps: the `github-token` check already reports only the source name, the login, and the scopes.

## Auth

None added. The daemon stays loopback-bound and unauthenticated; `ao vm serve` verifies an AO token on every request before proxying (ADR 0002). A second token check here would duplicate the gateway and diverge from it.

`/api/v1/doctor` is deliberately **not** added to `lanControlBlockedPrefixes`: that list is the loopback-only *control* surface (`/shutdown`, telemetry, mobile toggles, dev maintenance), and doctor is a read-only report behind the LAN listener's existing bearer auth.

## Tests

- `internal/doctor` — the check tests moved with the code (git, tmux, harnesses, claude-auth and its remediation, github-token, ao-binary, codex canary, hooks-log), plus one pinning the injected daemon check.
- `internal/cli/doctor_test.go` — trimmed to what the CLI still owns: the `--json` document the machine card reads, the grouped text output, and the daemon check the CLI supplies.
- `internal/httpd/controllers/doctor_test.go` — the served body: remediation survives serialization, a FAIL is a counted failure and not an HTTP error, no home path appears in the body, and a `redactHomePaths` table (including a sibling account that must not be mangled).
- `internal/httpd/doctor_route_test.go` — **the route is gateway-proxyable.** It walks the daemon router for the doctor route and drives that exact path through the real `vmgateway.NewHandler`: 401 (allowed by the path filter, stopped at auth) rather than 404 (refused by the allowlist), with `/api/v1/mobile/status` as the 404 control. A doctor route the gateway refuses to forward is the one failure mode nothing else would catch.

## Verification

- `go build ./...`, `go vet ./...`, `gofmt` clean.
- `go test ./...`: the only failures are the 5 pre-existing `internal/cli` spawn failures on `develop` and one `service/project` test that needs network to clone.
- `golangci-lint v2.12.2` clean on the touched packages.
- `npm run api` regenerated; both artifacts committed.

## Not done, on purpose

The desktop UI is not wired to this route. Task 12 (#31) owns the machine card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)