### PR TITLE
fix(security): strip git credentials in every origin-URL read

### DIFF
--- a/backend/internal/gitremote/gitremote.go
+++ b/backend/internal/gitremote/gitremote.go
@@ -1,0 +1,72 @@
+// Package gitremote reads a git repository's `origin` remote URL. It exists so
+// that credential stripping cannot be bypassed: OriginURL is the only accessor,
+// and it always sanitizes, so no caller has to remember to. Three independently
+// written resolvers previously duplicated this read and two of them persisted
+// the raw URL (issue #41).
+package gitremote
+
+import (
+	"net/url"
+	"strings"
+
+	aoprocess "github.com/aoagents/agent-orchestrator/backend/internal/process"
+)
+
+// OriginURL returns path's `origin` remote URL via
+// `git -C path remote get-url origin`, with any embedded credential stripped.
+// A missing remote, missing repo, or any other git error returns an empty
+// string: `project add` must not fail just because no origin is configured (the
+// SCM observer skips such projects).
+//
+// The result is sanitized because everything downstream of this function is a
+// place a credential must never reach: it is persisted to
+// projects.repo_origin_url, served as Project.Repo, and logged. That covers
+// both a credentialed AddInput.CloneURL (git records it verbatim as origin) and
+// a repo added by path whose own origin already carries one.
+func OriginURL(path string) string {
+	if path == "" {
+		return ""
+	}
+	out, err := aoprocess.Command("git", "-C", path, "remote", "get-url", "origin").Output()
+	if err != nil {
+		return ""
+	}
+	return sanitizeURL(strings.TrimSpace(string(out)))
+}
+
+// sanitizeURL removes any credential embedded in a git remote URL. A client may
+// legitimately POST `cloneUrl` as
+// `https://x-access-token:<token>@github.com/owner/repo.git`, which is how
+// non-interactive https git auth is normally expressed and what
+// GIT_TERMINAL_PROMPT=0 leaves as the practical option; git then records that
+// string verbatim as the repo's `origin`. The token has a job to do there, so
+// the clone's own .git/config keeps it, but it must not travel any further.
+//
+// raw is returned unchanged when there is nothing to strip, when it does not
+// parse as a URL at all, and for the scp-like SSH shorthand
+// (git@host:owner/repo.git), which url.Parse rejects outright and whose
+// userinfo is an SSH login name rather than a secret.
+func sanitizeURL(raw string) string {
+	if !strings.Contains(raw, "@") {
+		return raw
+	}
+	u, err := url.Parse(raw)
+	if err != nil || u.Scheme == "" || u.User == nil {
+		return raw
+	}
+	switch strings.ToLower(u.Scheme) {
+	case "ssh", "git+ssh":
+		// An ssh:// URL's userinfo is the login name (`git`), which is not a
+		// secret and which the remote stops working without. Drop only a
+		// password, which has no legitimate use over SSH.
+		if _, hasPassword := u.User.Password(); !hasPassword {
+			return raw
+		}
+		u.User = url.User(u.User.Username())
+	default:
+		// Over http(s) the username alone is a credential too: a bare
+		// `https://<token>@github.com/...` authenticates with no password.
+		u.User = nil
+	}
+	return u.String()
+}

--- a/backend/internal/gitremote/gitremote_test.go
+++ b/backend/internal/gitremote/gitremote_test.go
@@ -1,0 +1,174 @@
+package gitremote
+
+// Tests for the credential stripping. The table below is the contract: every
+// case above the divider must be stripped, every case below it must survive
+// byte-identical. The ssh-versus-https asymmetry is deliberate, see sanitizeURL.
+// Moved verbatim from internal/service/project/clone_test.go with the function
+// (issue #41).
+
+import (
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestSanitizeURL(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{
+			name: "https token as username and password",
+			raw:  "https://x-access-token:ghp_SECRET@github.com/acme/widgets.git",
+			want: "https://github.com/acme/widgets.git",
+		},
+		{
+			name: "https token as username only",
+			raw:  "https://ghp_SECRET@github.com/acme/widgets.git",
+			want: "https://github.com/acme/widgets.git",
+		},
+		{
+			name: "https user and password",
+			raw:  "https://alice:s3cr3t@git.example.com/acme/widgets.git",
+			want: "https://git.example.com/acme/widgets.git",
+		},
+		{
+			name: "https percent-encoded password",
+			raw:  "https://alice:p%40ss%3Aword@git.example.com/acme/widgets.git",
+			want: "https://git.example.com/acme/widgets.git",
+		},
+		{
+			name: "http is treated the same as https",
+			raw:  "http://alice:s3cr3t@git.example.com/acme/widgets.git",
+			want: "http://git.example.com/acme/widgets.git",
+		},
+		{
+			name: "port and query are preserved",
+			raw:  "https://alice:s3cr3t@git.example.com:8443/acme/widgets.git",
+			want: "https://git.example.com:8443/acme/widgets.git",
+		},
+		{
+			name: "uppercase scheme",
+			raw:  "HTTPS://alice:s3cr3t@git.example.com/acme/widgets.git",
+			want: "https://git.example.com/acme/widgets.git",
+		},
+
+		// Everything below must survive untouched.
+		{
+			name: "plain https is unchanged",
+			raw:  "https://github.com/acme/widgets.git",
+			want: "https://github.com/acme/widgets.git",
+		},
+		{
+			name: "scp-like shorthand keeps its ssh user",
+			raw:  "git@github.com:acme/widgets.git",
+			want: "git@github.com:acme/widgets.git",
+		},
+		{
+			name: "ssh scheme keeps its login name",
+			raw:  "ssh://git@github.com/acme/widgets.git",
+			want: "ssh://git@github.com/acme/widgets.git",
+		},
+		{
+			name: "ssh scheme with a port keeps its login name",
+			raw:  "ssh://git@github.com:2222/acme/widgets.git",
+			want: "ssh://git@github.com:2222/acme/widgets.git",
+		},
+		{
+			name: "ssh scheme drops a password but keeps the login name",
+			raw:  "ssh://git:s3cr3t@github.com/acme/widgets.git",
+			want: "ssh://git@github.com/acme/widgets.git",
+		},
+		{
+			name: "git+ssh keeps its login name",
+			raw:  "git+ssh://git@github.com/acme/widgets.git",
+			want: "git+ssh://git@github.com/acme/widgets.git",
+		},
+		{
+			name: "local path is unchanged",
+			raw:  "/srv/git/acme/widgets.git",
+			want: "/srv/git/acme/widgets.git",
+		},
+		{
+			name: "file url is unchanged",
+			raw:  "file:///srv/git/acme/widgets.git",
+			want: "file:///srv/git/acme/widgets.git",
+		},
+		{
+			name: "empty is unchanged",
+			raw:  "",
+			want: "",
+		},
+		{
+			name: "an at sign in the path is not userinfo",
+			raw:  "https://git.example.com/acme/wid@gets.git",
+			want: "https://git.example.com/acme/wid@gets.git",
+		},
+		{
+			name: "unparseable input is returned verbatim",
+			raw:  "git@host:acme/wid\x7fgets.git",
+			want: "git@host:acme/wid\x7fgets.git",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := sanitizeURL(tc.raw); got != tc.want {
+				t.Fatalf("sanitizeURL(%q) = %q, want %q", tc.raw, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSanitizeURL_LeaksNoSecret(t *testing.T) {
+	const secret = "ghp_SUPERSECRET"
+	for _, raw := range []string{
+		"https://x-access-token:" + secret + "@github.com/acme/widgets.git",
+		"https://" + secret + "@github.com/acme/widgets.git",
+		"https://alice:" + secret + "@git.example.com:8443/acme/widgets.git",
+		"ssh://git:" + secret + "@github.com/acme/widgets.git",
+	} {
+		if got := sanitizeURL(raw); strings.Contains(got, secret) {
+			t.Fatalf("sanitizeURL(%q) still contains the secret: %q", raw, got)
+		}
+	}
+}
+
+// OriginURL must strip a credential the repo's own .git/config carries, which is
+// the case for a repo added by path whose origin was set up with a token, and for
+// a clone AO itself made from a credentialed cloneUrl.
+func TestOriginURL_StripsCredentialFromRealRepo(t *testing.T) {
+	const secret = "ghp_SUPERSECRET"
+	dir := t.TempDir()
+	mustGit(t, "init", dir)
+	mustGit(t, "-C", dir, "remote", "add", "origin", "https://x-access-token:"+secret+"@github.com/acme/widgets.git")
+
+	got := OriginURL(dir)
+	if strings.Contains(got, secret) {
+		t.Fatalf("OriginURL leaked the token: %q", got)
+	}
+	if got != "https://github.com/acme/widgets.git" {
+		t.Fatalf("OriginURL = %q, want https://github.com/acme/widgets.git", got)
+	}
+}
+
+func TestOriginURL_EmptyWhenNoOriginOrNoRepo(t *testing.T) {
+	dir := t.TempDir()
+	mustGit(t, "init", dir)
+	if got := OriginURL(dir); got != "" {
+		t.Fatalf("OriginURL on a repo with no origin = %q, want \"\"", got)
+	}
+	if got := OriginURL(filepath.Join(dir, "nope")); got != "" {
+		t.Fatalf("OriginURL on a missing repo = %q, want \"\"", got)
+	}
+	if got := OriginURL(""); got != "" {
+		t.Fatalf("OriginURL(\"\") = %q, want \"\"", got)
+	}
+}
+
+func mustGit(t *testing.T, args ...string) {
+	t.Helper()
+	if out, err := exec.Command("git", args...).CombinedOutput(); err != nil {
+		t.Fatalf("git %v: %v (%s)", args, err, out)
+	}
+}

--- a/backend/internal/legacyimport/importer.go
+++ b/backend/internal/legacyimport/importer.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
-	aoprocess "github.com/aoagents/agent-orchestrator/backend/internal/process"
+	"github.com/aoagents/agent-orchestrator/backend/internal/gitremote"
 )
 
 // Store is the narrow slice of the rewrite's native storage layer the importer
@@ -93,7 +93,7 @@ func Run(ctx context.Context, store Store, opts Options) (Report, error) {
 	}
 	resolveOrigin := opts.RepoOriginURL
 	if resolveOrigin == nil {
-		resolveOrigin = defaultRepoOriginURL
+		resolveOrigin = gitremote.OriginURL
 	}
 
 	rep := Report{DryRun: opts.DryRun}
@@ -174,18 +174,4 @@ func quote(s string) string {
 		return `"?"`
 	}
 	return `"` + s + `"`
-}
-
-// defaultRepoOriginURL resolves a repo's git origin URL, "" when the repo is
-// absent or has no origin. Matches the rewrite's resolveGitOriginURL.
-func defaultRepoOriginURL(path string) string {
-	if path == "" {
-		return ""
-	}
-	cmd := aoprocess.Command("git", "-C", path, "remote", "get-url", "origin")
-	out, err := cmd.Output()
-	if err != nil {
-		return ""
-	}
-	return strings.TrimSpace(string(out))
 }

--- a/backend/internal/legacyimport/importer_test.go
+++ b/backend/internal/legacyimport/importer_test.go
@@ -3,6 +3,7 @@ package legacyimport
 import (
 	"context"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -159,6 +160,43 @@ func TestLegacyConfigError_NilWhenAbsentOrEmpty(t *testing.T) {
 	}
 	if LegacyConfigError(context.Background(), filepath.Join(t.TempDir(), "nope")) != nil {
 		t.Fatal("LegacyConfigError on a missing root = non-nil, want nil")
+	}
+}
+
+// The default origin resolver (Options.RepoOriginURL left nil, which is how the
+// daemon and `ao import` call Run) must not persist a credential embedded in the
+// legacy repo's own origin remote. It used to read the URL raw, so a token in
+// .git/config landed in projects.repo_origin_url, from where it is served by
+// GET /api/v1/projects/{id} and logged. Issue #41.
+func TestRun_DefaultOriginResolverStripsCredential(t *testing.T) {
+	const secret = "ghp_SUPERSECRET"
+	repo := t.TempDir()
+	mustGit(t, "init", repo)
+	mustGit(t, "-C", repo, "remote", "add", "origin", "https://x-access-token:"+secret+"@github.com/acme/widgets.git")
+
+	root := filepath.Join(t.TempDir(), ".agent-orchestrator")
+	mustMkdir(t, filepath.Join(root, "projects", "alpha", "sessions"))
+	mustWrite(t, filepath.Join(root, "config.yaml"), "projects:\n  alpha:\n    path: "+repo+"\n")
+
+	store := newFakeStore()
+	// RepoOriginURL deliberately nil: this exercises the real resolver.
+	opts := Options{Root: root, Now: time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)}
+	if _, err := Run(context.Background(), store, opts); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	got := store.projects["alpha"].RepoOriginURL
+	if strings.Contains(got, secret) {
+		t.Fatalf("imported repoOriginURL leaked the token: %q", got)
+	}
+	if got != "https://github.com/acme/widgets.git" {
+		t.Fatalf("imported repoOriginURL = %q, want https://github.com/acme/widgets.git", got)
+	}
+}
+
+func mustGit(t *testing.T, args ...string) {
+	t.Helper()
+	if out, err := exec.Command("git", args...).CombinedOutput(); err != nil {
+		t.Fatalf("git %v: %v (%s)", args, err, out)
 	}
 }
 

--- a/backend/internal/observe/scm/observer.go
+++ b/backend/internal/observe/scm/observer.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/gitremote"
 	"github.com/aoagents/agent-orchestrator/backend/internal/observe"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 	aoprocess "github.com/aoagents/agent-orchestrator/backend/internal/process"
@@ -494,7 +495,7 @@ func (o *Observer) discoverSubjects(ctx context.Context) (map[string]*subject, [
 				continue
 			}
 			if p.RepoOriginURL == "" && p.Path != "" {
-				if url := resolveGitOriginURL(p.Path); url != "" {
+				if url := gitremote.OriginURL(p.Path); url != "" {
 					p.RepoOriginURL = url
 					if err := o.store.UpsertProject(ctx, p); err != nil {
 						o.logger.Warn("scm observer: backfill origin URL persist failed", "project", p.ID, "err", err)
@@ -1443,18 +1444,6 @@ func normalizePRState(draft, merged, closed bool) string {
 	default:
 		return string(domain.PRStateOpen)
 	}
-}
-
-// resolveGitOriginURL runs `git -C path remote get-url origin` and returns the
-// trimmed URL, or "" if the command fails (missing repo, no origin remote, etc).
-// The observer uses this to backfill projects that were registered before
-// project.Add resolved origin URLs at add time.
-func resolveGitOriginURL(path string) string {
-	out, err := aoprocess.Command("git", "-C", path, "remote", "get-url", "origin").Output()
-	if err != nil {
-		return ""
-	}
-	return strings.TrimSpace(string(out))
 }
 
 // gitRemoteURLs lists the fetch URL of every git remote configured at path. It

--- a/backend/internal/observe/scm/observer_test.go
+++ b/backend/internal/observe/scm/observer_test.go
@@ -748,6 +748,43 @@ func TestPoll_IgnoresForkPRWithMatchingBranch(t *testing.T) {
 	}
 }
 
+// The origin-URL backfill runs on an ordinary poll with no user action, so it is
+// the one write that can persist a credential nobody handed to AO: the user set
+// up origin with a token themselves, after the project was added by path. The
+// backfill used to read the remote raw, putting the token in
+// projects.repo_origin_url, whence GET /api/v1/projects/{id} serves it and the
+// tracker intake warning logs it to journald. Issue #41.
+func TestPoll_BackfilledOriginURLStripsCredential(t *testing.T) {
+	const secret = "ghp_SUPERSECRET"
+	dir := t.TempDir()
+	mustGit(t, "init", dir)
+	mustGit(t, "-C", dir, "remote", "add", "origin", "https://x-access-token:"+secret+"@github.com/o/r.git")
+
+	store := &fakeStore{
+		sessions: []domain.SessionRecord{{ID: "p-1", ProjectID: "p", Metadata: domain.SessionMetadata{Branch: "ao/p-1/root"}}},
+		// No RepoOriginURL: exactly the row the backfill exists for.
+		projects: map[string]domain.ProjectRecord{"p": {ID: "p", Path: dir}},
+		prs:      map[domain.SessionID][]domain.PullRequest{},
+		checks:   map[string][]domain.PullRequestCheck{},
+	}
+	provider := &fakeProvider{
+		repoGuards:   map[string]ports.SCMGuardResult{prKey(testRepo, 0): {ETag: "v1"}},
+		openPRs:      map[string][]ports.SCMPRObservation{},
+		observations: map[string]ports.SCMObservation{},
+	}
+	obs := newTestObserver(store, provider, &fakeLifecycle{}, time.Unix(1, 0).UTC())
+	if err := obs.Poll(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	got := store.projects["p"].RepoOriginURL
+	if strings.Contains(got, secret) {
+		t.Fatalf("backfilled repoOriginURL leaked the token: %q", got)
+	}
+	if got != "https://github.com/o/r.git" {
+		t.Fatalf("backfilled repoOriginURL = %q, want https://github.com/o/r.git", got)
+	}
+}
+
 func mustGit(t *testing.T, args ...string) {
 	t.Helper()
 	if out, err := exec.Command("git", args...).CombinedOutput(); err != nil {

--- a/backend/internal/service/project/clone.go
+++ b/backend/internal/service/project/clone.go
@@ -166,44 +166,6 @@ func parseCloneURL(raw string) (owner, repo string, err error) {
 	return owner, repo, nil
 }
 
-// sanitizeOriginURL removes any credential embedded in a git remote URL. A
-// client may legitimately POST `cloneUrl` as
-// `https://x-access-token:<token>@github.com/owner/repo.git`, which is how
-// non-interactive https git auth is normally expressed and what
-// GIT_TERMINAL_PROMPT=0 leaves as the practical option; git then records that
-// string verbatim as the repo's `origin`. The token has a job to do there, so
-// the clone's own .git/config keeps it, but it must not travel any further.
-// See resolveGitOriginURL.
-//
-// raw is returned unchanged when there is nothing to strip, when it does not
-// parse as a URL at all, and for the scp-like SSH shorthand
-// (git@host:owner/repo.git), which url.Parse rejects outright and whose
-// userinfo is an SSH login name rather than a secret.
-func sanitizeOriginURL(raw string) string {
-	if !strings.Contains(raw, "@") {
-		return raw
-	}
-	u, err := url.Parse(raw)
-	if err != nil || u.Scheme == "" || u.User == nil {
-		return raw
-	}
-	switch strings.ToLower(u.Scheme) {
-	case "ssh", "git+ssh":
-		// An ssh:// URL's userinfo is the login name (`git`), which is not a
-		// secret and which the remote stops working without. Drop only a
-		// password, which has no legitimate use over SSH.
-		if _, hasPassword := u.User.Password(); !hasPassword {
-			return raw
-		}
-		u.User = url.User(u.User.Username())
-	default:
-		// Over http(s) the username alone is a credential too: a bare
-		// `https://<token>@github.com/...` authenticates with no password.
-		u.User = nil
-	}
-	return u.String()
-}
-
 func sanitizeDirComponent(s string) (string, error) {
 	s = strings.TrimSpace(s)
 	if s == "" || s == "." || s == ".." || !safeDirComponent.MatchString(s) {

--- a/backend/internal/service/project/clone_test.go
+++ b/backend/internal/service/project/clone_test.go
@@ -1,9 +1,10 @@
 package project
 
 // Internal tests for the clone flow's rejection paths. They exercise
-// cloneRepository, parseCloneURL, sanitizeDirComponent, classifyCloneError, and
-// sanitizeOriginURL directly, which the external project_test package cannot
-// reach. End-to-end coverage through Service.Add lives in service_test.go.
+// cloneRepository, parseCloneURL, sanitizeDirComponent, and classifyCloneError
+// directly, which the external project_test package cannot reach. End-to-end
+// coverage through Service.Add lives in service_test.go. Origin-URL credential
+// stripping now lives in internal/gitremote, and is tested there.
 
 import (
 	"context"
@@ -416,127 +417,6 @@ func TestSanitizeDirComponent(t *testing.T) {
 	} {
 		if got, err := sanitizeDirComponent(bad); err == nil {
 			t.Fatalf("sanitizeDirComponent(%q) = %q, want an error", bad, got)
-		}
-	}
-}
-
-func TestSanitizeOriginURL(t *testing.T) {
-	for _, tc := range []struct {
-		name string
-		raw  string
-		want string
-	}{
-		{
-			name: "https token as username and password",
-			raw:  "https://x-access-token:ghp_SECRET@github.com/acme/widgets.git",
-			want: "https://github.com/acme/widgets.git",
-		},
-		{
-			name: "https token as username only",
-			raw:  "https://ghp_SECRET@github.com/acme/widgets.git",
-			want: "https://github.com/acme/widgets.git",
-		},
-		{
-			name: "https user and password",
-			raw:  "https://alice:s3cr3t@git.example.com/acme/widgets.git",
-			want: "https://git.example.com/acme/widgets.git",
-		},
-		{
-			name: "https percent-encoded password",
-			raw:  "https://alice:p%40ss%3Aword@git.example.com/acme/widgets.git",
-			want: "https://git.example.com/acme/widgets.git",
-		},
-		{
-			name: "http is treated the same as https",
-			raw:  "http://alice:s3cr3t@git.example.com/acme/widgets.git",
-			want: "http://git.example.com/acme/widgets.git",
-		},
-		{
-			name: "port and query are preserved",
-			raw:  "https://alice:s3cr3t@git.example.com:8443/acme/widgets.git",
-			want: "https://git.example.com:8443/acme/widgets.git",
-		},
-		{
-			name: "uppercase scheme",
-			raw:  "HTTPS://alice:s3cr3t@git.example.com/acme/widgets.git",
-			want: "https://git.example.com/acme/widgets.git",
-		},
-
-		// Everything below must survive untouched.
-		{
-			name: "plain https is unchanged",
-			raw:  "https://github.com/acme/widgets.git",
-			want: "https://github.com/acme/widgets.git",
-		},
-		{
-			name: "scp-like shorthand keeps its ssh user",
-			raw:  "git@github.com:acme/widgets.git",
-			want: "git@github.com:acme/widgets.git",
-		},
-		{
-			name: "ssh scheme keeps its login name",
-			raw:  "ssh://git@github.com/acme/widgets.git",
-			want: "ssh://git@github.com/acme/widgets.git",
-		},
-		{
-			name: "ssh scheme with a port keeps its login name",
-			raw:  "ssh://git@github.com:2222/acme/widgets.git",
-			want: "ssh://git@github.com:2222/acme/widgets.git",
-		},
-		{
-			name: "ssh scheme drops a password but keeps the login name",
-			raw:  "ssh://git:s3cr3t@github.com/acme/widgets.git",
-			want: "ssh://git@github.com/acme/widgets.git",
-		},
-		{
-			name: "git+ssh keeps its login name",
-			raw:  "git+ssh://git@github.com/acme/widgets.git",
-			want: "git+ssh://git@github.com/acme/widgets.git",
-		},
-		{
-			name: "local path is unchanged",
-			raw:  "/srv/git/acme/widgets.git",
-			want: "/srv/git/acme/widgets.git",
-		},
-		{
-			name: "file url is unchanged",
-			raw:  "file:///srv/git/acme/widgets.git",
-			want: "file:///srv/git/acme/widgets.git",
-		},
-		{
-			name: "empty is unchanged",
-			raw:  "",
-			want: "",
-		},
-		{
-			name: "an at sign in the path is not userinfo",
-			raw:  "https://git.example.com/acme/wid@gets.git",
-			want: "https://git.example.com/acme/wid@gets.git",
-		},
-		{
-			name: "unparseable input is returned verbatim",
-			raw:  "git@host:acme/wid\x7fgets.git",
-			want: "git@host:acme/wid\x7fgets.git",
-		},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			if got := sanitizeOriginURL(tc.raw); got != tc.want {
-				t.Fatalf("sanitizeOriginURL(%q) = %q, want %q", tc.raw, got, tc.want)
-			}
-		})
-	}
-}
-
-func TestSanitizeOriginURL_LeaksNoSecret(t *testing.T) {
-	const secret = "ghp_SUPERSECRET"
-	for _, raw := range []string{
-		"https://x-access-token:" + secret + "@github.com/acme/widgets.git",
-		"https://" + secret + "@github.com/acme/widgets.git",
-		"https://alice:" + secret + "@git.example.com:8443/acme/widgets.git",
-		"ssh://git:" + secret + "@github.com/acme/widgets.git",
-	} {
-		if got := sanitizeOriginURL(raw); strings.Contains(got, secret) {
-			t.Fatalf("sanitizeOriginURL(%q) still contains the secret: %q", raw, got)
 		}
 	}
 }

--- a/backend/internal/service/project/service.go
+++ b/backend/internal/service/project/service.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/config"
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/gitremote"
 	"github.com/aoagents/agent-orchestrator/backend/internal/httpd/apierr"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 	aoprocess "github.com/aoagents/agent-orchestrator/backend/internal/process"
@@ -251,7 +252,7 @@ func (m *Service) Add(ctx context.Context, in AddInput) (Project, error) {
 			return Project{}, err
 		}
 		row.Kind = domain.ProjectKindWorkspace
-		row.RepoOriginURL = resolveGitOriginURL(path)
+		row.RepoOriginURL = gitremote.OriginURL(path)
 		if err := m.store.UpsertWorkspaceProject(ctx, row, repos); err != nil {
 			return Project{}, apierr.Internal("PROJECT_ADD_FAILED", "Failed to register workspace project")
 		}
@@ -279,7 +280,7 @@ func (m *Service) Add(ctx context.Context, in AddInput) (Project, error) {
 			row.Config.DefaultBranch = branch
 		}
 	}
-	row.RepoOriginURL = resolveGitOriginURL(path)
+	row.RepoOriginURL = gitremote.OriginURL(path)
 	if err := m.store.UpsertProject(ctx, row); err != nil {
 		return Project{}, apierr.Internal("PROJECT_ADD_FAILED", "Failed to register project")
 	}
@@ -673,25 +674,6 @@ func validateScratchProjectConfig(cfg domain.ProjectConfig) error {
 		return errors.New("scratch projects do not support reviewers")
 	}
 	return nil
-}
-
-// resolveGitOriginURL returns the project's `origin` remote URL via
-// `git -C path remote get-url origin`. A missing remote, missing repo, or any
-// other git error returns an empty string — `project add` must not fail just
-// because no origin is configured (the SCM observer skips such projects).
-//
-// The result is passed through sanitizeOriginURL, because everything downstream
-// of this function is a place a credential must never reach: it is persisted to
-// projects.repo_origin_url, served as Project.Repo, and logged. This is the
-// single choke point for every RepoOriginURL assignment, so stripping here
-// covers both a credentialed AddInput.CloneURL (git records it verbatim as
-// origin) and a repo added by path whose own origin already carries one.
-func resolveGitOriginURL(path string) string {
-	out, err := aoprocess.Command("git", "-C", path, "remote", "get-url", "origin").Output()
-	if err != nil {
-		return ""
-	}
-	return sanitizeOriginURL(strings.TrimSpace(string(out)))
 }
 
 // resolveDefaultBranch returns the repo's default branch, preferring the

--- a/backend/internal/service/project/workspace_registration.go
+++ b/backend/internal/service/project/workspace_registration.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/gitremote"
 	"github.com/aoagents/agent-orchestrator/backend/internal/httpd/apierr"
 	aoprocess "github.com/aoagents/agent-orchestrator/backend/internal/process"
 )
@@ -175,7 +176,7 @@ func detectWorkspaceChildren(ctx context.Context, parent string, projectID domai
 			ProjectID:     projectID,
 			Name:          name,
 			RelativePath:  filepath.ToSlash(name),
-			RepoOriginURL: resolveGitOriginURL(child),
+			RepoOriginURL: gitremote.OriginURL(child),
 			RegisteredAt:  registeredAt,
 		})
 	}
@@ -213,7 +214,7 @@ func validateWorkspaceChild(ctx context.Context, child string) error {
 			"suggestedFix": "Check out the repository's default branch (for example `main`) and retry.",
 		})
 	}
-	if origin := resolveGitOriginURL(child); origin == "" {
+	if origin := gitremote.OriginURL(child); origin == "" {
 		return apierr.Invalid("WORKSPACE_CHILD_ORIGIN_REQUIRED", "Workspace child repositories must have an origin remote configured", map[string]any{
 			"path":         child,
 			"suggestedFix": "Run `git remote add origin <url>` in the child repository, then retry.",


### PR DESCRIPTION
Closes #41.

## The defect

#20 stripped credentials in `project.resolveGitOriginURL` and left a comment
asserting it was "the single choke point for every RepoOriginURL assignment". It
was not. Two independently written resolvers with the same shape persisted the
raw URL:

- `legacyimport.defaultRepoOriginURL` (`ao import`)
- `observe/scm.resolveGitOriginURL`, whose backfill in `discoverSubjects` fires
  on an ordinary observer poll with **no user action**, after which
  `trackerintake/observer.go:175` logs `projects.repo_origin_url` verbatim.

Failure scenario: a project is added by path before it has an origin remote, the
user later sets origin to `https://x-access-token:<token>@github.com/o/r.git`.
The next scm poll persists the token, from where `GET /api/v1/projects/{id}`
serves it and the tracker-intake warning writes it to journald.

`go test ./internal/service/project/` passed with 147 tests throughout, because
the defect was outside that package. That is why #20 looked complete.

## The fix

Rather than export the sanitizer and leave three call sites to remember to call
it, the git read itself moves into `internal/gitremote`. `gitremote.OriginURL`
is now the only accessor for a repo's origin and it always sanitizes, so the
invariant holds because there is nothing else to call, not because three authors
remembered. Net effect is 214 lines deleted against 335 added, most of the
addition being tests.

The stripping logic moved byte-identical (`sanitizeURL`), with its table test.
The deliberate ssh-versus-https asymmetry is unchanged and still covered: an
https remote with no userinfo returns through the no-`@` fast path unserialized,
scp-like `git@host:owner/repo.git` is untouched, `ssh://git@host:2222/...` keeps
its login name and port, http(s) userinfo is stripped even when it is a bare
username. The now-false choke-point comment is gone along with the function it
described; the truthful version of the claim lives in the package doc.

## On making it enforceable rather than remembered

The brief asked whether anything could enforce the invariant instead of relying
on memory. A single accessor was the answer, and it came out smaller than the
alternative, so it is in. A lint or a typed `OriginURL` string wrapper on top of
that would be over-engineering for one accessor with four callers, so no.

## Tests

Three, one per affected path, and each was verified to fail with the sanitizing
call temporarily removed:

- `gitremote.TestOriginURL_StripsCredentialFromRealRepo` (`project add`, clone)
- `legacyimport.TestRun_DefaultOriginResolverStripsCredential` (`ao import`,
  `Options.RepoOriginURL` left nil so the real resolver runs)
- `scm.TestPoll_BackfilledOriginURLStripsCredential` (the no-user-action poll)

Each builds a real temp repo with a credentialed origin and asserts the token is
absent from what gets persisted.

Verification run locally: `gofmt -l .` clean, `go build ./...`, `go vet ./...`,
`go test -race` on the four touched packages, and `go test ./...` for the whole
backend: 3009 passed, 4 skipped, and the 5 known pre-existing
`internal/cli` spawn failures (HTTP 404, unrelated to this change and untouched).

## Risks and notes

- Behaviour change is confined to the two paths that were leaking. The already
  sanitized path keeps identical output.
- No migration. Nothing has ever been deployed, so there are no rows to fix.
- `scm.gitRemoteURLs` (the all-remotes read used for cross-fork PR discovery) is
  out of scope here: its output is parsed into repo identities, not persisted or
  logged. Worth a look if that ever changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)