### PR TITLE
fix(doctor): bound the harness probe, trim the HTTP report, harden the gateway

### DIFF
--- a/backend/internal/cli/root.go
+++ b/backend/internal/cli/root.go
@@ -103,8 +103,14 @@ func DefaultDeps() Deps {
 	}
 }
 
+// commandOutput runs a probe through the shared helper, which bounds the wait
+// on the output pipes (aoprocess.WaitDelay). `ao doctor` shells out to Node
+// CLIs that spawn children of their own, and without that bound a surviving
+// grandchild holding the pipe keeps Wait blocked forever: the probe's context
+// deadline kills the direct child and nothing else, so the command never
+// returns to the user.
 func commandOutput(ctx context.Context, name string, args ...string) ([]byte, error) {
-	return aoprocess.CommandContext(ctx, name, args...).CombinedOutput()
+	return aoprocess.CombinedOutput(ctx, name, args...)
 }
 
 // runInteractive inherits the process's own stdio so the child owns the
@@ -122,6 +128,7 @@ func runInteractive(ctx context.Context, name string, args ...string) error {
 func commandOutputInDir(ctx context.Context, dir, name string, args ...string) ([]byte, error) {
 	cmd := aoprocess.CommandContext(ctx, name, args...)
 	cmd.Dir = dir
+	cmd.WaitDelay = aoprocess.WaitDelay // same pipe-holding grandchild problem, see commandOutput
 	return cmd.CombinedOutput()
 }
 

--- a/backend/internal/cli/whoami.go
+++ b/backend/internal/cli/whoami.go
@@ -8,7 +8,6 @@ package cli
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -51,19 +50,20 @@ func (c *commandContext) runWhoami(cmd *cobra.Command, machineFile string) error
 }
 
 // resolveMachineFilePath mirrors vmgateway.Resolve exactly: the flag wins, then
-// AO_MACHINE_FILE, then ~/.ao/machine.json. It deliberately does not use the
-// AO_DATA_DIR-resolved data dir, because the reader does not look there either,
-// and the two have to name the same file or this command would confidently
-// report a binding the gateway never sees.
+// AO_MACHINE_FILE, then the gateway's own default. The default comes from
+// vmgateway.DefaultMachineFilePath rather than being spelled out a second time,
+// because the two have to name the same file or this command would confidently
+// report a binding the gateway never sees. That function documents why the
+// default is the AO home directory and not the AO_DATA_DIR-resolved data dir.
 func resolveMachineFilePath(override string) (string, error) {
 	for _, candidate := range []string{override, os.Getenv("AO_MACHINE_FILE")} {
 		if candidate = strings.TrimSpace(candidate); candidate != "" {
 			return candidate, nil
 		}
 	}
-	home, err := os.UserHomeDir()
+	path, err := vmgateway.DefaultMachineFilePath()
 	if err != nil {
 		return "", fmt.Errorf("resolve the machine file path: %w", err)
 	}
-	return filepath.Join(home, ".ao", "machine.json"), nil
+	return path, nil
 }

--- a/backend/internal/doctor/doctor.go
+++ b/backend/internal/doctor/doctor.go
@@ -55,6 +55,13 @@ type Check struct {
 	// desktop's machine card) can show exactly what to run instead of parsing
 	// it back out of Message. Empty when there is no single command to name.
 	Remediation string `json:"remediation,omitempty"`
+	// PublicMessage replaces Message for a consumer off this machine, when
+	// Message says more than a remote caller should be told. It is deliberately
+	// not serialized: `ao doctor` and `ao doctor --json` run locally and keep
+	// the full Message, and the daemon's HTTP route (a body that crosses the
+	// network, see httpd/controllers.doctorReport) projects this instead when
+	// it is set. Empty means Message is safe to publish as-is.
+	PublicMessage string `json:"-"`
 }
 
 // Section names group the checks in a report, and the names and probe
@@ -82,6 +89,21 @@ const (
 	minGitVersion         = "2.25.0"
 	githubDoctorUserAgent = "ao-agent-orchestrator/doctor"
 	probeTimeout          = 2 * time.Second
+
+	// harnessAuthTimeout is the claude-auth probe's own budget. probeTimeout is
+	// sized for `git --version`: a local binary that prints a line. `claude auth
+	// status --json` is a Node CLI cold start, which on a 1 vCPU VM routinely
+	// takes longer than that, and it may talk to the network. Timing out there
+	// produces a WARN that the desktop maps to "harness not set up", so too
+	// small a budget makes a correctly signed-in machine report as unconfigured
+	// and sends the user back to `ao vm setup-harness`.
+	harnessAuthTimeout = 10 * time.Second
+
+	// maxProbeOutputInMessage caps how much harness output a check message may
+	// quote. These messages cross the network on GET /api/v1/doctor, so a
+	// future harness release that prints something long, or something private,
+	// on this path cannot turn the report into a transcript of it.
+	maxProbeOutputInMessage = 200
 )
 
 // ClaudeAuthStatusArgs is the harness's own machine-readable answer to "is
@@ -126,8 +148,13 @@ func DefaultDeps() Deps {
 	}
 }
 
+// commandOutput runs a probe through the shared helper, which bounds the wait
+// on the output pipes (aoprocess.WaitDelay). A probe that ignored that would
+// hang the whole report, and now the HTTP request behind it, whenever a
+// grandchild outlives the probe's context: `claude` is a Node CLI and spawns
+// exactly such children.
 func commandOutput(ctx context.Context, name string, args ...string) ([]byte, error) {
-	return aoprocess.CommandContext(ctx, name, args...).CombinedOutput()
+	return aoprocess.CombinedOutput(ctx, name, args...)
 }
 
 func (d Deps) withDefaults() Deps {
@@ -217,7 +244,7 @@ func (d Deps) checkClaudeAuth(ctx context.Context) Check {
 	if err != nil || path == "" {
 		return warn(fmt.Sprintf("claude not found in PATH; install the Claude Code CLI, then run `%s`", setupCmd))
 	}
-	reqCtx, cancel := context.WithTimeout(ctx, probeTimeout)
+	reqCtx, cancel := context.WithTimeout(ctx, harnessAuthTimeout)
 	defer cancel()
 	probe := strings.Join(ClaudeAuthStatusArgs, " ")
 	out, cmdErr := d.CommandOutput(reqCtx, path, ClaudeAuthStatusArgs...)
@@ -262,11 +289,15 @@ func (s claudeAuthStatus) describe() string {
 // --json` output. It slices to the outermost braces first because the probe
 // runs through CombinedOutput, so an unrelated notice on stderr (an update
 // banner, a deprecation warning) would otherwise make valid JSON unparseable.
+//
+// The "no JSON" error quotes only a truncated head of that output: the error
+// becomes the check Message, which GET /api/v1/doctor serves, so whatever a
+// future claude release decides to print must not be echoed wholesale.
 func parseClaudeAuthStatus(out []byte) (claudeAuthStatus, error) {
 	clean := ansiRE.ReplaceAllString(string(out), "")
 	start, end := strings.Index(clean, "{"), strings.LastIndex(clean, "}")
 	if start < 0 || end < start {
-		return claudeAuthStatus{}, fmt.Errorf("no JSON object in output %q", strings.TrimSpace(clean))
+		return claudeAuthStatus{}, fmt.Errorf("no JSON object in output %q", truncate(strings.TrimSpace(clean), maxProbeOutputInMessage))
 	}
 	var status claudeAuthStatus
 	if err := json.Unmarshal([]byte(clean[start:end+1]), &status); err != nil {
@@ -568,7 +599,26 @@ func (d Deps) checkGitHubToken(ctx context.Context) Check {
 	if scopes != "" {
 		scopeMsg = "scopes: " + scopes
 	}
-	return Check{Level: Pass, Section: SectionGitHub, Name: "github-token", Message: fmt.Sprintf("%s token valid for %s (%s)", source, login, scopeMsg)}
+	return Check{
+		Level: Pass, Section: SectionGitHub, Name: "github-token",
+		Message: fmt.Sprintf("%s token valid for %s (%s)", source, login, scopeMsg),
+		// The login names the GitHub account this machine acts as and the scope
+		// list is the exact capability of the credential sitting on it. Both are
+		// what you want locally and neither is anyone else's business, so the
+		// remote projection gets the answer to the question only: is the token
+		// good.
+		PublicMessage: fmt.Sprintf("%s token valid", source),
+	}
+}
+
+// truncate shortens s to at most maxRunes characters and says that it did.
+// Rune-based so a cut never lands mid-sequence and produces mojibake.
+func truncate(s string, maxRunes int) string {
+	runes := []rune(s)
+	if len(runes) <= maxRunes {
+		return s
+	}
+	return string(runes[:maxRunes]) + "... (truncated)"
 }
 
 func (d Deps) githubToken(ctx context.Context) (token, source string, err error) {

--- a/backend/internal/doctor/doctor_test.go
+++ b/backend/internal/doctor/doctor_test.go
@@ -590,3 +590,95 @@ func writeHooksLogLines(t *testing.T, dataDir string, lines ...string) {
 		t.Fatal(err)
 	}
 }
+
+// TestClaudeAuthProbeGetsItsOwnBudget is the readiness signal not lying. The
+// generic probeTimeout is sized for `git --version`; `claude auth status
+// --json` is a Node CLI cold start, which on a 1 vCPU VM routinely takes
+// longer and may touch the network. Timing out there produces a WARN the
+// desktop maps to "harness missing", so a correctly signed-in machine would
+// report as unconfigured and send the user back to setup.
+func TestClaudeAuthProbeGetsItsOwnBudget(t *testing.T) {
+	setConfigEnv(t)
+	budgets := map[string]time.Duration{}
+	deps := testDeps(t, map[string]string{"git": "/bin/git", "claude": "/bin/claude"},
+		func(ctx context.Context, name string, args ...string) ([]byte, error) {
+			deadline, ok := ctx.Deadline()
+			if !ok {
+				t.Fatalf("probe %s %v ran with no deadline at all", name, args)
+			}
+			budgets[name+" "+strings.Join(args, " ")] = time.Until(deadline)
+			switch {
+			case name == "/bin/git":
+				return []byte("git version 2.43.0\n"), nil
+			case strings.Join(args, " ") == "--version":
+				return []byte("2.1.220 (Claude Code)\n"), nil
+			default:
+				return []byte(`{"loggedIn":true,"authMethod":"claudeai"}`), nil
+			}
+		})
+
+	if check := findCheck(t, Run(context.Background(), deps), "claude-auth"); check.Level != Pass {
+		t.Fatalf("claude-auth check = %+v, want PASS", check)
+	}
+
+	authBudget := budgets["/bin/claude auth status --json"]
+	if authBudget <= probeTimeout {
+		t.Errorf("claude auth probe budget = %s, want more than the generic probe timeout %s", authBudget, probeTimeout)
+	}
+	if authBudget > harnessAuthTimeout {
+		t.Errorf("claude auth probe budget = %s, want at most %s", authBudget, harnessAuthTimeout)
+	}
+	// The cheap local probes keep the small budget: a slow harness is no
+	// reason to let `git --version` hang the report.
+	if gitBudget := budgets["/bin/git --version"]; gitBudget > probeTimeout {
+		t.Errorf("git probe budget = %s, want the generic probe timeout %s", gitBudget, probeTimeout)
+	}
+}
+
+// TestParseClaudeAuthStatusTruncatesEchoedOutput: this error becomes the check
+// Message, which GET /api/v1/doctor serves, so whatever a future claude release
+// prints on a zero-exit non-JSON path must not be echoed wholesale.
+func TestParseClaudeAuthStatusTruncatesEchoedOutput(t *testing.T) {
+	noise := strings.Repeat("x", 5000)
+	_, err := parseClaudeAuthStatus([]byte(noise))
+	if err == nil {
+		t.Fatal("expected an error: there is no JSON object in the output")
+	}
+	if len(err.Error()) > maxProbeOutputInMessage+100 {
+		t.Fatalf("error is %d bytes, want the echoed output truncated near %d", len(err.Error()), maxProbeOutputInMessage)
+	}
+	if !strings.Contains(err.Error(), "truncated") {
+		t.Errorf("error = %q, want it to say the output was truncated", err.Error())
+	}
+}
+
+// TestGitHubTokenPassKeepsIdentityLocal: `ao doctor` on the machine names the
+// account and the token's scopes, because that is the useful local answer. The
+// HTTP projection gets PublicMessage, which answers only "is the token good":
+// the login is the GitHub identity this machine acts as, and the scope list is
+// the exact capability of the credential sitting on it.
+func TestGitHubTokenPassKeepsIdentityLocal(t *testing.T) {
+	setConfigEnv(t)
+	srv := githubServer(t, http.StatusOK, `{"login":"octocat"}`, "repo, workflow, read:org")
+	deps := testDeps(t, map[string]string{"git": "/bin/git"}, gitOnly)
+	t.Setenv("AO_GITHUB_TOKEN", "env-token")
+	deps.HTTPClient = srv.Client()
+	deps.GitHubRESTBase = srv.URL
+
+	check := findCheck(t, Run(context.Background(), deps), "github-token")
+	if check.Level != Pass {
+		t.Fatalf("github-token check = %+v, want PASS", check)
+	}
+	if !strings.Contains(check.Message, "octocat") || !strings.Contains(check.Message, "repo, workflow, read:org") {
+		t.Errorf("local message = %q, want the login and scopes kept for `ao doctor`", check.Message)
+	}
+	if check.PublicMessage == "" {
+		t.Fatal("public message is empty, so the HTTP route would serve the login and scopes")
+	}
+	if strings.Contains(check.PublicMessage, "octocat") || strings.Contains(check.PublicMessage, "read:org") {
+		t.Errorf("public message = %q, want neither the login nor the scope list", check.PublicMessage)
+	}
+	if !strings.Contains(check.PublicMessage, "AO_GITHUB_TOKEN") {
+		t.Errorf("public message = %q, want it to still name which credential answered", check.PublicMessage)
+	}
+}

--- a/backend/internal/httpd/controllers/doctor.go
+++ b/backend/internal/httpd/controllers/doctor.go
@@ -6,12 +6,23 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/doctor"
 	"github.com/aoagents/agent-orchestrator/backend/internal/httpd/envelope"
 )
+
+// reportTTL is how long one run of the checks answers every request. A report
+// costs six subprocesses, a temp-file write probe, and one authenticated call
+// to the GitHub API with this machine's own token, so an uncached route lets a
+// burst multiply all of it and burn the operator's GitHub rate limit. The
+// desktop machine card polls this on a timer, so caching is not optional; the
+// window is short enough that a fix the user just applied still shows up on
+// their next look.
+const reportTTL = 10 * time.Second
 
 // DoctorController owns GET /api/v1/doctor: the health checks `ao doctor`
 // runs, served so the desktop can read a remote machine's readiness. It sits
@@ -27,6 +38,16 @@ type DoctorController struct {
 	// Checks runs the health checks. Nil runs the production set; tests
 	// inject fakes rather than spawning real probes.
 	Checks func(ctx context.Context) []doctor.Check
+	// Now is the clock the cache ages against. Nil means time.Now.
+	Now func() time.Time
+
+	// ponytail: one mutex around the whole run, so a burst waits on the first
+	// caller's probes instead of each starting its own. Move to a
+	// single-flight that serves the stale report while a refresh runs if a
+	// slow probe ever makes the wait itself the problem.
+	mu       sync.Mutex
+	cached   []doctor.Check
+	cachedAt time.Time
 }
 
 // Register mounts the doctor route on the supplied router.
@@ -35,11 +56,32 @@ func (c *DoctorController) Register(r chi.Router) {
 }
 
 func (c *DoctorController) report(w http.ResponseWriter, r *http.Request) {
+	envelope.WriteJSON(w, http.StatusOK, doctorReport(c.checks(r.Context())))
+}
+
+// checks returns the current report, running the probes only when the cached
+// one has aged out.
+func (c *DoctorController) checks(ctx context.Context) []doctor.Check {
 	run := c.Checks
 	if run == nil {
 		run = runDoctorChecks
 	}
-	envelope.WriteJSON(w, http.StatusOK, doctorReport(run(r.Context())))
+	now := c.Now
+	if now == nil {
+		now = time.Now
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.cached != nil && now().Sub(c.cachedAt) < reportTTL {
+		return c.cached
+	}
+	// Detached from this request: every caller queued behind the mutex is
+	// waiting on this one run, so the first client hanging up must not cancel
+	// the probes the rest of them are getting.
+	c.cached = run(context.WithoutCancel(ctx))
+	c.cachedAt = now()
+	return c.cached
 }
 
 // runDoctorChecks runs the production check set. The daemon answers the daemon
@@ -57,22 +99,47 @@ func runDoctorChecks(ctx context.Context) []doctor.Check {
 	return doctor.Run(ctx, deps)
 }
 
+// homeUnresolvedMessage replaces every check message when the machine's home
+// directory cannot be resolved. See doctorReport.
+const homeUnresolvedMessage = "message withheld: this machine's home directory could not be resolved, " +
+	"so paths in this message could not be redacted"
+
 // doctorReport projects the checks onto the wire shape, counting failures the
 // same way `ao doctor` does.
+//
+// Two things are dropped on the way out. A check that carries a PublicMessage
+// says more locally than a remote caller should be told (the github-token
+// check names the GitHub login and the token's scopes), so the remote-safe
+// message replaces it. And when the home directory cannot be resolved at all,
+// redaction cannot run, so messages are withheld rather than sent unredacted:
+// the only privacy control on this route failing open, silently, is the
+// failure mode worth designing against.
 func doctorReport(checks []doctor.Check) DoctorReportResponse {
-	home, _ := os.UserHomeDir()
+	home, homeErr := os.UserHomeDir()
 	report := DoctorReportResponse{Checks: make([]DoctorCheckResponse, 0, len(checks))}
 	for _, check := range checks {
 		if check.Level == doctor.Fail {
 			report.Failures++
 		}
-		report.Checks = append(report.Checks, DoctorCheckResponse{
+		message := check.Message
+		if check.PublicMessage != "" {
+			message = check.PublicMessage
+		}
+		out := DoctorCheckResponse{
 			Level:       string(check.Level),
 			Section:     check.Section,
 			Name:        check.Name,
-			Message:     redactHomePaths(check.Message, home),
+			Message:     redactHomePaths(message, home),
 			Remediation: redactHomePaths(check.Remediation, home),
-		})
+		}
+		if homeErr != nil || strings.TrimSpace(home) == "" {
+			// Level, Name, Section and Remediation stay: they are the machine's
+			// readiness, which is what this route exists for, and Remediation is
+			// a fixed command. Only the free text, which is where paths live, is
+			// held back.
+			out.Message = homeUnresolvedMessage
+		}
+		report.Checks = append(report.Checks, out)
 	}
 	report.OK = report.Failures == 0
 	return report
@@ -84,15 +151,48 @@ func doctorReport(checks []doctor.Check) DoctorReportResponse {
 // git a machine resolves, where the ao binary lives) stay whole, because there
 // the path is the diagnostic and it is not private.
 //
-// It only rewrites home as a directory prefix, never a bare mention of it, so
-// a sibling account whose name merely starts with the same letters is not
-// mangled. A data dir moved outside home with AO_DATA_DIR is reported in full;
-// at that point the path is the finding.
+// It rewrites the home directory as a prefix and as a whole path (a data dir
+// set to home itself), but never a name that merely starts with the same
+// letters, so a sibling account like /home/ubuntu2 is left alone. A data dir
+// moved outside home with AO_DATA_DIR is reported in full; at that point the
+// path is the finding.
+//
+// An empty home means redaction could not run. Callers must treat that as a
+// reason to withhold the message, not to send it: this function cannot, since
+// it has nothing to rewrite with.
 func redactHomePaths(message, home string) string {
 	sep := string(filepath.Separator)
 	home = strings.TrimSuffix(home, sep)
 	if home == "" || home == sep {
 		return message
 	}
-	return strings.ReplaceAll(message, home+sep, "~"+sep)
+
+	var b strings.Builder
+	rest := message
+	for {
+		i := strings.Index(rest, home)
+		if i < 0 {
+			b.WriteString(rest)
+			return b.String()
+		}
+		b.WriteString(rest[:i])
+		rest = rest[i+len(home):]
+		if rest == "" || !continuesName(rest[0]) {
+			b.WriteString("~")
+		} else {
+			b.WriteString(home)
+		}
+	}
+}
+
+// continuesName reports whether c could be the next character of the same
+// directory name. It is what separates /home/ubuntu/.ao and "/home/ubuntu (4
+// bytes)", both of which name the home directory, from /home/ubuntu2, which
+// names a different account.
+func continuesName(c byte) bool {
+	switch {
+	case c >= 'a' && c <= 'z', c >= 'A' && c <= 'Z', c >= '0' && c <= '9':
+		return true
+	}
+	return c == '-' || c == '_' || c == '.'
 }

--- a/backend/internal/httpd/controllers/doctor_test.go
+++ b/backend/internal/httpd/controllers/doctor_test.go
@@ -8,7 +8,10 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 
@@ -112,6 +115,11 @@ func TestRedactHomePaths(t *testing.T) {
 		{"path under home", filepath.Join(home, ".ao", "ao.db"), home, "~" + sep + filepath.Join(".ao", "ao.db")},
 		{"trailing separator on home", filepath.Join(home, ".ao"), home + sep, "~" + sep + ".ao"},
 		{"path outside home", filepath.Join(sep+"usr", "bin", "git"), home, filepath.Join(sep+"usr", "bin", "git")},
+		// AO_DATA_DIR set to the home directory itself: no trailing separator,
+		// so a prefix-only rewrite misses it entirely.
+		{"home itself", home, home, "~"},
+		{"home itself mid-sentence", "dataDir=" + home + " port=3001", home, "dataDir=~ port=3001"},
+		{"home at the end of a sentence", "database not created yet in " + home, home, "database not created yet in ~"},
 		{"sibling account is not mangled", filepath.Join(sep+"home", "ubuntu2", "x"), home, filepath.Join(sep+"home", "ubuntu2", "x")},
 		{"unknown home leaves the message alone", filepath.Join(home, ".ao"), "", filepath.Join(home, ".ao")},
 		{"root home leaves the message alone", filepath.Join(sep+"etc", "ao"), sep, filepath.Join(sep+"etc", "ao")},
@@ -122,5 +130,135 @@ func TestRedactHomePaths(t *testing.T) {
 				t.Errorf("redactHomePaths(%q, %q) = %q, want %q", tc.message, tc.home, got, tc.want)
 			}
 		})
+	}
+}
+
+// TestDoctorReportWithholdsGitHubIdentity is the privacy property M-C names:
+// this body crosses the network to whoever holds a token for the machine, and
+// the GitHub login is the identity this machine acts as while the scope list is
+// the exact capability of the credential sitting on it. `ao doctor` locally
+// still reports both; only the projection drops them.
+func TestDoctorReportWithholdsGitHubIdentity(t *testing.T) {
+	report, body := doctorResponse(t, []doctor.Check{{
+		Level: doctor.Pass, Section: doctor.SectionGitHub, Name: "github-token",
+		Message:       "AO_GITHUB_TOKEN token valid for octocat (scopes: repo, workflow, read:org)",
+		PublicMessage: "AO_GITHUB_TOKEN token valid",
+	}})
+
+	for _, secret := range []string{"octocat", "read:org", "workflow", "scopes"} {
+		if strings.Contains(body, secret) {
+			t.Errorf("response leaks %q: %s", secret, body)
+		}
+	}
+	if len(report.Checks) != 1 || report.Checks[0].Message != "AO_GITHUB_TOKEN token valid" {
+		t.Fatalf("checks = %+v, want the public message served instead", report.Checks)
+	}
+	// Still a usable readiness answer: name, level, and "the token is good".
+	if report.Checks[0].Name != "github-token" || report.Checks[0].Level != "PASS" {
+		t.Errorf("check = %+v, want the check itself intact", report.Checks[0])
+	}
+}
+
+// TestDoctorReportWithholdsMessagesWhenHomeIsUnknown: redaction is the only
+// privacy control on this route, and it cannot run without a home directory to
+// rewrite. Failing open silently (which is what discarding the UserHomeDir
+// error did) is the failure mode worth designing against, so the messages are
+// withheld and say so.
+func TestDoctorReportWithholdsMessagesWhenHomeIsUnknown(t *testing.T) {
+	unsetHomeEnv(t)
+	if home, err := os.UserHomeDir(); err == nil && home != "" {
+		t.Skipf("home directory still resolves to %q on this platform", home)
+	}
+
+	report, body := doctorResponse(t, []doctor.Check{{
+		Level: doctor.Pass, Section: doctor.SectionCore, Name: "sqlite",
+		Message:     "/home/ubuntu/.ao/ao.db (4096 bytes)",
+		Remediation: "ao start",
+	}})
+
+	if strings.Contains(body, "/home/ubuntu") {
+		t.Fatalf("response leaks an unredactable path: %s", body)
+	}
+	check := report.Checks[0]
+	if !strings.Contains(check.Message, "withheld") {
+		t.Errorf("message = %q, want it to say the message was withheld and why", check.Message)
+	}
+	// The readiness answer itself survives: this route exists to report it.
+	if check.Name != "sqlite" || check.Level != "PASS" || check.Remediation != "ao start" {
+		t.Errorf("check = %+v, want name, level, and remediation kept", check)
+	}
+}
+
+// TestDoctorReportIsCachedAcrossABurst: one report costs six subprocesses, a
+// temp-file write probe, and an authenticated call to the GitHub API with this
+// machine's own token. The desktop machine card polls this on a timer, so
+// without the TTL a burst multiplies all of it and burns the operator's own
+// GitHub rate limit.
+func TestDoctorReportIsCachedAcrossABurst(t *testing.T) {
+	var runs int32
+	now := time.Now()
+	c := &DoctorController{
+		Checks: func(context.Context) []doctor.Check {
+			atomic.AddInt32(&runs, 1)
+			return []doctor.Check{{Level: doctor.Pass, Section: doctor.SectionCore, Name: "daemon", Message: "serving this request"}}
+		},
+		Now: func() time.Time { return now },
+	}
+	r := chi.NewRouter()
+	c.Register(r)
+
+	var wg sync.WaitGroup
+	for range 20 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			rec := httptest.NewRecorder()
+			r.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/doctor", http.NoBody))
+			if rec.Code != http.StatusOK {
+				t.Errorf("GET /doctor = %d", rec.Code)
+			}
+		}()
+	}
+	wg.Wait()
+
+	if got := atomic.LoadInt32(&runs); got != 1 {
+		t.Fatalf("probe runs = %d, want 1: a burst inside the TTL must run the probes once", got)
+	}
+
+	// Past the TTL the machine is probed again, so a fix the user just applied
+	// shows up rather than being cached away.
+	now = now.Add(reportTTL + time.Second)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/doctor", http.NoBody))
+	if got := atomic.LoadInt32(&runs); got != 2 {
+		t.Fatalf("probe runs = %d, want 2 once the TTL has passed", got)
+	}
+}
+
+// TestDoctorReportRunOutlivesTheFirstCaller: every request queued behind the
+// mutex is waiting on one run, so the client that happened to trigger it
+// hanging up must not cancel the probes the rest of them are getting.
+func TestDoctorReportRunOutlivesTheFirstCaller(t *testing.T) {
+	c := &DoctorController{Checks: func(ctx context.Context) []doctor.Check {
+		level := doctor.Pass
+		if ctx.Err() != nil {
+			level = doctor.Fail
+		}
+		return []doctor.Check{{Level: level, Section: doctor.SectionCore, Name: "daemon", Message: "serving this request"}}
+	}}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	checks := c.checks(ctx)
+	if len(checks) != 1 || checks[0].Level != doctor.Pass {
+		t.Fatalf("checks = %+v, want the run detached from the cancelled request", checks)
+	}
+}
+
+func unsetHomeEnv(t *testing.T) {
+	t.Helper()
+	// t.Setenv restores on cleanup; "" is what UserHomeDir treats as unset.
+	for _, key := range []string{"HOME", "USERPROFILE", "HOMEDRIVE", "HOMEPATH"} {
+		t.Setenv(key, "")
 	}
 }

--- a/backend/internal/process/command.go
+++ b/backend/internal/process/command.go
@@ -3,7 +3,21 @@ package process
 import (
 	"context"
 	"os/exec"
+	"time"
 )
+
+// WaitDelay bounds how long a command's Wait may keep blocking on the output
+// pipes after its context has already killed the direct child.
+//
+// It matters for every short probe run through CombinedOutput: exec is handed
+// a non-*os.File writer, so it creates an os.Pipe plus a copy goroutine, and
+// Wait does not return until every holder of the write end has closed it. On
+// context expiry exec kills only the direct child, so a grandchild that
+// inherited the pipe (a Node CLI's worker, git's transport helper) keeps Wait
+// blocked for as long as it likes, and the context deadline the caller set
+// buys nothing. See the same reasoning at cloneWaitDelay in
+// internal/service/project/clone.go, which is where this bit AO first.
+const WaitDelay = 2 * time.Second
 
 // Command creates a non-interactive child process. On Windows it suppresses
 // transient console windows for CLI tools launched by the desktop daemon.
@@ -13,9 +27,22 @@ func Command(name string, args ...string) *exec.Cmd {
 	return cmd
 }
 
-// CommandContext is Command with cancellation support.
+// CommandContext is Command with cancellation support. A caller that reads the
+// child's output through a pipe (CombinedOutput, Output, StdoutPipe) should set
+// cmd.WaitDelay = WaitDelay, or use CombinedOutput below, so a surviving
+// grandchild cannot outlast ctx.
 func CommandContext(ctx context.Context, name string, args ...string) *exec.Cmd {
 	cmd := exec.CommandContext(ctx, name, args...)
 	configureHidden(cmd)
 	return cmd
+}
+
+// CombinedOutput runs name under ctx and returns its combined stdout and
+// stderr, bounded by WaitDelay so the call cannot outlive ctx by more than
+// that even when a grandchild is still holding the output pipe open. It is
+// the form every short-lived probe should use.
+func CombinedOutput(ctx context.Context, name string, args ...string) ([]byte, error) {
+	cmd := CommandContext(ctx, name, args...)
+	cmd.WaitDelay = WaitDelay
+	return cmd.CombinedOutput()
 }

--- a/backend/internal/process/command_test.go
+++ b/backend/internal/process/command_test.go
@@ -1,0 +1,43 @@
+package process
+
+import (
+	"context"
+	"runtime"
+	"testing"
+	"time"
+)
+
+// TestCombinedOutputReturnsWhenAGrandchildOutlivesTheContext is the whole point
+// of WaitDelay. `sh` exits when the context kills it, but the background child
+// it spawned inherited the output pipe and keeps the write end open. Without
+// WaitDelay, Wait blocks on that pipe for as long as the grandchild lives, so
+// the caller's context deadline buys nothing and the goroutine leaks: this test
+// hangs until the go test timeout rather than failing.
+func TestCombinedOutputReturnsWhenAGrandchildOutlivesTheContext(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("needs a POSIX shell to spawn a grandchild holding the pipe")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	done := make(chan time.Duration, 1)
+	go func() {
+		start := time.Now()
+		// The backgrounded sleep inherits stdout/stderr, so it holds the pipe
+		// open long past the deadline that kills the shell itself.
+		_, _ = CombinedOutput(ctx, "sh", "-c", "sleep 60 & sleep 60")
+		done <- time.Since(start)
+	}()
+
+	// Generous: the deadline plus WaitDelay plus room for a loaded CI box.
+	budget := 200*time.Millisecond + WaitDelay + 10*time.Second
+	select {
+	case elapsed := <-done:
+		if elapsed > budget {
+			t.Fatalf("CombinedOutput took %s, want it bounded by the context plus WaitDelay", elapsed)
+		}
+	case <-time.After(budget):
+		t.Fatal("CombinedOutput did not return: a grandchild is still holding the output pipe")
+	}
+}

--- a/backend/internal/vmgateway/config.go
+++ b/backend/internal/vmgateway/config.go
@@ -98,7 +98,7 @@ type Options struct {
 func Resolve(opts Options, dataDir string) (Config, error) {
 	machineFilePath := firstNonEmpty(opts.MachineFile, os.Getenv("AO_MACHINE_FILE"))
 	if machineFilePath == "" {
-		p, err := defaultMachineFilePath()
+		p, err := DefaultMachineFilePath()
 		if err != nil {
 			return Config{}, err
 		}
@@ -196,7 +196,24 @@ func normalizeDomain(domain, source string) (string, error) {
 	return domain, nil
 }
 
-func defaultMachineFilePath() (string, error) {
+// DefaultMachineFilePath is where machine.json lives when AO_MACHINE_FILE and
+// --machine-file are both unset: ~/.ao/machine.json, the AO home directory,
+// NOT the AO_DATA_DIR-resolved data dir that CertDir above uses.
+//
+// That asymmetry is deliberate, and it is the answer to a review finding that
+// read it as a bug. AO_DATA_DIR moves durable data (the SQLite database, the
+// ACME cert cache). machine.json is this machine's binding identity and sits
+// beside running.json, which has the same shape: pinned to ~/.ao and moved
+// only by its own override (AO_RUN_FILE there, AO_MACHINE_FILE here). Deriving
+// it from the data dir instead would move the file the gateway reads without
+// moving the file `ao setup-vm` writes (setupPlan.MachineFile is
+// <home>/.ao/machine.json regardless of AO_DATA_DIR), so an operator who set
+// AO_DATA_DIR would get a gateway looking in a place nothing ever writes.
+//
+// It is exported so `ao whoami` resolves the same path from the same line of
+// code: the two must name the same file, or whoami confidently reports a
+// binding the gateway never sees.
+func DefaultMachineFilePath() (string, error) {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return "", fmt.Errorf("resolve machine file path: %w", err)

--- a/backend/internal/vmgateway/config_test.go
+++ b/backend/internal/vmgateway/config_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -235,4 +236,49 @@ func TestReadMachineFile_Malformed(t *testing.T) {
 	if _, err := ReadMachineFile(path); err == nil {
 		t.Fatal("expected an error for malformed JSON")
 	}
+}
+
+// TestDefaultMachineFilePath_IsHomeNotDataDir pins the asymmetry with CertDir
+// above, which a review read as a bug: AO_DATA_DIR moves durable data, while
+// machine.json is binding identity pinned to ~/.ao and moved only by
+// AO_MACHINE_FILE. `ao setup-vm` writes <home>/.ao/machine.json whatever
+// AO_DATA_DIR says, so deriving the read path from the data dir would point the
+// gateway at a file nothing ever writes. `ao whoami` resolves through this same
+// function so the two can never drift.
+func TestDefaultMachineFilePath_IsHomeNotDataDir(t *testing.T) {
+	home := t.TempDir()
+	setHomeEnv(t, home)
+
+	got, err := DefaultMachineFilePath()
+	if err != nil {
+		t.Fatalf("DefaultMachineFilePath: %v", err)
+	}
+	if want := filepath.Join(home, ".ao", "machine.json"); got != want {
+		t.Fatalf("DefaultMachineFilePath = %q, want %q", got, want)
+	}
+
+	// A data dir somewhere else entirely must not move it.
+	t.Setenv("AO_DATA_DIR", t.TempDir())
+	cfg, err := Resolve(Options{
+		Domain: "vm.example.com", MachineID: "machine-1", AccountID: "account-1",
+	}, t.TempDir())
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if cfg.Domain != "vm.example.com" {
+		t.Fatalf("Domain = %q", cfg.Domain)
+	}
+	after, err := DefaultMachineFilePath()
+	if err != nil || after != got {
+		t.Fatalf("DefaultMachineFilePath = %q (err %v), want it unchanged at %q", after, err, got)
+	}
+}
+
+func setHomeEnv(t *testing.T, home string) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Setenv("USERPROFILE", home)
+		return
+	}
+	t.Setenv("HOME", home)
 }

--- a/backend/internal/vmgateway/jwks.go
+++ b/backend/internal/vmgateway/jwks.go
@@ -133,7 +133,15 @@ func (c *JWKSCache) Get(ctx context.Context) (*KeySet, error) {
 	c.refreshing = true
 	c.mu.Unlock()
 
-	fresh, err := c.fetch(ctx)
+	// Detached from the triggering request: the keyset is the whole gateway's,
+	// not this caller's. A client that hangs up mid-refresh would otherwise
+	// cancel the fetch every other request is about to depend on, which on a
+	// warm cache records a 30 second failureBackoff against a control plane
+	// that is perfectly healthy, and on a cold start fails that request closed.
+	// The HTTP client's own timeout is what bounds it instead.
+	fetchCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), c.fetchTimeout())
+	fresh, err := c.fetch(fetchCtx)
+	cancel()
 
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -151,6 +159,16 @@ func (c *JWKSCache) Get(ctx context.Context) (*KeySet, error) {
 	c.keys = fresh
 	c.fetchedAt = c.now()
 	return c.keys, nil
+}
+
+// fetchTimeout bounds a detached refresh. It mirrors the HTTP client's own
+// timeout so an injected client without one (a test's, or a caller that set
+// Timeout: 0) still cannot leave a fetch running indefinitely.
+func (c *JWKSCache) fetchTimeout() time.Duration {
+	if c.client != nil && c.client.Timeout > 0 {
+		return c.client.Timeout
+	}
+	return 10 * time.Second
 }
 
 func (c *JWKSCache) fetch(ctx context.Context) (*KeySet, error) {

--- a/backend/internal/vmgateway/jwks_test.go
+++ b/backend/internal/vmgateway/jwks_test.go
@@ -260,3 +260,40 @@ func TestJWKSCache_FailsClosedWithoutEverSucceeding(t *testing.T) {
 		t.Fatal("expected an error: no cached keyset exists and the fetch failed, so verification must fail closed")
 	}
 }
+
+// TestJWKSCache_RefreshSurvivesTheTriggeringRequest pins that the refresh runs
+// on its own context. The keyset belongs to the whole gateway, so a client that
+// hangs up mid-refresh must not cancel the fetch: doing so records a 30 second
+// failureBackoff against a control plane that is perfectly healthy, and on a
+// cold start fails that request closed for no reason.
+func TestJWKSCache_RefreshSurvivesTheTriggeringRequest(t *testing.T) {
+	pub, _, _ := ed25519.GenerateKey(nil)
+	cancelled := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Hang until the caller's context is gone, then answer normally. A
+		// fetch running on that context would already have failed by here.
+		<-cancelled
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(jwksBody(t, testKid, pub))
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cache := NewJWKSCache(srv.URL, srv.Client())
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		cancel()
+		close(cancelled)
+	}()
+
+	ks, err := cache.Get(ctx)
+	<-done
+	if err != nil {
+		t.Fatalf("Get: %v, want the refresh to outlive the cancelled request", err)
+	}
+	if len(ks.candidates(testKid)) != 1 {
+		t.Fatal("expected the fetched key to be usable")
+	}
+}

--- a/backend/internal/vmgateway/proxy.go
+++ b/backend/internal/vmgateway/proxy.go
@@ -239,7 +239,21 @@ func extractToken(r *http.Request) (string, bool) {
 // cookie is attached by the browser to any request to this host, so
 // accepting it on a state-changing method would leave corsGate as the sole
 // CSRF defence.
+//
+// An Origin header is required on both, which is what makes corsGate a real
+// gate rather than one a request can opt out of: corsGate passes a request
+// with no Origin straight through, and the cookie is SameSite=None
+// (TOKEN_CONTRACT.md), so a hostile page's `new Image().src =
+// "https://vm.example.com/api/v1/events"` would otherwise be an authenticated
+// SSE stream held open on the daemon. Every browser API that can reach these
+// two routes sends an Origin (fetch, EventSource, and the WebSocket
+// handshake all do), and a non-browser client authenticates with the
+// Authorization header, which this does not touch. So a cookie with no Origin
+// is only ever the shape no legitimate caller has.
 func cookieAuthAllowed(r *http.Request) bool {
+	if r.Header.Get("Origin") == "" {
+		return false
+	}
 	if r.URL.Path == muxPath {
 		return true
 	}

--- a/backend/internal/vmgateway/proxy_test.go
+++ b/backend/internal/vmgateway/proxy_test.go
@@ -253,6 +253,7 @@ func TestGateway_Mux_AcceptsCookieOrHeader(t *testing.T) {
 	tg.daemonCalls = nil
 
 	req = httptest.NewRequest(http.MethodGet, muxPath, nil)
+	req.Header.Set("Origin", testOrigin) // a WebSocket handshake always carries one
 	req.AddCookie(&http.Cookie{Name: gatewayCookieName, Value: token})
 	rec = httptest.NewRecorder()
 	tg.handler.ServeHTTP(rec, req)
@@ -307,6 +308,7 @@ func TestGateway_UpstreamCORSHeaders_NotDuplicated(t *testing.T) {
 func TestGateway_Events_AcceptsCookie(t *testing.T) {
 	tg := newTestGateway(t)
 	req := httptest.NewRequest(http.MethodGet, eventsPath, nil)
+	req.Header.Set("Origin", testOrigin) // EventSource always sends one
 	req.AddCookie(&http.Cookie{Name: gatewayCookieName, Value: tg.validToken(t)})
 	rec := httptest.NewRecorder()
 
@@ -349,6 +351,46 @@ func TestGateway_Cookie_RejectedOnEveryOtherRoute(t *testing.T) {
 	}
 	if len(tg.daemonCalls) != 0 {
 		t.Errorf("a cookie-only request must never reach the daemon, got %d calls", len(tg.daemonCalls))
+	}
+}
+
+// TestGateway_Cookie_RejectedWithoutOrigin closes corsGate's one hole: it lets
+// a request with no Origin through untouched, and the gateway cookie is
+// SameSite=None, so the browser attaches it cross-site. Without this, a
+// hostile page's `new Image().src = "https://vm.example.com/api/v1/events"`
+// (an image load sends no Origin) is an authenticated SSE stream held open on
+// the daemon, and the same shape reaches /mux. Every browser API that can
+// legitimately reach these two routes sends an Origin; a non-browser client
+// uses the Authorization header, which this does not touch.
+func TestGateway_Cookie_RejectedWithoutOrigin(t *testing.T) {
+	tg := newTestGateway(t)
+	token := tg.validToken(t)
+
+	for _, path := range []string{eventsPath, muxPath} {
+		t.Run(path, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, path, nil)
+			req.AddCookie(&http.Cookie{Name: gatewayCookieName, Value: token})
+			rec := httptest.NewRecorder()
+
+			tg.handler.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusUnauthorized {
+				t.Errorf("status = %d, want 401: the ambient cookie must not authenticate a request with no Origin", rec.Code)
+			}
+		})
+	}
+	if len(tg.daemonCalls) != 0 {
+		t.Errorf("an originless cookie request must never reach the daemon, got %d calls", len(tg.daemonCalls))
+	}
+
+	// The header path is what non-browser clients use, and it must be
+	// unaffected: no Origin, no cookie, still 200.
+	req := httptest.NewRequest(http.MethodGet, eventsPath, nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+	tg.handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET %s with only an Authorization header: status = %d, want 200", eventsPath, rec.Code)
 	}
 }
 


### PR DESCRIPTION
Closes #39.

Fixes H3 and M2 from the client review, and M-C, M-D, L-G, L-A, L-C, L-H from the server review.

## H3, the probe that could hang forever

`aoprocess.CommandContext` set no `WaitDelay`, so `CombinedOutput` handed exec a non-`*os.File` writer, exec created an `os.Pipe`, and `Wait` did not return until every holder of the write end closed it. On context expiry exec kills only the direct child; `claude` is a Node CLI that spawns children, and one grandchild inheriting the pipe kept `Wait` blocked regardless of the 2 second context. Since #36 exposed `doctor.Run` at `GET /api/v1/doctor`, that was a request that never completed and a goroutine that never returned.

Fixed at the source rather than at two call sites: `process.CombinedOutput` sets `cmd.WaitDelay` (2s, the same reasoning as `cloneWaitDelay` from #20), and `internal/doctor` and `internal/cli` both go through it. `commandOutputInDir` sets the same delay.

`TestCombinedOutputReturnsWhenAGrandchildOutlivesTheContext` spawns `sh -c "sleep 60 & sleep 60"`, so the backgrounded child holds the pipe long past the deadline that kills the shell. Verified it fails (hangs to the budget) with the `WaitDelay` line removed and passes with it, rather than passing for a reason unrelated to the fix.

## M2 and L-G, the readiness signal that lied

`claude auth status --json` now has its own `harnessAuthTimeout = 10s`. The shared `probeTimeout` is sized for `git --version`; a Node cold start on a 1 vCPU VM exceeds it, and the WARN it produced maps to `harness: "missing"` in the desktop, so a correctly signed-in machine reported as not set up. The cheap local probes keep the 2s budget, which the test asserts both ways.

`parseClaudeAuthStatus` now truncates the output it quotes at 200 runes, since that error becomes a check `Message` that crosses the wire.

## M-C, what crosses the wire and what it costs

- The `github-token` PASS check keeps `AO_GITHUB_TOKEN token valid for octocat (scopes: repo, workflow, read:org)` for `ao doctor` locally, and carries a new `PublicMessage` (`AO_GITHUB_TOKEN token valid`) that the HTTP projection serves instead. `PublicMessage` has `json:"-"`, so `ao doctor --json` is byte-identical.
- `DoctorController` memoizes the report behind a 10s TTL under one mutex, so a burst runs the six subprocesses, the write probe and the authenticated `GET https://api.github.com/user` once instead of N times. The run is detached from the triggering request's context, so the client that happened to trigger it hanging up does not cancel the probes everyone queued behind it is getting.

**On `lanControlBlockedPrefixes`: decided not to add `/api/v1/doctor`, deliberately.** That list is the loopback-only *control* surface (`/shutdown`, `/internal/`, the mobile control routes, the dev routes): things that change state or that only the daemon's own operator may reach. Doctor is a read-only readiness report, the LAN listener already requires the Connect Mobile password on every request, and a mobile readiness view is a plausible consumer. Stated so it is a decision and not an oversight: what a LAN client holding that password can still read is tool versions, the daemon's loopback port, the db path and size, and a hooks log line. If that is judged too much, the one-line block is the cheaper change and I will make it.

## M-D, redaction that silently did nothing

`home, _ := os.UserHomeDir()` discarded the error and the function returned the message unchanged when `home == ""`, so under a unit that sets `AO_DATA_DIR` but not `HOME` the only privacy control on the route did nothing, with no signal. An unresolvable home now **withholds** `Message` and says so; `Level`, `Name`, `Section` and `Remediation` survive, because the readiness answer is what the route exists for and `Remediation` is a fixed command.

`redactHomePaths` also rewrites the home directory named on its own (`dataDir=/home/ubuntu port=3001`, or a data dir that is home itself), which the `home + separator` key missed, while still leaving `/home/ubuntu2` alone.

## L-A, L-C, L-H

- **L-A:** `cookieAuthAllowed` now requires an `Origin`. `corsGate` passes an originless request straight through and the cookie is `SameSite=None`, so `new Image().src = "https://vm.example.com/api/v1/events"` from a hostile page was an authenticated proxied SSE connection. Scoped to the two cookie-authenticated routes: `EventSource` and the WebSocket handshake both send an `Origin`, and non-browser clients use the `Authorization` header, which is untouched (asserted in the test).
- **L-C:** the JWKS refresh runs on `context.WithoutCancel` plus the client's own timeout. A client disconnecting mid-refresh was cancelling a refresh the whole gateway shares, which recorded a 30s `failureBackoff` against a healthy control plane. Verified the test fails against the old code.
- **L-H:** closed as a **documented decision, not a relocation**, and this is the one place I did not do what the finding asked. Deriving the default `machine.json` from the data dir would move the file the gateway *reads* without moving the file `ao setup-vm` *writes* (`setupPlan.MachineFile` is `<home>/.ao/machine.json` whatever `AO_DATA_DIR` says), so an operator who set `AO_DATA_DIR` would get a gateway looking where nothing ever writes. `machine.json` is binding identity with the same shape as `running.json`: pinned to `~/.ao`, moved only by its own override (`AO_MACHINE_FILE`, which is exactly what the systemd unit sets). What was a real defect is that the path was spelled out in three places; `DefaultMachineFilePath` is now exported, documents the asymmetry with `CertDir`, is used by `ao whoami`, and is pinned by a test. Happy to switch to the relocation if you disagree.

## Not regressed

- `claude-auth` check name, its PASS/WARN semantics (never FAIL), and `remediation`: untouched. `ClaudeHarnessName` and `ClaudeAuthStatusArgs` unchanged.
- `ao doctor` text and `--json`: unchanged. The new field is `json:"-"` and the HTTP DTO is unchanged, so `npm run api` produces no drift (`openapi.yaml` and `schema.ts` untouched).
- The gateway's token verifier, its deny-by-default allowlist, and ADR 0002 conformance: untouched.
- `backend/internal/cli/setupvm*` (issue #38's worker), `controlplane/`, and `frontend/`: untouched.

## Tests

New: the grandchild-outlives-the-context hang test, the claude-auth budget test, the truncation test, the local-vs-public github-token message test, the response-does-not-carry-the-login-or-scopes test, the withheld-when-home-is-unknown test, the cached-across-a-burst test, the run-outlives-the-first-caller test, the cookie-without-Origin test, the JWKS-refresh-survives-the-request test, the machine-file-default test, and three redaction cases.

Two existing gateway tests now set an `Origin` on their cookie requests, which is what a browser does on both routes.

```
go build ./... && go vet ./...                     clean
go test ./...                                      3021 passed, 5 failed, 4 skipped
go test -race ./internal/{httpd/controllers,vmgateway,doctor,process}   280 passed
golangci-lint v2.12.2 on every touched package     0 issues
npm run api                                        no drift
```

The 5 failures are the documented pre-existing `spawn_test.go` HTTP 404s, untouched by this work.

## Risk

The behaviour change most worth a second look is L-A: any client that authenticates to `/mux` or the SSE stream with the cookie and no `Origin` now gets a 401 instead of a 200. The desktop does not do that (both browser APIs send one) and header clients are unaffected, but it is the one change that can break a caller rather than only bounding one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
