### PR TITLE
fix(desktop): report machines honestly, keep sign-in and cache correct

### DIFF
--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -41,7 +41,7 @@ import { promisify } from "node:util";
 import { type DaemonLaunchSpec, resolveDaemonLaunch } from "./shared/daemon-launch";
 import { createListenPortScanner, defaultRunFilePath, parseRunFile } from "./shared/daemon-discovery";
 import type { DaemonStatus } from "./shared/daemon-status";
-import { readRemoteDaemonConfig, type RemoteDaemonConfig } from "./shared/remote-daemon";
+import { machineDaemonStatus, readRemoteDaemonConfig, type RemoteDaemonConfig } from "./shared/remote-daemon";
 import { attachAppShortcuts } from "./main/app-shortcuts";
 import { KEYBOARD_SHORTCUTS_HELP_CHANNEL } from "./shared/shortcuts";
 import {
@@ -64,7 +64,7 @@ import { createAoMachinesController } from "./main/ao-machines";
 import type { AoMachine } from "./shared/ao-machines";
 import { isAllowedAppExternalURL, openAllowedAppExternalURL } from "./main/external-open";
 import { buildWindowsAppMenuTemplate } from "./main/menu";
-import { createRemoteDaemonLifecycle, machineDaemonStatus } from "./main/remote-daemon";
+import { createRemoteDaemonLifecycle } from "./main/remote-daemon";
 
 // Globals injected at compile time by @electron-forge/plugin-vite.
 declare const MAIN_WINDOW_VITE_DEV_SERVER_URL: string | undefined;

--- a/frontend/src/main/ao-account-store.test.ts
+++ b/frontend/src/main/ao-account-store.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment node
-import { mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { mkdtemp, readdir, readFile, rm, stat, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, expect, test } from "vitest";
@@ -48,6 +48,32 @@ test("the refresh token never appears on disk in plaintext, and the file is owne
 	// Identity stays readable so the signed-in row renders without a keychain unlock.
 	expect(raw).toContain("dev@example.com");
 	expect((await stat(file)).mode & 0o777).toBe(0o600);
+});
+
+// The refresh token rotates on use, so the copy a write replaces is already
+// revoked. A temp file left behind, or reused because it happens to carry this
+// pid, is an encrypted credential nobody owns.
+test("leaves no temp file behind, and never names one after the pid", async () => {
+	await writeStoredAccount(stateDir, fakeSafeStorage(), { account, refreshToken: "rt_secret" });
+	await writeStoredAccount(stateDir, fakeSafeStorage(), { account, refreshToken: "rt_rotated" });
+
+	expect(await readdir(stateDir)).toEqual([AO_ACCOUNT_FILE_NAME]);
+	await expect(readFile(path.join(stateDir, `.ao-account-${process.pid}.json`), "utf8")).rejects.toThrow();
+});
+
+test("a failed write leaves nothing to clean up and does not damage the stored token", async () => {
+	const safeStorage = fakeSafeStorage();
+	await writeStoredAccount(stateDir, safeStorage, { account, refreshToken: "rt_secret" });
+
+	const exploding: SafeStorageLike = {
+		...safeStorage,
+		encryptString: () => {
+			throw new Error("keychain locked");
+		},
+	};
+	await expect(writeStoredAccount(stateDir, exploding, { account, refreshToken: "rt_rotated" })).rejects.toThrow();
+	expect(await readdir(stateDir)).toEqual([AO_ACCOUNT_FILE_NAME]);
+	await expect(readStoredAccount(stateDir, safeStorage)).resolves.toEqual({ account, refreshToken: "rt_secret" });
 });
 
 test("nothing at all is written when the OS has no credential store", async () => {

--- a/frontend/src/main/ao-account-store.ts
+++ b/frontend/src/main/ao-account-store.ts
@@ -1,4 +1,5 @@
-import { mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
+import { randomBytes } from "node:crypto";
+import { mkdir, open, readFile, rename, rm } from "node:fs/promises";
 import path from "node:path";
 import type { AoAccount } from "../shared/ao-account";
 
@@ -116,11 +117,29 @@ export async function writeStoredAccount(
 	};
 
 	// Atomic write, mirroring app-state.json: a temp file in the same dir then a
-	// rename, so a reader never sees a half-written credential.
+	// rename, so a reader never sees a half-written credential. The name carries
+	// random bytes rather than the pid, because `mode` applies only when the file
+	// is created, so a stale temp left by a crashed run with the same pid would be
+	// reopened with whatever mode it already had.
 	await mkdir(stateDir, { recursive: true, mode: 0o750 });
-	const tmp = path.join(stateDir, `.ao-account-${process.pid}.json`);
-	await writeFile(tmp, `${JSON.stringify(file, null, 2)}\n`, { mode: 0o600 });
-	await rename(tmp, accountFilePath(stateDir));
+	const tmp = path.join(stateDir, `.ao-account-${randomBytes(8).toString("hex")}.json`);
+	// fsync before the rename: the refresh token rotates on use, so the copy this
+	// replaces is already revoked server-side. A rename that outlives its data
+	// across a power loss would leave the install with no usable token at all.
+	try {
+		const handle = await open(tmp, "wx", 0o600);
+		try {
+			await handle.writeFile(`${JSON.stringify(file, null, 2)}\n`);
+			await handle.sync();
+		} finally {
+			await handle.close();
+		}
+		await rename(tmp, accountFilePath(stateDir));
+	} catch (err) {
+		// Never leave an encrypted token lying about under a temp name.
+		await rm(tmp, { force: true });
+		throw err;
+	}
 }
 
 /** Sign-out: delete the stored token. Absent file is success, not an error. */

--- a/frontend/src/main/ao-control-token.test.ts
+++ b/frontend/src/main/ao-control-token.test.ts
@@ -4,7 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, expect, test, vi } from "vitest";
 import { readStoredAccount, writeStoredAccount, type SafeStorageLike } from "./ao-account-store";
-import { createControlPlaneTokenSource } from "./ao-control-token";
+import { createControlPlaneTokenSource, STORE_ROTATED_TOKEN_FAILURE } from "./ao-control-token";
 
 // Same stand-in as ao-account-store.test.ts: reversible, and different from the
 // plaintext, which is all these tests need from it.
@@ -119,6 +119,30 @@ test("a response missing either token is a failure, not a half-applied rotation"
 	await expect(source(noRotation as unknown as typeof fetch).get()).rejects.toThrow(/replacement refresh token/);
 	// The refresh token on disk is untouched, so the next attempt can retry it.
 	await expect(readStoredAccount(stateDir, safeStorage)).resolves.toMatchObject({ refreshToken: "rt_1" });
+});
+
+// The exchange already revoked the token on disk, so a write that fails here is
+// a dead sign-in, not a transient filesystem problem, and the message has to say
+// so or the user retries something that can never work again.
+test("a failed persist after a successful exchange says the sign-in has to be redone", async () => {
+	await writeStoredAccount(stateDir, safeStorage, { account, refreshToken: "rt_1" });
+	const fetchImpl = vi.fn(async () => tokenResponse({ access_token: "at_1", expires_in: 900, refresh_token: "rt_2" }));
+	const lockedKeychain: SafeStorageLike = {
+		...safeStorage,
+		encryptString: () => {
+			throw new Error("ENOSPC: no space left on device");
+		},
+	};
+	const tokens = createControlPlaneTokenSource({
+		stateDir,
+		controlPlaneUrl: CONTROL_PLANE,
+		safeStorage: lockedKeychain,
+		fetchImpl: fetchImpl as unknown as typeof fetch,
+	});
+
+	await expect(tokens.get()).rejects.toThrow(STORE_ROTATED_TOKEN_FAILURE);
+	// The underlying cause is still carried, for anyone reading a log.
+	await expect(tokens.get()).rejects.toThrow(/ENOSPC/);
 });
 
 test("clear drops the cached token, so sign-out leaves nothing behind", async () => {

--- a/frontend/src/main/ao-control-token.ts
+++ b/frontend/src/main/ao-control-token.ts
@@ -30,6 +30,12 @@ const EXPIRY_SKEW_MS = 60_000;
 /** Fallback when the token endpoint omits `expires_in`; the contract's default. */
 const DEFAULT_TTL_SECONDS = 15 * 60;
 
+/** Said when the rotated refresh token could not be stored. See exchange(). */
+export const STORE_ROTATED_TOKEN_FAILURE =
+	"This computer's AO sign-in could not be saved after being refreshed, so it is no longer valid. Sign in again.";
+
+const errorMessage = (err: unknown): string => (err instanceof Error ? err.message : String(err));
+
 export type ControlPlaneTokenDeps = {
 	/** The ~/.ao state dir, where the encrypted refresh token lives. */
 	stateDir: string;
@@ -106,7 +112,15 @@ export function createControlPlaneTokenSource(deps: ControlPlaneTokenDeps): Cont
 		// Persisted before the access token is handed out: the presented refresh
 		// token is already revoked, so losing the replacement here would lock this
 		// install out until the user signs in again.
-		await writeStoredAccount(deps.stateDir, deps.safeStorage, { account: stored.account, refreshToken: rotated });
+		try {
+			await writeStoredAccount(deps.stateDir, deps.safeStorage, { account: stored.account, refreshToken: rotated });
+		} catch (err) {
+			// The exchange succeeded, which revoked the token still on disk. Whatever
+			// stopped the write, the sign-in is gone and only signing in again brings
+			// it back, so say that rather than reporting a filesystem error that reads
+			// as something a retry would fix.
+			throw new Error(`${STORE_ROTATED_TOKEN_FAILURE} (${errorMessage(err)})`);
+		}
 
 		const ttlSeconds = typeof expiresIn === "number" && expiresIn > 0 ? expiresIn : DEFAULT_TTL_SECONDS;
 		cached = { token: accessToken, expiresAt: now() + ttlSeconds * 1000 };

--- a/frontend/src/main/ao-machines.test.ts
+++ b/frontend/src/main/ao-machines.test.ts
@@ -224,6 +224,53 @@ test("signing out forgets the token and falls back to this computer", async () =
 	expect(active.at(-1)).toBeNull();
 });
 
+test("a refresh already in flight cannot re-point a signed-out install", async () => {
+	let releaseList = (): void => undefined;
+	const listArrived = new Promise<void>((resolve) => {
+		releaseList = resolve;
+	});
+	// A previous run left this computer pointed at mch_1.
+	const before = controller(fakeFetch([machineRow()], { "https://vm.example.com": true }));
+	await before.refresh();
+	await before.select("mch_1");
+
+	const machines = createAoMachinesController({
+		stateDir,
+		env: {},
+		safeStorage,
+		localMachineName: "This Mac",
+		onActiveChange: (machine) => active.push(machine),
+		fetchImpl: (async (input: string) => {
+			if (String(input).endsWith("/api/v1/machines")) {
+				await listArrived;
+				return listResponse(machineRow());
+			}
+			return new Response("not found", { status: 404 });
+		}) as unknown as typeof fetch,
+		probeTimeoutMs: 50,
+		tokenSource: signedIn,
+	});
+	await machines.restore();
+
+	// Sign out lands while the list request is still open, holding a token the
+	// refresh fetched before the reset.
+	const inFlight = machines.refresh();
+	await machines.reset();
+	releaseList();
+	await inFlight;
+
+	expect(machines.getState()).toMatchObject({ status: "signed-out", activeMachineId: LOCAL_MACHINE_ID });
+	expect(active.at(-1)).toBeNull();
+	await expect(readFile(path.join(stateDir, AO_MACHINE_FILE_NAME), "utf8")).rejects.toThrow();
+});
+
+test("the machine file's temp name is random, so a stale one from a reused pid cannot be adopted", async () => {
+	const machines = controller(fakeFetch([machineRow()], { "https://vm.example.com": true }));
+	await machines.refresh();
+	await machines.select("mch_1");
+	await expect(readFile(path.join(stateDir, `.ao-machine-${process.pid}.json`), "utf8")).rejects.toThrow();
+});
+
 test("a bad AO_CONTROL_URL is reported, never a silent fall back to production", async () => {
 	const machines = createAoMachinesController({
 		stateDir,

--- a/frontend/src/main/ao-machines.ts
+++ b/frontend/src/main/ao-machines.ts
@@ -1,3 +1,4 @@
+import { randomBytes } from "node:crypto";
 import { mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
 import {
@@ -130,7 +131,9 @@ async function writePersisted(stateDir: string, machine: PersistedMachine | null
 	const file: MachineFile = { version: SCHEMA_VERSION, machine };
 	// Atomic write, mirroring app-state.json and ao-account.json.
 	await mkdir(stateDir, { recursive: true, mode: 0o750 });
-	const tmp = path.join(stateDir, `.ao-machine-${process.pid}.json`);
+	// Random, not the pid: `mode` applies only on create, so a stale temp from a
+	// crashed run with the same pid would be reused with whatever mode it had.
+	const tmp = path.join(stateDir, `.ao-machine-${randomBytes(8).toString("hex")}.json`);
 	await writeFile(tmp, `${JSON.stringify(file, null, 2)}\n`, { mode: 0o600 });
 	await rename(tmp, machineFilePath(stateDir));
 }
@@ -180,6 +183,14 @@ export function createAoMachinesController(deps: AoMachinesControllerDeps): AoMa
 	let active: AoMachine | null = null;
 	let status: AoMachinesStatus = "signed-out";
 	let lastError: string | null = null;
+
+	/**
+	 * Bumped by anything that decides what is active out of band, which today is
+	 * sign-out. A refresh that was already past `tokenSource.get()` when the user
+	 * signed out still holds a usable token and would otherwise finish by writing
+	 * ao-machine.json for an install that has no account left.
+	 */
+	let generation = 0;
 
 	function currentState(): AoMachinesState {
 		const local = localMachine(deps.localMachineName);
@@ -242,9 +253,11 @@ export function createAoMachinesController(deps: AoMachinesControllerDeps): AoMa
 		}
 	}
 
-	async function probeAll(): Promise<void> {
-		const results = await Promise.all(remote.map(probe));
-		remote = remote.map((machine, index) => ({ ...machine, reachability: results[index] }));
+	async function probeAll(superseded: () => boolean): Promise<void> {
+		const probed = remote;
+		const results = await Promise.all(probed.map(probe));
+		if (superseded()) return;
+		remote = probed.map((machine, index) => ({ ...machine, reachability: results[index] }));
 		if (!active) return;
 		const refreshed = remote.find((machine) => machine.id === active?.id);
 		if (!refreshed) return;
@@ -256,6 +269,9 @@ export function createAoMachinesController(deps: AoMachinesControllerDeps): AoMa
 	}
 
 	async function refresh(): Promise<AoMachinesState> {
+		const startedAt = generation;
+		const superseded = (): boolean => generation !== startedAt;
+
 		if (configError) {
 			status = "error";
 			lastError = configError;
@@ -270,6 +286,9 @@ export function createAoMachinesController(deps: AoMachinesControllerDeps): AoMa
 		lastError = null;
 		try {
 			const token = await tokenSource.get();
+			// Sign-out landed while this was in flight. Its answer describes an account
+			// that is gone, so it is dropped rather than written over the reset.
+			if (superseded()) return currentState();
 			if (!token) {
 				// Signed out. There is no way to reach a registered machine without an
 				// account, so fall back to this computer, which needs none.
@@ -278,7 +297,9 @@ export function createAoMachinesController(deps: AoMachinesControllerDeps): AoMa
 				await setActive(null);
 				return currentState();
 			}
-			remote = await fetchMachines(token);
+			const listed = await fetchMachines(token);
+			if (superseded()) return currentState();
+			remote = listed;
 			status = "ready";
 			const stillRegistered = active ? (remote.find((machine) => machine.id === active?.id) ?? null) : null;
 			// A revoked machine is absent from the list. Falling back to this
@@ -286,6 +307,7 @@ export function createAoMachinesController(deps: AoMachinesControllerDeps): AoMa
 			if (active && !stillRegistered) await setActive(null);
 			else if (stillRegistered) await setActive(stillRegistered);
 		} catch (err) {
+			if (superseded()) return currentState();
 			// The control plane is unreachable or refused the token. Keep the machine
 			// that is already active and let the probe below say whether it is up:
 			// a control-plane outage does not make a working machine unusable.
@@ -294,7 +316,7 @@ export function createAoMachinesController(deps: AoMachinesControllerDeps): AoMa
 			if (active && !remote.some((machine) => machine.id === active?.id)) remote = [active];
 		}
 
-		await probeAll();
+		await probeAll(superseded);
 		return currentState();
 	}
 
@@ -328,6 +350,7 @@ export function createAoMachinesController(deps: AoMachinesControllerDeps): AoMa
 		},
 
 		async reset(): Promise<void> {
+			generation += 1;
 			tokenSource?.clear();
 			remote = [];
 			status = "signed-out";

--- a/frontend/src/main/ao-pkce.test.ts
+++ b/frontend/src/main/ao-pkce.test.ts
@@ -52,13 +52,23 @@ test("a matching callback yields the code", () => {
 	expect(parseCallback("/callback?code=abc&state=st", "st")).toEqual({ code: "abc" });
 });
 
-test("a callback whose state does not match is rejected, not exchanged", () => {
-	expect(parseCallback("/callback?code=abc&state=other", "st")).toEqual({
-		error: expect.stringContaining("did not match"),
+test("a callback whose state does not match is a mismatch, not an error", () => {
+	// `mismatch`, not `error`: the caller must keep waiting for the real callback
+	// rather than ending the sign-in on a stray hit. Same length as the
+	// expectation, and one character longer, both mismatch.
+	expect(parseCallback("/callback?code=abc&state=xt", "st")).toEqual({
+		mismatch: expect.stringContaining("did not match"),
+	});
+	expect(parseCallback("/callback?code=abc&state=stt", "st")).toEqual({
+		mismatch: expect.stringContaining("did not match"),
 	});
 	// A missing state is a mismatch too, and an empty expectation never matches.
-	expect(parseCallback("/callback?code=abc", "st")).toEqual({ error: expect.stringContaining("did not match") });
-	expect(parseCallback("/callback?code=abc&state=", "")).toEqual({ error: expect.stringContaining("did not match") });
+	expect(parseCallback("/callback?code=abc", "st")).toEqual({ mismatch: expect.stringContaining("did not match") });
+	expect(parseCallback("/callback?code=abc&state=", "")).toEqual({ mismatch: expect.stringContaining("did not match") });
+	// A multibyte state must compare as a mismatch, not throw on byte length.
+	expect(parseCallback(`/callback?code=abc&state=${encodeURIComponent("é")}`, "st")).toEqual({
+		mismatch: expect.stringContaining("did not match"),
+	});
 });
 
 test("an OAuth error is reported, and access_denied reads as a decline", () => {

--- a/frontend/src/main/ao-pkce.ts
+++ b/frontend/src/main/ao-pkce.ts
@@ -1,4 +1,4 @@
-import { createHash, randomBytes } from "node:crypto";
+import { createHash, randomBytes, timingSafeEqual } from "node:crypto";
 
 /**
  * PKCE (RFC 7636) and authorization-request helpers for the desktop login flow.
@@ -57,7 +57,25 @@ export function buildAuthorizeUrl(input: AuthorizeUrlInput): string {
 	return url.toString();
 }
 
-export type CallbackResult = { code: string } | { error: string };
+export type CallbackResult =
+	| { code: string }
+	// The authorization server said no, and it proved it was answering our own
+	// request by carrying our `state`. This ends the sign-in.
+	| { error: string }
+	// Not our callback: wrong `state`, or a URL we could not read one out of. Says
+	// nothing about the sign-in in flight, so the caller must not end it on this.
+	| { mismatch: string };
+
+/** Timing-safe `state` comparison. Unequal lengths are a mismatch, cheaply. */
+function stateMatches(actual: string, expected: string): boolean {
+	if (!expected) return false;
+	// Byte lengths, not character counts: timingSafeEqual throws on a length
+	// mismatch, and a multibyte callback value can match in characters and not
+	// in bytes.
+	const got = Buffer.from(actual);
+	const want = Buffer.from(expected);
+	return got.length === want.length && timingSafeEqual(got, want);
+}
 
 /**
  * Validate a loopback callback. `state` is checked before anything else is read,
@@ -69,12 +87,11 @@ export function parseCallback(rawUrl: string, expectedState: string): CallbackRe
 	try {
 		params = new URL(rawUrl, "http://127.0.0.1").searchParams;
 	} catch {
-		return { error: "The sign-in callback URL was malformed." };
+		return { mismatch: "The sign-in callback URL was malformed." };
 	}
 
-	const state = params.get("state") ?? "";
-	if (!expectedState || state !== expectedState) {
-		return { error: "The sign-in callback did not match this request and was rejected." };
+	if (!stateMatches(params.get("state") ?? "", expectedState)) {
+		return { mismatch: "The sign-in callback did not match this request and was rejected." };
 	}
 
 	const oauthError = params.get("error");

--- a/frontend/src/main/loopback-callback.test.ts
+++ b/frontend/src/main/loopback-callback.test.ts
@@ -25,10 +25,44 @@ test("binds loopback on an ephemeral port and hands back the matching code", asy
 });
 
 test("rejects a callback whose state does not match and never resolves a code", async () => {
-	const callback = await startLoopbackCallback("st");
+	// Long enough that the request below finishes before the listener gives up.
+	const callback = await startLoopbackCallback("st", 300);
 	const page = await get(`${callback.redirectUri}?code=abc&state=forged`);
 	expect(page.status).toBe(400);
-	await expect(callback.code).rejects.toThrow(/did not match/);
+	// The forged code is never handed out: the listener waits for the real
+	// callback and gives up on its own timeout instead.
+	await expect(callback.code).rejects.toThrow(/timed out/);
+});
+
+// The hazard: a wrong-state hit is anything on this machine that touches the
+// port, including a browser prefetch, a scanner, or a page walking the ephemeral
+// range. Ending the sign-in on one would let any of those abort every login.
+test("keeps waiting after a wrong-state hit, and still accepts the real callback", async () => {
+	const callback = await startLoopbackCallback("st");
+
+	expect((await get(`${callback.redirectUri}?code=stolen&state=forged`)).status).toBe(400);
+	expect((await get(`${callback.redirectUri}?code=stolen`)).status).toBe(400);
+	expect((await get(`${callback.redirectUri}?error=access_denied&state=forged`)).status).toBe(400);
+
+	const page = await get(`${callback.redirectUri}?code=abc&state=st`);
+	expect(page.status).toBe(200);
+	await expect(callback.code).resolves.toBe("abc");
+});
+
+test("ends the sign-in on an OAuth error that did carry our state", async () => {
+	const callback = await startLoopbackCallback("st");
+	const page = await get(`${callback.redirectUri}?error=access_denied&state=st`);
+	expect(page.status).toBe(400);
+	await expect(callback.code).rejects.toThrow(/declined/);
+});
+
+test("escapes the authorization server's error description into the page", async () => {
+	const callback = await startLoopbackCallback("st");
+	const description = encodeURIComponent("<script>alert(1)</script>");
+	const page = await get(`${callback.redirectUri}?error=server_error&error_description=${description}&state=st`);
+	expect(page.body).not.toContain("<script>");
+	expect(page.body).toContain("&lt;script&gt;");
+	await expect(callback.code).rejects.toThrow();
 });
 
 test("ignores a request on any other path without consuming the one callback", async () => {

--- a/frontend/src/main/loopback-callback.ts
+++ b/frontend/src/main/loopback-callback.ts
@@ -24,10 +24,21 @@ export type LoopbackCallback = {
 	close: () => void;
 };
 
+/**
+ * The only text on this page that is not a literal is an OAuth error
+ * description, which comes from the authorization server, so it is escaped
+ * rather than interpolated raw.
+ */
+const escapeHtml = (raw: string): string =>
+	raw.replace(
+		/[&<>"']/g,
+		(char) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" })[char] ?? char,
+	);
+
 const PAGE = (heading: string, body: string) =>
-	`<!doctype html><meta charset="utf-8"><title>${heading}</title>` +
+	`<!doctype html><meta charset="utf-8"><title>${escapeHtml(heading)}</title>` +
 	`<body style="font:15px system-ui;margin:14vh auto;max-width:26rem;text-align:center">` +
-	`<h1 style="font-size:1.1rem">${heading}</h1><p style="color:#666">${body}</p></body>`;
+	`<h1 style="font-size:1.1rem">${escapeHtml(heading)}</h1><p style="color:#666">${escapeHtml(body)}</p></body>`;
 
 function respond(res: ServerResponse, status: number, heading: string, body: string): void {
 	res.writeHead(status, { "content-type": "text/html; charset=utf-8", connection: "close" });
@@ -64,6 +75,15 @@ export async function startLoopbackCallback(
 			return;
 		}
 		const result = parseCallback(url, expectedState);
+		if ("mismatch" in result) {
+			// A hit that does not carry our `state` is not our browser: a prefetch, a
+			// scanner, a stale tab, or a page spraying the ephemeral range. It gets a
+			// 400 and nothing else, because ending the sign-in on it would let any of
+			// those abort every login attempt on this machine. The real callback is
+			// still awaited, until the timeout.
+			respond(res, 400, "Not this sign-in", result.mismatch);
+			return;
+		}
 		if ("error" in result) {
 			respond(res, 400, "Sign-in was rejected", result.error);
 			finish({ error: new Error(result.error) });

--- a/frontend/src/main/remote-daemon.test.ts
+++ b/frontend/src/main/remote-daemon.test.ts
@@ -155,7 +155,7 @@ describe("an active registered machine", () => {
 
 		await expect(lifecycle.start(localStart, vi.fn())).resolves.toEqual({
 			state: "error",
-			code: "not_configured",
+			code: "machine_transport_missing",
 			message: expect.stringContaining("cannot sign in to it yet"),
 		});
 		expect(localStart).not.toHaveBeenCalled();

--- a/frontend/src/main/remote-daemon.test.ts
+++ b/frontend/src/main/remote-daemon.test.ts
@@ -1,11 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import type { AoMachine } from "../shared/ao-machines";
-import {
-	createRemoteDaemonLifecycle,
-	installRemoteDaemonCookie,
-	machineDaemonStatus,
-	remoteDaemonReadyStatus,
-} from "./remote-daemon";
+import { machineDaemonStatus } from "../shared/remote-daemon";
+import { createRemoteDaemonLifecycle, installRemoteDaemonCookie, remoteDaemonReadyStatus } from "./remote-daemon";
 
 const machine = (extra: Partial<AoMachine> = {}): AoMachine => ({
 	id: "mch_1",
@@ -149,14 +145,18 @@ describe("an active registered machine", () => {
 		};
 	};
 
-	it("re-points the app at that machine's base URL", async () => {
+	// TASK 13: this becomes "re-points the app at that machine's base URL", with a
+	// ready status carrying baseUrl, once the desktop can present a
+	// machine-audience token. Until then the app must not point at a machine it
+	// cannot authenticate to.
+	it("owns the app's daemon status without claiming a connection it cannot make", async () => {
 		const lifecycle = createRemoteDaemonLifecycle(null, null, () => machineDaemonStatus(machine()));
 		const { localStart } = localCalls();
 
 		await expect(lifecycle.start(localStart, vi.fn())).resolves.toEqual({
-			state: "ready",
-			baseUrl: "https://vm.example.com",
-			message: "Connected to ao-build-01",
+			state: "error",
+			code: "not_configured",
+			message: expect.stringContaining("cannot sign in to it yet"),
 		});
 		expect(localStart).not.toHaveBeenCalled();
 	});
@@ -199,20 +199,6 @@ describe("an active registered machine", () => {
 		const lifecycle = createRemoteDaemonLifecycle(config, null, () => machineDaemonStatus(machine()));
 
 		await expect(lifecycle.start(vi.fn(), vi.fn())).resolves.toEqual(remoteDaemonReadyStatus(config));
-	});
-});
-
-describe("machineDaemonStatus", () => {
-	it("says when a machine was last seen, or that it never has been", () => {
-		expect(machineDaemonStatus(machine({ reachability: "offline" })).message).toContain("never connected");
-		expect(machineDaemonStatus(machine({ reachability: "offline", lastSeen: "2020-01-01T09:00:00Z" })).message)
-			.toMatch(/Last seen .+ ago\./);
-	});
-
-	it("is connecting, not ready, before the machine has answered", () => {
-		expect(machineDaemonStatus(machine({ reachability: "unknown" }))).toMatchObject({ state: "starting" });
-		// Nothing is pointed at a machine that has not answered yet.
-		expect(machineDaemonStatus(machine({ reachability: "unknown" })).baseUrl).toBeUndefined();
 	});
 });
 

--- a/frontend/src/main/remote-daemon.ts
+++ b/frontend/src/main/remote-daemon.ts
@@ -1,5 +1,4 @@
 import { REMOTE_PAIRING_COOKIE_NAME, type RemoteDaemonConfig } from "../shared/remote-daemon";
-import { formatLastSeen, type AoMachine } from "../shared/ao-machines";
 import type { DaemonStatus } from "../shared/daemon-status";
 
 type CookieStore = {
@@ -28,32 +27,6 @@ export async function installRemoteDaemonCookie(store: CookieStore, config: Remo
 
 export function remoteDaemonReadyStatus(config: RemoteDaemonConfig): DaemonStatus {
 	return { state: "ready", baseUrl: config.baseUrl, message: "Connected to remote daemon" };
-}
-
-/**
- * The app's daemon status while a registered machine is the active one.
- *
- * An unreachable machine is an error status, not the absence of one, and that
- * is the whole point: createRemoteDaemonLifecycle only falls through to the
- * local daemon when there is no status here at all. A remote machine being
- * down therefore cannot spawn a local daemon, because the code path that
- * spawns one is never reached rather than being skipped by a condition.
- */
-export function machineDaemonStatus(machine: AoMachine): DaemonStatus {
-	if (machine.reachability === "offline") {
-		const seen = formatLastSeen(machine.lastSeen);
-		return {
-			state: "error",
-			code: "daemon_unreachable",
-			message: seen
-				? `${machine.name} is not reachable. Last seen ${seen}.`
-				: `${machine.name} is not reachable, and has never connected to AO.`,
-		};
-	}
-	if (machine.reachability === "unknown") {
-		return { state: "starting", message: `Connecting to ${machine.name}…` };
-	}
-	return { state: "ready", baseUrl: machine.baseUrl, message: `Connected to ${machine.name}` };
 }
 
 export function createRemoteDaemonLifecycle(

--- a/frontend/src/renderer/lib/bridge.ts
+++ b/frontend/src/renderer/lib/bridge.ts
@@ -8,6 +8,8 @@ import {
 	type AoMachinesState,
 } from "../../shared/ao-machines";
 import { DEFAULT_CONTROL_PLANE_URL } from "../../shared/control-plane";
+import { machineDaemonStatus } from "../../shared/remote-daemon";
+import type { DaemonStatus } from "../../shared/daemon-status";
 export type { FeatureBuild } from "../../main/feature-builds";
 
 const BROWSER_PREVIEW_ACCOUNT_STATE: AoAccountState = {
@@ -62,6 +64,21 @@ const browserPreviewMachinesState = (): AoMachinesState => ({
 	activeMachineId: previewActiveMachineId,
 });
 
+/**
+ * What the app's daemon status would be for the machine picked in preview, from
+ * the same function the main process uses. Picking a registered machine here
+ * therefore shows the real not-ready state rather than a preview-only stand-in.
+ */
+const browserPreviewDaemonStatus = (): DaemonStatus => {
+	const active = BROWSER_PREVIEW_MACHINES.find((machine) => machine.id === previewActiveMachineId);
+	if (!active || active.local) {
+		return { state: "stopped", message: "Electron preload is not available in browser preview." };
+	}
+	return machineDaemonStatus(active);
+};
+
+const previewDaemonStatusListeners = new Set<(status: DaemonStatus) => void>();
+
 export const aoBridge: AoBridge =
 	window.ao ??
 	({
@@ -104,13 +121,13 @@ export const aoBridge: AoBridge =
 			readText: async () => (navigator.clipboard?.readText ? navigator.clipboard.readText() : ""),
 		},
 		daemon: {
-			getStatus: async () => ({
-				state: "stopped",
-				message: "Electron preload is not available in browser preview.",
-			}),
+			getStatus: async () => browserPreviewDaemonStatus(),
 			start: async () => ({ state: "starting" }),
 			stop: async () => ({ state: "stopped" }),
-			onStatus: () => () => undefined,
+			onStatus: (listener: (status: DaemonStatus) => void) => {
+				previewDaemonStatusListeners.add(listener);
+				return () => previewDaemonStatusListeners.delete(listener);
+			},
 		},
 		telemetry: {
 			getBootstrap: async () => null,
@@ -217,6 +234,8 @@ export const aoBridge: AoBridge =
 			refresh: async () => browserPreviewMachinesState(),
 			select: async (machineId: string) => {
 				previewActiveMachineId = machineId;
+				const status = browserPreviewDaemonStatus();
+				previewDaemonStatusListeners.forEach((listener) => listener(status));
 				return browserPreviewMachinesState();
 			},
 		},

--- a/frontend/src/renderer/lib/daemon-failure.ts
+++ b/frontend/src/renderer/lib/daemon-failure.ts
@@ -13,6 +13,8 @@ export function daemonFailureTitle(status: DaemonStatus): string {
 			return "AO daemon is not ready yet";
 		case "not_configured":
 			return "AO daemon is not configured";
+		case "machine_transport_missing":
+			return "This build cannot reach a registered machine yet";
 		case "daemon_unreachable":
 			return "AO daemon is unreachable";
 		case "identity_mismatch":
@@ -37,6 +39,8 @@ export function daemonFailureHint(status: DaemonStatus): string {
 			return "The daemon has not passed its readiness check yet. Open details below for more information.";
 		case "not_configured":
 			return "Set AO_DAEMON_COMMAND or run the desktop app from a source checkout.";
+		case "machine_transport_missing":
+			return "Pick this computer under Settings, Machines to keep working.";
 		case "daemon_unreachable":
 		case "identity_mismatch":
 			return "Stop the conflicting daemon, then restart the desktop app.";

--- a/frontend/src/renderer/lib/query-client.test.ts
+++ b/frontend/src/renderer/lib/query-client.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, expect, test } from "vitest";
+import { setApiBaseUrl } from "./api-client";
+import { clearQueryCacheOnMachineSwitch, queryClient } from "./query-client";
+
+let stop: (() => void) | null = null;
+afterEach(() => {
+	stop?.();
+	stop = null;
+	queryClient.clear();
+});
+
+/**
+ * Switching machines re-points every request at a different daemon, and query
+ * keys carry no machine dimension: machine A's sessions are cached under
+ * exactly the keys machine B reads. The hazard is not a stale render, it is a
+ * user acting on the wrong machine's session list.
+ */
+test("a change of daemon empties the cache, so no machine's data outlives it", () => {
+	stop = clearQueryCacheOnMachineSwitch();
+	setApiBaseUrl("https://a.example.com");
+	queryClient.setQueryData(["sessions"], [{ id: "from-machine-a" }]);
+
+	setApiBaseUrl("https://b.example.com");
+
+	expect(queryClient.getQueryData(["sessions"])).toBeUndefined();
+});
+
+test("a refresh that lands on the same daemon keeps the cache", () => {
+	stop = clearQueryCacheOnMachineSwitch();
+	setApiBaseUrl("https://a.example.com");
+	queryClient.setQueryData(["sessions"], [{ id: "from-machine-a" }]);
+
+	setApiBaseUrl("https://a.example.com/");
+
+	expect(queryClient.getQueryData(["sessions"])).toEqual([{ id: "from-machine-a" }]);
+});

--- a/frontend/src/renderer/lib/query-client.ts
+++ b/frontend/src/renderer/lib/query-client.ts
@@ -1,4 +1,5 @@
 import { QueryClient } from "@tanstack/react-query";
+import { subscribeApiBaseUrl } from "./api-client";
 
 export const queryClient = new QueryClient({
 	defaultOptions: {
@@ -8,3 +9,23 @@ export const queryClient = new QueryClient({
 		},
 	},
 });
+
+/**
+ * Drop everything cached when the app is re-pointed at a different daemon.
+ * Called once from the app root.
+ *
+ * Query keys carry no machine dimension, so machine A's projects and sessions
+ * are cached under exactly the keys machine B reads. Without this, a switch
+ * renders A's session list under B's identity, and a request already in flight
+ * to A resolves afterwards and writes A's answer into the same key, which is
+ * the one a user could act on. Clearing beats adding a machine dimension to
+ * every key: it is one line, and it cannot be forgotten on a key added later.
+ *
+ * setApiBaseUrl only notifies on an actual change, so this does not fire on a
+ * refresh that lands on the same daemon.
+ */
+export function clearQueryCacheOnMachineSwitch(): () => void {
+	return subscribeApiBaseUrl(() => {
+		queryClient.clear();
+	});
+}

--- a/frontend/src/renderer/main.tsx
+++ b/frontend/src/renderer/main.tsx
@@ -5,7 +5,7 @@ import { QueryClientProvider } from "@tanstack/react-query";
 import { RouterProvider } from "@tanstack/react-router";
 import "@xterm/xterm/css/xterm.css";
 import "./styles.css";
-import { queryClient } from "./lib/query-client";
+import { clearQueryCacheOnMachineSwitch, queryClient } from "./lib/query-client";
 import { createAppRouter } from "./router";
 import { TelemetryBoundary } from "./components/TelemetryBoundary";
 import { initTelemetry } from "./lib/telemetry";
@@ -14,6 +14,8 @@ import { startDaemonFailureTelemetry } from "./lib/daemon-telemetry";
 const router = createAppRouter(queryClient);
 void initTelemetry();
 startDaemonFailureTelemetry();
+// Nothing cached under machine A may be read under machine B.
+clearQueryCacheOnMachineSwitch();
 
 declare module "@tanstack/react-router" {
 	interface Register {

--- a/frontend/src/shared/ao-machines.test.ts
+++ b/frontend/src/shared/ao-machines.test.ts
@@ -119,6 +119,17 @@ describe("parseMachineOrigin", () => {
 			expect(parseMachineOrigin(raw)).toBeNull();
 		}
 	});
+
+	// Same rule as AO_CONTROL_URL. A machine row with an http public_url would
+	// otherwise become the app's API base URL over a readable network, and
+	// isRemoteDaemonBaseUrl would stop treating it as remote at the same time.
+	test("allows plain HTTP only for a gateway on this machine", () => {
+		expect(parseMachineOrigin("http://vm.example.com")).toBeNull();
+		expect(parseMachineOrigin("http://10.0.0.4:8080")).toBeNull();
+		expect(parseMachineOrigin("http://127.0.0.1:8080")).toBe("http://127.0.0.1:8080");
+		expect(parseMachineOrigin("http://localhost:8080")).toBe("http://localhost:8080");
+		expect(parseMachineOrigin("http://[::1]:8080")).toBe("http://[::1]:8080");
+	});
 });
 
 describe("localMachine", () => {

--- a/frontend/src/shared/ao-machines.ts
+++ b/frontend/src/shared/ao-machines.ts
@@ -8,6 +8,8 @@
  * I/O, so the main process owns the fetch and the renderer owns the rendering.
  */
 
+import { isLoopbackHost } from "./control-plane";
+
 /** Machine zero. Never comes from the control plane and never needs an account. */
 export const LOCAL_MACHINE_ID = "local";
 
@@ -89,7 +91,11 @@ export function parseMachineOrigin(raw: unknown): string | null {
 	} catch {
 		return null;
 	}
-	if (url.protocol !== "https:" && url.protocol !== "http:") return null;
+	// Same rule as AO_CONTROL_URL: HTTPS, or plain HTTP only for a gateway on this
+	// machine. A remote machine reached over HTTP would carry the session over a
+	// network anyone on the path can read, and isRemoteDaemonBaseUrl would stop
+	// treating it as remote, so credentials would silently change behaviour too.
+	if (url.protocol !== "https:" && !(url.protocol === "http:" && isLoopbackHost(url.hostname))) return null;
 	if (url.pathname !== "/" || url.search || url.hash || url.username || url.password) return null;
 	return url.origin;
 }

--- a/frontend/src/shared/control-plane.ts
+++ b/frontend/src/shared/control-plane.ts
@@ -12,6 +12,11 @@ export const DEFAULT_CONTROL_PLANE_URL = "https://ao.agentlab.in";
 
 const LOOPBACK_HOSTS = new Set(["127.0.0.1", "::1", "localhost"]);
 
+/** Whether a URL's hostname is this machine. `[::1]` arrives bracketed from URL. */
+export function isLoopbackHost(hostname: string): boolean {
+	return LOOPBACK_HOSTS.has(hostname) || LOOPBACK_HOSTS.has(hostname.replace(/^\[|\]$/g, ""));
+}
+
 /**
  * Resolve the control-plane origin from the environment. Returns an origin with
  * no trailing slash so it can be concatenated with a path, matching the way the
@@ -36,8 +41,7 @@ export function readControlPlaneUrl(env: Record<string, string | undefined>): st
 	}
 	// Plain HTTP is allowed only for a control plane on this machine, which is the
 	// one case where there is no network to intercept the authorization code.
-	const loopback = LOOPBACK_HOSTS.has(url.hostname) || LOOPBACK_HOSTS.has(url.hostname.replace(/^\[|\]$/g, ""));
-	if (url.protocol !== "https:" && !(url.protocol === "http:" && loopback)) {
+	if (url.protocol !== "https:" && !(url.protocol === "http:" && isLoopbackHost(url.hostname))) {
 		throw new Error("AO_CONTROL_URL must be HTTPS, or HTTP on 127.0.0.1 for a locally-run control plane");
 	}
 	return url.origin;

--- a/frontend/src/shared/daemon-status.ts
+++ b/frontend/src/shared/daemon-status.ts
@@ -13,7 +13,10 @@ export type DaemonFailureCode =
 	| "port_unconfirmed"
 	| "not_ready"
 	| "identity_mismatch"
-	| "datadir_unwritable";
+	| "datadir_unwritable"
+	// TASK 13 PLACEHOLDER: a registered machine is up but this build has no
+	// credential for it. Delete this with machineTransportMissingStatus.
+	| "machine_transport_missing";
 
 export type DaemonStatus = {
 	state: "starting" | "ready" | "stopped" | "error";

--- a/frontend/src/shared/remote-daemon.test.ts
+++ b/frontend/src/shared/remote-daemon.test.ts
@@ -1,5 +1,19 @@
 import { describe, expect, it } from "vitest";
-import { isRemoteDaemonBaseUrl, readRemoteDaemonConfig } from "./remote-daemon";
+import type { AoMachine } from "./ao-machines";
+import { isRemoteDaemonBaseUrl, machineDaemonStatus, readRemoteDaemonConfig } from "./remote-daemon";
+
+const machine = (extra: Partial<AoMachine> = {}): AoMachine => ({
+	id: "mch_1",
+	name: "ao-build-01",
+	baseUrl: "https://vm.example.com",
+	local: false,
+	createdAt: null,
+	lastSeen: null,
+	reachability: "online",
+	harness: "unknown",
+	harnessCommand: null,
+	...extra,
+});
 
 describe("readRemoteDaemonConfig", () => {
 	it("returns a normalized remote config for an HTTPS origin and URL-safe token", () => {
@@ -52,5 +66,29 @@ describe("isRemoteDaemonBaseUrl", () => {
 
 	it("does not recognize loopback HTTP", () => {
 		expect(isRemoteDaemonBaseUrl("http://127.0.0.1:4317")).toBe(false);
+	});
+});
+
+describe("machineDaemonStatus", () => {
+	it("says when a machine was last seen, or that it never has been", () => {
+		expect(machineDaemonStatus(machine({ reachability: "offline" })).message).toContain("never connected");
+		expect(machineDaemonStatus(machine({ reachability: "offline", lastSeen: "2020-01-01T09:00:00Z" })).message)
+			.toMatch(/Last seen .+ ago\./);
+	});
+
+	it("is connecting, not ready, before the machine has answered", () => {
+		expect(machineDaemonStatus(machine({ reachability: "unknown" }))).toMatchObject({ state: "starting" });
+		// Nothing is pointed at a machine that has not answered yet.
+		expect(machineDaemonStatus(machine({ reachability: "unknown" })).baseUrl).toBeUndefined();
+	});
+
+	// The regression this guards: a "ready" status here sets the renderer's API
+	// base URL, and with no machine-audience token in this build every REST call
+	// and both EventSources would 401 under a UI that says Connected.
+	it("does not hand out a base URL for a reachable machine while there is no credential for it", () => {
+		const status = machineDaemonStatus(machine({ reachability: "online" }));
+		expect(status.state).not.toBe("ready");
+		expect(status.baseUrl).toBeUndefined();
+		expect(status.message).toContain("ao-build-01");
 	});
 });

--- a/frontend/src/shared/remote-daemon.ts
+++ b/frontend/src/shared/remote-daemon.ts
@@ -1,3 +1,6 @@
+import { formatLastSeen, type AoMachine } from "./ao-machines";
+import type { DaemonStatus } from "./daemon-status";
+
 export const REMOTE_PAIRING_COOKIE_NAME = "ao_hosted_pair";
 
 export type RemoteDaemonConfig = { baseUrl: string; token: string };
@@ -17,4 +20,53 @@ export function readRemoteDaemonConfig(env: Record<string, string | undefined>):
 
 export function isRemoteDaemonBaseUrl(baseUrl: string): boolean {
 	return baseUrl.startsWith("https://");
+}
+
+/**
+ * The app's daemon status while a registered machine is the active one.
+ *
+ * An unreachable machine is an error status, not the absence of one, and that
+ * is the whole point: createRemoteDaemonLifecycle only falls through to the
+ * local daemon when there is no status here at all. A remote machine being
+ * down therefore cannot spawn a local daemon, because the code path that
+ * spawns one is never reached rather than being skipped by a condition.
+ *
+ * Shared rather than main-process-only so browser preview shows the same
+ * states, from the same copy, as the packaged app.
+ */
+export function machineDaemonStatus(machine: AoMachine): DaemonStatus {
+	if (machine.reachability === "offline") {
+		const seen = formatLastSeen(machine.lastSeen);
+		return {
+			state: "error",
+			code: "daemon_unreachable",
+			message: seen
+				? `${machine.name} is not reachable. Last seen ${seen}.`
+				: `${machine.name} is not reachable, and has never connected to AO.`,
+		};
+	}
+	if (machine.reachability === "unknown") {
+		return { state: "starting", message: `Connecting to ${machine.name}…` };
+	}
+	return machineTransportMissingStatus(machine);
+}
+
+/**
+ * TASK 13 PLACEHOLDER. Delete this function and return
+ * `{ state: "ready", baseUrl: machine.baseUrl, message: "Connected to ..." }`
+ * from machineDaemonStatus when the remote transport lands.
+ *
+ * A reachable machine is not a usable one yet: every route on it wants a
+ * machine-audience access token, and the desktop mints none (see the scope note
+ * at the top of main/ao-control-token.ts). Reporting ready would point the
+ * renderer at the gateway and turn every REST call and both EventSources into
+ * 401s under a UI that says "Connected". Naming the missing piece is the honest
+ * answer until there is a credential to send.
+ */
+function machineTransportMissingStatus(machine: AoMachine): DaemonStatus {
+	return {
+		state: "error",
+		code: "not_configured",
+		message: `${machine.name} is up, but this build cannot sign in to it yet. Reaching a registered machine needs the remote transport, which is not in this build. Use this computer for now.`,
+	};
 }

--- a/frontend/src/shared/remote-daemon.ts
+++ b/frontend/src/shared/remote-daemon.ts
@@ -66,7 +66,7 @@ export function machineDaemonStatus(machine: AoMachine): DaemonStatus {
 function machineTransportMissingStatus(machine: AoMachine): DaemonStatus {
 	return {
 		state: "error",
-		code: "not_configured",
+		code: "machine_transport_missing",
 		message: `${machine.name} is up, but this build cannot sign in to it yet. Reaching a registered machine needs the remote transport, which is not in this build. Use this computer for now.`,
 	};
 }


### PR DESCRIPTION
Closes #40.

Fixes M1, M3, M4, M5, M9, L1, L2, L6, L8 from the client-side review. Frontend only; `backend/` and `controlplane/` are untouched.

## M3, the one a user hits first

`machineDaemonStatus` returned `{ state: "ready", baseUrl }` for an online machine, which made it the app's daemon status, so the renderer called `setApiBaseUrl(baseUrl)` and every REST call and both EventSources re-pointed at the gateway. No machine-audience token exists in the desktop yet (task 13), so picking a machine produced a UI saying "Connected to ao-build-01" over 401s.

A reachable machine now returns a not-ready status naming the reason. The whole placeholder is one function, `machineTransportMissingStatus`, marked TASK 13 PLACEHOLDER with the exact line to restore. Nothing else in the function changed: offline and unknown behave as before, and the status is still non-null for all three reachability values, so the structural local-daemon spawn guard is intact.

## M1, one stray request no longer kills a sign-in

`parseCallback` now returns `{ mismatch }` for a wrong or missing `state`, or a URL it could not read a `state` out of, and `{ error }` only for an OAuth error that did carry our `state`. The listener answers a mismatch with 400 and keeps waiting; only an error ends the flow. Covered by `keeps waiting after a wrong-state hit, and still accepts the real callback` in `loopback-callback.test.ts`.

## M4, the query cache

`clearQueryCacheOnMachineSwitch()` subscribes to `subscribeApiBaseUrl` at the app root and calls `queryClient.clear()`. Chosen over adding a machine dimension to every query key: one line, and it cannot be forgotten on a key added later. `setApiBaseUrl` only notifies on an actual change, so a refresh onto the same daemon keeps the cache.

## The rest

- **M5**: `parseMachineOrigin` allows plain HTTP only for loopback, using `isLoopbackHost` extracted from `readControlPlaneUrl` rather than a second rule.
- **M9**: `fsync` before the rename, and a persist failure after a successful exchange reports that the sign-in must be redone, carrying the underlying cause. A failed write leaves no temp file and does not damage the token already stored.
- **L1** HTML-escaped error description, **L2** timing-safe `state` compare, **L6** generation counter so an in-flight refresh cannot re-point a signed-out install, **L8** random temp-file names.

`machineDaemonStatus` moved from `main/remote-daemon.ts` to `shared/remote-daemon.ts` (pure function, no Electron) so browser preview renders the same states from the same copy as the packaged app. Preview's `daemon.getStatus`/`onStatus` now derive from the machine picked in the picker, which is how the M3 state is demoed with `ao preview`.

## Not regressed

`safeStorage` still fails closed and is still checked before the browser opens; neither failure path deletes the file. The loopback listener is still 127.0.0.1-only, still validates `state` before reading the code, still accepts exactly one real callback, and still closes on success, error, timeout and in `finally` with `closeAllConnections()`. The spawn guard is still `applyRemoteStatus(setStatus) ?? localStart()` with a non-null status for every reachability value. The `userData` pin and both state files under `~/.ao` are unchanged. `AO_REMOTE_URL`/`AO_REMOTE_TOKEN` still work and still take precedence (`currentStatus` checks `config` first). No machine-audience token is minted anywhere, and no URL or token can be typed into the app.

## Tests

`npm test` 1216 passed / 100 files, `npx vitest run` (CI's default config) 1216 passed, `npm run typecheck` and `npm run typecheck:e2e` clean. New coverage: the wrong-state-does-not-end-the-login test, the M3 no-base-URL-without-a-credential test, loopback HTTP origin rules, the signed-out refresh race, temp-file naming and cleanup, the failed-persist message, and the cache clear.

Renderer smoke was not run locally: port 5173 is held by another session's dev server. CI runs it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)