### PR TITLE
fix(controlplane): harden the device flow's approval path

### DIFF
--- a/controlplane/TOKEN_CONTRACT.md
+++ b/controlplane/TOKEN_CONTRACT.md
@@ -55,6 +55,12 @@ plane and it already publishes that origin everywhere.
 - **Machine audience:** from the RFC 8628 device flow, at the end of
   `ao setup-vm`. The polling response carries the machine id, the account id,
   and the public URL, which is what `~/.ao/machine.json` is written from.
+- **`publicUrl` is a full origin on the control-plane side** (`https://vm.example.com`,
+  scheme included, no path and no trailing slash, and `http` only for a loopback
+  host) **and is reduced to a bare hostname on the gateway side**, where
+  `ao vm serve` feeds it to the certificate whitelist. Neither side accepts the
+  other's form, so a value that is not a clean origin is rejected at
+  registration rather than stored and failed on at certificate time.
 - **Control-plane audience:** by exchanging a refresh token at
   `POST /api/v1/token` (`grant_type=refresh_token`), which rotates the refresh
   token in the same response.

--- a/controlplane/internal/api/api.go
+++ b/controlplane/internal/api/api.go
@@ -144,15 +144,26 @@ func Unauthorized(w http.ResponseWriter) {
 	WriteError(w, http.StatusUnauthorized, "invalid_token", "a valid access token is required")
 }
 
+// MaxBodyBytes caps the request body every endpoint here reads through
+// ReadParams. Nothing this API accepts is large: the biggest field is a
+// base64url refresh token. The cap applies to both body shapes, because
+// net/http's own default is 10 MiB and the one unauthenticated endpoint
+// (POST /device/code) writes a permanent row per request.
+const MaxBodyBytes = 1 << 16
+
 // ReadParams accepts either a form-encoded body, which is what the OAuth
 // specs use, or a JSON object, which is what a Go or Electron client is more
 // likely to send. Both are read into url.Values so handlers do not care which
 // arrived. A JSON value that is not a string is ignored rather than
 // stringified, so a client cannot smuggle a number or an object into a field.
+//
+// Both branches cap the body at MaxBodyBytes. An over-long body surfaces as an
+// error here, which every caller turns into a 400.
 func ReadParams(w http.ResponseWriter, r *http.Request) (url.Values, error) {
+	r.Body = http.MaxBytesReader(w, r.Body, MaxBodyBytes)
 	if ct := r.Header.Get("Content-Type"); strings.HasPrefix(ct, "application/json") {
 		var raw map[string]any
-		if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 1<<16)).Decode(&raw); err != nil {
+		if err := json.NewDecoder(r.Body).Decode(&raw); err != nil {
 			return nil, err
 		}
 		values := url.Values{}

--- a/controlplane/internal/api/api_test.go
+++ b/controlplane/internal/api/api_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -154,6 +155,73 @@ func TestTokenEndpoint_RejectsBadRequestsIdentically(t *testing.T) {
 		"refresh_token": {"whatever"},
 	}); rec.Code != http.StatusBadRequest {
 		t.Errorf("wrong grant_type: status = %d, want 400", rec.Code)
+	}
+}
+
+// TestTokenEndpoint_ConcurrentExchangesLoseWithInvalidGrantNotAServerError
+// pins the error shape a losing rotation gets. Exactly one exchange has always
+// committed, so there was never a double rotation, but the loser used to get a
+// 500 server_error out of SQLite's read-to-write upgrade on a deferred
+// transaction. A client reads that as transient, retries with the token the
+// winner already revoked, and signs the operator out even though a valid
+// rotated token exists in the other window.
+func TestTokenEndpoint_ConcurrentExchangesLoseWithInvalidGrantNotAServerError(t *testing.T) {
+	svc, issuer, _ := newTestService(t)
+
+	mux := http.NewServeMux()
+	svc.Register(mux)
+
+	// Several rounds, because the upgrade only fails for a racer whose snapshot
+	// went stale: one round is not a reliable reproduction.
+	for round := range 5 {
+		refresh, err := issuer.IssueRefreshToken(context.Background(), testAccountID, "install-1")
+		if err != nil {
+			t.Fatalf("IssueRefreshToken() unexpected error: %v", err)
+		}
+
+		const racers = 8
+		var (
+			wg     sync.WaitGroup
+			start  = make(chan struct{})
+			codes  = make([]int, racers)
+			bodies = make([]string, racers)
+		)
+		for i := range racers {
+			wg.Add(1)
+			go func(i int) {
+				defer wg.Done()
+				req := httptest.NewRequest(http.MethodPost, "/api/v1/token",
+					strings.NewReader(url.Values{"refresh_token": {refresh}}.Encode()))
+				req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+				rec := httptest.NewRecorder()
+				<-start
+				mux.ServeHTTP(rec, req)
+				codes[i] = rec.Code
+				bodies[i] = rec.Body.String()
+			}(i)
+		}
+		close(start)
+		wg.Wait()
+
+		successes := 0
+		for i, code := range codes {
+			switch code {
+			case http.StatusOK:
+				successes++
+			case http.StatusBadRequest:
+				if !strings.Contains(bodies[i], "invalid_grant") {
+					t.Errorf("round %d racer %d: 400 body %q, want invalid_grant", round, i, bodies[i])
+				}
+			default:
+				t.Errorf("round %d racer %d: status = %d, want 200 or 400/invalid_grant, body: %s",
+					round, i, code, bodies[i])
+			}
+		}
+		// The property that already held, asserted so the error-shape fix
+		// cannot quietly cost it: a refresh token is single use.
+		if successes != 1 {
+			t.Errorf("round %d: successes = %d, want exactly 1", round, successes)
+		}
 	}
 }
 

--- a/controlplane/internal/auth/oauth.go
+++ b/controlplane/internal/auth/oauth.go
@@ -80,9 +80,21 @@ func sanitizeNext(next string) string {
 	return next
 }
 
+// flowCookieParts is how many "|" separated fields the flow cookie payload
+// carries: state, verifier, expiry, next.
+const flowCookieParts = 4
+
+// setFlowCookie packs the flow state into the signed ao_oauth_flow cookie.
+//
+// Next goes last because it is the only field that can contain a "|": it is a
+// caller-supplied path, and one caller builds it from a URL an attacker can
+// influence (the device page's ?user_code=). Putting it last lets the split on
+// the way back stop counting after three separators and keep the rest verbatim,
+// instead of a crafted link producing five parts and failing sign-in at the
+// callback with no explanation.
 func (s *Service) setFlowCookie(w http.ResponseWriter, f flowState) {
 	exp := time.Now().Add(flowTTL)
-	payload := strings.Join([]string{f.State, f.Verifier, f.Next, strconv.FormatInt(exp.Unix(), 10)}, "|")
+	payload := strings.Join([]string{f.State, f.Verifier, strconv.FormatInt(exp.Unix(), 10), f.Next}, "|")
 	http.SetCookie(w, &http.Cookie{
 		Name:     flowCookieName,
 		Value:    s.signedCookieValue(payload),
@@ -117,18 +129,21 @@ func (s *Service) flowFromRequest(r *http.Request) (flowState, bool) {
 	if !ok {
 		return flowState{}, false
 	}
-	parts := strings.Split(payload, "|")
-	if len(parts) != 4 {
+	// SplitN, not Split: the last field is Next, which may legitimately
+	// contain a "|". The signature above already proved this payload is ours,
+	// so the only question here is how to read it, not whether to trust it.
+	parts := strings.SplitN(payload, "|", flowCookieParts)
+	if len(parts) != flowCookieParts {
 		return flowState{}, false
 	}
-	exp, err := strconv.ParseInt(parts[3], 10, 64)
+	exp, err := strconv.ParseInt(parts[2], 10, 64)
 	if err != nil {
 		return flowState{}, false
 	}
 	if time.Now().Unix() > exp {
 		return flowState{}, false
 	}
-	return flowState{State: parts[0], Verifier: parts[1], Next: parts[2]}, true
+	return flowState{State: parts[0], Verifier: parts[1], Next: parts[3]}, true
 }
 
 func (s *Service) handleGoogleLogin(w http.ResponseWriter, r *http.Request) {

--- a/controlplane/internal/auth/oauth_test.go
+++ b/controlplane/internal/auth/oauth_test.go
@@ -206,6 +206,32 @@ func TestLoginFlow_UpsertsAccountAndIssuesSession(t *testing.T) {
 	}
 }
 
+// TestLoginFlow_NextSurvivesTheFlowCookieSeparator pins the round trip for a
+// next that contains the character the flow cookie payload is joined on. The
+// device page builds next from r.URL.RequestURI(), which carries a
+// caller-supplied ?user_code=, so a crafted link used to send a signed-out
+// operator into a sign-in that always failed at the callback with no
+// explanation. Denial only, but silent and reachable from a link.
+func TestLoginFlow_NextSurvivesTheFlowCookieSeparator(t *testing.T) {
+	tokenHandler, userinfoHandler := fakeGoogleHandlers(t, "google-subject-1", "operator@example.test")
+	s, _ := newTestServiceWithGoogle(t, tokenHandler, userinfoHandler)
+
+	for _, next := range []string{
+		"/device?user_code=A|B",
+		"/device?user_code=|||",
+		"/device",
+	} {
+		resp := runLoginFlow(t, s, next)
+		if resp.StatusCode != http.StatusFound {
+			t.Errorf("callback for next %q: status = %d, want 302", next, resp.StatusCode)
+			continue
+		}
+		if loc := resp.Header.Get("Location"); loc != next {
+			t.Errorf("callback for next %q redirected to %q, want the requested target", next, loc)
+		}
+	}
+}
+
 func TestLoginFlow_SecondLoginSameSubjectReusesAccountAndUpdatesEmail(t *testing.T) {
 	tokenHandler1, userinfoHandler1 := fakeGoogleHandlers(t, "google-subject-1", "old@example.test")
 	s, srv := newTestServiceWithGoogle(t, tokenHandler1, userinfoHandler1)

--- a/controlplane/internal/device/codes.go
+++ b/controlplane/internal/device/codes.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"math/big"
+	"net"
 	"net/url"
 	"strings"
 	"sync"
@@ -38,6 +39,14 @@ const (
 	// hold the drawn value, so more than a couple of retries means something
 	// is wrong rather than unlucky.
 	maxCodeGenerationAttempts = 5
+
+	// maxMachineNameRunes caps machine_name on the device authorization
+	// endpoint. That endpoint is unauthenticated and the row it writes is
+	// permanent, so the name is attacker-chosen storage: without a cap, one
+	// request writes however much the body limit allows. 128 is well past any
+	// hostname or label an operator would type, and the approval page displays
+	// the value, so a longer one would not render usefully anyway.
+	maxMachineNameRunes = 128
 )
 
 // newUserCode returns a fresh user code in storage form (unformatted,
@@ -127,7 +136,26 @@ func normalizePublicURL(raw string) (string, error) {
 	if p := strings.Trim(u.Path, "/"); p != "" {
 		return "", fmt.Errorf("public_url %q must be a bare origin with no path", raw)
 	}
+	// http is a local-development affordance only. The desktop builds its base
+	// URL from this value and sends the bearer token and the Secure ao_gw_token
+	// cookie to it, and `ao vm serve` only ever listens on TLS, so a plaintext
+	// origin for a routable host is a machine that cannot work whose
+	// registration nonetheless succeeded.
+	if u.Scheme == "http" && !isLoopbackHost(u.Hostname()) {
+		return "", fmt.Errorf("public_url %q must use https: http is accepted only for a loopback host", raw)
+	}
 	return u.Scheme + "://" + strings.ToLower(u.Host), nil
+}
+
+// isLoopbackHost reports whether host names this machine. "localhost" is
+// matched by name because it is not an IP literal; everything else goes
+// through net.IP, so 127.0.0.2 and [::1] are covered as well as 127.0.0.1.
+func isLoopbackHost(host string) bool {
+	if strings.EqualFold(host, "localhost") {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
 }
 
 // hostOf returns the hostname of an already-normalized public URL, used as
@@ -141,10 +169,11 @@ func hostOf(publicURL string) string {
 
 const (
 	// attemptWindow and attemptsPerWindow bound how fast one signed-in
-	// account may guess user codes on the enter-code page. The device code
-	// endpoint needs no equivalent because a device code has 256 bits of
-	// entropy, but a user code has about 34, so the page is the oracle worth
-	// closing.
+	// account may guess user codes. Both browser POSTs that read a user_code
+	// out of a form are metered by it: the enter-code page, and the decision
+	// POST that actually binds a machine. The device code endpoint needs no
+	// equivalent because a device code has 256 bits of entropy, but a user code
+	// has about 34, so those two are the oracle worth closing.
 	attemptWindow     = time.Minute
 	attemptsPerWindow = 10
 )
@@ -156,6 +185,14 @@ const (
 // instance today (one Caddy site on one box) and accounts are Google-verified,
 // so both are fine; if it is ever replicated, move this to a table or a shared
 // store, otherwise each replica grants the full allowance.
+//
+// Two more ceilings, so this control is not over-trusted. It is keyed by
+// account, so N Google accounts buy N times the allowance (10N guesses a
+// minute); the real bound on guessing is the 34 bits and the 15 minute code
+// lifetime, not this. And l.seen never evicts, so it holds one entry per
+// account that has ever submitted a code, bounded by the account count, which
+// is small today. If either stops being true, key the window on the request's
+// IP as well and sweep l.seen on a ticker.
 type attemptLimiter struct {
 	mu    sync.Mutex
 	seen  map[string][]time.Time

--- a/controlplane/internal/device/codes_test.go
+++ b/controlplane/internal/device/codes_test.go
@@ -84,7 +84,11 @@ func TestNormalizePublicURL(t *testing.T) {
 		{"vm.example.com", "https://vm.example.com"},
 		{"https://VM.Example.COM", "https://vm.example.com"},
 		{"  https://vm.example.com  ", "https://vm.example.com"},
+		// http is the local-development affordance, so it is accepted for a
+		// loopback host and nothing else.
 		{"http://127.0.0.1:8443", "http://127.0.0.1:8443"},
+		{"http://localhost:8443", "http://localhost:8443"},
+		{"http://[::1]:8443", "http://[::1]:8443"},
 	}
 	for _, tt := range ok {
 		got, err := normalizePublicURL(tt.raw)
@@ -108,10 +112,33 @@ func TestNormalizePublicURL(t *testing.T) {
 		"https://vm.example.com?x=1",
 		"https://vm.example.com#frag",
 		"https://",
+		// Plaintext for a routable host: the desktop would send the bearer
+		// token and the Secure gateway cookie to it in the clear, and
+		// `ao vm serve` only ever listens on TLS, so the registration would
+		// succeed and produce a machine that cannot work.
+		"http://vm.example.com",
+		"http://vm.example.com:8443",
+		"http://203.0.113.10",
+		"http://localhost.evil.example.com",
 	}
 	for _, raw := range bad {
 		if got, err := normalizePublicURL(raw); err == nil {
 			t.Errorf("normalizePublicURL(%q) = %q, want an error", raw, got)
+		}
+	}
+}
+
+func TestIsLoopbackHost(t *testing.T) {
+	for _, host := range []string{"localhost", "LocalHost", "127.0.0.1", "127.0.0.2", "::1"} {
+		if !isLoopbackHost(host) {
+			t.Errorf("isLoopbackHost(%q) = false, want true", host)
+		}
+	}
+	// "localhost." and a name that merely ends in localhost are other people's
+	// hosts, and 0.0.0.0 is not loopback.
+	for _, host := range []string{"", "vm.example.com", "notlocalhost", "localhost.example.com", "0.0.0.0", "8.8.8.8"} {
+		if isLoopbackHost(host) {
+			t.Errorf("isLoopbackHost(%q) = true, want false", host)
 		}
 	}
 }

--- a/controlplane/internal/device/endpoints.go
+++ b/controlplane/internal/device/endpoints.go
@@ -1,6 +1,7 @@
 package device
 
 import (
+	"fmt"
 	"log"
 	"net/http"
 	"net/url"
@@ -77,6 +78,16 @@ func (s *Service) handleDeviceCode(w http.ResponseWriter, r *http.Request) {
 	name := strings.TrimSpace(params.Get("machine_name"))
 	if name == "" {
 		name = hostOf(publicURL)
+	}
+	// This endpoint is unauthenticated and the row it writes is permanent, so
+	// the one attacker-chosen string on it is length checked here rather than
+	// left to whatever the body limit happens to be. Runes, not bytes: the name
+	// is displayed to a human, and a byte cap would silently give a non-Latin
+	// script a quarter of the allowance.
+	if len([]rune(name)) > maxMachineNameRunes {
+		api.WriteError(w, http.StatusBadRequest, errInvalidRequest,
+			fmt.Sprintf("machine_name must be at most %d characters", maxMachineNameRunes))
+		return
 	}
 
 	now := time.Now().UTC()

--- a/controlplane/internal/device/flow_test.go
+++ b/controlplane/internal/device/flow_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -97,6 +98,22 @@ func (h *harness) do(method, target, account string, body url.Values) *httptest.
 		req = httptest.NewRequest(method, target, strings.NewReader(body.Encode()))
 		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	}
+	if account != "" {
+		req.Header.Set(signInHeader, account)
+	}
+	rec := httptest.NewRecorder()
+	h.mux.ServeHTTP(rec, req)
+	return rec
+}
+
+// doFrom is do with a browser Origin header on the request, which is how a
+// test says "this POST came from that page".
+func (h *harness) doFrom(origin, method, target, account string, body url.Values) *httptest.ResponseRecorder {
+	h.t.Helper()
+
+	req := httptest.NewRequest(method, target, strings.NewReader(body.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Origin", origin)
 	if account != "" {
 		req.Header.Set(signInHeader, account)
 	}
@@ -595,6 +612,250 @@ func TestSubmitCode_UnknownCodeIsRejectedAndRateLimited(t *testing.T) {
 	// The limit is per account: it does not lock out everyone else.
 	if rec := h.do(http.MethodPost, "/device", accountB, url.Values{"user_code": {"WDJB-MJHT"}}); rec.Code == http.StatusTooManyRequests {
 		t.Error("a second account was rate limited by the first account's guesses")
+	}
+}
+
+// TestDecision_GuessingIsRateLimitedOnBothActions is the companion to
+// TestSubmitCode_UnknownCodeIsRejectedAndRateLimited on the handler that
+// actually changes state. Approving is what a guessed user code buys: the
+// guesser's account gets the victim's VM. Denying is the same unmetered
+// primitive and silently kills someone else's setup. Both are metered.
+func TestDecision_GuessingIsRateLimitedOnBothActions(t *testing.T) {
+	for _, action := range []string{"approve", "deny"} {
+		t.Run(action, func(t *testing.T) {
+			h := newHarness(t)
+
+			// Every response on this path is distinguishable (200 hit, 400
+			// unknown, 409 used), so an unmetered guess is an oracle. The cap
+			// is what makes it not one.
+			var last *httptest.ResponseRecorder
+			for range attemptsPerWindow + 2 {
+				last = h.do(http.MethodPost, "/device/decision", accountA, url.Values{
+					"user_code": {"WDJB-MJHT"},
+					"action":    {action},
+				})
+			}
+			if last.Code != http.StatusTooManyRequests {
+				t.Errorf("status after %d %s guesses = %d, want 429", attemptsPerWindow+2, action, last.Code)
+			}
+
+			// A code that exists is refused too once the allowance is spent,
+			// so the limit is not merely a message on the miss path.
+			issued := h.requestCode(testPublicURL, "prod vm")
+			rec := h.do(http.MethodPost, "/device/decision", accountA, url.Values{
+				"user_code": {issued.UserCode},
+				"action":    {action},
+			})
+			if rec.Code != http.StatusTooManyRequests {
+				t.Errorf("a live code past the allowance = %d, want 429", rec.Code)
+			}
+			assertNoMachines(t, h.db)
+			var status string
+			if err := h.db.QueryRow(`SELECT status FROM device_codes`).Scan(&status); err != nil {
+				t.Fatalf("read status: %v", err)
+			}
+			if status != statusPending {
+				t.Errorf("status = %q, want it still %q: a rate limited request must not act", status, statusPending)
+			}
+
+			// The limit is per account, so one guesser cannot lock out the
+			// operator who is legitimately mid-setup.
+			if rec := h.do(http.MethodPost, "/device/decision", accountB, url.Values{
+				"user_code": {"WDJB-MJHT"},
+				"action":    {action},
+			}); rec.Code == http.StatusTooManyRequests {
+				t.Error("a second account was rate limited by the first account's guesses")
+			}
+		})
+	}
+}
+
+// TestDecision_RejectsACrossOriginPost covers the CSRF case SameSite=Lax does
+// not: SameSite is scoped to the registrable domain, so a page on another host
+// under the same domain is same-site and its POST carries the session cookie.
+func TestDecision_RejectsACrossOriginPost(t *testing.T) {
+	h := newHarness(t)
+	issued := h.requestCode(testPublicURL, "prod vm")
+	form := url.Values{"user_code": {issued.UserCode}, "action": {"approve"}}
+
+	// Same registrable domain, different origin: this is the attacker.
+	for _, origin := range []string{"https://evil.ao.test", "https://evil.example.com", "http://ao.test"} {
+		rec := h.doFrom(origin, http.MethodPost, "/device/decision", accountA, form)
+		if rec.Code != http.StatusForbidden {
+			t.Errorf("approval with Origin %q = %d, want 403", origin, rec.Code)
+		}
+	}
+	assertNoMachines(t, h.db)
+
+	// The enter-code page is guarded too, so a cross-origin POST cannot burn
+	// the victim's attempt allowance either.
+	if rec := h.doFrom("https://evil.ao.test", http.MethodPost, "/device", accountA,
+		url.Values{"user_code": {issued.UserCode}}); rec.Code != http.StatusForbidden {
+		t.Errorf("submit with a foreign Origin = %d, want 403", rec.Code)
+	}
+
+	// The control plane's own page still works, which is what stops this being
+	// a fix that breaks the flow.
+	if rec := h.doFrom(testOrigin, http.MethodPost, "/device", accountA,
+		url.Values{"user_code": {issued.UserCode}}); rec.Code != http.StatusOK {
+		t.Fatalf("submit from %s = %d, want 200, body: %s", testOrigin, rec.Code, rec.Body)
+	}
+	if rec := h.doFrom(testOrigin, http.MethodPost, "/device/decision", accountA, form); rec.Code != http.StatusOK {
+		t.Fatalf("approval from %s = %d, want 200, body: %s", testOrigin, rec.Code, rec.Body)
+	}
+	var count int
+	if err := h.db.QueryRow(`SELECT count(*) FROM machines`).Scan(&count); err != nil {
+		t.Fatalf("count machines: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("machines rows = %d, want 1 after a same-origin approval", count)
+	}
+}
+
+// TestDecision_ConcurrentApprovalsLoseWithAConflictNotAServerError is the
+// device-flow half of the deferred-transaction fix. Two tabs approving the same
+// code used to produce a 500 from the SQLite read-to-write upgrade, which reads
+// as "retry" when the true answer is "someone already did this".
+func TestDecision_ConcurrentApprovalsLoseWithAConflictNotAServerError(t *testing.T) {
+	h := newHarness(t)
+	issued := h.requestCode(testPublicURL, "prod vm")
+
+	const racers = 6
+	var (
+		wg    sync.WaitGroup
+		start = make(chan struct{})
+		codes = make([]int, racers)
+	)
+	for i := range racers {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-start
+			codes[i] = h.do(http.MethodPost, "/device/decision", accountA, url.Values{
+				"user_code": {issued.UserCode},
+				"action":    {"approve"},
+			}).Code
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	approved := 0
+	for i, code := range codes {
+		switch code {
+		case http.StatusOK:
+			approved++
+		case http.StatusConflict:
+		default:
+			t.Errorf("racer %d: status = %d, want 200 or 409", i, code)
+		}
+	}
+	if approved != 1 {
+		t.Errorf("approvals = %d, want exactly 1", approved)
+	}
+}
+
+func TestDeviceCodeEndpoint_RejectsAnOverlongMachineName(t *testing.T) {
+	h := newHarness(t)
+
+	// The endpoint is unauthenticated and its row is permanent, so the one
+	// attacker-chosen string on it is capped.
+	rec := h.do(http.MethodPost, "/device/code", "", url.Values{
+		"public_url":   {testPublicURL},
+		"machine_name": {strings.Repeat("n", maxMachineNameRunes+1)},
+	})
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("an overlong machine_name = %d, want 400", rec.Code)
+	}
+	var count int
+	if err := h.db.QueryRow(`SELECT count(*) FROM device_codes`).Scan(&count); err != nil {
+		t.Fatalf("count device codes: %v", err)
+	}
+	if count != 0 {
+		t.Errorf("device_codes rows = %d, want 0: a rejected request must not write", count)
+	}
+
+	// Exactly at the cap is fine, and the cap counts runes, not bytes, so a
+	// name in a non-Latin script is not silently a quarter of the allowance.
+	for _, name := range []string{
+		strings.Repeat("n", maxMachineNameRunes),
+		strings.Repeat("é", maxMachineNameRunes),
+	} {
+		if rec := h.do(http.MethodPost, "/device/code", "", url.Values{
+			"public_url":   {testPublicURL},
+			"machine_name": {name},
+		}); rec.Code != http.StatusOK {
+			t.Errorf("a %d rune machine_name = %d, want 200", len([]rune(name)), rec.Code)
+		}
+	}
+}
+
+func TestDeviceCodeEndpoint_RejectsAnOversizedBody(t *testing.T) {
+	h := newHarness(t)
+
+	// net/http's own default is 10 MiB, and the form branch used to inherit it,
+	// so one request could write megabytes into a permanent row.
+	for _, tt := range []struct{ name, contentType, body string }{
+		{"form", "application/x-www-form-urlencoded",
+			"public_url=vm.example.com&machine_name=" + strings.Repeat("n", api.MaxBodyBytes+1)},
+		{"json", "application/json",
+			`{"public_url":"vm.example.com","machine_name":"` + strings.Repeat("n", api.MaxBodyBytes+1) + `"}`},
+	} {
+		req := httptest.NewRequest(http.MethodPost, "/device/code", strings.NewReader(tt.body))
+		req.Header.Set("Content-Type", tt.contentType)
+		rec := httptest.NewRecorder()
+		h.mux.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("%s body over %d bytes = %d, want 400", tt.name, api.MaxBodyBytes, rec.Code)
+		}
+	}
+
+	var count int
+	if err := h.db.QueryRow(`SELECT count(*) FROM device_codes`).Scan(&count); err != nil {
+		t.Fatalf("count device codes: %v", err)
+	}
+	if count != 0 {
+		t.Errorf("device_codes rows = %d, want 0", count)
+	}
+}
+
+func TestDeviceCodeEndpoint_SweepsExpiredRowsSoTheTableIsBounded(t *testing.T) {
+	h := newHarness(t)
+
+	first := h.requestCode(testPublicURL, "prod vm")
+	if rec := h.approve(first.UserCode, accountA); rec.Code != http.StatusOK {
+		t.Fatalf("approval status = %d, want 200", rec.Code)
+	}
+	h.expireCodes()
+
+	// Nothing used to delete a device_codes row, so an unauthenticated caller
+	// could grow the file that sits beside the signing keys without bound.
+	h.requestCode(testPublicURL, "another vm")
+
+	var count int
+	if err := h.db.QueryRow(`SELECT count(*) FROM device_codes`).Scan(&count); err != nil {
+		t.Fatalf("count device codes: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("device_codes rows = %d, want 1: the expired row should be swept", count)
+	}
+
+	// The sweep is a size bound, not the expiry mechanism, and it does not
+	// take the machine the approval registered with it.
+	var machines int
+	if err := h.db.QueryRow(`SELECT count(*) FROM machines`).Scan(&machines); err != nil {
+		t.Fatalf("count machines: %v", err)
+	}
+	if machines != 1 {
+		t.Errorf("machines rows = %d, want 1: sweeping a device code must not unbind a machine", machines)
+	}
+
+	// A live row is never swept.
+	live := h.requestCode(testPublicURL, "live vm")
+	h.requestCode(testPublicURL, "one more")
+	if _, _, failure := h.poll(live.DeviceCode); failure.Error != errAuthorizationPending {
+		t.Errorf("poll of a live code after a sweep = %q, want authorization_pending", failure.Error)
 	}
 }
 

--- a/controlplane/internal/device/pages.go
+++ b/controlplane/internal/device/pages.go
@@ -54,12 +54,53 @@ func (s *Service) handleEnterCodePage(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// sameOrigin reports whether a browser POST came from this control plane's
+// own pages, writing the rejection page itself when it did not.
+//
+// Origin is the check rather than a CSRF token because browsers send it on
+// every POST, the Service already knows the one origin it serves, and a token
+// would need the sessions interface extended to hand out a signing key. A
+// missing Origin is allowed through: a non-browser client (curl, `ao`, a test)
+// sends none, and every browser that would carry the ambient session cookie
+// does send one.
+func (s *Service) sameOrigin(w http.ResponseWriter, r *http.Request) bool {
+	if o := r.Header.Get("Origin"); o != "" && o != s.publicOrigin {
+		s.renderEnterPage(w, http.StatusForbidden, enterPageData{
+			Error: "That request did not come from this page.",
+		})
+		return false
+	}
+	return true
+}
+
+// allowAttempt records one user-code attempt against accountID and reports
+// whether it is within the allowance, writing the rejection page itself when
+// it is not.
+//
+// Both browser POSTs go through it, not just the enter-code page: they both
+// take a user_code out of a form, and the one that binds a machine to this
+// account is the one worth guessing against, so metering only the other one
+// meters nothing.
+func (s *Service) allowAttempt(w http.ResponseWriter, accountID, userCode string) bool {
+	if s.attempts.allow(accountID) {
+		return true
+	}
+	s.renderEnterPage(w, http.StatusTooManyRequests, enterPageData{
+		UserCode: formatUserCode(userCode),
+		Error:    "Too many attempts. Wait a minute and try again.",
+	})
+	return false
+}
+
 // handleSubmitCode looks up the typed code and, if it is live, renders the
 // confirmation page. It never approves: approval is a separate POST, so
 // following a verification_uri_complete link cannot bind a machine by itself.
 func (s *Service) handleSubmitCode(w http.ResponseWriter, r *http.Request) {
 	accountID, ok := s.requireAccount(w, r, verificationPath)
 	if !ok {
+		return
+	}
+	if !s.sameOrigin(w, r) {
 		return
 	}
 	if err := r.ParseForm(); err != nil {
@@ -73,11 +114,7 @@ func (s *Service) handleSubmitCode(w http.ResponseWriter, r *http.Request) {
 	// A user code is short enough to guess given enough tries, so the page is
 	// rate limited per signed-in account. The check runs before the lookup so
 	// a burst of wrong codes cannot be used to time the database either.
-	if !s.attempts.allow(accountID) {
-		s.renderEnterPage(w, http.StatusTooManyRequests, enterPageData{
-			UserCode: formatUserCode(userCode),
-			Error:    "Too many attempts. Wait a minute and try again.",
-		})
+	if !s.allowAttempt(w, accountID, userCode) {
 		return
 	}
 
@@ -110,12 +147,20 @@ func (s *Service) handleSubmitCode(w http.ResponseWriter, r *http.Request) {
 // handleDecision is the approval confirmation: it binds the code to the
 // signed-in account and registers the machine, or denies the request.
 //
-// The session cookie is SameSite=Lax, which browsers do not attach to a
-// cross-site POST, so a third-party page cannot drive this form on a
-// signed-in operator's behalf.
+// This is the state-changing half of the flow and the only place a guessed
+// user_code is worth anything, so it carries the same two controls the
+// enter-code page does: an Origin check and the per-account attempt limiter.
+//
+// The session cookie's SameSite=Lax is not the defence on its own. SameSite is
+// scoped to the registrable domain, not the origin, so any other host under
+// the control plane's own domain is same-site and its cross-origin POST would
+// still carry the cookie. sameOrigin is what closes that.
 func (s *Service) handleDecision(w http.ResponseWriter, r *http.Request) {
 	accountID, ok := s.requireAccount(w, r, verificationPath)
 	if !ok {
+		return
+	}
+	if !s.sameOrigin(w, r) {
 		return
 	}
 	if err := r.ParseForm(); err != nil {
@@ -125,6 +170,13 @@ func (s *Service) handleDecision(w http.ResponseWriter, r *http.Request) {
 
 	userCode := normalizeUserCode(r.PostForm.Get("user_code"))
 	now := time.Now().UTC()
+
+	// Both actions are metered, not just approve: deny is the same unmetered
+	// primitive against the same code space, and a hit silently kills someone
+	// else's setup.
+	if !s.allowAttempt(w, accountID, userCode) {
+		return
+	}
 
 	if r.PostForm.Get("action") == "deny" {
 		if err := s.deny(r.Context(), userCode); err != nil && !errors.Is(err, errCodeNotPending) {

--- a/controlplane/internal/device/store.go
+++ b/controlplane/internal/device/store.go
@@ -5,6 +5,8 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"log"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -24,8 +26,9 @@ var (
 	// code was never issued or because a human mistyped it.
 	errCodeNotFound = errors.New("device code not found")
 	// errCodeExpired means the row exists but is past expires_at. Expiry is
-	// enforced on every read here, not merely displayed on the page, because
-	// nothing sweeps the table.
+	// enforced on every read here, not merely displayed on the page: the sweep
+	// on the create path is a size bound, not the expiry mechanism, so a row
+	// that outlives its expiry until the next sweep is still refused.
 	errCodeExpired = errors.New("device code expired")
 	// errCodeNotPending means the row was already approved, denied, or marked
 	// expired. It is what stops a device code being approved twice, including
@@ -50,8 +53,13 @@ func (s *Service) createDeviceCode(ctx context.Context, name, publicURL string, 
 		return "", "", err
 	}
 
+	s.sweepExpired(ctx, now)
+
 	// user_code is UNIQUE, so a collision with a code that is still in the
-	// table is possible, if unlikely. Redraw rather than failing the request.
+	// table is possible, if unlikely. Redraw rather than failing the request,
+	// but only for that one error: retrying a SQLITE_BUSY or a broken schema
+	// four more times just wastes inserts and then reports the last failure
+	// instead of the first.
 	for attempt := 0; attempt < maxCodeGenerationAttempts; attempt++ {
 		userCode, err = newUserCode()
 		if err != nil {
@@ -66,8 +74,40 @@ func (s *Service) createDeviceCode(ctx context.Context, name, publicURL string, 
 		if err == nil {
 			return deviceCode, userCode, nil
 		}
+		if !isUserCodeCollision(err) {
+			return "", "", fmt.Errorf("insert device code: %w", err)
+		}
 	}
 	return "", "", fmt.Errorf("insert device code: %w", err)
+}
+
+// isUserCodeCollision reports whether err is the UNIQUE violation on
+// device_codes.user_code, the one insert failure worth redrawing the code for.
+//
+// It matches on the constraint text rather than a driver error code so this
+// package does not have to import the SQLite driver to name one integer. The
+// column name is in the message, so this cannot be confused with a UNIQUE
+// violation on device_code or on another table.
+func isUserCodeCollision(err error) bool {
+	return err != nil &&
+		strings.Contains(err.Error(), "UNIQUE constraint failed") &&
+		strings.Contains(err.Error(), "device_codes.user_code")
+}
+
+// sweepExpired deletes device_codes rows that are past their expiry. It runs
+// on the create path because that is the only unauthenticated write here, so
+// it is where the table grows, and one DELETE over an indexed comparison is
+// cheaper than the row it is about to insert.
+//
+// An expired row carries nothing: every read path already rejects one, so
+// deleting it changes no answer this service gives, and the machines row an
+// approval created lives in a separate table the sweep does not touch. A
+// failure is logged and swallowed, because a sweep that did not run must not
+// fail the request that triggered it.
+func (s *Service) sweepExpired(ctx context.Context, now time.Time) {
+	if _, err := s.db.ExecContext(ctx, `DELETE FROM device_codes WHERE expires_at < ?`, now); err != nil {
+		log.Printf("device: sweep expired device codes: %v", err)
+	}
 }
 
 // lookupPending returns the pending, unexpired row for a typed user code, so

--- a/controlplane/internal/device/store_test.go
+++ b/controlplane/internal/device/store_test.go
@@ -1,0 +1,70 @@
+package device
+
+import (
+	"testing"
+	"time"
+)
+
+// TestIsUserCodeCollision_TellsTheRedrawableErrorApart uses errors the real
+// driver produced, not hand-written ones, because the whole point of the check
+// is that it recognises what SQLite actually says. createDeviceCode used to
+// treat every insert failure as a collision and burn five redraws on a
+// SQLITE_BUSY or a broken schema before reporting only the last one.
+func TestIsUserCodeCollision_TellsTheRedrawableErrorApart(t *testing.T) {
+	h := newHarness(t)
+	now := time.Now().UTC()
+
+	issued := h.requestCode(testPublicURL, "prod vm")
+	var userCode string
+	if err := h.db.QueryRow(`SELECT user_code FROM device_codes`).Scan(&userCode); err != nil {
+		t.Fatalf("read the stored user code: %v", err)
+	}
+	if userCode == "" || issued.UserCode == "" {
+		t.Fatal("no code was issued")
+	}
+
+	insert := func(deviceCode, code string, expiresAt any) error {
+		_, err := h.db.Exec(
+			`INSERT INTO device_codes
+			   (device_code, user_code, status, created_at, expires_at, machine_name, machine_public_url)
+			 VALUES (?, ?, ?, ?, ?, ?, ?)`,
+			deviceCode, code, statusPending, now, expiresAt, "vm", testPublicURL)
+		return err
+	}
+
+	// The one error worth redrawing for.
+	collision := insert(hashCode("another-device-code"), userCode, now.Add(deviceCodeTTL))
+	if collision == nil {
+		t.Fatal("inserting a duplicate user_code succeeded, want a UNIQUE violation")
+	}
+	if !isUserCodeCollision(collision) {
+		t.Errorf("isUserCodeCollision(%v) = false, want true", collision)
+	}
+
+	// A UNIQUE violation on the other unique column is not it: redrawing the
+	// user code would never resolve it.
+	var storedDeviceCode string
+	if err := h.db.QueryRow(`SELECT device_code FROM device_codes`).Scan(&storedDeviceCode); err != nil {
+		t.Fatalf("read the stored device code: %v", err)
+	}
+	dup := insert(storedDeviceCode, "ZZZZZZZZ", now.Add(deviceCodeTTL))
+	if dup == nil {
+		t.Fatal("inserting a duplicate device_code succeeded, want a UNIQUE violation")
+	}
+	if isUserCodeCollision(dup) {
+		t.Errorf("isUserCodeCollision(%v) = true for a device_code collision, want false", dup)
+	}
+
+	// And neither is a constraint failure that has nothing to do with either.
+	notNull := insert(hashCode("yet-another"), "YYYYYYYY", nil)
+	if notNull == nil {
+		t.Fatal("inserting a NULL expires_at succeeded, want a NOT NULL violation")
+	}
+	if isUserCodeCollision(notNull) {
+		t.Errorf("isUserCodeCollision(%v) = true for a NOT NULL violation, want false", notNull)
+	}
+
+	if isUserCodeCollision(nil) {
+		t.Error("isUserCodeCollision(nil) = true, want false")
+	}
+}

--- a/controlplane/internal/storage/sqlite/db.go
+++ b/controlplane/internal/storage/sqlite/db.go
@@ -24,10 +24,23 @@ var migrationsFS embed.FS
 // pragmas are applied on every connection open. WAL + NORMAL lets readers run
 // concurrently with the writer; busy_timeout absorbs brief writer contention;
 // foreign_keys enforces the accounts/machines/refresh_tokens references.
+//
+// _txlock=immediate makes every read-write transaction take the write lock at
+// BEGIN instead of upgrading at its first write. Every transaction in this
+// service is read-then-write (refresh token rotation, device code approval,
+// poll), and SQLite does not run the busy handler for a read-to-write upgrade
+// whose snapshot has gone stale, so under a deferred BEGIN the losing side of a
+// race gets SQLITE_BUSY straight back and the busy_timeout above never applies.
+// That surfaced as the loser being told server_error, retrying with a token the
+// winner had already revoked, and signing the operator out, when the correct
+// answer was the ordinary invalid_grant. An immediate BEGIN turns the race back
+// into a wait the timeout absorbs, after which the loser reads the committed
+// state and returns the right error.
 const pragmas = "?_pragma=journal_mode(WAL)" +
 	"&_pragma=busy_timeout(5000)" +
 	"&_pragma=foreign_keys(ON)" +
-	"&_pragma=synchronous(NORMAL)"
+	"&_pragma=synchronous(NORMAL)" +
+	"&_txlock=immediate"
 
 // Open opens (creating if absent) the SQLite database under dataDir, runs
 // pending goose migrations, and returns the *sql.DB. Unlike the desktop


### PR DESCRIPTION
Closes #37.

Fixes H-A, H-B, M-A, M-B, M-E, L-D, L-E, L-F from the server-side review. Scope is `controlplane/` only.

## H-A: the attempt limiter was on the wrong handler

`s.attempts.allow` was called in exactly one place, `handleSubmitCode` (`POST /device`), which only renders the confirmation page. `handleDecision` (`POST /device/decision`) read `user_code` straight out of the form and called `s.approve` with no limiter and no server-side link back to any earlier request. Responses there are fully distinguishable (200 hit, 400 unknown or expired, 409 used), so the ~34 bit user-code space had a clean oracle on the one path where a guess is worth something: a hit binds the victim's VM to the guesser's account, after which `ao vm serve` accepts the guesser's tokens including on `/mux`.

Both POSTs now go through a shared `allowAttempt`, and both actions are metered. `deny` is the same unmetered primitive and a hit silently kills someone else's setup, so it is covered too.

## H-B: an unauthenticated unbounded permanent write

`POST /device/code` has no auth and nothing anywhere deleted a `device_codes` row, and that file sits in the same directory as the EdDSA signing keys and the `accounts` and `refresh_tokens` tables. Three changes:

1. `machine_name` capped at 128 runes (runes, not bytes, so a non-Latin script does not silently get a quarter of the allowance).
2. `api.ReadParams` now caps the form branch at the same 64 KiB the JSON branch already had. It was inheriting net/http's 10 MiB default, so one urlencoded request could write megabytes into a permanent row.
3. `createDeviceCode` sweeps rows past `expires_at` before inserting. Those rows carry nothing: every read path already rejects them, and the `machines` row an approval created is a separate table the sweep does not touch.

Caddy is not treated as the mitigation, since nothing in this repo configures it.

## M-A: Origin check on the approval POST

`SameSite=Lax` was the only CSRF defence, and `SameSite` is scoped to the registrable domain rather than the origin, so any other host under `agentlab.in` was same-site and its cross-origin POST carried the session cookie. Both POSTs now compare `Origin` against the `publicOrigin` the Service already holds.

**Origin, not a per-session CSRF token, deliberately.** Browsers send `Origin` on every POST, the Service already knows the one origin it serves, and this needs no template change and no new state. A real token would require extending the `sessions` interface to hand out a signing key, which is a larger change for a case this closes. A missing `Origin` still passes, so `curl` and the tests keep working; every browser that would carry the ambient cookie sends one.

## M-B: the loser of a concurrent rotation got a 500

The DSN gains `_txlock=immediate`. SQLite does not run the busy handler for a read-to-write upgrade whose snapshot has gone stale, so `busy_timeout(5000)` never applied and the losing side of a concurrent refresh rotation got `SQLITE_BUSY`, which is not one of the three sentinels mapped to `invalid_grant` and so became `500 server_error`. A client reads that as transient, retries with the token the winner already revoked, and forces a spurious sign-out.

Exactly one rotation always committed, so there was never a double rotation or any corruption; this is the error shape only. Because every transaction in the service is read-then-write, the same DSN change also fixes the milder cases in `device.approve` (two tabs approving one code, 500 instead of 409) and `device.poll`.

## M-E, and the lows

- **M-E:** `normalizePublicURL` accepted `http://` for any host, so a plaintext origin for a routable host registered successfully and the desktop then sent the bearer token and the `Secure` `ao_gw_token` cookie to it in the clear. `http` is now accepted only for a loopback host, which is what the existing `http://127.0.0.1:8443` test case was really about.
- **L-D:** the OAuth flow cookie payload puts `Next` last and reads it back with `SplitN`, so a `|` in `next` no longer fails sign-in at the callback with no explanation. `device/pages.go` builds `next` from `r.URL.RequestURI()`, which carries an attacker-influenced `?user_code=`.
- **L-E:** the limiter's `ponytail:` comment now names its two real ceilings, the linear per-account bypass and the lack of eviction, alongside the replication caveat it already mentioned.
- **L-F:** `createDeviceCode` redraws only on a `device_codes.user_code` UNIQUE violation instead of on any insert error, so a `SQLITE_BUSY` or a schema fault no longer costs five wasted inserts and then reports only the last one.

## Documentation

`TOKEN_CONTRACT.md` now states that `publicUrl` is a full origin on the control-plane side and a bare hostname on the gateway side. That reasoning previously lived only in two Go doc comments.

## Tests

Every finding has a test that fails without its fix. Each was confirmed by reverting the fix in place and re-running:

| Finding | Test |
| --- | --- |
| H-A | `TestDecision_GuessingIsRateLimitedOnBothActions` (subtests `approve` and `deny`) |
| H-B name cap | `TestDeviceCodeEndpoint_RejectsAnOverlongMachineName` |
| H-B body cap | `TestDeviceCodeEndpoint_RejectsAnOversizedBody` (form and JSON) |
| H-B sweep | `TestDeviceCodeEndpoint_SweepsExpiredRowsSoTheTableIsBounded` |
| M-A | `TestDecision_RejectsACrossOriginPost` |
| M-B | `TestTokenEndpoint_ConcurrentExchangesLoseWithInvalidGrantNotAServerError`, `TestDecision_ConcurrentApprovalsLoseWithAConflictNotAServerError` |
| M-E | `TestNormalizePublicURL`, `TestIsLoopbackHost` |
| L-D | `TestLoginFlow_NextSurvivesTheFlowCookieSeparator` |
| L-F | `TestIsUserCodeCollision_TellsTheRedrawableErrorApart` (real driver errors, not hand-written ones) |

`go test -race ./...` passes across all 9 controlplane packages.

## Verified invariants not regressed

The review's device-flow list still holds and is still asserted: unbiased CSPRNG user codes over RFC 8628's alphabet, 256 bit device codes stored SHA-256 hashed with the plaintext never written, server-side poll interval that deliberately does not advance `last_polled_at` on a `slow_down`, expiry enforced on every read path (the new sweep is a size bound, not the expiry mechanism), single approval under real concurrency, the approval POST validating the session and not just the GET, `verification_uri_complete` unable to approve anything, and a re-bind of the same VM keeping its machine id.

🤖 Generated with [Claude Code](https://claude.com/claude-code)