### PR TITLE
fix(cli): unquote WorkingDirectory and refuse a root target in setup-vm

### DIFF
--- a/backend/internal/cli/setupvm.go
+++ b/backend/internal/cli/setupvm.go
@@ -36,6 +36,11 @@ const (
 	// 2s loopback budget is too tight.
 	setupVMHTTPTimeout = 10 * time.Second
 	setupVMUserAgent   = "ao-agent-orchestrator/setup-vm"
+	// setupUnitSettle is how long to wait after starting a unit before asking
+	// whether it is still running. Long enough for an immediate crash to show up
+	// as anything other than active, short enough to add nothing noticeable to a
+	// healthy run.
+	setupUnitSettle = 2 * time.Second
 	// defaultSetupVMProbeURL is the off-box port prober. A cloud firewall is
 	// invisible from inside the box, so confirming 80 and 443 needs a host that
 	// is not this one, and the AO control plane is the one such host setup-vm
@@ -133,7 +138,7 @@ func (c *commandContext) runSetupVM(cmd *cobra.Command, opts setupVMOptions) err
 		return writeSetupText(out, renderSetupDryRun(plan, warnings))
 	}
 
-	gatewayStarted, notes, err := c.installSetupVM(ctx, out, plan)
+	units, notes, err := c.installSetupVM(ctx, out, plan)
 	if err != nil {
 		return err
 	}
@@ -141,7 +146,14 @@ func (c *commandContext) runSetupVM(cmd *cobra.Command, opts setupVMOptions) err
 	bindErr := c.bindSetupVM(ctx, out, plan, controlPlaneURL)
 	if bindErr == nil {
 		plan.Bound = true
-		gatewayStarted = true
+		// The binding step restarted the gateway, so whether it is running is a
+		// fresh question: it reads machine.json at startup and refuses to serve
+		// on anything it cannot parse.
+		gatewayActive, gatewayNote := c.confirmSetupUnitActive(ctx, setupVMGatewayUnit)
+		units.GatewayRunning = gatewayActive
+		if gatewayNote != "" {
+			notes = append(notes, gatewayNote)
+		}
 	} else {
 		// The install is done and correct; only the binding is missing. The
 		// summary still has to print, because it is what tells the user how to
@@ -149,7 +161,7 @@ func (c *commandContext) runSetupVM(cmd *cobra.Command, opts setupVMOptions) err
 		notes = append(notes, "binding did not complete: "+bindErr.Error())
 	}
 
-	if err := writeSetupText(out, renderSetupSummary(plan, gatewayStarted, append(warnings, notes...))); err != nil {
+	if err := writeSetupText(out, renderSetupSummary(plan, units, append(warnings, notes...))); err != nil {
 		return err
 	}
 	return bindErr
@@ -176,6 +188,14 @@ func (c *commandContext) probeSetupPlatform() setupPlatform {
 
 func (c *commandContext) probeSetupPreflight(ctx context.Context, domain string, opts setupVMOptions) setupPreflight {
 	preflight := setupPreflight{Domain: domain, UID: os.Getuid()}
+
+	// Who the units would run as is a preflight fact, not an install-time one: a
+	// root target has to be refused before anything on this box is touched. A
+	// lookup failure is left empty here and reported by buildSetupPlan, which is
+	// where the error already has the better wording for it.
+	if target, err := setupTargetUser(); err == nil {
+		preflight.TargetUser = target.Username
+	}
 
 	if sudoPath, err := c.deps.LookPath("sudo"); err == nil {
 		preflight.SudoPath = sudoPath
@@ -245,21 +265,57 @@ func (c *commandContext) setupUnitActive(ctx context.Context, unit string) bool 
 	return err == nil
 }
 
+// confirmSetupUnitActive answers whether a unit is really running, and returns
+// the note to carry when it is not. `systemctl start` returning 0 is not
+// evidence for these two units: both are Type=simple, so systemd considers the
+// job done the instant the process is forked, even when it exits a millisecond
+// later. The settle wait is what makes an immediate exit visible at all, since a
+// crash-looping unit reports activating rather than active while it waits out
+// RestartSec.
+func (c *commandContext) confirmSetupUnitActive(ctx context.Context, unit string) (bool, string) {
+	c.deps.Sleep(setupUnitSettle)
+	if c.setupUnitActive(ctx, unit) {
+		return true, ""
+	}
+	return false, fmt.Sprintf(
+		"%s was started but is not active, so it exited on its own. This machine will not work"+
+			"\n  until it stays up. Look at why:"+
+			"\n    sudo systemctl status %s"+
+			"\n    sudo journalctl -u %s -n 50",
+		unit, unit, unit)
+}
+
 func (c *commandContext) setupHTTPClient() *http.Client {
 	client := *c.deps.HTTPClient
 	client.Timeout = setupVMHTTPTimeout
 	return &client
 }
 
+// discoverPublicIP asks each endpoint in turn what this box's address looks like
+// from the internet, and prefers an IPv4 answer. On a dual-stack box the answer
+// is whichever family the request happened to go out over, and a v6 answer read
+// against a perfectly good A record is reported as a DNS mismatch that does not
+// exist. A v6-only box finds no v4 answer at any endpoint and keeps the one it
+// has, so nothing is lost by looking.
 func (c *commandContext) discoverPublicIP(ctx context.Context) (string, error) {
 	client := c.setupHTTPClient()
 	var lastErr error
+	var otherFamily string
 	for _, endpoint := range setupVMPublicIPEndpoints {
 		ip, err := fetchSetupPublicIP(ctx, client, endpoint)
-		if err == nil {
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		if parsed := net.ParseIP(ip); parsed != nil && parsed.To4() != nil {
 			return ip, nil
 		}
-		lastErr = err
+		if otherFamily == "" {
+			otherFamily = ip
+		}
+	}
+	if otherFamily != "" {
+		return otherFamily, nil
 	}
 	if lastErr == nil {
 		lastErr = errors.New("no public IP endpoint configured")
@@ -398,50 +454,51 @@ func setupTargetUser() (*user.User, error) {
 // install
 // ---------------------------------------------------------------------------
 
-// installSetupVM performs every mutation, in order. It reports whether the
-// gateway ended up running, plus any note the summary has to carry. Each step is
+// installSetupVM performs every mutation, in order. It reports which units ended
+// up actually running, plus any note the summary has to carry. Each step is
 // skipped when it is already done, so a second run of ao setup-vm changes
 // nothing and restarts nothing.
-func (c *commandContext) installSetupVM(ctx context.Context, out io.Writer, plan setupPlan) (bool, []string, error) {
+func (c *commandContext) installSetupVM(ctx context.Context, out io.Writer, plan setupPlan) (setupUnitStates, []string, error) {
 	step := func(format string, args ...any) error {
 		_, err := fmt.Fprintf(out, "==> "+format+"\n", args...)
 		return err
 	}
+	var units setupUnitStates
 	var notes []string
 
 	for _, dir := range plan.setupDirs() {
 		if err := c.runSetupPrivileged(ctx, "install", "-d", "-m", "0700", "-o", plan.User, "-g", plan.Group, dir); err != nil {
-			return false, notes, err
+			return units, notes, err
 		}
 	}
 	if err := step("state directories ready under %s, owned by %s", plan.AODir, plan.User); err != nil {
-		return false, notes, err
+		return units, notes, err
 	}
 
 	if err := c.ensureSetupPackages(ctx, out, plan.Packages); err != nil {
-		return false, notes, err
+		return units, notes, err
 	}
 	binaryChanged, err := c.ensureSetupBinary(ctx, out, plan)
 	if err != nil {
-		return false, notes, err
+		return units, notes, err
 	}
 
 	daemonChanged, err := c.writeSetupUnit(ctx, out, setupVMDaemonUnit, renderDaemonUnit(plan))
 	if err != nil {
-		return false, notes, err
+		return units, notes, err
 	}
 	gatewayChanged, err := c.writeSetupUnit(ctx, out, setupVMGatewayUnit, renderGatewayUnit(plan))
 	if err != nil {
-		return false, notes, err
+		return units, notes, err
 	}
 	if daemonChanged || gatewayChanged {
 		if err := c.runSetupPrivileged(ctx, "systemctl", "daemon-reload"); err != nil {
-			return false, notes, err
+			return units, notes, err
 		}
 	}
 
 	if err := c.runSetupPrivileged(ctx, "systemctl", "enable", setupVMDaemonUnit, setupVMGatewayUnit); err != nil {
-		return false, notes, err
+		return units, notes, err
 	}
 	// Only a changed unit earns a restart: restarting the daemon kills the
 	// agent sessions it is supervising, which a re-run must not do. A new
@@ -451,10 +508,15 @@ func (c *commandContext) installSetupVM(ctx context.Context, out io.Writer, plan
 		daemonAction = "restart"
 	}
 	if err := c.runSetupPrivileged(ctx, "systemctl", daemonAction, setupVMDaemonUnit); err != nil {
-		return false, notes, err
+		return units, notes, err
 	}
-	if err := step("%s enabled and running", setupVMDaemonUnit); err != nil {
-		return false, notes, err
+	daemonActive, daemonNote := c.confirmSetupUnitActive(ctx, setupVMDaemonUnit)
+	units.DaemonRunning = daemonActive
+	if daemonNote != "" {
+		notes = append(notes, daemonNote)
+	}
+	if err := step("%s %s", setupVMDaemonUnit, setupUnitStateText(daemonActive)); err != nil {
+		return units, notes, err
 	}
 	if binaryChanged && daemonAction == "start" {
 		notes = append(notes, fmt.Sprintf(
@@ -466,7 +528,7 @@ func (c *commandContext) installSetupVM(ctx context.Context, out io.Writer, plan
 	if !plan.Bound {
 		// `ao vm serve` reads machine.json once at startup and cannot serve
 		// without it, so starting it now would only produce a restart loop.
-		return false, notes, step("%s enabled but not started: this machine is not bound yet", setupVMGatewayUnit)
+		return units, notes, step("%s enabled but not started: this machine is not bound yet", setupVMGatewayUnit)
 	}
 	// The gateway holds no session state, so a new binary or unit is safe to
 	// restart into immediately.
@@ -475,9 +537,23 @@ func (c *commandContext) installSetupVM(ctx context.Context, out io.Writer, plan
 		gatewayAction = "restart"
 	}
 	if err := c.runSetupPrivileged(ctx, "systemctl", gatewayAction, setupVMGatewayUnit); err != nil {
-		return false, notes, err
+		return units, notes, err
 	}
-	return true, notes, step("%s enabled and running", setupVMGatewayUnit)
+	gatewayActive, gatewayNote := c.confirmSetupUnitActive(ctx, setupVMGatewayUnit)
+	units.GatewayRunning = gatewayActive
+	if gatewayNote != "" {
+		notes = append(notes, gatewayNote)
+	}
+	return units, notes, step("%s %s", setupVMGatewayUnit, setupUnitStateText(gatewayActive))
+}
+
+// setupUnitStateText is what the progress line says about a unit that was just
+// started. "running" is a claim, so it is only made when is-active agreed.
+func setupUnitStateText(active bool) string {
+	if active {
+		return "enabled and running"
+	}
+	return "enabled, but not running: see the warnings at the end of this run"
 }
 
 func (c *commandContext) ensureSetupPackages(ctx context.Context, out io.Writer, packages []string) error {

--- a/backend/internal/cli/setupvm_bind.go
+++ b/backend/internal/cli/setupvm_bind.go
@@ -138,7 +138,10 @@ func (c *commandContext) bindSetupVM(ctx context.Context, out io.Writer, plan se
 	if err := c.runSetupPrivileged(ctx, "systemctl", "restart", setupVMGatewayUnit); err != nil {
 		return fmt.Errorf("restart %s so it reads the new binding: %w", setupVMGatewayUnit, err)
 	}
-	_, err = fmt.Fprintf(out, "==> %s restarted, so it has read the new binding\n", setupVMGatewayUnit)
+	// Whether it came back up is checked by the caller, which owns the summary:
+	// the unit is Type=simple, so this restart returning 0 says only that a
+	// process was forked.
+	_, err = fmt.Fprintf(out, "==> %s restarted so it reads the new binding\n", setupVMGatewayUnit)
 	return err
 }
 
@@ -180,8 +183,7 @@ func (c *commandContext) pollForBinding(ctx context.Context, base string, auth d
 		// Waiting first is deliberate: a code cannot have been approved in the
 		// instant it was issued, and RFC 8628 section 3.4 has the client wait
 		// the interval before every request, including the first.
-		c.deps.Sleep(interval)
-		if err := ctx.Err(); err != nil {
+		if err := c.sleepUntilCancelled(ctx, interval); err != nil {
 			return vmgateway.MachineFile{}, err
 		}
 		if c.deps.Now().After(deadline) {
@@ -217,6 +219,25 @@ func (c *commandContext) pollForBinding(ctx context.Context, base string, auth d
 		default:
 			return vmgateway.MachineFile{}, fmt.Errorf("the AO control plane refused the device code: %w", err)
 		}
+	}
+}
+
+// sleepUntilCancelled waits d, or returns as soon as ctx is cancelled. The poll
+// interval is server-supplied and reaches 60 seconds after slow_down backoff, so
+// waiting it out before noticing a Ctrl-C is a minute of a terminal that looks
+// hung. deps.Sleep is injected (the tests drive a fake clock through it) so it is
+// raced rather than replaced by a timer; the goroutine ends when the sleep does.
+func (c *commandContext) sleepUntilCancelled(ctx context.Context, d time.Duration) error {
+	done := make(chan struct{})
+	go func() {
+		c.deps.Sleep(d)
+		close(done)
+	}()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-done:
+		return ctx.Err()
 	}
 }
 

--- a/backend/internal/cli/setupvm_bind_test.go
+++ b/backend/internal/cli/setupvm_bind_test.go
@@ -405,6 +405,31 @@ func TestDeviceFlowPollsAtTheServerIntervalAndBacksOff(t *testing.T) {
 	}
 }
 
+// TestDeviceFlowStopsAtOnceWhenTheContextIsCancelled covers Ctrl-C during the
+// wait between polls. The interval is server-supplied and reaches 60 seconds
+// after slow_down backoff, so a wait that only checks cancellation afterwards is
+// up to a minute of a terminal that looks hung. A real clock is used here on
+// purpose: the point is the elapsed time, not the sequence.
+func TestDeviceFlowStopsAtOnceWhenTheContextIsCancelled(t *testing.T) {
+	c := &commandContext{deps: Deps{Now: time.Now, Sleep: time.Sleep}.withDefaults()}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	start := time.Now()
+	// The endpoint is never reached: the wait comes first and the cancellation
+	// has to win it.
+	_, err := c.pollForBinding(ctx, "http://127.0.0.1:1",
+		deviceAuthorization{DeviceCode: "irrelevant", Interval: 3, ExpiresIn: 900}, 15*time.Minute)
+	elapsed := time.Since(start)
+
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("pollForBinding err = %v, want context.Canceled", err)
+	}
+	if elapsed > time.Second {
+		t.Fatalf("pollForBinding took %s to notice a cancelled context, want it to return at once", elapsed)
+	}
+}
+
 // TestDeviceFlowNeverPrintsTheDeviceCode pins the one security property of the
 // printed output: the user code is meant to be shown, the device code is a
 // bearer secret and must not reach the terminal, a URL, or a log.

--- a/backend/internal/cli/setupvm_plan.go
+++ b/backend/internal/cli/setupvm_plan.go
@@ -221,6 +221,11 @@ type setupPreflight struct {
 	ResolvedIPs []string
 	ResolveErr  error
 
+	// TargetUser is who both units would run as: SUDO_USER when the command was
+	// run through sudo, otherwise the login user. Root is refused, because the
+	// daemon runs agent sessions, git, and gh.
+	TargetUser string
+
 	Ports []setupPortProbe
 	Reach setupReachability
 	// GatewayActive is whether this machine's own gateway unit is already
@@ -257,6 +262,12 @@ func evaluatePreflight(pf setupPreflight) (problems []setupProblem, warnings []s
 		warnings = append(warnings, unverifiedReachabilityDetail(pf)+
 			"\n  This is the one thing setup cannot check for you and cannot fix. If the ports are"+
 			"\n  closed, the gateway will never get a certificate."+
+			// The local probe is not a substitute either: it binds loopback, so a
+			// listener bound to this machine's public address alone never shows up
+			// in it and `ao vm serve` would still lose the wildcard bind later.
+			"\n  Preflight only bound "+portList(setupVMPorts)+" on 127.0.0.1, which is enough to catch a"+
+			"\n  missing privilege or a wildcard listener, but not one bound to this machine's public"+
+			"\n  address alone."+
 			"\n"+strings.Join(prefixLines(firewallRemediation(pf.Cloud, pf.Domain, setupVMPorts), "  "), "\n"))
 	}
 	return problems, warnings
@@ -278,6 +289,14 @@ func unverifiedReachabilityDetail(pf setupPreflight) string {
 }
 
 func checkSetupPrivilege(pf setupPreflight) *setupProblem {
+	// A root target user is a privilege problem, not a path problem, so it is
+	// reported here: preflight stops before the first mutation, which keeps the
+	// "nothing on this machine was changed" guarantee. buildSetupPlan rejects it
+	// again for anything that reaches it another way.
+	if isRootSetupIdentity(pf.TargetUser) {
+		problem := rootSetupUserProblem(pf.Domain)
+		return &problem
+	}
 	if pf.UID == 0 {
 		return nil
 	}
@@ -307,6 +326,42 @@ func checkSetupPrivilege(pf setupPreflight) *setupProblem {
 	return nil
 }
 
+// isRootSetupIdentity reports whether a user or group name is the superuser.
+// Only the name is available at this point, which is enough: this runs on the
+// Ubuntu box the platform gate already checked for, where uid 0 is root.
+func isRootSetupIdentity(name string) bool {
+	return strings.TrimSpace(name) == "root"
+}
+
+// rootSetupUserProblem is the single wording for a root target user, shared by
+// the preflight check and buildSetupPlan so the two can never disagree about
+// why it is refused or how to fix it.
+func rootSetupUserProblem(domain string) setupProblem {
+	rerun := "ao setup-vm --domain " + domain
+	if strings.TrimSpace(domain) == "" {
+		rerun = "ao setup-vm --domain <your domain>"
+	}
+	return setupProblem{
+		Check: "target user",
+		Detail: "both systemd units would run as root, and the daemon runs your agent sessions, git, " +
+			"and gh, so it must not be root",
+		Remediation: []string{
+			"This machine's login user is root, which is the default on DigitalOcean and Hetzner,",
+			"and it is also what sudo -i and sudo su - leave behind. There is no unprivileged user",
+			"to hand the agents to, so create one and run setup again as that user:",
+			"  adduser --disabled-password --gecos \"\" ao",
+			"  usermod -aG sudo ao",
+			"  echo 'ao ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/90-ao && chmod 0440 /etc/sudoers.d/90-ao",
+			"  sudo -u ao sudo " + rerun,
+			"If this machine already has a human user, log in as them and run this instead:",
+			"  sudo " + rerun,
+			"Either way SUDO_USER then names the human who owns the machine, and that is who both",
+			"units run as. The gateway still reaches :80 and :443, through CAP_NET_BIND_SERVICE",
+			"rather than through privilege.",
+		},
+	}
+}
+
 func checkSetupDNS(pf setupPreflight) *setupProblem {
 	if pf.PublicIPErr != nil {
 		return &setupProblem{
@@ -329,7 +384,7 @@ func checkSetupDNS(pf setupPreflight) *setupProblem {
 		}
 	}
 	for _, ip := range pf.ResolvedIPs {
-		if ip == pf.PublicIP {
+		if sameSetupIP(ip, pf.PublicIP) {
 			return nil
 		}
 	}
@@ -339,6 +394,17 @@ func checkSetupDNS(pf setupPreflight) *setupProblem {
 			pf.Domain, strings.Join(pf.ResolvedIPs, ", "), pf.PublicIP),
 		Remediation: dnsRemediation(pf.Domain, pf.PublicIP, pf.ResolvedIPs),
 	}
+}
+
+// sameSetupIP compares two addresses as addresses rather than as strings, so a
+// non-canonical answer such as 2001:0DB8::1 matches the 2001:db8::1 a resolver
+// hands back and preflight does not report a DNS mismatch that does not exist.
+func sameSetupIP(a, b string) bool {
+	ipA, ipB := net.ParseIP(strings.TrimSpace(a)), net.ParseIP(strings.TrimSpace(b))
+	if ipA == nil || ipB == nil {
+		return strings.EqualFold(strings.TrimSpace(a), strings.TrimSpace(b))
+	}
+	return ipA.Equal(ipB)
 }
 
 func dnsRemediation(domain, publicIP string, resolved []string) []string {
@@ -360,6 +426,17 @@ func dnsRemediation(domain, publicIP string, resolved []string) []string {
 		"The gateway gets its certificate over ACME, which only succeeds once the domain resolves",
 		"to this machine, so this has to be right before setup can finish.",
 	)
+	if len(resolved) > 0 {
+		// A dual-stack box can be reported as a mismatch against a record that is
+		// perfectly correct for the other family: whichever address this machine
+		// was seen at is the one preflight compares. Naming the right one by hand
+		// is the escape hatch, and it is the same flag the undiscoverable case uses.
+		lines = append(lines,
+			"If this machine has more than one public address and the record above is already right,",
+			"name the address that record points at and run setup again:",
+			"  ao setup-vm --domain "+domain+" --public-ip "+resolved[0],
+		)
+	}
 	return lines
 }
 
@@ -619,6 +696,15 @@ func buildSetupPlan(in setupPlanInput) (setupPlan, error) {
 	if strings.TrimSpace(in.User) == "" {
 		return setupPlan{}, fmt.Errorf("no target user for the systemd units")
 	}
+	// The invariant systemdUnit documents: User and Group are never root. The
+	// preflight check refuses this earlier and with the full remediation; this is
+	// the pure guard that makes the invariant true for every caller.
+	if isRootSetupIdentity(in.User) || isRootSetupIdentity(in.Group) {
+		return setupPlan{}, fmt.Errorf(
+			"refusing to install units that run as root: %s\n%s",
+			rootSetupUserProblem(in.Domain).Detail,
+			strings.Join(prefixLines(rootSetupUserProblem(in.Domain).Remediation, "  "), "\n"))
+	}
 	if !isLinuxAbs(in.Home) {
 		return setupPlan{}, fmt.Errorf("home directory %q for user %s is not an absolute path", in.Home, in.User)
 	}
@@ -660,10 +746,31 @@ func buildSetupPlan(in setupPlanInput) (setupPlan, error) {
 		}
 		*override.dest = value
 	}
+	// machine.json is the one file the gateway must be able to read as an
+	// unprivileged user, and the install only creates and chowns directories
+	// inside ~/.ao. An AO_MACHINE_FILE pointing outside it would be written into
+	// a parent this run created as root, mode 0700, which the gateway user cannot
+	// traverse: it would then refuse to start on a machine that had just been
+	// bound successfully.
+	if !insideSetupDir(plan.AODir, plan.MachineFile) {
+		return setupPlan{}, fmt.Errorf(
+			"AO_MACHINE_FILE=%q is outside %s. All AO state lives under ~/.ao, and the gateway runs as "+
+				"%s, so a machine file anywhere else is one it cannot read; unset it or point it inside %s",
+			plan.MachineFile, plan.AODir, plan.User, plan.AODir)
+	}
 	// Matches vmgateway's own default so the unit is explicit about a path the
 	// gateway would otherwise derive on its own.
 	plan.CertDir = slashPath(plan.DataDir, "vm-gateway", "certs")
 	return plan, nil
+}
+
+// insideSetupDir reports whether p is dir or below it, comparing whole path
+// components so /home/ubuntu/.aoelsewhere is not read as being inside
+// /home/ubuntu/.ao. Both are Linux paths for the target box, so path is right
+// here and filepath is not.
+func insideSetupDir(dir, p string) bool {
+	dir, p = path.Clean(dir), path.Clean(p)
+	return p == dir || strings.HasPrefix(p, dir+"/")
 }
 
 // slashPath joins Linux paths regardless of the OS this command was compiled
@@ -713,12 +820,25 @@ type systemdUnit struct {
 	// AmbientCaps lets a non-root service bind a privileged port without
 	// running as root.
 	AmbientCaps []string
-	Comment     []string
+	// Restart is the systemd restart policy, defaulting to on-failure. The
+	// gateway holds no session state and overrides it to always, so a clean
+	// exit still comes back; the daemon supervises live agent sessions, so its
+	// deliberate exits are left alone.
+	Restart string
+	Comment []string
 }
 
-// renderSystemdUnit writes a unit file. Environment and WorkingDirectory
-// values are always quoted: systemd splits on whitespace otherwise, and a home
-// directory with a space in it would silently produce a broken unit.
+// renderSystemdUnit writes a unit file.
+//
+// Environment= values are quoted, and that is deliberate: it is parsed as a
+// list of words, so systemd splits it on whitespace and does unquote it.
+// WorkingDirectory= is the opposite case and must never be quoted. It is a
+// single value that systemd hands straight to
+// path_simplify_and_warn(PATH_CHECK_ABSOLUTE|PATH_CHECK_FATAL) with no
+// unquoting, so a leading double quote is not an absolute path, the parse
+// handler returns -ENOEXEC, and the whole unit refuses to load rather than
+// ignoring one setting. A space needs no escaping there for the same reason the
+// quoting was wrong: the setting takes the rest of the line as one path.
 func renderSystemdUnit(u systemdUnit) string {
 	var b strings.Builder
 	for _, line := range u.Comment {
@@ -734,12 +854,19 @@ func renderSystemdUnit(u systemdUnit) string {
 	if len(u.After) > 0 {
 		fmt.Fprintf(&b, "After=%s\n", strings.Join(u.After, " "))
 	}
+	// systemd's default start rate limit is 5 starts in 10 seconds, and with
+	// RestartSec=5 a unit that fails at boot burns that budget in 30 seconds and
+	// enters failed, where nothing retries it until a human runs
+	// systemctl reset-failed. A gateway that cannot bind :443 for the first half
+	// minute after boot, or that hits one transient ACME error, would stop for
+	// good on an unattended VM. Turning the limit off keeps systemd retrying.
+	b.WriteString("StartLimitIntervalSec=0\n")
 
 	b.WriteString("\n[Service]\n")
 	b.WriteString("Type=simple\n")
 	fmt.Fprintf(&b, "User=%s\n", u.User)
 	fmt.Fprintf(&b, "Group=%s\n", u.Group)
-	fmt.Fprintf(&b, "WorkingDirectory=%q\n", u.WorkingDir)
+	fmt.Fprintf(&b, "WorkingDirectory=%s\n", u.WorkingDir)
 	for _, kv := range u.Env {
 		fmt.Fprintf(&b, "Environment=%q\n", kv[0]+"="+kv[1])
 	}
@@ -749,7 +876,11 @@ func renderSystemdUnit(u systemdUnit) string {
 		fmt.Fprintf(&b, "CapabilityBoundingSet=%s\n", strings.Join(u.AmbientCaps, " "))
 		b.WriteString("NoNewPrivileges=yes\n")
 	}
-	b.WriteString("Restart=on-failure\n")
+	restart := u.Restart
+	if restart == "" {
+		restart = "on-failure"
+	}
+	fmt.Fprintf(&b, "Restart=%s\n", restart)
 	b.WriteString("RestartSec=5\n")
 	b.WriteString("KillSignal=SIGTERM\n")
 	b.WriteString("TimeoutStopSec=30\n")
@@ -832,6 +963,10 @@ func renderGatewayUnit(p setupPlan) string {
 		Env:         env,
 		ExecStart:   p.BinaryPath + " vm serve",
 		AmbientCaps: []string{"CAP_NET_BIND_SERVICE"},
+		// The gateway holds no session state, and a stopped gateway is a machine
+		// that shows Offline in the desktop for no visible reason, so every exit
+		// earns a restart.
+		Restart: "always",
 	})
 }
 
@@ -839,10 +974,19 @@ func renderGatewayUnit(p setupPlan) string {
 // The closing summary
 // ---------------------------------------------------------------------------
 
+// setupUnitStates is what `systemctl is-active` said about each unit after it
+// was started. Both units are Type=simple, so a successful `systemctl start`
+// proves only that a process was forked; the summary must not report a unit as
+// running on that alone.
+type setupUnitStates struct {
+	DaemonRunning  bool
+	GatewayRunning bool
+}
+
 // renderSetupSummary is the last thing ao setup-vm prints. It reports the
 // machine as installed but not ready, and names every remaining step with the
 // exact command, rather than implying the machine is done.
-func renderSetupSummary(p setupPlan, gatewayStarted bool, warnings []string) string {
+func renderSetupSummary(p setupPlan, units setupUnitStates, warnings []string) string {
 	var b strings.Builder
 	b.WriteString("\nao setup-vm finished. This machine is installed, but not yet ready to use.\n")
 
@@ -850,10 +994,17 @@ func renderSetupSummary(p setupPlan, gatewayStarted bool, warnings []string) str
 	fmt.Fprintf(&b, "  ao binary        %s\n", p.BinaryPath)
 	fmt.Fprintf(&b, "  packages         %s\n", strings.Join(p.Packages, ", "))
 	fmt.Fprintf(&b, "  state directory  %s (owned by %s)\n", p.AODir, p.User)
-	fmt.Fprintf(&b, "  daemon unit      %s (enabled, running, loopback only)\n", slashPath(setupVMUnitDir, setupVMDaemonUnit))
+	daemonState := "enabled, running, loopback only"
+	if !units.DaemonRunning {
+		daemonState = "enabled, but not running: see the warnings below"
+	}
+	fmt.Fprintf(&b, "  daemon unit      %s (%s)\n", slashPath(setupVMUnitDir, setupVMDaemonUnit), daemonState)
 	gatewayState := "enabled, not started: this machine is not bound yet"
-	if gatewayStarted {
+	switch {
+	case units.GatewayRunning:
 		gatewayState = "enabled, running"
+	case p.Bound:
+		gatewayState = "enabled, but not running: see the warnings below"
 	}
 	fmt.Fprintf(&b, "  gateway unit     %s (%s)\n", slashPath(setupVMUnitDir, setupVMGatewayUnit), gatewayState)
 
@@ -878,7 +1029,7 @@ func renderSetupSummary(p setupPlan, gatewayStarted bool, warnings []string) str
 		fmt.Fprintf(&b, "       sudo systemctl start %s\n", setupVMGatewayUnit)
 	} else {
 		fmt.Fprintf(&b, "\n  %d. This machine is already bound (%s), and ao setup-vm restarted\n", next(), p.MachineFile)
-		fmt.Fprintf(&b, "     %s so it has read that binding. Check it at any time:\n", setupVMGatewayUnit)
+		fmt.Fprintf(&b, "     %s so it reads that binding. Check it at any time:\n", setupVMGatewayUnit)
 		b.WriteString("       ao whoami\n")
 		b.WriteString("     If you ever change that file by hand, restart the gateway yourself, because\n")
 		b.WriteString("     `ao vm serve` reads it once at startup:\n")
@@ -893,6 +1044,22 @@ func renderSetupSummary(p setupPlan, gatewayStarted bool, warnings []string) str
 	fmt.Fprintf(&b, "\n  %d. No git credentials on this machine, so private repositories cannot be cloned.\n", next())
 	b.WriteString("     gh is installed; authenticate it once:\n")
 	b.WriteString("       gh auth login\n")
+
+	// Nothing in the run proves 80 and 443 are reachable from the internet: a
+	// cloud firewall is invisible from inside the box, and the certificate is
+	// only ordered on the first TLS handshake, so a blocked port shows up much
+	// later as a machine that is Offline for no stated reason. This is a step the
+	// operator has to run, not a warning, so it is numbered like the rest.
+	fmt.Fprintf(&b, "\n  %d. Nobody has confirmed %s are reachable from the internet. setup-vm cannot\n",
+		next(), portList(setupVMPorts))
+	b.WriteString("     check that from this machine, because a cloud firewall is invisible from inside\n")
+	b.WriteString("     the box. Run these two from any machine that is not this one, your laptop for\n")
+	b.WriteString("     example:\n")
+	fmt.Fprintf(&b, "       nc -vz %s 80\n", p.Domain)
+	fmt.Fprintf(&b, "       nc -vz %s 443\n", p.Domain)
+	b.WriteString("     If either one refuses or times out, open the port in your cloud provider's\n")
+	b.WriteString("     firewall and in ufw. Until both answer, the gateway never gets a certificate,\n")
+	b.WriteString("     because Let's Encrypt validates over :80.\n")
 
 	b.WriteString("\nCheck this machine at any time:\n")
 	b.WriteString("  ao doctor\n")

--- a/backend/internal/cli/setupvm_plan_test.go
+++ b/backend/internal/cli/setupvm_plan_test.go
@@ -175,6 +175,7 @@ func passingPreflight() setupPreflight {
 	return setupPreflight{
 		Domain:      "vm.example.com",
 		UID:         0,
+		TargetUser:  "ubuntu",
 		PublicIP:    "203.0.113.10",
 		ResolvedIPs: []string{"203.0.113.10"},
 		Ports:       []setupPortProbe{{Port: 80}, {Port: 443}},
@@ -194,6 +195,12 @@ func TestEvaluatePreflight_Passing(t *testing.T) {
 	}
 	if !strings.Contains(joined, "sudo ufw allow 80/tcp") || !strings.Contains(joined, "nc -vz vm.example.com 443") {
 		t.Fatalf("the unverified warning must still print the firewall fix and the off-box check:\n%s", joined)
+	}
+	// The local probe binds loopback only, so it cannot see a listener bound to
+	// the public address alone. Saying so is the difference between a passed check
+	// and a proven one.
+	if !strings.Contains(joined, "127.0.0.1") {
+		t.Fatalf("the warning must say the local probe only bound loopback:\n%s", joined)
 	}
 }
 
@@ -220,6 +227,32 @@ func TestEvaluatePreflight_SudoProblems(t *testing.T) {
 			t.Fatalf("problems = %+v, want none", problems)
 		}
 	})
+}
+
+// TestEvaluatePreflight_RefusesARootTargetUser is the preflight half of the
+// root guard. A DigitalOcean or Hetzner box, or anyone who ran sudo -i, is root
+// with SUDO_USER unset, so nothing else in preflight objects: UID 0 is exactly
+// what the privilege check wants. Both units would then run as root, so ao daemon
+// would run every agent session, every git, and every gh as root. It has to
+// surface here, before anything on the box is touched, and not later as an
+// install-time error.
+func TestEvaluatePreflight_RefusesARootTargetUser(t *testing.T) {
+	pf := passingPreflight()
+	pf.TargetUser = "root"
+	problems, _ := evaluatePreflight(pf)
+	problem := assertProblem(t, problems, "target user", "adduser")
+	if !strings.Contains(problem.Detail, "root") {
+		t.Errorf("the detail must say the units would run as root: %q", problem.Detail)
+	}
+	if !strings.Contains(strings.Join(problem.Remediation, "\n"), "sudo ao setup-vm --domain vm.example.com") {
+		t.Errorf("remediation must name how to re-run as a human user: %v", problem.Remediation)
+	}
+	// The privilege check still has to be the one that reports it, so the
+	// no-mutation guarantee holds.
+	if !strings.HasPrefix(renderPreflightFailure(problems), "Preflight failed. Nothing on this machine was changed.") {
+		t.Error("a root target user must be a preflight failure, which changes nothing")
+	}
+	assertNoDashes(t, renderPreflightFailure(problems))
 }
 
 func TestEvaluatePreflight_DNSProblems(t *testing.T) {
@@ -253,6 +286,23 @@ func TestEvaluatePreflight_DNSProblems(t *testing.T) {
 		problem := assertProblem(t, problems, "DNS", "AAAA")
 		if strings.Contains(strings.Join(problem.Remediation, "\n"), " A ") {
 			t.Errorf("an IPv6 address must not be described as an A record: %v", problem.Remediation)
+		}
+	})
+	t.Run("a non-canonical IPv6 answer is not a mismatch", func(t *testing.T) {
+		pf := passingPreflight()
+		pf.PublicIP = "2001:0DB8::1"
+		pf.ResolvedIPs = []string{"2001:db8::1"}
+		if problems, _ := evaluatePreflight(pf); len(problems) != 0 {
+			t.Fatalf("problems = %+v, want none: these two spellings are the same address", problems)
+		}
+	})
+	t.Run("a real mismatch offers the explicit address", func(t *testing.T) {
+		pf := passingPreflight()
+		pf.ResolvedIPs = []string{"198.51.100.7"}
+		problems, _ := evaluatePreflight(pf)
+		problem := assertProblem(t, problems, "DNS", "--public-ip 198.51.100.7")
+		if !strings.Contains(strings.Join(problem.Remediation, "\n"), "more than one public address") {
+			t.Errorf("a dual-stack box needs the escape hatch explained: %v", problem.Remediation)
 		}
 	})
 	t.Run("public IP undiscoverable", func(t *testing.T) {
@@ -469,16 +519,84 @@ func TestBuildSetupPlan_RejectsRelativeOverrides(t *testing.T) {
 func TestBuildSetupPlan_HonorsAbsoluteOverrides(t *testing.T) {
 	plan, err := buildSetupPlan(setupPlanInput{
 		Domain: "vm.example.com", User: "ubuntu", Home: "/home/ubuntu",
-		DataDir: "/srv/ao/data", RunFile: "/srv/ao/running.json", MachineFile: "/srv/ao/machine.json",
+		DataDir: "/srv/ao/data", RunFile: "/srv/ao/running.json",
+		// The machine file has to stay inside ~/.ao, which the next test covers.
+		MachineFile: "/home/ubuntu/.ao/machines/this-one.json",
 	})
 	if err != nil {
 		t.Fatalf("buildSetupPlan err = %v", err)
 	}
-	if plan.DataDir != "/srv/ao/data" || plan.RunFile != "/srv/ao/running.json" || plan.MachineFile != "/srv/ao/machine.json" {
+	if plan.DataDir != "/srv/ao/data" || plan.RunFile != "/srv/ao/running.json" {
 		t.Fatalf("absolute overrides were not honored: %+v", plan)
+	}
+	if plan.MachineFile != "/home/ubuntu/.ao/machines/this-one.json" {
+		t.Fatalf("MachineFile = %q, want the override inside ~/.ao honored", plan.MachineFile)
 	}
 	if plan.CertDir != "/srv/ao/data/vm-gateway/certs" {
 		t.Errorf("CertDir = %q, want it to follow the overridden data dir", plan.CertDir)
+	}
+}
+
+// TestBuildSetupPlan_RejectsAMachineFileOutsideAODir keeps the one file the
+// gateway must be able to read inside the only tree this install creates and
+// chowns. A machine.json under a parent this run created as root, mode 0700,
+// is one the gateway user cannot traverse, so `ao vm serve` would refuse to
+// start on a machine that had just been bound successfully.
+func TestBuildSetupPlan_RejectsAMachineFileOutsideAODir(t *testing.T) {
+	for _, machineFile := range []string{
+		"/srv/ao/machine.json",
+		"/etc/ao/machine.json",
+		// A prefix match on the string alone would let this one through.
+		"/home/ubuntu/.aoelsewhere/machine.json",
+		"/home/ubuntu/.ao/../machine.json",
+	} {
+		t.Run(machineFile, func(t *testing.T) {
+			_, err := buildSetupPlan(setupPlanInput{
+				Domain: "vm.example.com", User: "ubuntu", Home: "/home/ubuntu", MachineFile: machineFile,
+			})
+			if err == nil {
+				t.Fatalf("AO_MACHINE_FILE=%q must be refused: the gateway could not read it", machineFile)
+			}
+			if !strings.Contains(err.Error(), "AO_MACHINE_FILE") {
+				t.Errorf("the error must name the variable at fault: %v", err)
+			}
+		})
+	}
+	// The directory itself is fine, and so is a subdirectory of it.
+	for _, machineFile := range []string{"/home/ubuntu/.ao/machine.json", "/home/ubuntu/.ao/sub/machine.json"} {
+		if _, err := buildSetupPlan(setupPlanInput{
+			Domain: "vm.example.com", User: "ubuntu", Home: "/home/ubuntu", MachineFile: machineFile,
+		}); err != nil {
+			t.Errorf("AO_MACHINE_FILE=%q is inside ~/.ao and must be honored: %v", machineFile, err)
+		}
+	}
+}
+
+// TestBuildSetupPlan_RejectsRoot is the pure half of the root guard, and it is
+// what makes systemdUnit's documented invariant ("User and Group are never
+// root") true rather than aspirational.
+func TestBuildSetupPlan_RejectsRoot(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		in   setupPlanInput
+	}{
+		{name: "user", in: setupPlanInput{Domain: "vm.example.com", User: "root", Home: "/root"}},
+		{name: "group", in: setupPlanInput{Domain: "vm.example.com", User: "ubuntu", Group: "root", Home: "/home/ubuntu"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := buildSetupPlan(tc.in)
+			if err == nil {
+				t.Fatal("a root identity must be refused: the daemon runs agent sessions, git, and gh")
+			}
+			if !strings.Contains(err.Error(), "root") {
+				t.Errorf("the error must say what is wrong: %v", err)
+			}
+			// The same remediation the preflight problem carries, so an operator
+			// who somehow reaches this path is not told less.
+			if !strings.Contains(err.Error(), "adduser") {
+				t.Errorf("the error must name the fix: %v", err)
+			}
+		})
 	}
 }
 
@@ -522,12 +640,16 @@ func TestRenderDaemonUnit(t *testing.T) {
 		"[Install]",
 		"User=ubuntu",
 		"Group=ubuntu",
-		`WorkingDirectory="/home/ubuntu/.ao/data"`,
+		// Unquoted, deliberately: see TestSetupUnitsQuoteOnlyTheListSettings.
+		"WorkingDirectory=/home/ubuntu/.ao/data",
 		`Environment="AO_DATA_DIR=/home/ubuntu/.ao/data"`,
 		`Environment="AO_RUN_FILE=/home/ubuntu/.ao/running.json"`,
 		`Environment="HOME=/home/ubuntu"`,
 		"ExecStart=/usr/local/bin/ao daemon",
+		// The daemon supervises live agent sessions, so a deliberate exit is left
+		// alone; only a failure earns a restart.
 		"Restart=on-failure",
+		"StartLimitIntervalSec=0",
 		"WantedBy=multi-user.target",
 		// The daemon spawns the harnesses, which install under the user's home.
 		`Environment="PATH=/home/ubuntu/.local/bin:/home/ubuntu/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"`,
@@ -551,7 +673,7 @@ func TestRenderGatewayUnit(t *testing.T) {
 	for _, want := range []string{
 		"User=ubuntu",
 		"Group=ubuntu",
-		`WorkingDirectory="/home/ubuntu/.ao/data"`,
+		"WorkingDirectory=/home/ubuntu/.ao/data",
 		`Environment="AO_DATA_DIR=/home/ubuntu/.ao/data"`,
 		`Environment="AO_MACHINE_FILE=/home/ubuntu/.ao/machine.json"`,
 		`Environment="AO_VM_DOMAIN=vm.example.com"`,
@@ -561,6 +683,11 @@ func TestRenderGatewayUnit(t *testing.T) {
 		"CapabilityBoundingSet=CAP_NET_BIND_SERVICE",
 		// The gateway fronts the daemon, so it starts after it.
 		"After=network-online.target ao-daemon.service",
+		// The gateway holds no session state, so every exit earns a restart, and
+		// systemd's default start rate limit is off so a gateway that fails for
+		// the first half minute after boot does not give up permanently.
+		"Restart=always",
+		"StartLimitIntervalSec=0",
 	} {
 		if !strings.Contains(unit, want) {
 			t.Errorf("gateway unit is missing %q:\n%s", want, unit)
@@ -573,6 +700,57 @@ func TestRenderGatewayUnit(t *testing.T) {
 		t.Error("the gateway unit should record that machine.json is read once at startup")
 	}
 	assertNoDashes(t, unit)
+}
+
+// TestSetupUnitsQuoteOnlyTheListSettings is the regression test for the defect
+// that would have made the very first real run fail after apt had already
+// installed packages and both units had been written.
+//
+// systemd only unquotes settings it parses as a list of words. Environment= is
+// one of those, so quoting it is right and stays. WorkingDirectory= is not: the
+// raw value goes to path_simplify_and_warn with PATH_CHECK_ABSOLUTE and
+// PATH_CHECK_FATAL, so a value starting with a double quote is not an absolute
+// path, the parse handler returns -ENOEXEC, and the unit refuses to load at all
+// rather than ignoring one setting. The golden assertions in this file used to
+// bake in the quoted form, which is why CI stayed green while the box would not
+// have booted the service.
+func TestSetupUnitsQuoteOnlyTheListSettings(t *testing.T) {
+	plan := testSetupPlan(t)
+	for name, unit := range map[string]string{
+		setupVMDaemonUnit:  renderDaemonUnit(plan),
+		setupVMGatewayUnit: renderGatewayUnit(plan),
+	} {
+		value, ok := unitSetting(unit, "WorkingDirectory")
+		if !ok {
+			t.Fatalf("%s has no WorkingDirectory:\n%s", name, unit)
+		}
+		if strings.ContainsAny(value, `"'`) {
+			t.Errorf("%s: WorkingDirectory=%s is quoted, which systemd treats as a fatal error and "+
+				"refuses to load the unit for", name, value)
+		}
+		if !strings.HasPrefix(value, "/") {
+			t.Errorf("%s: WorkingDirectory=%s must be a plain absolute path", name, value)
+		}
+		if value != plan.DataDir {
+			t.Errorf("%s: WorkingDirectory=%s, want the plan's data dir %s", name, value, plan.DataDir)
+		}
+		// Environment= is the opposite case and must keep its quotes: systemd
+		// splits that one on whitespace.
+		if !strings.Contains(unit, `Environment="AO_DATA_DIR=`+plan.DataDir+`"`) {
+			t.Errorf("%s: Environment= values must stay quoted, they are parsed as a list of words:\n%s", name, unit)
+		}
+	}
+}
+
+// unitSetting returns the raw value of the first occurrence of a unit setting,
+// exactly as systemd's parser would see it: no unquoting, no trimming.
+func unitSetting(unit, directive string) (string, bool) {
+	for _, line := range strings.Split(unit, "\n") {
+		if key, value, ok := strings.Cut(line, "="); ok && key == directive {
+			return value, true
+		}
+	}
+	return "", false
 }
 
 // TestSetupUnitsSetEveryPathAbsolutely is the regression test for the hazard
@@ -591,7 +769,7 @@ func TestSetupUnitsSetEveryPathAbsolutely(t *testing.T) {
 			}
 			switch directive {
 			case "WorkingDirectory":
-				if !strings.HasPrefix(value, `"/`) {
+				if !strings.HasPrefix(value, "/") {
 					t.Errorf("%s: %s must be absolute, got %q", name, directive, value)
 				}
 			case "ExecStart":
@@ -613,7 +791,8 @@ func TestSetupUnitsSetEveryPathAbsolutely(t *testing.T) {
 
 func TestRenderSetupSummary_Unbound(t *testing.T) {
 	plan := testSetupPlan(t)
-	summary := renderSetupSummary(plan, false, []string{"80 and 443 were not verified from outside"})
+	summary := renderSetupSummary(plan, setupUnitStates{DaemonRunning: true},
+		[]string{"80 and 443 were not verified from outside"})
 	for _, want := range []string{
 		"installed, but not yet ready",
 		"not bound to an AO account",
@@ -632,10 +811,53 @@ func TestRenderSetupSummary_Unbound(t *testing.T) {
 	assertNoDashes(t, summary)
 }
 
+// TestRenderSetupSummary_NamesTheOffBoxPortCheck pins the one preflight
+// requirement setup-vm cannot meet from inside the box. The control plane does
+// not implement the reachability probe, and a cloud firewall is invisible from
+// here, so the pair of nc commands is a numbered step the operator has to run,
+// not remediation text buried inside a warning.
+func TestRenderSetupSummary_NamesTheOffBoxPortCheck(t *testing.T) {
+	plan := testSetupPlan(t)
+	summary := renderSetupSummary(plan, setupUnitStates{DaemonRunning: true}, nil)
+	for _, want := range []string{
+		"nc -vz vm.example.com 80",
+		"nc -vz vm.example.com 443",
+		"cannot",
+		"from any machine that is not this one",
+	} {
+		if !strings.Contains(summary, want) {
+			t.Errorf("summary is missing %q:\n%s", want, summary)
+		}
+	}
+	// It is a numbered still-missing step, in the same list as the harness and
+	// the git credentials.
+	stillMissing := summary[strings.Index(summary, "Still missing"):]
+	if !strings.Contains(stillMissing, "nc -vz") {
+		t.Errorf("the off-box check must be one of the numbered steps:\n%s", stillMissing)
+	}
+	assertNoDashes(t, summary)
+}
+
+// TestRenderSetupSummary_DoesNotClaimAUnitItDidNotSeeRunning is M7 seen from the
+// summary: both units are Type=simple, so a successful `systemctl start` proves
+// only that a process was forked. A crash loop must not read as a green run.
+func TestRenderSetupSummary_DoesNotClaimAUnitItDidNotSeeRunning(t *testing.T) {
+	plan := testSetupPlan(t)
+	plan.Bound = true
+	summary := renderSetupSummary(plan, setupUnitStates{}, []string{"ao-daemon.service was started but is not active"})
+	if strings.Contains(summary, "enabled, running") {
+		t.Errorf("a unit that is not active must not be reported as running:\n%s", summary)
+	}
+	if strings.Count(summary, "not running") != 2 {
+		t.Errorf("both units were started and neither is active, so both lines must say so:\n%s", summary)
+	}
+	assertNoDashes(t, summary)
+}
+
 func TestRenderSetupSummary_Bound(t *testing.T) {
 	plan := testSetupPlan(t)
 	plan.Bound = true
-	summary := renderSetupSummary(plan, true, nil)
+	summary := renderSetupSummary(plan, setupUnitStates{DaemonRunning: true, GatewayRunning: true}, nil)
 	if !strings.Contains(summary, "already bound") {
 		t.Errorf("a bound machine's summary must say so:\n%s", summary)
 	}

--- a/backend/internal/cli/setupvm_test.go
+++ b/backend/internal/cli/setupvm_test.go
@@ -9,7 +9,9 @@ package cli
 import (
 	"context"
 	"errors"
+	"io"
 	"net/http"
+	"net/http/httptest"
 	"runtime"
 	"strings"
 	"sync"
@@ -122,6 +124,48 @@ func TestSetupVM_FailedPreflightChangesNothing(t *testing.T) {
 		t.Errorf("output must state that nothing was changed:\n%s", out)
 	}
 	assertNoSetupMutation(t, calls())
+}
+
+// TestDiscoverPublicIPPrefersAnIPv4Answer covers the dual-stack false mismatch:
+// on a box with both families the address an endpoint reports is whichever one
+// the request went out over, and a v6 answer read against a perfectly good A
+// record is a DNS mismatch that does not exist.
+func TestDiscoverPublicIPPrefersAnIPv4Answer(t *testing.T) {
+	answers := func(body string) *httptest.Server {
+		return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = io.WriteString(w, body)
+		}))
+	}
+	v6 := answers("2001:db8::1\n")
+	defer v6.Close()
+	v4 := answers("203.0.113.10\n")
+	defer v4.Close()
+
+	c := &commandContext{deps: Deps{HTTPClient: &http.Client{}}.withDefaults()}
+
+	restore := setupVMPublicIPEndpoints
+	t.Cleanup(func() { setupVMPublicIPEndpoints = restore })
+
+	// The v6 endpoint answers first and is still not the one that wins.
+	setupVMPublicIPEndpoints = []string{v6.URL, v4.URL}
+	got, err := c.discoverPublicIP(context.Background())
+	if err != nil {
+		t.Fatalf("discoverPublicIP err = %v", err)
+	}
+	if got != "203.0.113.10" {
+		t.Errorf("discoverPublicIP = %q, want the IPv4 answer: a v6 answer against an A record reports a mismatch that does not exist", got)
+	}
+
+	// A genuinely IPv6-only box finds no v4 answer anywhere and keeps the one it
+	// has, so nothing is lost by looking.
+	setupVMPublicIPEndpoints = []string{v6.URL}
+	got, err = c.discoverPublicIP(context.Background())
+	if err != nil {
+		t.Fatalf("discoverPublicIP err = %v", err)
+	}
+	if got != "2001:db8::1" {
+		t.Errorf("discoverPublicIP = %q, want the IPv6 answer when that is all there is", got)
+	}
 }
 
 // assertNoSetupMutation fails if the command ran anything that could have


### PR DESCRIPTION
Fixes the ten client-side review findings in `backend/internal/cli/setupvm*`. Closes #38.

## C1: `WorkingDirectory` was quoted, and systemd treats that as fatal

`setupvm_plan.go` emitted `WorkingDirectory=%q`, producing `WorkingDirectory="/home/ubuntu/.ao/data"`. Unit-file quoting is only honoured by settings systemd parses as a list of words. `Environment=` is one of those, so its quoting is correct and stays. `WorkingDirectory=` is not: the raw value goes to `path_simplify_and_warn(PATH_CHECK_ABSOLUTE|PATH_CHECK_FATAL)` with no unquoting, so a value starting with `"` is not an absolute path, the parse handler returns `-ENOEXEC`, and the unit refuses to load rather than ignoring one setting.

The reviewer marked this SUSPECTED because they had no systemd. **It reproduces.** systemd-analyze 255 in an `ubuntu:24.04` container, both units rendered by this code, with a stub `/usr/local/bin/ao` present so the only variable is the quoting:

```
=============== old (WorkingDirectory="/home/ubuntu/.ao/data") ===============
/etc/systemd/system/old-ao-gateway.service:20: WorkingDirectory= path is not absolute: "/home/ubuntu/.ao/data"
old-ao-gateway.service: Unit configuration has fatal error, unit will not be started.
Unit old-ao-gateway.service has a bad unit file setting.
[exit status: 1]

=============== old, daemon unit ===============
/etc/systemd/system/old-ao-daemon.service:18: WorkingDirectory= path is not absolute: "/home/ubuntu/.ao/data"
old-ao-daemon.service: Unit configuration has fatal error, unit will not be started.
Unit old-ao-daemon.service has a bad unit file setting.
[exit status: 1]

=============== fixed (WorkingDirectory=/home/ubuntu/.ao/data) ===============
fixed-ao-gateway.service   [exit status: 0]
fixed-ao-daemon.service    [exit status: 0]

=============== fixed, with a space in the path, unquoted ===============
spaced-ao-gateway.service (WorkingDirectory=/home/first last/.ao/data)   [exit status: 0]
```

That last line answers the escaping question: the setting takes the rest of the line as one path, so a space needs no `\x20` and no quotes. This is exactly why the quoting was wrong in the first place.

Both units are now `systemd-analyze verify` clean, including the new `StartLimitIntervalSec=0` and `Restart=always`.

### The tests that encoded the defect

Three assertions asserted the bug, which is why CI stayed green:

- `setupvm_plan_test.go:525`, the daemon golden: `` `WorkingDirectory="/home/ubuntu/.ao/data"` ``
- `setupvm_plan_test.go:554`, the gateway golden: the same string
- `setupvm_plan_test.go:593`, inside `TestSetupUnitsSetEveryPathAbsolutely`: `strings.HasPrefix(value, "\"/")`, so the check that existed to prove the path was absolute was passing *because* of the leading quote

Replaced with `TestSetupUnitsQuoteOnlyTheListSettings`, which fails on the old code: it reads the raw `WorkingDirectory=` value the way systemd's parser would, rejects any quote in it, requires a leading `/`, and separately requires `Environment=` to keep its quotes so the fix cannot be over-applied.

## H1: a root target user is now refused, in both places

`setupTargetUser()` falls back to `user.Current()` when `SUDO_USER` is unset or root, which is the default on DigitalOcean and Hetzner and the result of `sudo -i` anywhere. Preflight's privilege check passed silently on `UID == 0`, both units got `User=root`, and `systemdUnit`'s own doc comment claimed the opposite.

Rejected in both places the review asked for:

- `checkSetupPrivilege`, so it surfaces as a preflight problem and the "nothing on this machine was changed" guarantee holds. `setupPreflight` gained a `TargetUser` field, filled by the probe.
- `buildSetupPlan`, pure and unit-testable, covering `Group` as well as `User`, which makes the documented invariant true rather than aspirational.

Both paths share one wording (`rootSetupUserProblem`) so they cannot drift. The remediation names the fix: create an unprivileged user and re-run under `sudo -u`, or log in as an existing human and use `sudo`, with the reason `SUDO_USER` matters spelled out.

## H2: stop implying a check that cannot run

No server endpoint added, per the brief: `/api/v1/reachability` is another worker's half. The closing summary now carries the off-box `nc -vz <domain> 80` and `443` pair as a numbered still-missing step, alongside the harness and the git credentials, rather than only as remediation text inside a warning.

## The rest

- **M6.** An `AO_MACHINE_FILE` outside `~/.ao` is refused in `buildSetupPlan`. Its parent would be created by `writeMachineFile` as root, mode 0700, never chowned, so the 0600 file inside it would be one the gateway user cannot traverse to. Containment is compared by whole path components, so `/home/ubuntu/.aoelsewhere/...` and `..` traversal are both caught.
- **M7.** Every start and restart is followed by the existing `systemctl is-active` helper, after a 2 second settle so an immediate exit is visible at all (a crash-looping unit reports `activating` while it waits out `RestartSec`). A negative becomes a note carrying `systemctl status` and `journalctl -u <unit> -n 50`, and both the progress line and the summary stop saying "running" on evidence they do not have. The gateway is re-checked after the binding restart, since it reads `machine.json` at startup.
- **M8.** `StartLimitIntervalSec=0` on both units, in `[Unit]` where it belongs, plus `Restart=always` for the gateway, which holds no session state. The daemon keeps `Restart=on-failure` because it supervises live agent sessions.
- **L3.** DNS matching goes through `net.IP.Equal`, so `2001:0DB8::1` against a resolver's `2001:db8::1` is no longer a mismatch.
- **L4.** `discoverPublicIP` prefers an IPv4 answer, so a dual-stack box that reaches an endpoint over v6 is not reported as mismatching a correct A record. A v6-only box finds no v4 answer anywhere and keeps what it has. The mismatch remediation also now offers `--public-ip <resolved address>` as the escape hatch.
- **L5.** The unverified-reachability warning says the local probe only bound `127.0.0.1`, which cannot see a listener bound to the public address alone.
- **L7.** The device flow's inter-poll wait races `ctx.Done()`, so Ctrl-C is noticed at once instead of after up to 60 seconds of `slow_down` backoff.

## Not regressed

Checked each item on the do-not-regress list. Preflight still changes nothing on failure, and the two new rejections are both on that side of the line. Idempotency is untouched: content-compared writes, `dpkg-query` skips, `install -d` re-application, the SHA-256 binary comparison, and the deliberate choice not to restart the daemon unless its unit changed. The public IP check still fails closed with its 256 byte limit. `machine.json` still gets its atomic write, explicit 0600, root-only chown from the same `setupTargetUser()` that produced `plan.User`, and the read-back through `vmgateway.ReadMachineFile`. No secrets in argv, no device code printed, and the interval and `slow_down` handling are unchanged.

## Tests

`go test ./internal/cli/` passes apart from the five documented pre-existing `TestSpawn*` failures, which are unrelated to this change and left alone. `gofmt` clean, `golangci-lint v2.12.2` reports nothing in these files.

New coverage: `TestSetupUnitsQuoteOnlyTheListSettings` (C1, fails without the fix), `TestEvaluatePreflight_RefusesARootTargetUser` and `TestBuildSetupPlan_RejectsRoot` (H1, both layers), `TestRenderSetupSummary_NamesTheOffBoxPortCheck` (H2), `TestBuildSetupPlan_RejectsAMachineFileOutsideAODir` (M6), `TestRenderSetupSummary_DoesNotClaimAUnitItDidNotSeeRunning` (M7), the `StartLimitIntervalSec` and `Restart` golden assertions (M8), two DNS subtests (L3 and L4), `TestDiscoverPublicIPPrefersAnIPv4Answer` (L4), a loopback caveat assertion (L5), and `TestDeviceFlowStopsAtOnceWhenTheContextIsCancelled` (L7).

## Risk

The one behaviour change an existing user could notice is the `AO_MACHINE_FILE` refusal, which now fails a run that previously produced a gateway that could not start. Everything else either fixes a failure or adds an honest report of one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
