### PR TITLE
feat(controlplane): mint machine-audience tokens at POST /api/v1/machines/{id}/token

### DIFF
--- a/controlplane/README.md
+++ b/controlplane/README.md
@@ -91,8 +91,7 @@ curl -s http://127.0.0.1:8080/device/code \
 curl -s http://127.0.0.1:8080/device/token \
   -d grant_type=urn:ietf:params:oauth:grant-type:device_code \
   -d device_code=...
-# {"access_token":"...","token_type":"Bearer","expires_in":900,
-#  "machine_id":"...","account_id":"...","public_url":"https://vm.example.com"}
+# {"machine_id":"...","account_id":"...","public_url":"https://vm.example.com"}
 ```
 
 While the flow is in progress the poll returns HTTP 400 with an RFC 8628 error
@@ -102,8 +101,14 @@ faster than `interval`, `expired_token` once the code's 15 minutes are up, and
 returns 403 `access_denied`.
 
 `machine_id` is `machines.id`. It is the value that goes in `machineId` in
-`~/.ao/machine.json` and the `aud` of the access token in the same response;
-it is never the hostname or the public URL. See `TOKEN_CONTRACT.md`.
+`~/.ao/machine.json` and the `aud` of every access token minted for this
+machine; it is never the hostname or the public URL. See `TOKEN_CONTRACT.md`.
+
+That response deliberately carries no access token, unlike the RFC 8628
+section 3.5 shape it is otherwise. The VM verifies tokens rather than
+presenting them, so `ao setup-vm` never read the one that used to be there:
+minting it created and transmitted a live 15 minute credential on every bind
+for no consumer. Machine tokens come from the machine token endpoint below.
 
 A successful poll is repeatable until the device code expires, so a dropped
 response does not force the operator to approve a second code. Re-running the
@@ -128,7 +133,20 @@ curl -s http://127.0.0.1:8080/api/v1/token \
 curl -s http://127.0.0.1:8080/api/v1/machines -H 'Authorization: Bearer <access token>'
 # {"machines":[{"id":"...","name":"prod vm","public_url":"https://vm.example.com",
 #               "created_at":"...","last_seen":null}]}
+
+# Ask for a token addressed to one of your machines, so the desktop can call
+# that machine's gateway. No request body. Nothing rotates.
+curl -s -X POST http://127.0.0.1:8080/api/v1/machines/<machine id>/token \
+  -H 'Authorization: Bearer <access token>'
+# {"access_token":"...","token_type":"Bearer","expires_in":900}
 ```
+
+The token that comes back has `aud` = `machines.id` and `sub` = the account
+id, so it is a credential for that machine's gateway and is rejected by the
+control plane API, which is the point. A machine that belongs to another
+account, one that is revoked, and one that does not exist all answer the same
+404 `not_found`: distinguishing them would make this a machine-id enumeration
+oracle for anyone with an account.
 
 `internal/api` owns both the token endpoint and the authenticator; a feature
 package registering an `/api/v1` route takes that authenticator as a value

--- a/controlplane/TOKEN_CONTRACT.md
+++ b/controlplane/TOKEN_CONTRACT.md
@@ -52,9 +52,21 @@ plane and it already publishes that origin everywhere.
 
 ### How each is obtained
 
-- **Machine audience:** from the RFC 8628 device flow, at the end of
-  `ao setup-vm`. The polling response carries the machine id, the account id,
-  and the public URL, which is what `~/.ao/machine.json` is written from.
+- **Machine audience:** by asking for one at
+  `POST /api/v1/machines/{id}/token`, authenticated with a
+  **control-plane-audience** access token. The control plane checks that the
+  machine belongs to the calling account and is not revoked, then mints
+  `aud` = `machines.id`, `sub` = that account. A machine the caller does not
+  own answers exactly as one that does not exist: same 404, same body. The
+  refresh token is not a credential for this route, deliberately. A machine
+  token is wanted whenever the desktop switches machines or a 15 minute token
+  lapses, and rotating a 90 day credential on every one of those calls would
+  be both wasteful and a lockout race.
+- The RFC 8628 device flow does **not** hand out a machine token. Its polling
+  response carries the machine id, the account id, and the public URL, which
+  is what `~/.ao/machine.json` is written from, and nothing else: the VM
+  verifies tokens rather than presenting them, so a token in that response
+  would be a live credential minted for no reader.
 - **`publicUrl` is a full origin on the control-plane side** (`https://vm.example.com`,
   scheme included, no path and no trailing slash, and `http` only for a loopback
   host) **and is reduced to a bare hostname on the gateway side**, where

--- a/controlplane/internal/device/device.go
+++ b/controlplane/internal/device/device.go
@@ -1,7 +1,7 @@
 // Package device implements the RFC 8628 device authorization flow that
 // `ao setup-vm` uses to bind a VM to an account, the two browser pages that
 // flow goes through, the machine registration the approval performs, and the
-// authenticated list-machines API the desktop reads.
+// authenticated machines API the desktop reads and asks for machine tokens at.
 //
 // The one thing to get right here: the access tokens this package mints carry
 // `aud` = machines.id, never the machine's hostname and never its public URL.
@@ -73,10 +73,10 @@ type Service struct {
 	attempts *attemptLimiter
 }
 
-// NewService builds the device flow Service. issuer mints the access token
-// returned to a polling client once its code is approved; sessions identifies
-// the signed-in operator on the browser pages; apiAuth identifies the caller
-// of the machines API.
+// NewService builds the device flow Service. issuer mints the machine-audience
+// access tokens the machine token endpoint returns; sessions identifies the
+// signed-in operator on the browser pages; apiAuth identifies the caller of the
+// machines API.
 func NewService(db *sql.DB, issuer *tokens.Issuer, s sessions, apiAuth APIAuthenticator, publicOrigin string) (*Service, error) {
 	tmpl, err := template.ParseFS(templatesFS, "templates/*.html")
 	if err != nil {
@@ -109,6 +109,7 @@ func (s *Service) Register(mux *http.ServeMux) {
 
 	// The machine registry API the desktop reads.
 	mux.HandleFunc("GET /api/v1/machines", s.handleListMachines)
+	mux.HandleFunc("POST /api/v1/machines/{id}/token", s.handleMachineToken)
 }
 
 // verificationURI is the absolute URL of the enter-code page.

--- a/controlplane/internal/device/endpoints.go
+++ b/controlplane/internal/device/endpoints.go
@@ -39,21 +39,26 @@ type deviceCodeResponse struct {
 	Interval                int    `json:"interval"`
 }
 
-// tokenResponse is the RFC 8628 section 3.5 successful response, extended
-// with the machine triple `ao setup-vm` writes into machine.json: machine id,
-// account id, and public URL.
+// bindingResponse is what an approved poll returns: the machine triple
+// `ao setup-vm` writes into machine.json, and nothing else.
 //
-// machine_id is machines.id and is the `aud` of the access token in the same
-// response. A client writing machine.json must use this field for machineId
-// and must not substitute the public URL, or `ao vm serve` will reject every
-// token it is ever shown.
-type tokenResponse struct {
-	AccessToken string `json:"access_token"`
-	TokenType   string `json:"token_type"`
-	ExpiresIn   int    `json:"expires_in"`
-	MachineID   string `json:"machine_id"`
-	AccountID   string `json:"account_id"`
-	PublicURL   string `json:"public_url"`
+// It carries no access token, which is a deliberate departure from the RFC
+// 8628 section 3.5 response shape. The VM does not present tokens, it verifies
+// them, so `ao setup-vm` never decoded the one that used to be here; minting it
+// created a live 15 minute credential on every bind, sent it across the wire,
+// and handed it to a client whose only correct move was to drop it. The desktop
+// gets machine tokens from POST /api/v1/machines/{id}/token, against a
+// credential of its own. The one client of this endpoint is `ao setup-vm`, so
+// nothing generically OAuth reads this body.
+//
+// machine_id is machines.id, and it is the `aud` of every access token minted
+// for this machine. A client writing machine.json must use this field for
+// machineId and must not substitute the public URL, or `ao vm serve` will
+// reject every token it is ever shown.
+type bindingResponse struct {
+	MachineID string `json:"machine_id"`
+	AccountID string `json:"account_id"`
+	PublicURL string `json:"public_url"`
 }
 
 // handleDeviceCode is the device authorization endpoint: `ao setup-vm` calls
@@ -117,7 +122,8 @@ func (s *Service) handleDeviceCode(w http.ResponseWriter, r *http.Request) {
 // handleDeviceToken is the device access token request endpoint. It returns
 // the RFC 8628 error codes while the flow is in progress
 // (authorization_pending, slow_down, expired_token, access_denied) and, once
-// approved, an access token plus the machine triple.
+// approved, the machine triple. See bindingResponse for why no token comes
+// back with it.
 //
 // A successful poll is repeatable until the device code expires, rather than
 // consuming the code on first success. The device code is already bounded by
@@ -151,22 +157,10 @@ func (s *Service) handleDeviceToken(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// The audience is the machine id. Minting goes through the Issuer so this
-	// package never constructs a JWT and cannot pass a hostname here.
-	accessToken, err := s.issuer.IssueAccessToken(res.grant.AccountID, res.grant.MachineID)
-	if err != nil {
-		log.Printf("device: issue access token: %v", err)
-		api.WriteError(w, http.StatusInternalServerError, "server_error", "could not issue an access token")
-		return
-	}
-
-	api.WriteJSON(w, http.StatusOK, tokenResponse{
-		AccessToken: accessToken,
-		TokenType:   "Bearer",
-		ExpiresIn:   int(s.issuer.AccessTokenTTL().Seconds()),
-		MachineID:   res.grant.MachineID,
-		AccountID:   res.grant.AccountID,
-		PublicURL:   res.grant.PublicURL,
+	api.WriteJSON(w, http.StatusOK, bindingResponse{
+		MachineID: res.grant.MachineID,
+		AccountID: res.grant.AccountID,
+		PublicURL: res.grant.PublicURL,
 	})
 }
 

--- a/controlplane/internal/device/flow_test.go
+++ b/controlplane/internal/device/flow_test.go
@@ -144,7 +144,7 @@ func (h *harness) requestCode(publicURL, name string) deviceCodeResponse {
 
 // poll runs one device access token request and returns the recorder plus the
 // decoded body, whichever shape it has.
-func (h *harness) poll(deviceCode string) (*httptest.ResponseRecorder, tokenResponse, oauthError) {
+func (h *harness) poll(deviceCode string) (*httptest.ResponseRecorder, bindingResponse, oauthError) {
 	h.t.Helper()
 
 	rec := h.do(http.MethodPost, "/device/token", "", url.Values{
@@ -152,7 +152,7 @@ func (h *harness) poll(deviceCode string) (*httptest.ResponseRecorder, tokenResp
 		"device_code": {deviceCode},
 	})
 	var (
-		ok      tokenResponse
+		ok      bindingResponse
 		failure oauthError
 	)
 	if rec.Code == http.StatusOK {
@@ -220,7 +220,7 @@ func claimsOf(t *testing.T, token string) (aud, sub string) {
 	return claims.Aud, claims.Sub
 }
 
-func TestDeviceFlow_HappyPathBindsTheMachineAndMintsAMachineAudienceToken(t *testing.T) {
+func TestDeviceFlow_HappyPathBindsTheMachineAndReturnsOnlyTheTriple(t *testing.T) {
 	h := newHarness(t)
 
 	issued := h.requestCode(testPublicURL, "prod vm")
@@ -293,24 +293,19 @@ func TestDeviceFlow_HappyPathBindsTheMachineAndMintsAMachineAudienceToken(t *tes
 	if granted.PublicURL != testPublicURL {
 		t.Errorf("public_url = %q, want %q", granted.PublicURL, testPublicURL)
 	}
-	if granted.TokenType != "Bearer" {
-		t.Errorf("token_type = %q, want Bearer", granted.TokenType)
+	// And nothing else. A bind must not mint a credential the VM has no use
+	// for: `ao vm serve` verifies tokens, it never presents one, so a token in
+	// this body would be a live 15 minute credential created and transmitted
+	// for no reader. The desktop gets machine tokens from
+	// POST /api/v1/machines/{id}/token instead.
+	var body map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode poll body: %v", err)
 	}
-	if granted.ExpiresIn != int((15 * time.Minute).Seconds()) {
-		t.Errorf("expires_in = %d, want 900", granted.ExpiresIn)
-	}
-
-	// The trap this whole task exists to avoid: the audience is machines.id,
-	// never the hostname and never the public URL.
-	aud, sub := claimsOf(t, granted.AccessToken)
-	if sub != accountA {
-		t.Errorf("access token sub = %q, want the account id %q", sub, accountA)
-	}
-	if aud != machineID {
-		t.Errorf("access token aud = %q, want the machine id %q", aud, machineID)
-	}
-	if aud == testPublicURL || aud == "vm.example.com" {
-		t.Fatalf("access token aud = %q, which is the machine's address: it must be machines.id", aud)
+	for _, field := range []string{"access_token", "token_type", "expires_in", "refresh_token"} {
+		if _, present := body[field]; present {
+			t.Errorf("poll body carries %q, want only the machine triple", field)
+		}
 	}
 }
 

--- a/controlplane/internal/device/machine_token_test.go
+++ b/controlplane/internal/device/machine_token_test.go
@@ -1,0 +1,229 @@
+package device
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// machineTokenRaw asks for a token for machineID with the given bearer
+// credential (empty for none) and returns the raw recorder.
+func (h *harness) machineTokenRaw(machineID, bearer string) *httptest.ResponseRecorder {
+	h.t.Helper()
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/machines/"+machineID+"/token", nil)
+	if bearer != "" {
+		req.Header.Set("Authorization", "Bearer "+bearer)
+	}
+	rec := httptest.NewRecorder()
+	h.mux.ServeHTTP(rec, req)
+	return rec
+}
+
+// machineToken asks for a token and requires a 200, returning the decoded body.
+func (h *harness) machineToken(machineID, bearer string) machineTokenResponse {
+	h.t.Helper()
+
+	rec := h.machineTokenRaw(machineID, bearer)
+	if rec.Code != http.StatusOK {
+		h.t.Fatalf("POST machine token status = %d, want 200, body: %s", rec.Code, rec.Body)
+	}
+	var resp machineTokenResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		h.t.Fatalf("decode machine token response: %v", err)
+	}
+	return resp
+}
+
+// revokeMachine sets revoked_at on a machine, as a future revoke endpoint will.
+func (h *harness) revokeMachine(machineID string) {
+	h.t.Helper()
+
+	res, err := h.db.Exec(`UPDATE machines SET revoked_at = CURRENT_TIMESTAMP WHERE id = ?`, machineID)
+	if err != nil {
+		h.t.Fatalf("revoke machine: %v", err)
+	}
+	if n, _ := res.RowsAffected(); n != 1 {
+		h.t.Fatalf("revoke machine affected %d rows, want 1", n)
+	}
+}
+
+func TestMachineToken_MintsAMachineAudienceTokenForTheCallersMachine(t *testing.T) {
+	h := newHarness(t)
+	machineID := h.bindMachine(accountA, testPublicURL, "prod vm")
+
+	granted := h.machineToken(machineID, h.controlPlaneToken(accountA))
+	if granted.TokenType != "Bearer" {
+		t.Errorf("token_type = %q, want Bearer", granted.TokenType)
+	}
+	if want := int(h.svc.issuer.AccessTokenTTL().Seconds()); granted.ExpiresIn != want {
+		t.Errorf("expires_in = %d, want %d", granted.ExpiresIn, want)
+	}
+
+	// The trap this whole endpoint exists to avoid: the audience is
+	// machines.id, never the hostname and never the public URL.
+	aud, sub := claimsOf(t, granted.AccessToken)
+	if sub != accountA {
+		t.Errorf("access token sub = %q, want the account id %q", sub, accountA)
+	}
+	if aud != machineID {
+		t.Errorf("access token aud = %q, want the machine id %q", aud, machineID)
+	}
+	if aud == testPublicURL || aud == "vm.example.com" {
+		t.Fatalf("access token aud = %q, which is the machine's address: it must be machines.id", aud)
+	}
+
+	// The other half of the two-audience contract: what comes back here is a
+	// credential for that machine's gateway and not for this service, so
+	// presenting it to the control plane API fails the audience check.
+	if _, err := h.svc.issuer.VerifyControlPlaneToken(granted.AccessToken); err == nil {
+		t.Error("the machine token verifies as a control plane token, want it rejected on aud")
+	}
+	if rec := h.listMachinesRaw(granted.AccessToken); rec.Code != http.StatusUnauthorized {
+		t.Errorf("machine token on the machines API: status = %d, want 401", rec.Code)
+	}
+
+	// No refresh token is presented and none rotates: the caller can ask
+	// again with the same credential.
+	if again := h.machineToken(machineID, h.controlPlaneToken(accountA)); again.AccessToken == "" {
+		t.Error("a second request returned no access token")
+	}
+}
+
+func TestMachineToken_RequiresAControlPlaneAudienceToken(t *testing.T) {
+	h := newHarness(t)
+	machineID := h.bindMachine(accountA, testPublicURL, "prod vm")
+	ctx := context.Background()
+
+	// A machine-audience token is a credential for that machine's gateway, not
+	// for this service. Accepting one here would let a leaked machine token
+	// mint fresh machine tokens, including for the account's other machines.
+	machineToken, err := h.svc.issuer.IssueAccessToken(accountA, machineID)
+	if err != nil {
+		t.Fatalf("IssueAccessToken() unexpected error: %v", err)
+	}
+
+	// A refresh token goes only to the token endpoint. This route deliberately
+	// does not take one: it is called whenever the desktop switches machines or
+	// a 15 minute token lapses, and rotating a 90 day credential on every one
+	// of those is the lockout race this design avoids.
+	refresh, err := h.svc.issuer.IssueRefreshToken(ctx, accountA, "install-1")
+	if err != nil {
+		t.Fatalf("IssueRefreshToken() unexpected error: %v", err)
+	}
+
+	// A token from a different control plane: right shape, right claims, wrong
+	// signing key.
+	foreign := newHarness(t).controlPlaneToken(accountA)
+
+	valid := h.controlPlaneToken(accountA)
+	tampered := valid[:strings.LastIndex(valid, ".")] + ".AAAA"
+
+	for name, credential := range map[string]string{
+		"no credential":         "",
+		"machine audience":      machineToken,
+		"refresh token":         refresh,
+		"another control plane": foreign,
+		"tampered signature":    tampered,
+		"not a token at all":    "nonsense",
+		"empty bearer value":    " ",
+	} {
+		rec := h.machineTokenRaw(machineID, credential)
+		if rec.Code != http.StatusUnauthorized {
+			t.Errorf("%s: status = %d, want 401", name, rec.Code)
+		}
+		if got := rec.Header().Get("WWW-Authenticate"); !strings.Contains(got, "Bearer") {
+			t.Errorf("%s: WWW-Authenticate = %q, want a Bearer challenge", name, got)
+		}
+	}
+
+	// An expired token is rejected too: exp is checked, always.
+	expired, err := h.expiredIssuer().IssueControlPlaneToken(accountA)
+	if err != nil {
+		t.Fatalf("IssueControlPlaneToken() unexpected error: %v", err)
+	}
+	if rec := h.machineTokenRaw(machineID, expired); rec.Code != http.StatusUnauthorized {
+		t.Errorf("expired token: status = %d, want 401", rec.Code)
+	}
+
+	// The browser session alone is not a credential for the API either: the
+	// desktop cannot send one, and accepting an ambient cookie on a POST would
+	// make this route CSRF-reachable.
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/machines/"+machineID+"/token", nil)
+	req.Header.Set(signInHeader, accountA)
+	rec := httptest.NewRecorder()
+	h.mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("session cookie only: status = %d, want 401", rec.Code)
+	}
+
+	// The credential that is meant for this route still works, so none of the
+	// above is passing for the wrong reason.
+	if rec := h.machineTokenRaw(machineID, valid); rec.Code != http.StatusOK {
+		t.Errorf("control-plane-audience token: status = %d, want 200", rec.Code)
+	}
+}
+
+// TestMachineToken_UnownedMachinesAreIndistinguishable is the point of the
+// whole handler: a signed-in account must not be able to learn which machine
+// ids exist or who owns them. Someone else's machine, a revoked one, and one
+// that never existed all answer identically.
+func TestMachineToken_UnownedMachinesAreIndistinguishable(t *testing.T) {
+	h := newHarness(t)
+
+	mine := h.bindMachine(accountA, testPublicURL, "prod vm")
+	theirs := h.bindMachine(accountB, "https://vm.other.example.com", "their vm")
+	revoked := h.bindMachine(accountA, "https://vm.retired.example.com", "retired vm")
+	h.revokeMachine(revoked)
+
+	credential := h.controlPlaneToken(accountA)
+	answers := map[string]*httptest.ResponseRecorder{
+		"another account's machine":            h.machineTokenRaw(theirs, credential),
+		"a revoked machine":                    h.machineTokenRaw(revoked, credential),
+		"an unknown machine id":                h.machineTokenRaw("00000000-0000-0000-0000-000000000000", credential),
+		"a machine id that is not even a uuid": h.machineTokenRaw("not-a-machine", credential),
+	}
+
+	want := answers["an unknown machine id"]
+	for name, rec := range answers {
+		if rec.Code != http.StatusNotFound {
+			t.Errorf("%s: status = %d, want 404", name, rec.Code)
+		}
+		if rec.Body.String() != want.Body.String() {
+			t.Errorf("%s: body = %s, want the same body as an unknown machine id: %s", name, rec.Body, want.Body)
+		}
+		if got := rec.Header().Get("Content-Type"); got != want.Header().Get("Content-Type") {
+			t.Errorf("%s: Content-Type = %q, want %q", name, got, want.Header().Get("Content-Type"))
+		}
+	}
+
+	// Not passing for the wrong reason: the account's own live machine works.
+	if rec := h.machineTokenRaw(mine, credential); rec.Code != http.StatusOK {
+		t.Errorf("the caller's own machine: status = %d, want 200", rec.Code)
+	}
+	// And the owner of the machine account A could not reach still can.
+	if rec := h.machineTokenRaw(theirs, h.controlPlaneToken(accountB)); rec.Code != http.StatusOK {
+		t.Errorf("account B's own machine: status = %d, want 200", rec.Code)
+	}
+	// A revoked machine is refused to its own owner too, not merely hidden
+	// from strangers.
+	if rec := h.machineTokenRaw(revoked, credential); rec.Code != http.StatusNotFound {
+		t.Errorf("the owner's revoked machine: status = %d, want 404", rec.Code)
+	}
+}
+
+// TestMachineToken_EmptyMachineIDDoesNotFallThrough guards the route pattern:
+// an empty path segment must not reach the handler with an empty id, where a
+// query for account_id alone could match a row.
+func TestMachineToken_EmptyMachineIDDoesNotFallThrough(t *testing.T) {
+	h := newHarness(t)
+	h.bindMachine(accountA, testPublicURL, "prod vm")
+
+	rec := h.machineTokenRaw("", h.controlPlaneToken(accountA))
+	if rec.Code == http.StatusOK {
+		t.Errorf("POST /api/v1/machines//token returned 200 and body %s, want a rejection", rec.Body)
+	}
+}

--- a/controlplane/internal/device/machines.go
+++ b/controlplane/internal/device/machines.go
@@ -1,6 +1,10 @@
 package device
 
 import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
 	"log"
 	"net/http"
 
@@ -34,4 +38,95 @@ func (s *Service) handleListMachines(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	api.WriteJSON(w, http.StatusOK, machinesResponse{Machines: machines})
+}
+
+// machineTokenResponse is the machine-token endpoint's success body. It is the
+// control plane token endpoint's shape minus the refresh token, which does not
+// belong here: nothing rotates on this call.
+//
+// The machine id is not echoed back. The caller put it in the path, and it is
+// the `aud` of the token in this body.
+type machineTokenResponse struct {
+	AccessToken string `json:"access_token"`
+	TokenType   string `json:"token_type"`
+	ExpiresIn   int    `json:"expires_in"`
+}
+
+// handleMachineToken mints an access token addressed to one of the calling
+// account's machines, so the desktop can call that machine's gateway.
+//
+// The credential for this route is the same control-plane-audience access
+// token every other /api/v1 route takes, not the refresh token: a machine
+// token is wanted whenever the desktop switches machines or a 15 minute token
+// lapses, and putting that on the refresh token would rotate a 90 day
+// credential on every one of those calls.
+//
+// The token comes out of the same Issuer.IssueAccessToken the device flow's
+// approval used to call, so `aud` is machines.id, never the hostname or the
+// public URL, and `sub` is the account id.
+func (s *Service) handleMachineToken(w http.ResponseWriter, r *http.Request) {
+	accountID, ok := s.apiAuth(r)
+	if !ok {
+		api.Unauthorized(w)
+		return
+	}
+
+	machineID := r.PathValue("id")
+	owned, err := s.ownsMachine(r.Context(), accountID, machineID)
+	if err != nil {
+		log.Printf("device: look up machine for token: %v", err)
+		api.WriteError(w, http.StatusInternalServerError, "server_error", "could not issue an access token")
+		return
+	}
+	if !owned {
+		// One answer for "no such machine", "someone else's machine", and
+		// "revoked". Anything that distinguished them would turn a signed-in
+		// account into an oracle for which machine ids exist and who owns
+		// them, over a namespace the caller can enumerate.
+		notFound(w)
+		return
+	}
+
+	accessToken, err := s.issuer.IssueAccessToken(accountID, machineID)
+	if err != nil {
+		log.Printf("device: issue machine access token: %v", err)
+		api.WriteError(w, http.StatusInternalServerError, "server_error", "could not issue an access token")
+		return
+	}
+
+	api.WriteJSON(w, http.StatusOK, machineTokenResponse{
+		AccessToken: accessToken,
+		TokenType:   "Bearer",
+		ExpiresIn:   int(s.issuer.AccessTokenTTL().Seconds()),
+	})
+}
+
+// notFound is the answer to a machine id this account may not have a token
+// for, whatever the reason.
+func notFound(w http.ResponseWriter) {
+	api.WriteError(w, http.StatusNotFound, "not_found", "no such machine")
+}
+
+// ownsMachine reports whether machineID is one of accountID's live machines.
+//
+// Both conditions are in one query on purpose. Reading the row and then
+// comparing account_id in Go would take a visibly different path for a machine
+// that does not exist than for one owned by someone else, and this endpoint's
+// whole rejection story is that those two are the same answer. One indexed
+// primary key lookup either matches every condition or matches nothing.
+func (s *Service) ownsMachine(ctx context.Context, accountID, machineID string) (bool, error) {
+	var found string
+	err := s.db.QueryRowContext(ctx,
+		`SELECT id FROM machines
+		  WHERE id = ? AND account_id = ? AND revoked_at IS NULL`,
+		machineID, accountID,
+	).Scan(&found)
+	switch {
+	case err == nil:
+		return true, nil
+	case errors.Is(err, sql.ErrNoRows):
+		return false, nil
+	default:
+		return false, fmt.Errorf("look up machine %q: %w", machineID, err)
+	}
 }

--- a/controlplane/internal/device/store.go
+++ b/controlplane/internal/device/store.go
@@ -266,7 +266,7 @@ func registerMachine(ctx context.Context, tx *sql.Tx, accountID, name, publicURL
 }
 
 // grant is what a successful poll returns: the triple `ao setup-vm` writes
-// into machine.json, plus the access token minted for it.
+// into machine.json.
 type grant struct {
 	MachineID string
 	AccountID string


### PR DESCRIPTION
Closes #47

## What

Adds `POST /api/v1/machines/{id}/token`, so a signed-in desktop install can obtain a machine-audience access token. `POST /api/v1/token` mints only control-plane-audience tokens, so task 13's remote transport had no credential to carry.

**Shape** (for the desktop worker on #48):

```
POST /api/v1/machines/{id}/token
Authorization: Bearer <control-plane-audience access token>
(no request body)

200 {"access_token":"<jwt>","token_type":"Bearer","expires_in":900}
401 {"error":"invalid_token","error_description":"a valid access token is required"}   + WWW-Authenticate
404 {"error":"not_found","error_description":"no such machine"}
500 {"error":"server_error","error_description":"could not issue an access token"}
```

The token has `aud` = `machines.id` and `sub` = the account id, minted by the existing `Issuer.IssueAccessToken` (untouched, the golden fixtures pin it), same TTL and the same `expires_in` reporting as the control plane path. The machine id is not echoed back: the caller put it in the path and it is the token's `aud`. Nothing rotates, so the call is repeatable.

## Decisions worth reviewing

- **Authenticated with the control-plane-audience bearer, not the refresh token.** A machine token is wanted whenever the desktop switches machines or a 15 minute token lapses. Putting that on the refresh token would rotate a 90 day credential on every one of those calls and reintroduce the lockout race #45 fixed. No `audience` parameter was added to `POST /api/v1/token` for the same reason.
- **Unowned, revoked, and nonexistent machines are indistinguishable.** One indexed query on `(id, account_id, revoked_at IS NULL)`; all three land on the same 404 with the same body. Reading the row and then comparing `account_id` in Go would take a visibly different path for "does not exist" than for "someone else's", which is exactly the machine-id enumeration oracle this has to avoid.
- **The device flow no longer returns a machine token.** `ao setup-vm` deliberately never decoded it (`backend/internal/cli/setupvm_bind.go`), and the VM verifies tokens rather than presenting them, so it was a live 15 minute credential created and transmitted on every bind for no consumer. The poll response is now the machine triple alone; the departure from the RFC 8628 section 3.5 shape is documented on the struct, in `TOKEN_CONTRACT.md`, and in the README.

## Tests

`controlplane/internal/device/machine_token_test.go`, modelled on `TestListMachines_RequiresAControlPlaneAudienceToken`:

- 401 for a refresh token, a machine-audience token, a token from a different control plane, a tampered signature, an expired token, an empty bearer, garbage, no credential, and a session-cookie-only request, then 200 for the correct credential so nothing passes for the wrong reason.
- Another account's machine, a revoked machine, an unknown id, and a non-uuid id all return an identical status, body, and Content-Type, with a 200 for the caller's own live machine and for the other account's own machine alongside, so the 404s are not passing because everything 404s.
- Happy path pins `aud` = machines.id (never the hostname or public URL), `sub` = the account, `token_type`, `expires_in`, and that the minted token is rejected by both `VerifyControlPlaneToken` and `GET /api/v1/machines`.
- The device flow happy path now asserts the poll body carries no `access_token`, `token_type`, `expires_in`, or `refresh_token`.

`cd controlplane && go vet ./... && go test -race ./...`: 112 passed in 9 packages, `gofmt -l .` clean.

## Follow-up, not done here

`backend/internal/cli/setupvm_bind.go`'s comment on `deviceTokenResponse` still says "the access token in the same body is deliberately not decoded". The behaviour stays correct (nothing to decode now), but the sentence is stale. `backend/` was out of scope for this task, so it is left for whoever owns that file next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)