### PR TITLE
docs: preserve the review reports and record the hosted AO v1 build

### DIFF
--- a/deploy/hosted/README.md
+++ b/deploy/hosted/README.md
@@ -1,5 +1,19 @@
 # Hosted AO proxy
 
+> **Scope note (2026-07-30).** This file documents the **pairing-secret Caddy proxy**, the
+> pre-accounts hosted path. It is still the only path that has ever run on a VM, and it keeps
+> working on purpose: spec task 15 removes `AO_REMOTE_URL`, `AO_REMOTE_TOKEN`, and the
+> `ao_hosted_pair` secret only after the fresh-VM run (task 14) passes, so remote mode is
+> never untestable mid-build.
+>
+> The replacement is `ao setup-vm` plus `ao vm serve`: per-account registered machines and
+> short-lived per-machine JWTs instead of one shared secret, and the `ao` binary itself
+> holding `:80` and `:443` instead of Caddy. It is merged but **unrun**; task 14 owns
+> standing it up on a clean Ubuntu LTS VM and writing the deployment guide for it. Do not
+> read the accounts path out of this file, and do not add results here that have not
+> happened. See [`docs/adr/0002-hosted-public-gateway.md`](../../docs/adr/0002-hosted-public-gateway.md)
+> and [`docs/hosted-ao-v1-build-log.md`](../../docs/hosted-ao-v1-build-log.md).
+
 This deployment exposes the AO daemon on a VM through Caddy at
 `https://api.ao.agentlab.in`. The daemon remains loopback-only on
 `127.0.0.1:3001`; Caddy is the only public listener and permits requests only
@@ -51,7 +65,11 @@ substitution, which is required for the cookie regular-expression matcher.
 Create an A record for `api.ao.agentlab.in` that points to `YOUR_VM_PUBLIC_IP`.
 Allow TCP ports 80 and 443 through both the Azure NSG and the VM host firewall.
 Do not expose port 3001. Do not add a public daemon bind, a second daemon
-listener, or a proxy route for a browser preview server.
+listener, or a proxy route for a browser preview server. The one permitted
+network-facing bind besides this proxy is `ao vm serve`, the VM gateway, which
+is a separate process from the daemon and is covered by ADR 0002; that carve-out
+is in `AGENTS.md` and does not widen anything here. Caddy and `ao vm serve` both
+want `:80` and `:443`, so they cannot run on the same VM at the same time.
 
 `app://renderer` is already the Go daemon's default allowed CORS origin. Do
 not set `AO_ALLOWED_ORIGINS` on the VM in a way that overwrites that default.

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,6 +18,8 @@ Start with [architecture.md](architecture.md) for the current backend model and
 | [STATUS.md](STATUS.md)                                 | What is shipped on `main` today and what is still in flight.                                                          |
 | [stack.md](stack.md)                                   | Accepted library/runtime choices, pending stack decisions, and dependencies explicitly avoided for V1.                |
 | [telemetry.md](telemetry.md)                           | Telemetry collection, privacy safeguards, configuration, and PostHog dashboard guidance.                              |
+| [hosted-ao-v1-build-log.md](hosted-ao-v1-build-log.md) | Hosted AO v1: batch structure, PR per spec task, and the decisions that are not derivable from the diff.              |
+| [reviews/](reviews/)                                   | Preserved code-review reports, each finding mapped to the PR that fixed it.                                            |
 
 ## Mental model
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -83,6 +83,53 @@ surface (`npm run sqlc`, `npm run api`).
   actions, persistent read history, mark-read controls, and Electron app toasts
   while the app is running.
 
+## Hosted AO v1: accounts and registered machines
+
+Tracked separately because it lives on `develop`, not `main`, and because it is not
+usable end to end yet. Spec:
+[`superpowers/specs/2026-07-29-hosted-ao-v1-accounts-and-machines.md`](superpowers/specs/2026-07-29-hosted-ao-v1-accounts-and-machines.md).
+Decisions, the PR-per-task table, and the review history:
+[`hosted-ao-v1-build-log.md`](hosted-ao-v1-build-log.md).
+
+**12 of the 15 spec tasks are merged into `develop`** (batches 1 through 4), plus
+`GET /api/v1/doctor` ([#36](https://github.com/agentlab-in/hosted-ao/pull/36)), which was
+added mid-build so the desktop could read remote machine readiness.
+
+Merged:
+
+- **Control plane** (`controlplane/`): Google login with PKCE, EdDSA signing keys and JWKS,
+  access and refresh token issuance with rotation, the RFC 8628 device flow, the machine
+  registry, and the authenticated `GET /api/v1/machines`.
+- **VM gateway** (`ao vm serve`): ACME TLS, JWT verification against the control plane's
+  JWKS, machine allowlist, reverse proxy to the loopback daemon, deny-by-default path
+  allowlist, CORS preflight handling.
+- **CLI**: `ao setup-vm` (Ubuntu preflight, dependency install, systemd units for daemon and
+  gateway, device binding, `machine.json`), `ao vm setup-harness claude`, `ao whoami`, and
+  `cloneUrl` on `POST /api/v1/projects`.
+- **Desktop**: AO account login through the system browser, the machine list, picker, and
+  switching.
+
+Still open, in spec order:
+
+- **Task 13, desktop authenticated remote transport**
+  ([#48](https://github.com/agentlab-in/hosted-ao/issues/48)): in flight. Bearer tokens on
+  REST and SSE, the JWT-valued `ao_gw_token` cookie for `/mux`, and silent refresh. Its
+  prerequisite, `POST /api/v1/machines/{id}/token`
+  ([#47](https://github.com/agentlab-in/hosted-ao/issues/47)), is in flight alongside it:
+  nothing currently mints a machine-audience token for a desktop install, so the remote
+  transport has no credential to carry. Until both land, picking a machine in the desktop
+  reports a not-ready state on purpose.
+- **Task 14, fresh-VM end-to-end verification and docs**: blocked on hardware. It needs an
+  Ubuntu LTS VM, a DNS A record pointing at it, and a hand-created Google OAuth client. No
+  part of the hosted stack has run on a real VM yet: the gateway has never obtained a
+  certificate, and the device flow has never run against real DNS.
+- **Task 15, retire the env-var pairing path**: gated on task 14 passing. `AO_REMOTE_URL`,
+  `AO_REMOTE_TOKEN`, and the `ao_hosted_pair` shared secret are removed only once accounts
+  are proven end to end, so remote mode is never untestable mid-build.
+
+Three code-review reports covering batches 1 through 4 are preserved in
+[`reviews/`](reviews/), with every finding mapped to the PR that fixed it.
+
 ## In flight / not yet a runtime feature
 
 - **Tracker lane**: GitHub tracker adapter exists, but there is no daemon

--- a/docs/hosted-ao-v1-build-log.md
+++ b/docs/hosted-ao-v1-build-log.md
@@ -1,0 +1,275 @@
+# Hosted AO v1 build log
+
+What was built, in what order, and the decisions that are **not derivable from the diff**.
+The git log already records what changed; this file records why, where the reasoning lives
+only in a review thread, an issue body, or a conversation.
+
+- **Intent** is `docs/superpowers/specs/2026-07-29-hosted-ao-v1-accounts-and-machines.md`.
+- **Findings** are the three preserved reports in [`reviews/`](reviews/).
+- **The token contract** is `controlplane/TOKEN_CONTRACT.md`.
+
+Everything merged so far landed on `develop` on 2026-07-30, between 08:46 and 14:23 IST,
+across 23 pull requests. Nothing in this file is a claim about a deployment: the fresh-VM
+run is task 14 and has not happened.
+
+## 1. Batch structure and which PR closed which task
+
+The spec breaks the work into five batches. Batches run in order; tasks inside a batch are
+independent and were built in parallel by separate AO workers.
+
+| Task | Batch | PR | Issue | State |
+| --- | --- | --- | --- | --- |
+| 1. Control plane skeleton and the token contract reference | 1 | [#5](https://github.com/agentlab-in/hosted-ao/pull/5) | [#1](https://github.com/agentlab-in/hosted-ao/issues/1) | merged |
+| 2. ADR 0002, hosted public gateway | 1 | [#4](https://github.com/agentlab-in/hosted-ao/pull/4) | [#2](https://github.com/agentlab-in/hosted-ao/issues/2) | merged |
+| 3. `cloneUrl` on `POST /api/v1/projects` | 1 | [#6](https://github.com/agentlab-in/hosted-ao/pull/6) | [#3](https://github.com/agentlab-in/hosted-ao/issues/3) | merged |
+| 4. Control plane: Google login | 2 | [#12](https://github.com/agentlab-in/hosted-ao/pull/12) | [#7](https://github.com/agentlab-in/hosted-ao/issues/7) | merged |
+| 5. Control plane: keys and tokens | 2 | [#13](https://github.com/agentlab-in/hosted-ao/pull/13) | [#8](https://github.com/agentlab-in/hosted-ao/issues/8) | merged |
+| 6. `ao vm serve` | 2 | [#14](https://github.com/agentlab-in/hosted-ao/pull/14) | [#9](https://github.com/agentlab-in/hosted-ao/issues/9) | merged |
+| 7. Control plane: device flow and registry | 3 | [#26](https://github.com/agentlab-in/hosted-ao/pull/26) | [#23](https://github.com/agentlab-in/hosted-ao/issues/23) | merged |
+| 8. `ao setup-vm`, part one | 3 | [#28](https://github.com/agentlab-in/hosted-ao/pull/28) | [#24](https://github.com/agentlab-in/hosted-ao/issues/24) | merged |
+| 9. Desktop: AO login | 3 | [#27](https://github.com/agentlab-in/hosted-ao/pull/27) | [#25](https://github.com/agentlab-in/hosted-ao/issues/25) | merged |
+| 10. `ao setup-vm`, part two | 4 | [#32](https://github.com/agentlab-in/hosted-ao/pull/32) | [#29](https://github.com/agentlab-in/hosted-ao/issues/29) | merged |
+| 11. `ao vm setup-harness claude` | 4 | [#33](https://github.com/agentlab-in/hosted-ao/pull/33) | [#30](https://github.com/agentlab-in/hosted-ao/issues/30) | merged |
+| 12. Desktop: machine list | 4 | [#35](https://github.com/agentlab-in/hosted-ao/pull/35) | [#31](https://github.com/agentlab-in/hosted-ao/issues/31) | merged |
+| 13. Desktop: authenticated remote transport | 5 | not opened | [#48](https://github.com/agentlab-in/hosted-ao/issues/48) | in flight |
+| 14. Fresh-VM end-to-end verification and docs | 5 | not opened | not filed | blocked on hardware |
+| 15. Retire the env-var pairing path | 5 | not opened | not filed | gated on task 14 |
+
+Two pieces of work were added mid-build and are not spec tasks:
+
+- **[#36](https://github.com/agentlab-in/hosted-ao/pull/36)** ([#34](https://github.com/agentlab-in/hosted-ao/issues/34)), `GET /api/v1/doctor`. Task 12 needed remote machine
+  readiness in the desktop, and `ao doctor` only existed as a CLI. Exposing the existing
+  checks over HTTP was cheaper than a second readiness surface, and it is what made the
+  desktop's harness state derivable at all. It is also what turned a hung local probe into a
+  hung HTTP request, which the second review round found as H3.
+- **[#47](https://github.com/agentlab-in/hosted-ao/issues/47)**, `POST /api/v1/machines/{id}/token`. Found while scoping task 13; see
+  section 2.2.
+
+The remaining ten PRs were fixes: [#11](https://github.com/agentlab-in/hosted-ao/pull/11)
+(CI, before any feature work, see section 2.4) and #18, #19, #20, #22, #42, #43, #44, #45,
+#46 against review findings. Section 3 covers what those rounds found.
+
+## 2. Decisions not derivable from the diff
+
+### 2.1 `publicUrl` is a full origin, and the gateway normalizes it
+
+`machine.json` carries `"publicUrl": "https://vm.example.com"`, a full origin with a scheme.
+`ao vm serve` reduces it to a bare hostname with `url.Parse` plus `u.Hostname()` in
+`normalizeDomain` (`backend/internal/vmgateway/config.go`) before handing it to
+`autocert.HostWhitelist`.
+
+The alternative was the writer emitting a bare hostname: rename the field to `domain` and
+have `ao setup-vm` write `vm.example.com`. That was rejected. Three consumers want an
+origin and only one wants a hostname:
+
+- the spec describes `setup-vm` as writing a "public URL",
+- the `machines.hostname` column is documented as the machine's public URL and is what the
+  poll response and `GET /api/v1/machines` return,
+- the desktop needs an origin to build an API base URL, and would otherwise have to
+  reconstruct one by guessing the scheme.
+
+Only `autocert.HostWhitelist` wants a hostname, so the reduction belongs at that one
+consumer. The reviewer laid out both options and recommended this one
+([batches 1 and 2](reviews/2026-07-30-review-batches-1-2.md), section 4); the decision was
+recorded in issue [#15](https://github.com/agentlab-in/hosted-ao/issues/15) before the fix
+was written.
+
+What made this urgent rather than cosmetic is the failure mode, finding H2:
+`HostWhitelist` runs `idna.Lookup.ToASCII` and, per its own documentation, **silently
+ignores** anything that fails to parse. A full URL therefore left the whitelist empty, so
+no certificate was ever issued and every TLS handshake failed while the gateway logged a
+clean start. The normalization now rejects loudly at boot rather than at certificate time,
+which is the second half of the decision: a value that cannot be reduced to a hostname is a
+startup error, not a warning.
+
+The residual asymmetry is recorded and **not fixed**: the control plane keeps a port in
+`publicUrl` (it stores `u.Host`) while the gateway drops it (`u.Hostname()`), so
+`https://vm.example.com:8443` registers cleanly and then certificates the wrong name. That
+is finding L-B in the server-side review, and no merged PR addresses it.
+
+### 2.2 The two-audience token split
+
+There are exactly two access token audiences. They differ only in `aud` and are not
+interchangeable in either direction:
+
+| `aud` | Means | Verified by |
+| --- | --- | --- |
+| `machines.id` | call that machine's gateway | `ao vm serve` on that VM |
+| `https://ao.agentlab.in` | call the control plane's API | the control plane itself |
+
+**Why it appeared mid-build.** The original contract had one audience, the machine. Task 7
+then added `GET /api/v1/machines`, the authenticated list the desktop consumes, and there
+was nothing to authenticate it with: a desktop install that has signed in but has not yet
+picked a machine holds no machine id, so it cannot hold a machine-audience token, so it
+cannot call the one endpoint that would tell it which machines exist. The refresh token was
+the only credential it had, and sending a 90 day credential on an ordinary resource call
+was not acceptable. The split resolves that: the refresh token buys a control-plane-audience
+token at `POST /api/v1/token`, and that token calls the control plane API.
+
+The control-plane audience is the control plane's own origin, the same string as `iss`,
+rather than a separate identifier. There is exactly one control plane and it already
+publishes that origin everywhere, so pinning `aud` to it also means a token minted by a
+staging control plane cannot be replayed against production even if the two shared a key.
+
+**Why `POST /api/v1/machines/{id}/token` is a separate endpoint rather than an `audience`
+parameter on the refresh grant.** Overloading `POST /api/v1/token` would rotate the refresh
+token on every machine-token request. Rotation is single-use by design: exchanging a refresh
+token revokes the presented one in the same transaction that issues its replacement. So a
+desktop that asks for a machine token per machine, or retries one, would be rotating its
+long-lived credential each time, and every rotation is another chance to hit the lockout
+race that #45 had to fix (a concurrent exchange returning 500, which a client retries with a
+token the winner already revoked, forcing a spurious sign-out). Keeping the refresh token on
+one path with one job removes the class of problem instead of hardening a wider version of
+it. The machine-token endpoint authenticates with a control-plane-audience bearer instead,
+through the middleware that already exists.
+
+This endpoint is task 13's prerequisite and is in flight as
+[#47](https://github.com/agentlab-in/hosted-ao/issues/47). Until it merges, the desktop
+mints no machine-audience token at all, which is why #44 had to make a picked machine report
+a distinct not-ready state rather than `ready`: the picker was claiming a connection the app
+had no credential to make.
+
+### 2.3 The fork detachment
+
+`agentlab-in/hosted-ao` began as a fork of `Untrivial-ai/agent-orchestrator` and was
+detached into a standalone repository. The shared history was **three commits**, ending at
+`a1fb47000 chore: scaffold backend/ and frontend/ skeletons for rewrite`, which is the merge
+base. Everything either side has done since is independent work on a rewrite scaffold.
+
+Detaching removed three concrete hazards, none of which are visible in any diff:
+
+- **Sync fork.** GitHub's fork UI offers to sync the default branch from upstream. On a
+  repository whose entire content diverged at a scaffold commit, accepting that is a
+  destructive no-op at best.
+- **Wrong PR base.** A fork's new-PR page defaults to the upstream repository. Every PR in
+  this build would have been proposed against `Untrivial-ai/agent-orchestrator` unless the
+  base was corrected by hand, every time.
+- **Actions behaviour on forks.** Fork repositories get different workflow defaults and
+  secret availability, and the inherited workflow set includes jobs that are explicitly
+  fork-aware. With required status checks on the default branch (section 2.4), a workflow
+  that behaves differently on a fork is a merge that hangs rather than a test that fails.
+
+The repository has no parent today, and `git merge-base origin/develop upstream/main`
+resolves to the scaffold commit, so both halves of this are checkable from a clone.
+
+### 2.4 The required-status-checks deadlock
+
+Fixed in [#11](https://github.com/agentlab-in/hosted-ao/pull/11), before any feature work.
+
+The ruleset on `develop` requires five contexts: `build-test`, `api-drift`, `lint`, `scan`,
+`controlplane-build-test`. Two of the workflows carried `pull_request: paths:` filters, so a
+PR touching neither `backend/` nor `controlplane/` never dispatched them.
+
+The distinction that makes this a deadlock rather than a nuisance: **a skipped job reports a
+status, a workflow that never runs does not.** A job skipped by a job-level `if:` is
+reported to the checks API as success and satisfies its required context. A workflow filtered
+out at the `on:` level never starts, so its context has no status at all and sits pending
+forever. The PR is not failing, so there is nothing to fix; it is not passing, so it cannot
+merge; and the branch is not stale, so re-running nothing changes nothing. A docs-only PR was
+permanently unmergeable.
+
+#11 removed the `paths:` filters from `go.yml` and `controlplane-go.yml` so both always
+dispatch, and renamed the control plane's `build-test` job to `controlplane-build-test`
+because it collided with the Go workflow's context of the same name, meaning the two
+workflows were reporting to a single required context and whichever finished last won.
+
+The rule this build follows since: **if a context is required, its workflow must dispatch on
+every pull request.** Filter inside the job, never at `on:`.
+
+### 2.5 `AO_REMOTE_URL` and `AO_REMOTE_TOKEN` are retired last, deliberately
+
+The pre-existing remote path is a single shared pairing secret: the desktop sends
+`AO_REMOTE_TOKEN` as the `ao_hosted_pair` cookie and Caddy compares it. Accounts and
+per-machine tokens replace it entirely. It would have been tidier to delete it when the
+gateway landed in task 6.
+
+It is instead task 15, gated on task 14 passing, and every task in between was required to
+keep it working (task 13's brief says so explicitly). The reason is sequencing, not
+sentiment: the accounts path cannot be exercised end to end until a real VM runs the full
+device flow with real DNS and a real certificate, which is task 14, which needs hardware.
+Removing the env-var path before that point would leave a window in which the old remote
+mode is gone and the new one is unproven, so remote mode would be untestable by any means at
+exactly the moment the build most needs to test it. Keeping both means the fresh-VM run has
+a working control to compare against.
+
+What is left after task 15: `AO_CONTROL_URL`, which selects which control plane to trust and
+can never skip authentication, stays as the development hatch.
+
+### 2.6 Two smaller decisions worth recording
+
+**`machine.json` stays at `~/.ao/machine.json`, not under `AO_DATA_DIR`.** Reported twice
+(L6, then L-H) as an inconsistency with `CertDir`, which does honour `AO_DATA_DIR`. #43
+closed it as a documented decision rather than a relocation: `ao setup-vm` writes
+`<home>/.ao/machine.json` regardless of `AO_DATA_DIR`, so deriving the gateway's read path
+from the data dir would have moved the file the gateway reads without moving the file
+setup-vm writes, leaving an operator who set `AO_DATA_DIR` with a gateway looking where
+nothing ever writes. `machine.json` is binding identity and has the same shape as
+`running.json`: pinned to `~/.ao`, moved only by its own override (`AO_MACHINE_FILE`, which
+is what the systemd unit sets). The real defect was that the path was spelled out in three
+places; `DefaultMachineFilePath` is now exported, carries the reasoning, and is pinned by a
+test.
+
+**`/api/v1/doctor` was deliberately not added to `lanControlBlockedPrefixes`.** That list is
+the loopback-only *control* surface: things that change state or that only the daemon's
+operator may reach. Doctor is a read-only readiness report, the LAN listener already requires
+the Connect Mobile password, and a mobile readiness view is a plausible consumer. Recorded in
+#43 so it reads as a decision and not an oversight, along with what a LAN client holding that
+password can still read: tool versions, the daemon's loopback port, the database path and
+size, and a hooks log line.
+
+## 3. The review rounds
+
+Two rounds, three reports, all preserved in [`reviews/`](reviews/) because `/tmp` is
+ephemeral and they are the only record of which findings were **confirmed** versus
+**suspected**, and of what was read and found correct and therefore does not need
+re-reviewing.
+
+| Report | Scope | Reviewed at | Findings |
+| --- | --- | --- | --- |
+| [batches 1 and 2](reviews/2026-07-30-review-batches-1-2.md) | everything merged through #14 | `193f6cc52` | 17: 0C 4H 5M 8L |
+| [batches 3 and 4, server](reviews/2026-07-30-review-batches-3-4-server.md) | control plane, gateway, tokens, daemon HTTP | `a7eb9c6b2` | 15: 0C 2H 5M 8L |
+| [batches 3 and 4, client](reviews/2026-07-30-review-batches-3-4-client.md) | CLI, `ao setup-vm`, desktop | `a7eb9c6b2` | 22: 1C 4H 9M 8L |
+
+Both rounds were read-only: the reviewers filed no PRs and no issues, and the orchestrator
+decided what got fixed. The findings were then grouped into fix issues by owning package, so
+each fix PR touched one area and the parallel workers could not collide: #15 the gateway,
+#16 the control plane, #17 the clone path, #21 the cross-module test, #37 the device flow,
+#38 setup-vm, #39 doctor and gateway, #40 the desktop, #41 the origin-URL writers.
+
+All 54 findings are mapped to the PR that fixed them in each report's header, with one
+exception, L-B, which no merged PR addresses.
+
+### 3.1 The two findings whose tests were asserting the bug
+
+Both rounds turned up a test that was green **because of** the defect, which is the reason a
+passing suite was not treated as evidence.
+
+- **C1**, the critical one. `setupvm_plan.go` emitted `WorkingDirectory=%q`, producing
+  `WorkingDirectory="/home/ubuntu/.ao/data"`. Unit-file quoting is only honoured by settings
+  parsed as a list of words; `Environment=` is one, `WorkingDirectory=` is not, so systemd
+  sees a value starting with a double quote, fails `PATH_CHECK_ABSOLUTE|PATH_CHECK_FATAL`,
+  and **refuses to load the unit** after apt has run, the binary is installed, and both units
+  are written. The assertion at `setupvm_plan_test.go:593` was
+  `strings.HasPrefix(value, "\"/")`. That assertion existed to prove the path was absolute,
+  and it was passing precisely because of the leading quote that made it not absolute. Two
+  more golden assertions at `:525` and `:554` baked in the quoted form. The suite was green,
+  the units were unloadable, and the test that was supposed to catch it had been written
+  against the broken output.
+- **L4** in the first round. `TestGateway_Mux_UsesCookieNotHeader` deliberately asserted that
+  `/mux` accepts the cookie and never the `Authorization` header. That is the narrowing the
+  finding objects to: it locks out the CLI, a test harness, and any non-browser client. The
+  test was not wrong about the code; it was pinning behaviour nobody had decided to want.
+
+### 3.2 Known gaps
+
+- **L-B is open.** The control plane keeps a port in `publicUrl`, the gateway drops it, and
+  nothing checks the two agree. No issue was filed.
+- **Five pre-existing `internal/cli` failures** (`spawn_test.go`, "daemon returned HTTP 404")
+  are unrelated to this build and were confirmed unrelated by both review rounds: `ao spawn`
+  calls `GET /api/v1/agents` against a stub that only serves `/api/v1/projects`. They
+  reproduce on `develop` with an isolated `AO_DATA_DIR` and `AO_RUN_FILE`, and none of the
+  hosted AO commits touch `spawn.go` or the agents route.
+- **No end-to-end evidence exists yet.** Everything above was verified by reading code and
+  running test suites. The gateway has never obtained a real certificate, the device flow has
+  never run against real DNS, and `ao setup-vm` has never been run on a VM. That is task 14,
+  and section 3 of the client-side review is the ranked pre-flight checklist for it.

--- a/docs/reviews/2026-07-30-review-batches-1-2.md
+++ b/docs/reviews/2026-07-30-review-batches-1-2.md
@@ -1,0 +1,761 @@
+> **Preserved from `/tmp/ao/review-batch-1-2_report.md`.** `/tmp` is ephemeral, so this is
+> the only copy. Everything below the horizontal rule is the report exactly as the reviewer
+> wrote it: no summarizing, no rewording, no reordering. The value is the file, the line, the
+> failure scenario, and the smallest fix, and a summary would destroy all four.
+>
+> | | |
+> | --- | --- |
+> | Reviewed state | `develop` @ `193f6cc52` |
+> | Date | 2026-07-30 |
+> | Reviewer session | `hosted-ao-12` (AO worker, read-only) |
+> | Findings | 17: 0 critical, 4 high, 5 medium, 8 low |
+>
+> **Where each finding was fixed.** Every finding was fixed. This mapping was added on
+> import and is not part of the original report.
+>
+> | Finding | Fixed in | Issue |
+> | --- | --- | --- |
+> | H1 duplicate `Access-Control-Allow-Origin` | [#19](https://github.com/agentlab-in/hosted-ao/pull/19) | [#15](https://github.com/agentlab-in/hosted-ao/issues/15) |
+> | H2 `publicUrl` fed to `autocert.HostWhitelist` as a hostname | [#19](https://github.com/agentlab-in/hosted-ao/pull/19) | [#15](https://github.com/agentlab-in/hosted-ao/issues/15) |
+> | H3 SSE cannot authenticate through the gateway | [#19](https://github.com/agentlab-in/hosted-ao/pull/19) | [#15](https://github.com/agentlab-in/hosted-ao/issues/15) |
+> | H4 `stale-if-error` never throttles and holds the mutex | [#19](https://github.com/agentlab-in/hosted-ao/pull/19) | [#15](https://github.com/agentlab-in/hosted-ao/issues/15) |
+> | M1 schema comment claims `machines.hostname` is the audience | [#18](https://github.com/agentlab-in/hosted-ao/pull/18) | [#16](https://github.com/agentlab-in/hosted-ao/issues/16) |
+> | M2 credential in `cloneUrl` persisted, served, and logged | [#20](https://github.com/agentlab-in/hosted-ao/pull/20) | [#17](https://github.com/agentlab-in/hosted-ao/issues/17) |
+> | M3 control-plane `DATA_DIR` defaults to `./data` | [#18](https://github.com/agentlab-in/hosted-ao/pull/18) | [#16](https://github.com/agentlab-in/hosted-ao/issues/16) |
+> | M4 `PUBLIC_ORIGIN` is not normalized | [#18](https://github.com/agentlab-in/hosted-ao/pull/18) | [#16](https://github.com/agentlab-in/hosted-ao/issues/16) |
+> | M5 nothing tests the issuer against the verifier | [#22](https://github.com/agentlab-in/hosted-ao/pull/22) | [#21](https://github.com/agentlab-in/hosted-ao/issues/21) |
+> | L1 `keys.Rotate` partial write | [#18](https://github.com/agentlab-in/hosted-ao/pull/18) | [#16](https://github.com/agentlab-in/hosted-ao/issues/16) |
+> | L2 client-controlled `X-Real-IP` / `X-Forwarded-*` forwarded | [#19](https://github.com/agentlab-in/hosted-ao/pull/19) | [#15](https://github.com/agentlab-in/hosted-ao/issues/15) |
+> | L3 preflight answered before the path allowlist | [#19](https://github.com/agentlab-in/hosted-ao/pull/19) | [#15](https://github.com/agentlab-in/hosted-ao/issues/15) |
+> | L4 `/mux` accepts only the cookie | [#19](https://github.com/agentlab-in/hosted-ao/pull/19) | [#15](https://github.com/agentlab-in/hosted-ao/issues/15) |
+> | L5 `ACCESS_TOKEN_TTL` is unbounded | [#18](https://github.com/agentlab-in/hosted-ao/pull/18) | [#16](https://github.com/agentlab-in/hosted-ao/issues/16) |
+> | L6 `machine.json` does not honour `AO_DATA_DIR` | **not closed by #19.** Re-reported as **L-H** by the server-side review, then closed in [#43](https://github.com/agentlab-in/hosted-ao/pull/43) | [#39](https://github.com/agentlab-in/hosted-ao/issues/39) |
+> | L7 data dir and database modes | [#18](https://github.com/agentlab-in/hosted-ao/pull/18) | [#16](https://github.com/agentlab-in/hosted-ao/issues/16) |
+> | L8 rejection paths with no test | clone-flow half in [#20](https://github.com/agentlab-in/hosted-ao/pull/20), the three gateway gaps in [#19](https://github.com/agentlab-in/hosted-ao/pull/19) | [#17](https://github.com/agentlab-in/hosted-ao/issues/17), [#15](https://github.com/agentlab-in/hosted-ao/issues/15) |
+>
+> L6 is the one worth stating plainly: it was the single finding this review raised that the
+> first round of fixes did not close. #43 closed it as a **documented decision rather than a
+> relocation**: `machine.json` stays at `~/.ao/machine.json` because deriving it from
+> `AO_DATA_DIR` would move the file the gateway reads without moving the file `ao setup-vm`
+> writes. `DefaultMachineFilePath` was exported, given the reasoning in its doc comment, and
+> pinned by a test. See the build log, [hosted-ao-v1-build-log.md](../hosted-ao-v1-build-log.md).
+
+---
+
+# Review: all merged Hosted AO v1 work (batches 1 and 2)
+
+Reviewer: AO worker `hosted-ao-12`. Read-only. Nothing was changed.
+Reviewed state: `develop` @ `193f6cc52`, commits `47454f320`, `dd7a248bf`, `dca252cd7`,
+`3579380d8`, `8ef0cf91b`, `820a7a565`, `193f6cc52` (56 files).
+
+## 1. Verdict
+
+Yes, safe to build batch 3 (device flow, machine registry) on top of, provided M1 and M4
+are fixed first, because batch 3 is exactly where they bite. Zero critical findings: the
+token verifier itself is sound, signature-before-claims, alg-pinned, fail-closed.
+Four high findings all land in batch 5 integration (gateway plus desktop), not in batch 3;
+two of them (H1, H3) mean the gateway as merged cannot serve the Electron renderer at all.
+
+## 2. Findings, ranked by severity
+
+### Critical
+
+None. Stated plainly rather than manufactured: I tried to break `VerifyToken` and could
+not. See section 5 for what that means concretely.
+
+### High
+
+---
+
+**H1. Duplicate `Access-Control-Allow-Origin` header breaks every browser request through
+the gateway. CONFIRMED (empirically reproduced).**
+
+`backend/internal/vmgateway/proxy.go:227-229` sets `Access-Control-Allow-Origin` and
+`Access-Control-Allow-Credentials` on the response writer, then calls `next` (which is
+eventually the reverse proxy). The daemon behind it sets the *same two headers* itself in
+`backend/internal/httpd/cors.go:53-55`, because the forwarded request still carries
+`Origin: app://renderer` and `app://renderer` is in `config.DefaultAllowedOrigins`
+(`backend/internal/config/config.go:70-72`). `httputil.ReverseProxy` merges the upstream
+response headers with `dst.Add`, not `dst.Set`, so both values survive.
+
+Failure scenario: the renderer issues `GET /api/v1/projects` with a valid Bearer token and
+`Origin: app://renderer`. Response contains
+`Access-Control-Allow-Origin: app://renderer, app://renderer`. Chromium rejects it
+("the 'Access-Control-Allow-Origin' header contains multiple values ... but only one is
+allowed") and the fetch fails. This is every REST call from the desktop app, not an edge
+case. I reproduced the header duplication with a standalone stdlib program modelling
+`corsGate` plus `NewSingleHostReverseProxy` plus a CORS-setting upstream:
+
+```
+Access-Control-Allow-Origin values      = ["app://renderer" "app://renderer"]
+Access-Control-Allow-Credentials values = ["true" "true"]
+```
+
+Why the tests miss it: the fake daemon in `proxy_test.go:36-42` sets only `X-From: daemon`,
+never CORS headers, so `TestGateway_ValidToken_ProxiesToDaemon` cannot see this.
+
+Smallest fix: in `newReverseProxy` (`proxy.go:63-78`), add a `ModifyResponse` that deletes
+the upstream's CORS headers so only the gateway's own survive:
+
+```go
+proxy.ModifyResponse = func(res *http.Response) error {
+    for _, h := range []string{
+        "Access-Control-Allow-Origin", "Access-Control-Allow-Credentials",
+        "Access-Control-Allow-Methods", "Access-Control-Allow-Headers",
+        "Access-Control-Max-Age", "Access-Control-Allow-Private-Network",
+    } {
+        res.Header.Del(h)
+    }
+    return nil
+}
+```
+
+Also make the test's fake daemon emit CORS headers, or the fix is untested.
+
+---
+
+**H2. `machine.json`'s `publicUrl` is fed to `autocert.HostWhitelist` as if it were a bare
+hostname, so the gateway will never obtain a certificate. CONFIRMED.**
+
+`backend/internal/vmgateway/config.go:120` does
+`cfg.Domain = firstNonEmpty(cfg.Domain, mf.PublicURL)`, and `Domain` goes straight to
+`autocert.HostWhitelist(cfg.Domain)` at `backend/internal/vmgateway/server.go:46`. The
+field is named and documented as a URL: `PublicURL string \`json:"publicUrl"\`` at
+`machinefile.go:19`; the spec says `setup-vm` writes "public URL"
+(`docs/superpowers/specs/2026-07-29-hosted-ao-v1-accounts-and-machines.md:139-140`) and the
+schema calls `machines.hostname` "the machine's public URL"
+(`controlplane/internal/storage/sqlite/migrations/0001_init.sql:15`).
+
+Failure scenario: `setup-vm` writes `{"publicUrl": "https://vm.example.com", ...}`.
+`HostWhitelist` runs `idna.Lookup.ToASCII("https://vm.example.com")`, which errors on the
+`:` and `/`, and per its own doc comment "invalid hosts will be silently ignored"
+(`golang.org/x/crypto@v0.51.0/acme/autocert/autocert.go:68-88`). The whitelist is therefore
+**empty**, so `HostPolicy` rejects every SNI name, no certificate is ever issued, and every
+TLS handshake on :443 fails. The gateway starts and logs success; nothing detects this until
+a real client connects. `--domain vm.example.com` on the command line works fine, which is
+why the tests pass: `config_test.go` only ever supplies bare hostnames.
+
+Smallest fix: normalize in `Resolve` and validate. After line 120:
+
+```go
+if cfg.Domain != "" && strings.Contains(cfg.Domain, "://") {
+    u, err := url.Parse(cfg.Domain)
+    if err != nil || u.Hostname() == "" {
+        return Config{}, fmt.Errorf("invalid public url %q in %s", cfg.Domain, machineFilePath)
+    }
+    cfg.Domain = u.Hostname()
+}
+if strings.ContainsAny(cfg.Domain, ":/") {
+    return Config{}, fmt.Errorf("domain %q must be a bare hostname", cfg.Domain)
+}
+```
+
+See section 4 for the contract wording the `setup-vm` worker needs.
+
+---
+
+**H3. SSE cannot authenticate through the gateway: the renderer uses `EventSource`, which
+cannot set an `Authorization` header, and the gateway accepts the cookie only on `/mux`.
+CONFIRMED.**
+
+`backend/internal/vmgateway/proxy.go:169-187`: `extractToken` returns the
+`ao_gw_token` cookie only when `r.URL.Path == muxPath`; every other path requires
+`Authorization: Bearer`. `/api/v1/events` is proxyable (`isProxyablePath` allows all of
+`/api/v1` except `mobile` and `dev`) and is the daemon's SSE route
+(`backend/internal/httpd/events.go:36`). The renderer connects to it with the browser
+`EventSource` API at `frontend/src/renderer/lib/event-transport.ts:85-86`:
+
+```ts
+source = new EventSource(`${baseUrl.replace(/\/+$/, "")}/api/v1/events`, {
+    withCredentials: isRemoteDaemonBaseUrl(baseUrl),
+});
+```
+
+`EventSource` has no header API at all. Note that the existing code already assumes
+*cookie* credentials for a remote daemon (`withCredentials`), and `api-client.ts:192`
+similarly sets `credentials: "include"` for remote REST. So the desktop side is built
+around a cookie and the gateway is built around a header, with `/mux` the only overlap.
+
+Failure scenario: desktop app points at `https://vm.example.com`. Every SSE connection is
+rejected 401 by `requireToken`, `EventSource` retries forever, and the app has no live
+session events. There is no workaround on the client: the API simply cannot send the header.
+
+`controlplane/TOKEN_CONTRACT.md:14-15` ("`Authorization: Bearer <jwt>` for REST and SSE")
+is the root of the disagreement; it is not achievable with the transport that exists.
+
+Smallest fix: accept the cookie as a fallback on safe, non-state-changing GET routes, and
+amend the contract. In `extractToken`:
+
+```go
+if r.URL.Path == muxPath || (r.Method == http.MethodGet && r.URL.Path == "/api/v1/events") {
+    if c, err := r.Cookie(gatewayCookieName); err == nil && c.Value != "" {
+        return c.Value, true
+    }
+}
+```
+
+Keep header-only for everything else on purpose: the cookie is ambient, so widening it to
+POST/PATCH/DELETE would make `corsGate` the sole CSRF defence. Then update
+`TOKEN_CONTRACT.md`'s transport line to say the cookie also carries SSE.
+
+---
+
+**H4. `stale-if-error` never throttles retries and holds the mutex across the network
+fetch, so a control-plane outage serializes every gateway request behind a 10s timeout.
+CONFIRMED.**
+
+`backend/internal/vmgateway/jwks.go:112-130`. `Get` takes `c.mu` with a `defer` unlock and
+then calls `c.fetch(ctx)` **while still holding it**. On the failure path
+(`jwks.go:121-125`) it returns the stale keyset but leaves `c.fetchedAt` untouched, so the
+staleness check at line 116 fails again on the very next request and a fresh fetch is
+attempted every single time.
+
+Failure scenario: the control plane is down (deploy, restart, network blip). The JWKS
+client timeout is 10s (`jwks.go:104`). Request 1 enters `Get`, blocks 10s holding `c.mu`,
+returns stale keys. Requests 2..N queue on the mutex. With 20 concurrent requests, the last
+one waits about 200 seconds. The desktop app's own timeouts fire and the user is
+disconnected, which is precisely the outcome the stale-if-error clause of
+`TOKEN_CONTRACT.md:21-22` exists to prevent. The same serialization also applies once per
+hour on the normal expiry path, but there it costs one request, not all of them.
+
+`TestJWKSCache_StaleIfError` (`jwks_test.go:110-141`) passes because it makes one request
+and asserts the keys come back, never that the failing fetch is not repeated.
+
+Smallest fix: record the failed attempt so it backs off, and do not hold the lock across
+the network call. Minimal version, keeping the current structure:
+
+```go
+const failureBackoff = 30 * time.Second
+
+fresh, err := c.fetch(ctx)
+if err != nil {
+    if c.keys != nil {
+        c.fetchedAt = c.now().Add(failureBackoff - c.ttl) // retry in failureBackoff, not immediately
+        return c.keys, nil
+    }
+    return nil, err
+}
+```
+
+Better, if the fix worker has room: use a `singleflight`-style guard so only one goroutine
+fetches and the rest immediately get the stale keyset.
+
+### Medium
+
+---
+
+**M1. The schema comment says `machines.hostname` (the public URL) is the JWT audience,
+contradicting `TOKEN_CONTRACT.md` and both implementations. CONFIRMED.**
+
+`controlplane/internal/storage/sqlite/migrations/0001_init.sql:14-17`:
+
+> "machines holds one row per VM bound to an account via ao setup-vm. hostname is the
+> machine's public URL, **used as both the JWT audience** and the reverse-proxy target."
+
+But `TOKEN_CONTRACT.md:11` says `aud` = machine id; the issuer sets
+`Aud: machineID` (`controlplane/internal/tokens/access.go:63`); the verifier compares `aud`
+against `cfg.MachineID`, which comes from `machine.json`'s `machineId`
+(`backend/internal/vmgateway/token.go:147`, `config.go:121`).
+
+Failure scenario: the batch-3 or batch-4 worker who writes the token-issuance endpoint reads
+the schema comment (the natural place to look when selecting from `machines`) and calls
+`IssueAccessToken(accountID, m.Hostname)`. The gateway then returns `ErrAudienceMismatch`
+for every request, 401 on everything, and the cause is invisible from either side. This is a
+comment, so it is individually trivial and exactly the kind of thing that compounds.
+
+Smallest fix: change the comment to "hostname is the machine's public URL, used as the
+reverse-proxy target. The JWT audience is `machines.id`, not this column."
+
+---
+
+**M2. A credential embedded in `cloneUrl` is persisted to the projects DB, returned by the
+projects API, and written to a daemon log. CONFIRMED.**
+
+`backend/internal/service/project/clone.go:53` passes `cloneURL` verbatim to `git clone`,
+so git stores it verbatim as `origin`. After the clone, `service.go:254` and
+`service.go:282` set `row.RepoOriginURL = resolveGitOriginURL(path)`, which shells out to
+`git remote get-url origin` (`service.go:682-688`). That value is returned as
+`Project.Repo` with `json:"repo"` (`backend/internal/service/project/types.go:22`) from
+`GET /api/v1/projects/{id}`, and is logged at
+`backend/internal/observe/trackerintake/observer.go:175`
+(`o.logger.Warn(..., "origin", project.RepoOriginURL)`).
+
+Failure scenario: the client POSTs
+`{"cloneUrl": "https://x-access-token:ghp_REDACTED@github.com/owner/repo.git"}`, which is
+the natural non-interactive form and is effectively invited by `GIT_TERMINAL_PROMPT=0`
+(`clone.go:55`). The PAT is now in `projects.repo_origin_url` on disk, in every projects API
+response, and in journald on the hosted VM indefinitely. The sink predates `#6`; `#6` is the
+first path that lets a client put a credentialed URL into it over HTTP.
+
+Smallest fix: strip userinfo before persisting. In `cloneRepository`, or right before the
+two `RepoOriginURL` assignments:
+
+```go
+if u, err := url.Parse(origin); err == nil && u.User != nil {
+    u.User = nil
+    origin = u.String()
+}
+```
+
+Note the error path is clean: `classifyCloneError` (`clone.go:74-96`) never returns raw git
+output, and `service_test.go:1005-1007` asserts that. Priority 6's requirement is met.
+
+---
+
+**M3. The control plane's default `DATA_DIR` is `./data`, relative to the process working
+directory, and the EdDSA signing keys live inside it. CONFIRMED.**
+
+`controlplane/internal/config/config.go:23` (`DefaultDataDir = "./data"`),
+`controlplane/internal/keys/keys.go:49` (`filepath.Join(dataDir, "keys")`).
+
+Failure scenario: a systemd unit without `WorkingDirectory=` runs with cwd `/`. Best case
+`keys.Load` fails on `MkdirAll("/data/keys")` and the service refuses to boot, which is
+loud and fine. Worse case, on a box where that path is writable, or after someone changes
+`WorkingDirectory`, `loadOrGenerate` finds no `active.json`, silently **generates a new key
+pair**, and starts signing with a `kid` no verifier has. Every VM's JWKS cache holds the old
+keys for up to an hour (`jwks.go:106`), so every token is rejected until the cache expires,
+and the `refresh_tokens` rows are in a SQLite file at the old path, so every desktop install
+must sign in again. Recovery requires noticing that a directory moved.
+
+Smallest fix: make `DATA_DIR` required (same treatment as the Google credentials at
+`config.go:99-107`), or default to an absolute path, and set `DATA_DIR=` plus
+`WorkingDirectory=` explicitly in the deployment unit. Either way, log the resolved absolute
+data dir and the active `kid` at boot so a silent regeneration is visible.
+
+---
+
+**M4. `PUBLIC_ORIGIN` is not normalized, so a trailing slash yields an `iss` the gateway
+will reject. CONFIRMED (latent: no wiring exists yet).**
+
+`controlplane/internal/config/config.go:87-89` stores `PUBLIC_ORIGIN` raw.
+`controlplane/internal/auth/auth.go:60` defensively trims it
+(`strings.TrimRight(cfg.PublicOrigin, "/")`) for the redirect URI, which shows the author
+expected a trailing slash in the wild. The issuer takes `issuerURL` verbatim into the `iss`
+claim (`tokens/access.go:41,61`). The gateway pins `iss` to
+`"https://ao.agentlab.in"` (`backend/internal/vmgateway/config.go:23`) and compares with
+`!=` (`token.go:144`).
+
+Failure scenario: `PUBLIC_ORIGIN=https://ao.agentlab.in/`. OAuth login works (the trim at
+`auth.go:60` saves it), and every access token then carries
+`iss: "https://ao.agentlab.in/"`. Every request to every VM fails with
+`ErrIssuerMismatch`, and the gateway logs only "token rejected", with no way to see the
+extra byte. Nothing currently calls `NewIssuer` (confirmed: zero non-test callers), so this
+is latent, and it is cheapest to close before the issuance endpoint is written.
+
+Smallest fix: normalize once in `config.Load`, at line 88:
+`cfg.PublicOrigin = strings.TrimRight(raw, "/")`, and drop the now-redundant trim in
+`auth.go:60`.
+
+---
+
+**M5. Nothing tests the issuer against the verifier, and nothing can, because they are
+separate Go modules. CONFIRMED (structural).**
+
+`controlplane/` and `backend/` are separate modules with separate CI workflows
+(`.github/workflows/controlplane-go.yml`, `.github/workflows/go.yml`). Each side tests
+itself against its own hand-written fixtures: `tokens_test.go:75-122` asserts the claims
+against literals it wrote, `token_test.go` verifies tokens signed by
+`signToken` (a test helper in the same package), `jwks_test.go:29-39` parses a JWKS the test
+itself constructs. No test ever feeds a control-plane-produced artifact to the gateway.
+
+Failure scenario: any future change to either side's encoding (padding, claim name, `kid`
+derivation, `x` encoding) passes both CI workflows green and fails only on a real VM in
+batch 5. This is the exact risk this review was commissioned to cover, and it is the one
+finding whose fix has lasting value.
+
+Smallest fix: commit a golden pair into `backend/internal/vmgateway/testdata/`: a
+`jwks.json` produced by `keys.Manager.JWKS()` and an `access_token.jwt` produced by
+`Issuer.IssueAccessToken` with a far-future `exp`. Add one `vmgateway` test that runs
+`parseKeySet(jwks.json)` then `VerifyToken(token, ks, opts)` and requires success. Add the
+mirror test in `controlplane/internal/keys` asserting the serialized JWKS field set still
+matches the fixture, so regenerating the fixture is a deliberate act.
+
+### Low
+
+**L1. `keys.Rotate` partial write leaves `active` and `next` identical after a restart.
+CONFIRMED.** `controlplane/internal/keys/keys.go:135-154` writes `active.json` (the promoted
+key) first and `next.json` second, updating memory only after both succeed. If the second
+write fails (disk full, EPERM), on-disk `active.json` holds the promoted key while
+in-memory `m.active` still holds the old one. After a restart, `Load` reads
+`active.json` == the promoted key and `next.json` == the *same* promoted key, so `JWKS()`
+publishes a duplicate `kid` and the rotation slot is gone. Nothing calls `Rotate` yet
+(confirmed: zero non-test callers). Fix: write both to temp files and rename, or write
+`next.json` first, and update memory only after both succeed.
+
+**L2. The gateway forwards client-controlled `X-Real-IP`, `X-Forwarded-*`, and the inbound
+`Host` into a daemon that trusts all three. CONFIRMED, not currently exploitable.**
+`proxy.go:80-93` strips only `Authorization` and `ao_gw_token`. `httputil.ReverseProxy`
+appends to any existing `X-Forwarded-For` and passes `X-Real-IP` through untouched, and it
+preserves the inbound `Host`. The daemon runs `middleware.RealIP`
+(`backend/internal/httpd/router.go:52`) and gates its control routes with
+`localControlRequest`, which trusts `r.Host` (`router.go:289-300`), a mechanism
+`lan_listener.go:44-51` explicitly documents as spoofable. Today every route it gates
+(`/shutdown`, `/internal/telemetry/*`) is outside the gateway's `/api/v1` plus `/mux`
+allowlist, and chi does not use `middleware.CleanPath` (verified), so
+`/api/v1/../shutdown` 404s at the daemon rather than normalizing onto `/shutdown`. So the
+allowlist is currently the only thing standing between a spoofed `Host: 127.0.0.1` and a
+loopback-only route. Fix: in the director, `r.Header.Del("X-Real-IP")` and
+`r.Header.Del("X-Forwarded-For")` before `ReverseProxy` re-adds the true peer address. Do
+**not** rewrite `r.Host` to the daemon address; leaving it as the public domain is what makes
+`localControlRequest` correctly refuse.
+
+**L3. CORS preflight is answered before the path allowlist, confirming that blocked routes
+exist. CONFIRMED.** `corsGate` is outermost (`proxy.go:51-55`) and its preflight branch
+returns 204 at `proxy.go:231-239` without consulting `isProxyablePath`. So
+`OPTIONS /api/v1/mobile/status` with `Origin: app://renderer` and
+`Access-Control-Request-Method: GET` returns 204, while the same path on any real method
+returns 404. Information disclosure only; no request body is proxied. Fix: check
+`isProxyablePath(r.URL.Path)` inside the preflight branch and `notFoundJSON` if false.
+
+**L4. `/mux` accepts only the cookie, never a Bearer header. CONFIRMED.**
+`proxy.go:170-176` returns early for `muxPath` and never looks at `Authorization`;
+`TestGateway_Mux_UsesCookieNotHeader` asserts this deliberately. `TOKEN_CONTRACT.md:14-17`
+says only that browsers *cannot* use a header, not that others *may not*. Consequence: the
+CLI, a test harness, or any non-browser client cannot open the terminal mux through the
+gateway. Fix: on `/mux`, try the cookie first and fall back to the header.
+
+**L5. `ACCESS_TOKEN_TTL` is unbounded. CONFIRMED.**
+`controlplane/internal/config/config.go:91-97` accepts any parseable duration. The spec
+allows 10 to 30 minutes (`config.go:27-29` restates this). Nothing anywhere checks an access
+token against a revocation list, so the TTL *is* the entire revocation window. A typo of
+`720h` issues month-long unrevocable tokens and no test or boot check objects. Fix: validate
+into `[10m, 30m]` in `Load` and fail loudly outside it.
+
+**L6. `machine.json` does not honour `AO_DATA_DIR`, while the gateway's cert dir does.
+CONFIRMED.** `backend/internal/vmgateway/config.go:160-166` resolves the default machine
+file from `os.UserHomeDir()` plus `.ao/machine.json`, whereas `CertDir` derives from the
+resolved `dataDir` (`config.go:132`), which honours `AO_DATA_DIR`. So
+`AO_DATA_DIR=/srv/ao` moves the certificates but not `machine.json`; only
+`AO_MACHINE_FILE` moves that. Not a hard-rule violation (nothing lands in an OS-default
+app-data location), but a real inconsistency for the `setup-vm` worker to trip over. Fix:
+either derive the default from `dataDir`, or state the split explicitly in the flag help.
+
+**L7. Control-plane data directory and database are mode 0750 / driver default while the
+keys subdirectory is 0700. CONFIRMED.** `controlplane/internal/storage/sqlite/db.go:39`
+and `controlplane/internal/auth/session.go:47` both `MkdirAll(dataDir, 0o750)`;
+`keys.Load` uses `0o700` for its own subdir (`keys.go:50`). `controlplane.db` is created by
+the driver at the process umask default and holds Google subjects, emails, and refresh-token
+hashes; `session_key` is correctly 0600 (`session.go:55`). Fix: use `0o700` for the data dir
+too, since everything in it is sensitive.
+
+**L8. Rejection paths with no test.** For the clone flow (`service_test.go:952-1031` covers
+the happy path, `CLONE_AUTH_FAILED`, `CLONE_URL_INVALID`, `PATH_AND_CLONE_URL_CONFLICT`,
+`CLONE_DESTINATION_EXISTS`): `CLONE_TIMEOUT`, `CLONE_HOST_NOT_FOUND`,
+`CLONE_HOST_KEY_UNVERIFIED`, `CLONE_REPO_NOT_FOUND`, the `CLONE_FAILED` default,
+`CLONE_NOT_CONFIGURED`, `CLONE_DEST_UNAVAILABLE`, scp-style URL parsing, and
+`parseCloneURL`/`sanitizeDirComponent` against adversarial owner/repo segments all have no
+direct test. For the gateway: no test that the upstream's CORS headers are not duplicated
+(H1), no test that a failing JWKS fetch is not retried per request (H4), and no test that
+`Resolve` rejects a `publicUrl` that is a URL rather than a hostname (H2). All three of my
+high gateway findings are invisible to the current suite.
+
+### Not a finding, recorded so it is not re-investigated
+
+`go test ./internal/cli/` has 5 pre-existing failures on `develop`
+(`TestSpawnCommand_MissingProjectContext`, `TestSpawnResolvesProjectFromAOSessionID`,
+`TestSpawnAOSessionIDFailureRequiresProject`, `TestSpawnResolvesProjectFromCWD`,
+`TestSpawnDefaultsToScratchWhenOnlyActiveProject`), all "daemon returned HTTP 404" because
+`ao spawn` calls `GET /api/v1/agents` (`internal/cli/spawn.go:190`) against a stub that only
+serves `/api/v1/projects`. Not caused by this work: none of the seven commits touch
+`internal/cli/spawn.go`, `spawn_test.go`, or the agents route (verified with
+`git diff --name-only 47454f320~1..HEAD`). They reproduce with an isolated
+`AO_DATA_DIR`/`AO_RUN_FILE`, so they are not an artifact of my session's live daemon either.
+
+## 3. Contract discrepancies: issuer vs verifier vs `TOKEN_CONTRACT.md`
+
+The core claim-by-claim comparison **matches**. Listed explicitly because "we checked and
+they agree" is the answer this section exists to give:
+
+| Item | Issuer (`tokens/access.go`, `keys/jwks.go`) | Verifier (`vmgateway/token.go`, `jwks.go`) | Contract | Verdict |
+|---|---|---|---|---|
+| `alg` | `"EdDSA"` (`access.go:83`) | requires exactly `"EdDSA"` (`token.go:95`) | EdDSA | match |
+| `typ` | `"JWT"` (`access.go:83`) | not checked | unspecified | match (unchecked is fine) |
+| `kid` | 16 hex chars, `sha256(pub)[:16]` (`keys.go:105-108`) | lookup hint only, falls back to all keys (`jwks.go:69-80`) | unspecified | match |
+| `iss` | `i.issuer`, unwired (`access.go:61`) | pinned `https://ao.agentlab.in`, `!=` compare (`token.go:144`) | `https://ao.agentlab.in` | match, but see M4 |
+| `sub` | `accountID` = `accounts.id`, a `uuid.NewString()` (`auth.go:90`) | `cfg.AccountID` from `machine.json.accountId` (`token.go:150`) | account id | match, both plain strings |
+| `aud` | `machineID`, a single string (`access.go:63`) | `cfg.MachineID` from `machine.json.machineId`, single-string `!=` (`token.go:147`) | machine id | match, but see M1 |
+| `exp` | `now + accessTTL`, Unix seconds (`access.go:64`) | `time.Unix(exp,0)`, rejects if `now > exp+skew` (`token.go:139-142`) | 15 min | match |
+| `iat` | Unix seconds (`access.go:65`) | not checked | present | match (contract only requires it be minted) |
+| `jti` | `uuid.NewString()` (`access.go:66`) | not checked | present | match |
+| Encoding | `base64.RawURLEncoding` all three segments (`access.go:91-97`) | `base64.RawURLEncoding` all three (`token.go:81,99,123`) | JWT | match, no padding disagreement |
+| JWKS `kty`/`crv` | `OKP` / `Ed25519` (`jwks.go:30-31`) | requires exactly `OKP` / `Ed25519`, skips others (`jwks.go:48`) | Ed25519 | match |
+| JWKS `x` | `RawURLEncoding(pub)` (`jwks.go:33`) | `RawURLEncoding`, length-checked to 32 (`jwks.go:51-53`) | implied | match |
+| JWKS `use`/`alg` | `"sig"` / `"EdDSA"` (`jwks.go:34-35`) | ignored | implied | match (ignoring is safe) |
+| JWKS key count | active plus next (`jwks.go:25`) | any number, at least one usable (`jwks.go:57-59`) | active plus next slot | match |
+| Skew | n/a | `DefaultSkew = 60s` (`token.go:14`), actually wired at `cli/vm.go:87` | 60s | match, wiring verified |
+| JWKS cache | server sets `max-age=3600` (`keys/http.go:21`) | `ttl = time.Hour` (`jwks.go:106`) | 1 hour | match |
+| stale-if-error | verifier-side per its own comment | present (`jwks.go:121-125`) | required | present but defective, see H4 |
+| Fail closed | n/a | `Get` errors with nothing cached, `requireToken` 401s (`jwks.go:125`, `proxy.go:148-152`) | implied | match |
+
+Remaining discrepancies, all already itemized above, gathered here because they compound:
+
+1. **M1**, `0001_init.sql:15` says `machines.hostname` is the JWT audience. It is not.
+2. **M4**, `PUBLIC_ORIGIN` is not normalized, so `iss` can differ from the pinned value by
+   one trailing byte.
+3. **H3**, `TOKEN_CONTRACT.md:14` promises Bearer-header transport for SSE, which the
+   renderer's `EventSource` cannot do and the gateway requires anyway.
+4. **H2**, the contract does not say whether `machine.json`'s `publicUrl` is an origin or a
+   bare hostname; the reader needs a hostname and the spec and schema both say URL.
+5. `TOKEN_CONTRACT.md:16-17` specifies the `/mux` cookie as "Secure, HttpOnly, host-only"
+   but says nothing about `SameSite`. The renderer is a cross-site context
+   (`app://renderer` reaching `https://vm.example.com`), so the cookie will need
+   `SameSite=None; Secure` or the browser will not attach it to the WebSocket handshake at
+   all. The contract should state this before the desktop worker guesses. Also note the
+   cookie name is defined only in gateway code (`ao_gw_token`, `proxy.go:16`) and appears
+   nowhere in `TOKEN_CONTRACT.md`; the desktop worker has to read Go source to find it.
+6. `TOKEN_CONTRACT.md` does not state the refresh token's TTL or its rotate-on-use rule.
+   The implementation picks 90 days (`refresh.go:21`) and rotates on every use
+   (`refresh.go:61-118`), both reasonable, neither written down. Add them so the desktop
+   worker does not re-derive.
+
+## 4. The `machine.json` contract, for the future `setup-vm` worker
+
+Reader: `backend/internal/vmgateway/machinefile.go`. Consumer: `Resolve` in
+`backend/internal/vmgateway/config.go:95-158`.
+
+Exact struct as merged (`machinefile.go:16-21`):
+
+```go
+type MachineFile struct {
+    MachineID string    `json:"machineId"`
+    AccountID string    `json:"accountId"`
+    PublicURL string    `json:"publicUrl"`
+    IssuedAt  time.Time `json:"issuedAt"`
+}
+```
+
+So the file `setup-vm` must write is exactly:
+
+```json
+{
+  "machineId": "3f2b1c8e-6d4a-4b7e-9c11-8a5f0e2d7b34",
+  "accountId": "9a7d4e21-0b3c-4f5a-8e6d-1c2b3a4f5e6d",
+  "publicUrl": "https://vm.example.com",
+  "issuedAt": "2026-07-30T09:34:21Z"
+}
+```
+
+Field by field:
+
+- **`machineId`** (string, required unless `--machine-id` or `AO_VM_MACHINE_ID` is given).
+  Becomes the expected `aud`, compared byte-for-byte and case-sensitively at
+  `token.go:147`. Must be byte-identical to `machines.id` and to whatever the control plane
+  puts in `aud`. That column is `TEXT PRIMARY KEY` (`0001_init.sql:19`) and the accounts
+  precedent is `uuid.NewString()` (`auth.go:90`), i.e. a lowercase hyphenated UUID, so match
+  that. It is **not** the hostname; see M1. The reader enforces no format: any non-empty
+  string is accepted, so a mismatch fails silently at request time, not at startup.
+- **`accountId`** (string, required unless overridden). Becomes the expected `sub`, compared
+  byte-for-byte and case-sensitively at `token.go:150`. Must equal `accounts.id`, a
+  `uuid.NewString()` value. Exactly one account per machine; the gateway has no concept of a
+  multi-entry allowlist.
+- **`publicUrl`** (string, required unless overridden). **This is the field to get right.**
+  The reader assigns it straight to `Config.Domain` (`config.go:120`), which becomes
+  `autocert.HostWhitelist(cfg.Domain)` (`server.go:46`) and is therefore matched against the
+  TLS SNI server name. It must be a **bare DNS hostname**: `vm.example.com`, no scheme, no
+  port, no trailing slash, no path. A full URL silently disables TLS entirely; see H2 for
+  why. Two ways to resolve, pick one and write it into `TOKEN_CONTRACT.md` or the spec:
+  - **(recommended)** Keep the field a full origin, since the spec, `machines.hostname`, and
+    the desktop (which needs an origin to build a base URL) all want a URL, and fix the
+    reader to extract the hostname with `url.Parse` plus `u.Hostname()`. Then `setup-vm`
+    writes `"https://vm.example.com"`.
+  - Or rename the field to `domain` and write a bare hostname. This diverges from the spec's
+    wording and leaves the desktop to reconstruct the origin.
+  Until this is decided, `setup-vm` should write a bare hostname, because that is what the
+  code as merged actually requires.
+- **`issuedAt`** (RFC 3339 timestamp). Parsed as `time.Time` by `encoding/json`, so it must
+  be RFC 3339 (`2026-07-30T09:34:21Z`). **The gateway never reads this value**, but a
+  malformed one fails the whole unmarshal (`machinefile.go:35`), which `Resolve` turns into
+  a fatal error (`config.go:104-107`), so a bad timestamp prevents the gateway from starting
+  over a field nobody consumes. Either emit valid RFC 3339 or make the reader tolerant.
+
+Behavioural contract the reader guarantees:
+
+- **A missing file is not an error.** `ReadMachineFile` returns `(nil, nil)` for
+  `os.ErrNotExist` (`machinefile.go:28-30`); that is the "not bound yet" state. The gateway
+  then starts only if flags or environment supply domain, machine id, and account id, and
+  otherwise exits with the message at `config.go:145-151`.
+- **A present but malformed file is fatal.** Any JSON error aborts startup.
+- **Unknown fields are ignored.** No `DisallowUnknownFields`, so `setup-vm` may add fields
+  (a name, a control-plane URL) without breaking the gateway.
+- **Precedence is flag, then environment, then `machine.json`, then built-in default**
+  (`config.go:116-123`). `setup-vm` cannot rely on the file winning.
+- **Partial files are allowed.** Any subset of the three required values may come from the
+  file; the rest must come from flags or environment.
+- **Default path is `$HOME/.ao/machine.json`** via `os.UserHomeDir` (`config.go:160-166`),
+  **not** the `AO_DATA_DIR`-resolved data dir. Only `AO_MACHINE_FILE` or `--machine-file`
+  relocates it; see L6.
+- **Mode 0600** is required by the spec
+  (`docs/superpowers/specs/2026-07-29-hosted-ao-v1-accounts-and-machines.md:139-140`). The
+  reader neither checks nor enforces it, so `setup-vm` owns that entirely.
+- The gateway reads the file **once, at startup** (`Resolve` is called from
+  `cli/vm.go:73`). Re-binding a machine requires restarting `ao vm serve`;
+  `setup-vm` should say so, or restart the unit itself.
+
+## 5. What I verified and found correct
+
+Does not need re-reviewing.
+
+**Token verification (`backend/internal/vmgateway/token.go`), read line by line:**
+- Signature is verified **before** the payload is decoded at all. The payload is
+  base64-decoded and unmarshalled at lines 123-130, strictly after the `verified` check at
+  lines 111-119. No claim is read before its signature is checked.
+- `alg` is pinned to `EdDSA` at line 95, before any key is consulted. `alg: none` and
+  `HS256` are both rejected there. The Ed25519 public key is never reachable as an HMAC
+  secret, because the only verification call in the package is `ed25519.Verify`
+  (line 112). Tested at `token_test.go:87-119`.
+- Signature length is checked against `ed25519.SignatureSize` (line 100) before use.
+- `aud` **and** `sub` are both checked, not just `exp` (lines 147-152), and
+  `VerifyOptions` refuses to run at all if any of issuer, audience, or subject is empty
+  (lines 71-73), so a misconfigured gateway cannot accidentally skip a check.
+- Missing `exp` is rejected rather than treated as "no expiry" (lines 132-134). A negative
+  `Skew` is clamped to zero (lines 135-138).
+- Fails closed: `ks == nil` or an empty key set returns `ErrBadSignature` (lines 103-105),
+  and `requireToken` 401s when `jwks.Get` errors (`proxy.go:148-152`).
+- No token material in logs or responses. `requireToken` logs only the sentinel error and
+  the path (`proxy.go:155`); the raw token is passed straight to `VerifyToken` and never
+  formatted into any message; `unauthorized` returns a fixed envelope
+  (`proxy.go:189-192`). The wrapped `base64`/`json` errors carry offsets and type names,
+  never token bytes.
+- Credentials are stripped before proxying: `Authorization` and the `ao_gw_token` cookie
+  are removed in the director, other cookies preserved (`proxy.go:80-93`), asserted at
+  `proxy_test.go:252-255`.
+
+**Loopback-only route blocking:** genuinely deny-by-default, not a blocklist. The allowlist
+is `/mux` exactly, plus `/api/v1` and below minus `/api/v1/mobile` and `/api/v1/dev`
+(`proxy.go:108-121`). `/shutdown` and `/internal/*` are excluded because they are not under
+`/api/v1` at all, which is strictly stronger than the LAN listener's blocklist. Bypass
+attempts I checked against the code rather than the test names:
+- Percent-encoding cannot bypass it: `hasPathPrefix` matches `r.URL.Path`, which Go has
+  already percent-decoded, so `/api/v1/%6dobile` is blocked, and `EscapedPath` preserves
+  the original encoding on the way out.
+- Casing: `/api/v1/Mobile` is allowed through the gateway but 404s at the daemon, because
+  chi is case-sensitive and no case-insensitive router sits in front of it.
+- `..` traversal: `/api/v1/../shutdown` is forwarded un-normalized, but the daemon does not
+  use `middleware.CleanPath` (verified in `router.go:51-56`), so chi 404s it rather than
+  routing onto `/shutdown`. Noted as L2 because the allowlist is what makes this safe.
+- Trailing slash: `/mux/` is not `/mux`, so it 404s. `hasPathPrefix` matches only on segment
+  boundaries, so `/api/v1/mobileapp` is correctly *not* caught by the `/api/v1/mobile`
+  block (`proxy.go:128-130`, `proxy_test.go:258-280`).
+- Deny returns 404, not 401/403, so a blocked route is not confirmed to exist
+  (`proxy.go:96-105`).
+
+**CORS:** a preflight is answered without a token, but no real request slips through. The
+preflight branch requires both `OPTIONS` and a non-empty `Access-Control-Request-Method`
+(`proxy.go:231`); `OPTIONS` without that header falls through to auth. `*` and the opaque
+`null` origin are filtered out of the allowlist (`proxy.go:207-209`), and the wired value is
+`config.DefaultAllowedOrigins` = `["app://renderer"]`, an origin web content cannot present.
+A hostile page's cross-origin WebSocket to `/mux` carries an `Origin` and is 403'd before
+auth, which is the right defence, since the cookie is ambient and browsers do not enforce
+same-origin on WebSocket themselves.
+
+**The `/mux` cookie is not a weaker path.** `extractToken` returns the cookie value and it
+goes through the identical `VerifyToken` call as a Bearer header (`proxy.go:154`). Same
+signature check, same `iss`/`aud`/`sub`/`exp` checks. The only asymmetry is L4 (the header is
+not accepted on `/mux`), which is a narrowing, not a weakening.
+
+**SSE and WebSocket plumbing:** `FlushInterval = -1` (`proxy.go:65`) is correct for both;
+`httputil.ReverseProxy` handles the `Connection: Upgrade` hijack itself. Auth headers are
+consumed at the gateway and not forwarded (see above). `ReadHeaderTimeout` is set on both
+listeners (`server.go:56,62`) and no write timeout is set, which is required for long-lived
+streams.
+
+**Key and secret handling:**
+- EdDSA private key files are 0600 and the directory 0700 (`keys.go:50,115`), asserted by
+  `TestLoad_KeyFilesAreMode0600`. `JWKS()` publishes only the public half
+  (`jwks.go:28-37`), asserted by `TestJWKS_PublishesActiveAndNextPublicKeysOnly`. No key
+  material is tracked in git (`git ls-files controlplane` shows source only) and
+  `/controlplane/data/` is gitignored (`.gitignore:31-34`). Nothing logs a private key.
+- Refresh tokens are stored hashed, never in plaintext: 32 bytes from `crypto/rand`
+  (`refresh.go:150-156`), SHA-256 hex on the way in (`refresh.go:158-161`), and the lookup
+  is by hash (`refresh.go:79`). Plain SHA-256 is the right choice here, not bcrypt, because
+  the input is 256 bits of CSPRNG output, not a password.
+- **Rotation genuinely invalidates the old token.** I read this specifically because it is
+  the classic silent failure. `RotateRefreshToken` (`refresh.go:66-118`) opens one
+  transaction, refuses an already-revoked row (lines 88-90), refuses an expired row
+  (lines 91-93), sets `revoked_at` on the presented row (lines 96-100), inserts the
+  replacement (lines 106-112), and commits once (line 114). A second presentation of the old
+  token hits the `revokedAt.Valid` branch and returns `ErrRefreshTokenRevoked`. The old
+  token is dead. `token_hash` is `UNIQUE` (`0001_init.sql:54`), and a concurrent double-use
+  contends on the write transaction rather than both succeeding.
+- Google client id and secret come only from the environment, and `Load` refuses to boot
+  without either (`config.go:99-107`). `controlplane/.env.example` has empty values for
+  both and no other credential; nothing else in it is sensitive.
+- PKCE uses `crypto/rand`: 32 bytes for the verifier, S256 challenge
+  (`oauth.go:53-62`); `state` is 24 bytes from `crypto/rand` (`oauth.go:66-72`) and is
+  validated against the signed flow cookie on callback, rejecting both empty and mismatched
+  (`oauth.go:183-186`), tested at `oauth_test.go:267-295`. The flow cookie is HMAC-SHA256
+  signed with a 32-byte key, compared with `hmac.Equal` (`session.go:89`), carries its own
+  10 minute expiry, and is cleared before the callback branches (`oauth.go:178`), so a
+  captured cookie cannot be replayed after use. `sanitizeNext` closes the open redirect by
+  requiring a single leading `/` (`oauth.go:76-81`, tested). `id_token` is deliberately not
+  parsed; the account is keyed on the userinfo `sub`, and both `sub` and `email` are required
+  to be non-empty (`oauth.go:297-302`).
+- The session cookie is `HttpOnly`, `SameSite=Lax`, host-only (no `Domain`), carries a
+  30 day expiry both in the cookie and inside the signed payload, and is `Secure` whenever
+  `PUBLIC_ORIGIN` is https (`session.go:100-108`, `auth.go:64`). It is not a guessable
+  session id at all: it is `accountID|exp` plus an HMAC-SHA256 tag, so forging one requires
+  the key, and the key file is 0600 (`session.go:55`). Tampered, wrong-key, and expired
+  cookies are all rejected and all three are tested (`session_test.go:69-121`).
+- The sign-in page is `html/template` with contextual escaping, `?error=` is mapped through
+  a fixed switch rather than echoed (`pages.go:41-52`), and the only interpolated URL is
+  built from `sanitizeNext` plus `url.QueryEscape`. No XSS vector found.
+
+**Hard-rule compliance:**
+- The daemon is untouched by `#14`: still `127.0.0.1`, still unauthenticated. Confirmed by
+  file list, no file under `internal/httpd/` or `internal/daemon/` appears in `193f6cc52`
+  except via the `vmgateway` package's own import of `envelope`.
+- `ao vm serve` stays inside ADR 0002: separate process, separate systemd unit, :80 for
+  ACME plus https redirect (nil fallback to `manager.HTTPHandler`, so nothing is ever served
+  plaintext, `server.go:55`), :443 for TLS, token verified before proxying, control routes
+  never proxied. `AGENTS.md:82-85` was amended with a narrow carve-out naming
+  `ao vm serve` specifically, exactly as the ADR's Consequences section requires.
+- `autocert.HostPolicy` is scoped to the single configured domain (`server.go:46`), so a
+  crafted `Host` to the VM's bare IP cannot trigger a certificate request for someone
+  else's name. `CertDir` resolves under the `AO_DATA_DIR`-honouring data dir
+  (`config.go:127-133`, `cli/vm.go:73`), never an OS-default app-data location, and it is
+  created before any socket is bound (`server.go:39`).
+- Graceful shutdown drains both listeners and cannot leak either serve goroutine
+  (`server.go:72-118`); the drain loop at lines 108-112 is correct.
+
+**`cloneUrl` (`#6`):**
+- The clone destination cannot escape `reposRoot`. `dest` is
+  `filepath.Join(m.reposRoot, owner+"-"+repo)` (`clone.go:38`) where both components passed
+  `safeDirComponent` = `^[A-Za-z0-9._-]+$` with explicit `.` and `..` rejection
+  (`clone.go:115,154-160`). No `/` can survive, so `Join` cannot traverse. I traced the
+  hostile cases: `https://host/../../etc/x.git` reduces to owner `etc`, repo `x`, because
+  only the last two segments are used (`clone.go:143-150`); scp-style
+  `git@host:a/b.git` parses correctly; absolute paths, empty owner, and empty repo are all
+  rejected.
+- Raw git output never reaches the client. `classifyCloneError` (`clone.go:74-96`) inspects
+  the output only to choose a branch and returns a fixed remediation string in every branch
+  including the default; `CLONE_TIMEOUT` likewise (`clone.go:64-67`). `service_test.go`
+  asserts the message contains neither `fatal:` nor the test server URL. A partial clone is
+  cleaned up so a retry is not blocked (`clone.go:62`).
+- `~/.ao/repos` honours `AO_DATA_DIR`: `ReposRoot: filepath.Join(cfg.DataDir, "repos")`
+  (`backend/internal/daemon/daemon.go:160`) with `cfg.DataDir` from `resolveDataDir()`
+  (`backend/internal/config/config.go:324-331`), which reads `AO_DATA_DIR` first.
+- One code path for local and remote: a single `Service.Add` and a single controller
+  (`backend/internal/httpd/controllers/projects.go:53-68`) decoding into `AddInput`. No
+  parallel remote implementation exists.
+- `openapi.yaml`, the Go DTO, and the generated TS schema agree exactly: `cloneUrl` is an
+  optional string in all three (`backend/internal/service/project/dto.go:20`,
+  `backend/internal/httpd/apispec/openapi.yaml:2236`,
+  `frontend/src/api/schema.ts:815`), and the documented 201/400/409/500 responses
+  (`specgen/build.go:684-691`) match the codes actually returned.
+
+**Cross-cutting:** no duplication or contradiction between `#12` and `#13` in
+`cmd/controlplane/main.go`, `internal/server/server.go`, or `internal/config/`. They
+compose cleanly: `server.New(db, km)` registers `/healthz` plus JWKS, then
+`authSvc.Register(mux)` adds the three auth routes to the same mux, with no route collision
+and no duplicated config keys. Both key stores (`keys/`, the auth `session_key`) sit under
+the same `DataDir` with distinct filenames. The migration covers `device_codes` and
+`machines` with the columns the next batches need, including the `status` CHECK constraint,
+the `user_code` UNIQUE constraint, `last_polled_at` for interval enforcement, and
+`revoked_at` on `machines`. Foreign keys are actually enforced (`_pragma=foreign_keys(ON)`,
+`db.go:29`), which many SQLite setups forget. The one gap batch 3 will hit is that
+`device_codes` has no index on `user_code`, but the UNIQUE constraint already provides one,
+so there is nothing to fix.
+
+Test suites as run by me: `controlplane` 44 passed across 7 packages;
+`backend/internal/vmgateway` and `backend/internal/service/project` all passed. The 5
+`internal/cli` failures are pre-existing and unrelated, see section 2.

--- a/docs/reviews/2026-07-30-review-batches-3-4-client.md
+++ b/docs/reviews/2026-07-30-review-batches-3-4-client.md
@@ -1,0 +1,746 @@
+> **Preserved from `/tmp/ao/review-client-side_report.md`.** `/tmp` is ephemeral, so this is
+> the only copy. Everything below the horizontal rule is the report exactly as the reviewer
+> wrote it: no summarizing, no rewording, no reordering. The value is the file, the line, the
+> failure scenario, and the smallest fix, and a summary would destroy all four. Section 3,
+> the ranked pre-flight risk list for the batch 5 VM run, has not happened yet and is the
+> checklist for task 14.
+>
+> | | |
+> | --- | --- |
+> | Reviewed state | `develop` @ `a7eb9c6b2` |
+> | Date | 2026-07-30 |
+> | Reviewer session | `hosted-ao-25` (AO worker, read-only) |
+> | Findings | 22: 1 critical (suspected), 4 high, 9 medium, 8 low |
+>
+> **Where each finding was fixed.** Every finding was fixed. This mapping was added on
+> import and is not part of the original report.
+>
+> | Finding | Fixed in | Issue |
+> | --- | --- | --- |
+> | C1 `WorkingDirectory` emitted quoted, systemd refuses the unit | [#46](https://github.com/agentlab-in/hosted-ao/pull/46) | [#38](https://github.com/agentlab-in/hosted-ao/issues/38) |
+> | H1 nothing stops both units installing as `User=root` | [#46](https://github.com/agentlab-in/hosted-ao/pull/46) | [#38](https://github.com/agentlab-in/hosted-ao/issues/38) |
+> | H2 the outside-in reachability check can never run | [#46](https://github.com/agentlab-in/hosted-ao/pull/46) | [#38](https://github.com/agentlab-in/hosted-ao/issues/38) |
+> | H3 the `claude auth status` probe can hang forever | [#43](https://github.com/agentlab-in/hosted-ao/pull/43) | [#39](https://github.com/agentlab-in/hosted-ao/issues/39) |
+> | H4 two more origin-URL writers bypass #20's stripping | [#42](https://github.com/agentlab-in/hosted-ao/pull/42) | [#41](https://github.com/agentlab-in/hosted-ao/issues/41) |
+> | M1 a wrong-state hit on the loopback port aborts the login | [#44](https://github.com/agentlab-in/hosted-ao/pull/44) | [#40](https://github.com/agentlab-in/hosted-ao/issues/40) |
+> | M2 harness probe budget too small, echoes the whole output | [#43](https://github.com/agentlab-in/hosted-ao/pull/43) | [#39](https://github.com/agentlab-in/hosted-ao/issues/39) |
+> | M3 a selected remote machine reports `ready` with no credential | [#44](https://github.com/agentlab-in/hosted-ao/pull/44) | [#40](https://github.com/agentlab-in/hosted-ao/issues/40) |
+> | M4 machine switching leaves the previous machine in the cache | [#44](https://github.com/agentlab-in/hosted-ao/pull/44) | [#40](https://github.com/agentlab-in/hosted-ao/issues/40) |
+> | M5 `parseMachineOrigin` accepts plain `http:` for any host | [#44](https://github.com/agentlab-in/hosted-ao/pull/44) | [#40](https://github.com/agentlab-in/hosted-ao/issues/40) |
+> | M6 `machine.json` parent directory is not chowned | [#46](https://github.com/agentlab-in/hosted-ao/pull/46) | [#38](https://github.com/agentlab-in/hosted-ao/issues/38) |
+> | M7 `systemctl start` success reported as "running" | [#46](https://github.com/agentlab-in/hosted-ao/pull/46) | [#38](https://github.com/agentlab-in/hosted-ao/issues/38) |
+> | M8 no start-rate-limit override | [#46](https://github.com/agentlab-in/hosted-ao/pull/46) | [#38](https://github.com/agentlab-in/hosted-ao/issues/38) |
+> | M9 a failed refresh-token persist locks the install out | [#44](https://github.com/agentlab-in/hosted-ao/pull/44) | [#40](https://github.com/agentlab-in/hosted-ao/issues/40) |
+> | L1 loopback page interpolates `error_description` unescaped | [#44](https://github.com/agentlab-in/hosted-ao/pull/44) | [#40](https://github.com/agentlab-in/hosted-ao/issues/40) |
+> | L2 `state` comparison is not constant-time | [#44](https://github.com/agentlab-in/hosted-ao/pull/44) | [#40](https://github.com/agentlab-in/hosted-ao/issues/40) |
+> | L3 DNS match compares IP strings | [#46](https://github.com/agentlab-in/hosted-ao/pull/46) | [#38](https://github.com/agentlab-in/hosted-ao/issues/38) |
+> | L4 dual-stack fallback can report a false DNS mismatch | [#46](https://github.com/agentlab-in/hosted-ao/pull/46) | [#38](https://github.com/agentlab-in/hosted-ao/issues/38) |
+> | L5 loopback-only port probe can pass while the public bind fails | [#46](https://github.com/agentlab-in/hosted-ao/pull/46) | [#38](https://github.com/agentlab-in/hosted-ao/issues/38) |
+> | L6 sign-out can be raced by an in-flight machine refresh | [#44](https://github.com/agentlab-in/hosted-ao/pull/44) | [#40](https://github.com/agentlab-in/hosted-ao/issues/40) |
+> | L7 Ctrl-C during the device flow waits out the poll interval | [#46](https://github.com/agentlab-in/hosted-ao/pull/46) | [#38](https://github.com/agentlab-in/hosted-ao/issues/38) |
+> | L8 temp-file name collides on pid reuse | [#44](https://github.com/agentlab-in/hosted-ao/pull/44) | [#40](https://github.com/agentlab-in/hosted-ao/issues/40) |
+>
+> The "Observation, not a finding" at the end of section 2 (the device flow mints a
+> machine-audience token that `ao setup-vm` deliberately never decodes, so a 15 minute
+> credential is minted on every bind for no consumer) was carried into
+> [#47](https://github.com/agentlab-in/hosted-ao/issues/47), which is in flight.
+
+---
+
+# Client-side review: CLI, `ao setup-vm`, desktop auth and machines
+
+Reviewed state: `develop` @ `a7eb9c6b2`. Scope: #20, #27, #28, #32, #33, #35.
+Read-only review. Nothing was changed, no PR, no issue. `ao setup-vm` was not run.
+
+## 1. Verdict
+
+Not on a VM I cared about, not yet. One suspected-critical defect in the systemd unit
+text would make the very first real run fail after it has already installed packages and
+written units, and there is no guard stopping both units from being installed as `User=root`
+on a VM whose login user is root, which is the default on DigitalOcean and Hetzner.
+The binding half, the atomic writes, the device flow, and the desktop spawn guard are good;
+the outside-in port check the spec requires can never actually run.
+
+Counts: 1 critical (suspected), 4 high, 9 medium, 8 low.
+
+## 2. Findings
+
+Severity is impact on the batch 5 run and on account security. Every finding is marked
+CONFIRMED (read the code that proves it) or SUSPECTED (reasoned, not executed).
+
+---
+
+### CRITICAL
+
+#### C1. `WorkingDirectory` is emitted quoted, which systemd rejects as a fatal setting
+`backend/internal/cli/setupvm_plan.go:742`
+
+```go
+fmt.Fprintf(&b, "WorkingDirectory=%q\n", u.WorkingDir)
+```
+
+produces `WorkingDirectory="/home/ubuntu/.ao/data"`.
+
+Status: SUSPECTED, high confidence. I could not execute it: there is no systemd on this
+machine and the Docker daemon is not running, and no CI job in `.github/workflows/`
+parses the generated units.
+
+What is wrong: unit-file quoting is only honoured by settings parsed as a list of words.
+`Environment=` is one of those and the quoting there is correct and documented.
+`WorkingDirectory=` is not: systemd's `config_parse_working_directory` runs specifier
+expansion and then `path_simplify_and_warn(..., PATH_CHECK_ABSOLUTE|PATH_CHECK_FATAL)`
+with no unquoting, so the value it sees is `"/home/ubuntu/.ao/data"` starting with a
+double quote, which is not an absolute path. Without a leading `-` on the value the check
+is fatal, the parse handler returns `-ENOEXEC`, and the unit refuses to load rather than
+merely ignoring the setting.
+
+Failure scenario: first real run on the fresh VM. Preflight passes. `install -d` runs,
+apt installs tmux/git/gh, the `ao` binary is installed to `/usr/local/bin/ao`, both unit
+files are written, `systemctl daemon-reload` succeeds. Then
+`systemctl enable ao-daemon.service ao-gateway.service` or
+`systemctl start ao-daemon.service` fails with `Unit configuration has a fatal error`
+or `Refusing`. `installSetupVM` returns that error at `setupvm.go:443` or `:453`,
+`runSetupVM` returns before the binding step, and the operator is left with a
+half-provisioned box, no summary, and no binding. Every re-run fails the same way.
+
+Smallest fix: `fmt.Fprintf(&b, "WorkingDirectory=%s\n", u.WorkingDir)` and update the two
+golden assertions at `setupvm_plan_test.go:525` and `:554` plus the
+`strings.HasPrefix(value, "\"/")` check at `:593`. If a home directory with a space is a
+concern, escape the space as `\x20` rather than quoting. Leave `Environment=%q` alone,
+that one is correct.
+
+Ten-second verification before the run, on any Linux box:
+
+```
+ao setup-vm --domain vm.example.com --dry-run    # prints both units
+# paste each into /tmp/x.service, then:
+systemd-analyze verify /tmp/x.service
+```
+
+---
+
+### HIGH
+
+#### H1. Nothing stops both units from being installed as `User=root`
+`backend/internal/cli/setupvm.go:382-395`, `setupvm_plan.go:618-642`, `:703-716`
+
+CONFIRMED.
+
+`setupTargetUser()` falls back to `user.Current()` whenever `SUDO_USER` is unset or is
+`root`. `buildSetupPlan` accepts whatever username it is handed; the only rejection is an
+empty user or a non-absolute home. `systemdUnit`'s own doc comment at
+`setupvm_plan.go:705-707` states the invariant "User and Group are never root", and
+nothing enforces it.
+
+Failure scenario: the operator SSHes into the VM as `root` (the default on DigitalOcean
+droplets and Hetzner servers, and the result of `sudo -i` or `sudo su -` anywhere).
+`SUDO_USER` is unset, `user.Current()` is root. Preflight's privilege check passes
+silently because `UID == 0`. The plan resolves `User=root`, `Group=root`,
+`AODir=/root/.ao`. Both units are written with `User=root`, so `ao daemon` runs every
+agent session, every `git`, and every `gh` as root, and `ao vm serve` runs as root while
+being handed `AmbientCapabilities=CAP_NET_BIND_SERVICE` it does not need. Nothing warns.
+This is the single most likely way the batch 5 box ends up wrong in a way nobody notices.
+
+Smallest fix: in `buildSetupPlan`, return an error when
+`strings.TrimSpace(in.User) == "root"`, with remediation naming the fix
+(`adduser --disabled-password ao && sudo -u ao ao setup-vm --domain ...`, or re-run under
+`sudo -u <human>`). Keep it in the pure function so it is unit-testable, and add the same
+check to `checkSetupPrivilege` so it surfaces as a preflight problem rather than a
+post-preflight error, which preserves the "nothing was changed" guarantee.
+
+#### H2. The outside-in reachability check the spec requires can never run
+`backend/internal/cli/setupvm.go:46`, `:288-292`
+
+CONFIRMED.
+
+`defaultSetupVMProbeURL = vmgateway.DefaultIssuer + "/api/v1/reachability"`. A repo-wide
+grep for `reachability` outside `backend/internal/cli` and the frontend finds no handler:
+the control plane does not implement that route. Separately,
+`probeSetupReachability` returns an empty `setupReachability{}` whenever the gateway is
+not already active, which is always true on a first run.
+
+So: first run, gateway not active, check skipped, warning printed. Second run, gateway
+active, the probe gets a 404, `setupHTTPGet` returns an error at `setupvm.go:329`,
+`Reach.Err` is set, warning printed. `blockedSetupPorts` returns nil in both cases
+because `Ran` is never true, so the "public reachability" problem at
+`setupvm_plan.go:251` is unreachable code. The spec at
+`docs/superpowers/specs/2026-07-29-hosted-ao-v1-accounts-and-machines.md:130-134` lists
+"confirm 80 and 443 are reachable from outside" as a preflight requirement and names the
+cloud firewall as "the one thing the script cannot fix, so it must detect and instruct".
+It instructs; it never detects.
+
+Failure scenario for batch 5: the cloud security group blocks 443. Preflight passes with
+a warning. Install succeeds, binding succeeds, the gateway starts, and then ACME never
+gets a certificate. The symptom the operator sees is a machine that shows Offline in the
+desktop for no stated reason, with the real cause buried in `journalctl -u ao-gateway`.
+
+Smallest fix, client side: this is safe-by-design (unverified never reports as closed), so
+the smallest honest change is to stop implying the check exists. Make the closing summary
+carry the off-box `nc -vz <domain> 80` / `443` pair as a numbered "still missing" step
+rather than only as remediation text inside a warning, so the operator is told to do the
+one check the tool cannot. The server-side endpoint is the other reviewer's half; flag it
+to them as unimplemented but referenced.
+
+#### H3. The `claude auth status` probe can hang forever despite its 2 second context
+`backend/internal/doctor/doctor.go:220-223` and `:129-131`
+
+CONFIRMED (the missing guard). SUSPECTED (that `claude` triggers it in practice).
+
+```go
+reqCtx, cancel := context.WithTimeout(ctx, probeTimeout)   // probeTimeout = 2s
+out, cmdErr := d.CommandOutput(reqCtx, path, ClaudeAuthStatusArgs...)
+...
+func commandOutput(ctx context.Context, name string, args ...string) ([]byte, error) {
+    return aoprocess.CommandContext(ctx, name, args...).CombinedOutput()
+}
+```
+
+`aoprocess.CommandContext` (`backend/internal/process/command.go:17-21`) sets no
+`WaitDelay` and no process group. `CombinedOutput` gives `exec` a non-`*os.File` writer,
+so `exec` creates an `os.Pipe` and a copy goroutine, and `Wait` does not return until
+every holder of the write end has closed it. On context expiry `exec` kills only the
+direct child. `claude` is a Node CLI that spawns children; any grandchild that inherits
+the pipe and survives blocks `Wait` indefinitely. This is precisely the hang class #20
+had to fix in `project/clone.go` with `cmd.WaitDelay`, and the fix was not applied here.
+
+Failure scenario: `ao doctor` on the VM never returns. Worse, #36 exposed the same
+`doctor.Run` at `GET /api/v1/doctor` (`backend/internal/httpd/api.go:81-84,113`), so one
+request leaks a goroutine and a hung request that never completes.
+
+Smallest fix: in `backend/internal/doctor/doctor.go:129-131` and
+`backend/internal/cli/root.go:106-108`, build the command and set
+`cmd.WaitDelay = 2 * time.Second` before `CombinedOutput()`. One line each.
+
+#### H4. #20's credential stripping is bypassed by two other origin-URL writers
+`backend/internal/legacyimport/importer.go:181-191`,
+`backend/internal/observe/scm/observer.go:1452-1458` and `:496-503`
+
+CONFIRMED. `go test ./internal/service/project/` passes (147 tests); the defect is
+outside that package.
+
+`service.go:686-688` asserts "This is the single choke point for every RepoOriginURL
+assignment". It is not. Two independently written resolvers with the same shape persist
+the raw URL:
+
+```go
+// legacyimport/importer.go:181
+func defaultRepoOriginURL(path string) string { ... return strings.TrimSpace(string(out)) }
+
+// observe/scm/observer.go:1452
+func resolveGitOriginURL(path string) string { ... return strings.TrimSpace(string(out)) }
+```
+
+Neither calls `sanitizeOriginURL`. The scm one is a background backfill at
+`observer.go:496-503` that writes through `store.UpsertProject`, so it fires on an
+ordinary observer poll with no user action. `trackerintake/observer.go:175` then logs the
+column verbatim:
+
+```go
+o.logger.Warn("tracker intake: skipping project without tracker scope",
+    "project", project.ID, "provider", cfg.Provider, "origin", project.RepoOriginURL)
+```
+
+Failure scenario: a project is added by path before it has an origin remote, then the
+user adds `https://x-access-token:ghp_...@github.com/o/r.git` as origin. The next scm
+observer poll persists the token into `projects.repo_origin_url`, from where it is served
+by `GET /api/v1/projects/{id}` (`service.go:772`) and written to journald by the tracker
+intake warning. Same for any legacy project imported by `ao import`.
+
+Smallest fix: export `sanitizeOriginURL` from `internal/service/project` (or move it to a
+tiny shared package) and wrap the return of both functions with it. Then correct the
+now-false comment at `service.go:686-688`.
+
+---
+
+### MEDIUM
+
+#### M1. Any wrong-state hit on the loopback port aborts the in-flight login
+`frontend/src/main/loopback-callback.ts:66-70`
+
+CONFIRMED.
+
+```go
+const result = parseCallback(url, expectedState);
+if ("error" in result) {
+    respond(res, 400, "Sign-in was rejected", result.error);
+    finish({ error: new Error(result.error) });   // <- kills the flow
+    return;
+}
+```
+
+`finish` sets `done`, clears the timer, rejects the `code` promise, and closes the
+listener. So the first request to `/callback` that carries a wrong or missing `state`
+ends the login, permanently, before the real browser callback arrives.
+
+Answer to "can a local web page hit the callback port and inject a code": it can reach
+the port (a page can `fetch("http://127.0.0.1:<port>/callback?...")`; the response is
+opaque to it under CORS but the handler still runs), and it cannot inject a code because
+`state` is 32 CSPRNG bytes it does not have. What it can do, with no knowledge of
+anything, is abort every sign-in attempt by spraying `/callback` across the ephemeral
+port range. A browser prefetch, a security scanner, or a second stale browser tab does
+the same by accident.
+
+Smallest fix: on a `state` mismatch specifically, respond 400 and return without calling
+`finish`, so the listener keeps waiting for the real callback until its timeout. Keep
+`finish` for a genuine OAuth `error` param that did match `state`.
+
+#### M2. The harness readiness probe has a 2 second budget and echoes the harness's whole output
+`backend/internal/doctor/doctor.go:84`, `:220`, `:269`
+
+CONFIRMED.
+
+`probeTimeout = 2 * time.Second` is shared with the cheap local probes and is used for
+`claude auth status --json`. A Node CLI cold start on a fresh 1 vCPU VM regularly exceeds
+that, and this probe may touch the network. The failure path is a WARN whose message is
+`could not read harness auth state (...: context deadline exceeded)`, which
+`shared/ao-machines.ts:129-140` maps to `harness: "missing"` and tells the user to run
+`ao vm setup-harness claude` again. So the readiness signal the desktop consumes is
+likely to report a correctly-signed-in machine as not set up.
+
+Second half: `parseClaudeAuthStatus` at `:269` embeds the entire cleaned combined output
+in the error, unbounded, and that error becomes the check `Message`, which is served by
+`GET /api/v1/doctor`. Whatever a future `claude` release prints on stderr goes into the
+report and into any log that captures it.
+
+Smallest fix: give this one check its own budget (a `harnessProbeTimeout = 10 * time.Second`
+constant) and truncate the echoed output in `parseClaudeAuthStatus` to a couple of hundred
+bytes.
+
+#### M3. A selected remote machine reports `ready` though the app has no credential for it
+`frontend/src/main/remote-daemon.ts:56`, `frontend/src/main.ts:1478-1481`
+
+CONFIRMED.
+
+`machineDaemonStatus` returns `{ state: "ready", baseUrl: machine.baseUrl }` for an online
+machine. `applyActiveMachine` sets that as the app's daemon status, the renderer's
+`applyDaemonStatus` (`renderer/lib/daemon-status.ts:8-9`) calls `setApiBaseUrl(baseUrl)`,
+and every REST call and both EventSources re-point at the gateway. There is no
+machine-audience token anywhere in the desktop yet (that is task 13, and
+`ao-control-token.ts:22-24` says so), and `installRemoteDaemonCookie` only runs for the
+`AO_REMOTE_URL`/`AO_REMOTE_TOKEN` env pairing. So selecting a machine from the picker
+today produces a UI that says "Connected to ao-build-01" and 401s on every request.
+
+Smallest fix: until task 13 lands, return a distinct non-ready status for a picker-selected
+machine (for example `{ state: "error", code: "not_configured", message: "Reaching a
+registered machine needs the remote transport, which is not in this build yet." }`), so the
+app does not claim a connection it cannot make. This is the one thing batch 5's task 13
+will most obviously find inadequate.
+
+#### M4. Machine switching leaves the previous machine's data in the query cache
+`frontend/src/renderer/lib/api-client.ts:39-45`; no `queryClient.clear()` anywhere in
+`frontend/src/renderer`
+
+CONFIRMED.
+
+`setApiBaseUrl` notifies `baseUrlListeners`, which is enough for the long-lived
+connections: `event-transport.ts:77-84` and `notifications.ts:199-206` both compare
+`sourceBaseUrl` to the new base URL and close and reopen the `EventSource`. That part is
+correct and in-flight SSE is torn down.
+
+What is not handled is the react-query cache and in-flight fetches. Query keys carry no
+machine or base-URL dimension (`sessionScmSummaryQueryKey()`, `aoMachinesQueryKey`, and
+the rest), and nothing clears or resets the cache when the base URL changes. So after a
+switch the UI renders machine A's projects and sessions under machine B's identity until
+the refetch lands, and a request that was already in flight to machine A resolves
+afterwards and writes machine A's response into the same cache key. The user can act on
+the wrong machine's session list.
+
+Smallest fix: in the renderer, subscribe to `subscribeApiBaseUrl` once at the app root and
+call `queryClient.clear()` in the listener.
+
+#### M5. `parseMachineOrigin` accepts plain `http:` for any host
+`frontend/src/shared/ao-machines.ts:92`
+
+CONFIRMED.
+
+```go
+if (url.protocol !== "https:" && url.protocol !== "http:") return null;
+```
+
+The type's own doc says "HTTPS origin of the machine's gateway". `readControlPlaneUrl`
+in the same tree gets this right (`shared/control-plane.ts:39-42`: https, or http only for
+loopback). A machine row with `public_url: "http://..."` is accepted here, becomes the
+app's API base URL, and `isRemoteDaemonBaseUrl` (`shared/remote-daemon.ts:18`) then returns
+false for it, so `credentials`/`withCredentials` silently change behaviour too.
+
+Smallest fix: copy the loopback rule from `control-plane.ts` into `parseMachineOrigin`.
+
+#### M6. `machine.json`'s parent directory is not chowned, so an `AO_MACHINE_FILE` override yields a file the gateway cannot reach
+`backend/internal/cli/setupvm_bind.go:346-380`
+
+CONFIRMED.
+
+The chown logic itself is correct for the default path. `chownMachineFile` chowns to
+`setupTargetUser()`, the same source as `plan.User`, so owner and `User=` cannot disagree;
+and when the process is not root the file is already created by the right user, so
+skipping the chown at `:387` is right. The default parent, `~/.ao`, was created by
+`install -d -o plan.User` in `installSetupVM`, so traversal works.
+
+The gap is the override. `writeMachineFile` does `os.MkdirAll(dir, 0o700)` as the current
+process, and `plan.MachineFile` can be redirected anywhere by `AO_MACHINE_FILE`
+(`setupvm_plan.go:650`). Under `sudo`, a parent created there is root-owned mode 0700 and
+is never chowned. The 0600 file inside it is chowned to the human, who then cannot
+traverse the directory to reach it. `ao vm serve` fails `ReadMachineFile` and refuses to
+start, on a machine that just bound successfully. This is exactly the failure mode the
+comment at `:382-385` is guarding against, one level up.
+
+Smallest fix: chown each directory component `writeMachineFile` creates, or simpler, refuse
+an `AO_MACHINE_FILE` that is not inside `plan.AODir` in `buildSetupPlan`, which also keeps
+the `~/.ao` hard rule.
+
+#### M7. `systemctl start`/`restart` success is reported as "running"
+`backend/internal/cli/setupvm.go:456`, `:480`, `setupvm_bind.go:138-142`
+
+CONFIRMED.
+
+Both units are `Type=simple`, for which systemd considers the job done as soon as the
+process is forked. So `systemctl start ao-daemon.service` returns 0 even when the process
+exits one millisecond later, and setup-vm prints
+`==> ao-daemon.service enabled and running` and
+`==> ao-gateway.service restarted, so it has read the new binding` on evidence it does not
+have. On the first real run, where the units have never executed, this is the difference
+between a clear failure and a green summary over a crash loop.
+
+Smallest fix: after each start/restart, run `systemctl is-active --quiet <unit>` (the helper
+already exists at `setupvm.go:240-246`) and turn a negative into a note carrying
+`systemctl status <unit>` and `journalctl -u <unit> -n 50`.
+
+#### M8. No start-rate-limit override, so a crash-looping gateway gives up permanently
+`backend/internal/cli/setupvm_plan.go:752-753`
+
+CONFIRMED (the omission). SUSPECTED (that it bites in batch 5).
+
+The units set `Restart=on-failure` and `RestartSec=5` and nothing else. systemd's default
+`StartLimitBurst=5` over `StartLimitIntervalSec=10s` still applies, and with a 5 second
+`RestartSec` a unit that fails immediately burns its budget and enters `failed`, where
+systemd stops retrying until someone runs `systemctl reset-failed`. A gateway that cannot
+bind :443 for the first 30 seconds after boot, or that exits on a transient ACME error,
+stops for good and never comes back on its own. On an unattended VM nobody notices until
+the desktop shows the machine Offline.
+
+Smallest fix: add `StartLimitIntervalSec=0` (or a burst wide enough to matter, plus
+`Restart=always` for the gateway, which holds no session state) to `renderSystemdUnit`.
+
+#### M9. Refresh rotation is persisted first, but a failed persist locks the install out
+`frontend/src/main/ao-control-token.ts:106-113`, `frontend/src/main/ao-account-store.ts:118-124`
+
+The #35 claim is CONFIRMED correct: `await writeStoredAccount(...)` at
+`ao-control-token.ts:109` happens before `cached` is set and before `accessToken` is
+returned, and the single-flight at `:118-128` prevents two concurrent exchanges from
+racing the rotation. `signOut` does clear the cache: `main.ts:1439-1445` awaits
+`aoMachines().reset()`, which calls `tokenSource?.clear()` at `ao-machines.ts:331`.
+
+The residual hole: if `writeStoredAccount` throws (safeStorage flipped unavailable, disk
+full, read-only home), the exchange throws and the access token is discarded, while the
+refresh token now on disk has already been revoked server-side by the rotation. Every
+later exchange gets `invalid_grant`. The same applies to the crash window: there is no
+`fsync` before the `rename` at `ao-account-store.ts:123`, so a power loss can lose the
+replacement even after the promise resolved.
+
+Failure scenario: the user's keychain is locked or the disk is full, the app tries one
+refresh, and the sign-in is dead until they sign in again. It is a forced re-login, not a
+security hole, but it is silent and the reported error will be about the write, not about
+the account.
+
+Smallest fix: `fsync` the temp file's handle before the rename, and on a write failure
+after a successful exchange, surface a message that says the sign-in has to be redone
+rather than the raw filesystem error.
+
+---
+
+### LOW
+
+#### L1. The loopback page interpolates `error_description` into HTML unescaped
+`frontend/src/main/loopback-callback.ts:27-35` and `:68`, with
+`frontend/src/main/ao-pkce.ts:90-94`
+
+CONFIRMED. `describeOauthError` returns `Sign-in failed: ${detail}` built from the
+callback's `error_description` query parameter, and `PAGE()` drops it into `<title>` and
+`<p>` with no escaping. Exploiting it requires knowing `state`, so the only party that can
+is the authorization server itself (or a redirect it controls), and the injected script
+runs in an `http://127.0.0.1:<ephemeral>` origin that holds nothing. Fix: HTML-escape
+`heading` and `body` in `PAGE`.
+
+#### L2. `state` comparison is not constant-time
+`frontend/src/main/ao-pkce.ts:76`. `state !== expectedState` short-circuits on the first
+differing byte. Extracting 43 base64url characters through HTTP round-trip timing on
+loopback is not realistic, but the fix is one line: `crypto.timingSafeEqual` on equal-length
+buffers, with a length check first.
+
+#### L3. DNS match compares IP strings instead of `net.IP.Equal`
+`backend/internal/cli/setupvm_plan.go:331-335`. `ip == pf.PublicIP` fails on any
+non-canonical form. The realistic trigger is `--public-ip 2001:0DB8::1` against a
+`LookupHost` answer of `2001:db8::1`, which reports a DNS mismatch that does not exist.
+Fix: `net.ParseIP(ip).Equal(net.ParseIP(pf.PublicIP))`.
+
+#### L4. Dual-stack fallback can fail preflight against a correct A record
+`backend/internal/cli/setupvm.go:51`, `:254-268`. I checked the two endpoints:
+`api.ipify.org` publishes A only (no AAAA), `ifconfig.me` publishes both. So the ordering
+mostly saves this: the first endpoint is reached over IPv4 and returns the v4 address. But
+if `api.ipify.org` is unreachable (Cloudflare blocked, DNS hiccup) and the box prefers
+IPv6, `ifconfig.me` answers with the v6 address and `checkSetupDNS` reports a mismatch
+against a perfectly good A record. The remediation is IPv6-aware
+(`setupvm_plan.go:345-348` picks AAAA correctly), so the advice is not wrong, just
+unnecessary. Fix: prefer an IPv4 answer when the resolved set is IPv4, or try both
+families and accept a match on either.
+
+#### L5. Loopback-only port probe can pass while the public bind will fail
+`backend/internal/cli/setupvm.go:215-231`. A listener bound to the box's public address
+only (`1.2.3.4:80`) leaves `127.0.0.1:80` free, so the probe passes and `ao vm serve`'s
+`:80` wildcard bind fails later. The comment explains why a public bind is not done here,
+which is right; the residual false pass is worth one line in the warning text.
+
+#### L6. Sign-out can be raced by an in-flight machine refresh
+`frontend/src/main.ts:1439-1445`, `frontend/src/main/ao-machines.ts:281-287`. A `refresh()`
+already past `tokenSource.get()` (cached token in hand) can complete after `reset()` and
+call `setActive(stillRegistered)`, re-writing `ao-machine.json` for a signed-out install.
+Fix: a monotonic generation counter checked before `setActive`.
+
+#### L7. Ctrl-C during the device flow waits out the poll interval
+`backend/internal/cli/setupvm_bind.go:183-186`. `c.deps.Sleep(interval)` is a plain
+`time.Sleep`; `ctx.Err()` is only checked afterwards, so an interrupt takes up to the
+server-supplied interval (5s, up to 60s after `slow_down` backoff) to be noticed. Fix:
+select on `ctx.Done()` and a timer.
+
+#### L8. Temp-file name collides on pid reuse
+`frontend/src/main/ao-account-store.ts:121-122` and `ao-machines.ts:133-134`. The temp
+name is `.ao-account-${process.pid}.json`. `writeFile`'s `mode` applies only on create, so
+a stale file left by a crashed run with the same pid is reused with whatever mode it had.
+Fix: append a random suffix, or `rm` the temp path first.
+
+### Observation, not a finding
+
+The device flow mints a machine-audience access token and returns it in the
+`/device/token` body, and `setupvm_bind.go:66-71` deliberately does not decode it. Not
+decoding it is the right client behaviour. The consequence is that a 15 minute credential
+for the machine is created and transmitted on every bind for no consumer. The issuing side
+is the other reviewer's half; worth raising with them.
+
+## 3. Pre-flight risk list for the batch 5 VM run
+
+Ranked by probability times cost. This is what I would check before touching the box.
+
+1. **`WorkingDirectory=` quoting (C1).** Highest probability, highest cost: it fails after
+   the box has been mutated and every re-run fails identically. Verify with
+   `ao setup-vm --dry-run` plus `systemd-analyze verify` on any Linux box before the real
+   run. If it reproduces, this is a one-character fix.
+
+2. **Running as root (H1).** If the VM's login user is root (DigitalOcean, Hetzner,
+   or any `sudo -i`), the install silently produces root-owned units and root-run agents.
+   Decide the target user before the run: create an unprivileged user, `ssh` in as them,
+   and run `sudo ao setup-vm --domain ...` so `SUDO_USER` is set. Check the dry-run's
+   `run as` line says the human, not `root`, before proceeding.
+
+3. **The gateway starts but never gets a certificate, and setup-vm says it is running
+   (M7 plus H2 plus M8).** `autocert` issues lazily on the first TLS handshake, so nothing
+   in the run proves ACME works. Expect the first `https://<domain>/` connection to hang
+   for several seconds and probably time out while the order completes, and expect the
+   desktop's 4 second probe (`ao-machines.ts:37`) to report the machine Offline on the
+   first refresh. Immediately after the run, by hand:
+   `systemctl is-active ao-daemon ao-gateway`, `journalctl -u ao-gateway -n 100`, then
+   `curl -sv https://<domain>/` twice, then confirm a file appeared under
+   `~/.ao/data/vm-gateway/certs`. Also confirm 80 and 443 from your laptop with
+   `nc -vz <domain> 80` and `443`, because the tool will not do it for you.
+
+4. **Cloud firewall on 80 and 443.** Open the security group before the run, not after.
+   Preflight will pass without it and everything downstream fails silently. `ufw` on the
+   box is the second layer, and Ubuntu cloud images usually have it inactive; check both.
+
+5. **DNS must already be correct and propagated.** Preflight fails closed and cleanly here,
+   which is right, but each failed attempt costs a round trip. `dig +short <domain>` from
+   your laptop must equal the box's public IP before the first run. Use a short TTL.
+
+6. **`apt-get` and the GitHub CLI repo.** A fresh VM often has `unattended-upgrades`
+   holding the dpkg lock in its first minutes, and `apt-get update` will fail with
+   "could not get lock". That aborts the run at `setupvm.go:500` with the box only
+   partly changed (directories created). Wait for cloud-init to settle
+   (`cloud-init status --wait`) before running. `ensureGitHubCLIRepo` also downloads a
+   keyring over the network with no fingerprint pin; that is a documented GitHub path,
+   but it is another network dependency at install time.
+
+7. **`ao doctor` may hang on the harness probe (H3).** After
+   `ao vm setup-harness claude`, run `ao doctor` with a wall-clock timeout
+   (`timeout 30 ao doctor`) so a hung probe is visible as a hang and not as a slow box.
+   Expect the `claude-auth` check to WARN with a deadline error even on success (M2).
+
+8. **The device flow needs a human at the terminal and a browser.** Fifteen minute code
+   lifetime, two restarts allowed, and a closed stdin answers "no" to the restart prompt
+   (`setupvm_bind.go:226-237`). Do not run setup-vm under `nohup`, `screen -d`, or any
+   wrapper that detaches stdin. Have the browser tab and the AO account ready before
+   starting the run.
+
+9. **Clock skew.** Both ACME and the gateway's JWT verification are time-sensitive
+   (`vmgateway.DefaultSkew`), and preflight does not check the clock. Confirm
+   `timedatectl` shows NTP synchronized before the run.
+
+10. **Selecting the machine in the desktop will not work yet (M3).** Expect the picker to
+    say Connected and every request to 401. That is task 13, not a regression, but do not
+    spend time debugging it as one.
+
+11. **Re-running setup-vm re-binds.** Verified harmless: the control plane reuses the
+    existing `machines` row for the same `(account, public_url)`
+    (`controlplane/internal/device/store.go:201-225`), so the machine id is stable and the
+    desktop's persisted machine does not go stale. It does need a human to approve in a
+    browser again on every run, so budget for that on each retry.
+
+## 4. What I verified and found correct
+
+`ao setup-vm`
+
+- **Preflight changes nothing on failure. Confirmed.** Traced every path: the platform
+  gate reads `/etc/os-release` and `LookPath` only; the preflight probes are `sudo -n true`,
+  a DMI read, two HTTPS GETs, a DNS lookup, `systemctl is-active`, and a bind-and-release
+  on loopback. `buildSetupVMPlan` (which can also fail, on a relative `AO_DATA_DIR`) runs
+  after preflight and before the first mutation. `installSetupVM` is the first thing that
+  touches the box and it is only reached with `problems` empty and `--dry-run` off.
+- **Idempotency. Confirmed on every axis I could check.** `writeSetupFile` compares content
+  before writing, so units are never duplicated and no file grows. `ensureSetupPackages`
+  skips installed packages via `dpkg-query`, and only touches the GitHub apt source when
+  `gh` is actually missing. `install -d` re-applies mode and ownership rather than failing
+  on an existing directory. `ensureSetupBinary` compares a SHA-256 of both files, so an
+  unchanged binary is not reinstalled, and it uses `install` rather than `cp`, which
+  unlinks the destination first and so avoids `ETXTBSY` against the running daemon. The
+  daemon is only restarted when its unit changed, deliberately, so a re-run does not kill
+  live agent sessions, and the replaced-binary case is reported as a note instead.
+- **The public IP check fails closed. Confirmed.** Both endpoints unreachable, or answering
+  with HTML, produce `PublicIPErr`, which `checkSetupDNS` turns into a hard preflight
+  problem with a `--public-ip` escape hatch. The 256 byte read limit means an HTML page
+  cannot accidentally parse as an address.
+- **Reachability never reports unverified as closed. Confirmed.** `blockedSetupPorts`
+  returns nil unless `Ran` is true, and `unverifiedReachabilityDetail` words the three
+  reasons separately. The design is right even though the check is inert (H2).
+- **`machine.json` write path. Confirmed correct for the default path.** Same-directory
+  temp file plus rename (atomic, no cross-filesystem rename), explicit 0600, chown only
+  when the process is root, chown target taken from the same `setupTargetUser()` that
+  produced `plan.User`, so the file's owner and the unit's `User=` cannot disagree. The
+  file is read back through `vmgateway.ReadMachineFile`, the gateway's own reader, before
+  the gateway is restarted. The only gap is the override case (M6).
+- **Re-bind preserves the old binding. Confirmed.** `bindSetupVM` prints the previous
+  binding, then does the whole device flow, and only writes after
+  `validateMachineFile` passes. Any abort before the write (Ctrl-C, denial, expiry,
+  transport loss) leaves the existing `machine.json` untouched, and `runSetupVM` still
+  prints the summary and returns the bind error.
+- **The device flow client. Confirmed on all four points.** It starts at the
+  server-supplied `interval` and only falls back when it is absent or nonsensical
+  (`devicePollStartInterval`); `slow_down` adds the RFC's 5 seconds, capped at 60
+  (`nextDevicePollInterval`); `expired_token` and `invalid_grant` both route to an offered
+  restart, bounded at two; `access_denied` is never retried. It waits before the first poll,
+  per RFC 8628 section 3.4. Bounded consecutive transport failures at 5.
+- **The device code is never printed, logged, or persisted. Confirmed.**
+  `renderDeviceInstructions` prints only `user_code` and the two verification URLs;
+  `verification_uri_complete` carries the user code, not the device code. The device code
+  travels in a POST body, never a query string. `deviceTokenResponse` deliberately does not
+  decode the access token, so it cannot be logged by accident.
+- **No secrets in argv or shell history. Confirmed.** Every `runSetupPrivileged` call site
+  passes only paths, unit names, package names, and `DEBIAN_FRONTEND=noninteractive`.
+  Nothing sensitive is ever an argument to a privileged command, so nothing is visible in
+  `ps`.
+- **The gateway user can write the ACME cert directory. Confirmed.**
+  `plan.CertDir = <DataDir>/vm-gateway/certs` is created by `install -d -m 0700 -o
+  plan.User`, the gateway unit runs as `plan.User`, `AO_VM_CERT_DIR` is set explicitly in
+  the unit, `vmgateway.Resolve` reads it, and `NewServer` `MkdirAll`s it before binding any
+  port. `autocert.DirCache` writes there in-process, and the gateway holds :80 for the
+  whole HTTP-01 lifetime, so the 60 day renewal has both the permission and the challenge
+  listener it needs. This one is fine.
+- **Paths are absolute and explicit. Confirmed.** A relative `AO_DATA_DIR`, `AO_RUN_FILE`,
+  or `AO_MACHINE_FILE` is rejected rather than absolutized, with the systemd rationale
+  spelled out. The unit environment sets `HOME`, `AO_DATA_DIR`, `AO_RUN_FILE`, and for the
+  gateway `AO_MACHINE_FILE`, `AO_VM_DOMAIN`, `AO_VM_CERT_DIR`. `slashPath` uses `path`, not
+  `filepath`, so the Windows leg of CLI E2E cannot mangle a Linux path.
+- **Unit ordering and separation. Confirmed.** Two units, never collapsed; the gateway has
+  `After=network-online.target ao-daemon.service`, the daemon has no capabilities and no
+  public port, the gateway has `CAP_NET_BIND_SERVICE` with a matching
+  `CapabilityBoundingSet` and `NoNewPrivileges=yes`. `Restart=on-failure` is right for a
+  process that exits 0 on SIGTERM.
+- **Domain normalization agrees with the gateway. Confirmed.** `normalizeSetupDomain`
+  rejects a port, a path, a bare IP, and a hostname with no dot;
+  `vmgateway.normalizeDomain` reduces `machine.json`'s origin the same way, and the
+  reasoning about `autocert.HostWhitelist` silently ignoring an unparseable host is right.
+
+Desktop
+
+- **`safeStorage` fails closed. Confirmed.** `writeStoredAccount` refuses to write when
+  `isEncryptionAvailable()` is false rather than falling back to plaintext, and the check
+  is also made before the browser is opened, so a user does not complete a Google login
+  only to have it thrown away. When availability flips to false after a token was stored,
+  `readStoredAccount` throws and `currentState` reports `unavailable` with the reason; on a
+  decrypt failure it reports `signed-out` with the reason. Neither path deletes the file,
+  so a re-locked or re-keyed keychain that comes back recovers without a re-login. This is
+  the right shape.
+- **The loopback listener. Confirmed on binding and shutdown.** `server.listen(0,
+  "127.0.0.1", ...)` is loopback-only, never `0.0.0.0`. `state` is validated before the
+  code is read (`parseCallback` checks it first). The listener accepts exactly one callback
+  (`done` guard), and `close()` runs on success, on error, on the 5 minute timeout, and in
+  the `finally` of `runDesktopLogin`, with `closeAllConnections()` so a browser keep-alive
+  cannot hold the port. An abandoned login leaves nothing bound. The timer is `unref`ed so
+  it never holds app exit. PKCE is S256 from 32 CSPRNG bytes, `plain` is unreachable, and
+  the module logs nothing. The one defect is the abort-on-mismatch behaviour (M1).
+- **The refresh rotation ordering claim is true (M9 covers the residual).**
+- **The local-daemon spawn guard is structural, as claimed. Confirmed.**
+  `remoteDaemonLifecycle.start` is `applyRemoteStatus(setStatus) ?? localStart()`, and
+  `activeMachineStatus()` returns a non-null status for all three reachability values, so
+  `localStart` is not reached rather than being skipped by a condition. `startLocalDaemon`
+  and `startDaemonInner` have no other callers in `main.ts`; `refresh` and `stop` are gated
+  the same way. `restore()` is awaited before `createWindow()` and before the first
+  `startDaemon()`, so a machine remembered from a previous run is in force before anything
+  can spawn a local daemon. Sign-out falls back to local through
+  `aoMachines().reset()`, and switching to `local` clears `activeMachineStatus` so the
+  local path resumes normally.
+- **In-flight SSE is torn down on a machine switch. Confirmed.** Both
+  `event-transport.ts` and `notifications.ts` subscribe to `subscribeApiBaseUrl` and
+  compare the recorded `sourceBaseUrl`, closing and reopening on a change. The residual
+  problem is the query cache, not the streams (M4).
+- **Hard rules intact. Confirmed.** `main.ts:102` still pins
+  `app.setPath("userData", path.join(os.homedir(), ".ao", "electron"))`, with the
+  crash-dumps comment above it. Both new state files (`ao-account.json`, `ao-machine.json`)
+  are written to `path.dirname(runFilePath())`, which resolves under `~/.ao`. Nothing
+  reaches for an OS default app-data location. `AO_REMOTE_URL`/`AO_REMOTE_TOKEN` still
+  work and still take precedence: `currentStatus` checks `config` before
+  `activeMachineStatus()`, and `readRemoteDaemonConfig`'s validation is unchanged.
+- **Token audiences match the contract. Confirmed.** The refresh token is presented at
+  exactly one place, `POST /api/v1/token` (`ao-control-token.ts:77`), and the resulting
+  control-plane-audience token is used only for `GET /api/v1/machines`
+  (`ao-machines.ts:210`). No machine-audience token is minted or cached anywhere in the
+  desktop yet, which matches `docs/desktop-login-contract.md:86-87`. Sign-out clears both
+  the on-disk refresh token and the in-memory access token.
+- **No URL and no token can be typed into the app. Confirmed.** The preload surface exposes
+  only `getState`, `refresh`, and `select(machineId)`; the renderer picks an id out of a
+  list the main process fetched.
+- **Renderer conformance.** `MachinesSection` and `AccountSection` are built from the
+  existing `components/ui` primitives (`Badge`, `Button`, `SettingsSection`), lucide icons,
+  and the established `settings-row-bar` / `text-settings-*` tokens. Nothing diverges from
+  agent-orchestrator that I can see. No findings.
+
+`#20` scheme-aware stripping (the parts that are correct)
+
+- `sanitizeOriginURL` is byte-correct on the cases that matter: an https remote with no
+  userinfo, including query, fragment, and trailing slash, is returned verbatim through the
+  no-`@` fast path; scp-like `git@host:owner/repo.git` is left alone (`url.Parse` gives it
+  no scheme); `ssh://git@host:2222/...` keeps the login name and port and only a password
+  would be dropped; `https://user:token@host/...` and bare-username-over-https are both
+  stripped; local and relative paths pass through unchanged. The ssh-versus-https asymmetry
+  is deliberate and documented at `clone.go:190-203`, and it is right.
+- `cmd.WaitDelay` is set on the only git exec in the package that talks to a remote
+  (`clone.go:67-68`), and it is transport-independent because there is no scheme branch,
+  so ssh is covered as well as https. Every other git exec in the package is local-only.
+- The partial-clone cleanup ordering is correct at the Go level: `os.RemoveAll(dest)`
+  (`clone.go:77`) runs after `CombinedOutput` returns, and `Wait` does not return until the
+  direct child is reaped; `WaitDelay` bounds the pipe wait, not the reap. The residual race
+  is SUSPECTED only: `aoprocess.Command` sets no process group, so on a context timeout
+  only `git clone` is killed and an orphaned `git-index-pack` grandchild could still be
+  writing into `dest` when `RemoveAll` starts. Not reproduced;
+  `TestCloneRepository_Timeout` stalls before any pack data flows, so it cannot exercise it.
+  Fix if wanted: `Setpgid` and kill the group.
+
+Test runs
+
+- `go test ./internal/cli/ ./internal/vmgateway/ ./internal/doctor/`: 446 passed,
+  5 failed, 3 skipped. All 5 failures are the known pre-existing `spawn_test.go`
+  `HTTP 404` failures, unrelated to this work.
+- `go test ./internal/service/project/`: all 147 pass.
+- `npx vitest run` over the nine new and changed desktop test files
+  (`ao-account`, `ao-account-store`, `ao-pkce`, `loopback-callback`, `ao-control-token`,
+  `ao-machines` main and shared, `remote-daemon`, `control-plane`): 84 passed, 0 failed.
+  Note that the golden unit assertions at `setupvm_plan_test.go:525`, `:554`, and `:593`
+  bake in the quoted `WorkingDirectory`, which is why the test suite is green while C1
+  stands.

--- a/docs/reviews/2026-07-30-review-batches-3-4-server.md
+++ b/docs/reviews/2026-07-30-review-batches-3-4-server.md
@@ -1,0 +1,635 @@
+> **Preserved from `/tmp/ao/review-server-side_report.md`.** `/tmp` is ephemeral, so this is
+> the only copy. Everything below the horizontal rule is the report exactly as the reviewer
+> wrote it: no summarizing, no rewording, no reordering. The value is the file, the line, the
+> failure scenario, and the smallest fix, and a summary would destroy all four.
+>
+> | | |
+> | --- | --- |
+> | Reviewed state | `develop` @ `a7eb9c6b2` |
+> | Date | 2026-07-30 |
+> | Reviewer session | `hosted-ao-24` (AO worker, read-only) |
+> | Findings | 15: 0 critical, 2 high, 5 medium, 8 low |
+>
+> **Where each finding was fixed.** This mapping was added on import and is not part of the
+> original report. One finding, L-B, is not closed by any merged PR; it is recorded as an
+> open gap rather than mapped to a PR that did not address it.
+>
+> | Finding | Fixed in | Issue |
+> | --- | --- | --- |
+> | H-A approval POST has no rate limiting | [#45](https://github.com/agentlab-in/hosted-ao/pull/45) | [#37](https://github.com/agentlab-in/hosted-ao/issues/37) |
+> | H-B `POST /device/code` unauthenticated, unbounded, never swept | [#45](https://github.com/agentlab-in/hosted-ao/pull/45) | [#37](https://github.com/agentlab-in/hosted-ao/issues/37) |
+> | M-A no CSRF token and no `Origin` check on the approval POST | [#45](https://github.com/agentlab-in/hosted-ao/pull/45) | [#37](https://github.com/agentlab-in/hosted-ao/issues/37) |
+> | M-B concurrent refresh exchange returns 500, not `invalid_grant` | [#45](https://github.com/agentlab-in/hosted-ao/pull/45) | [#37](https://github.com/agentlab-in/hosted-ao/issues/37) |
+> | M-C `GET /api/v1/doctor` publishes and costs too much | [#43](https://github.com/agentlab-in/hosted-ao/pull/43) | [#39](https://github.com/agentlab-in/hosted-ao/issues/39) |
+> | M-D `redactHomePaths` silently becomes a no-op | [#43](https://github.com/agentlab-in/hosted-ao/pull/43) | [#39](https://github.com/agentlab-in/hosted-ao/issues/39) |
+> | M-E `normalizePublicURL` accepts `http://` for any host | [#45](https://github.com/agentlab-in/hosted-ao/pull/45) | [#37](https://github.com/agentlab-in/hosted-ao/issues/37) |
+> | L-A `corsGate` passes an originless request straight through | [#43](https://github.com/agentlab-in/hosted-ao/pull/43) | [#39](https://github.com/agentlab-in/hosted-ao/issues/39) |
+> | L-B a port in `publicUrl` is dropped by the gateway, kept by the control plane | **not closed.** No merged PR addresses it, and it was not carried into #37 or #39 | none filed |
+> | L-C `JWKSCache.fetch` runs on the triggering request's context | [#43](https://github.com/agentlab-in/hosted-ao/pull/43) | [#39](https://github.com/agentlab-in/hosted-ao/issues/39) |
+> | L-D a `\|` in `next` breaks sign-in | [#45](https://github.com/agentlab-in/hosted-ao/pull/45) | [#37](https://github.com/agentlab-in/hosted-ao/issues/37) |
+> | L-E the attempt limiter is per-account, in-memory, never evicts | [#45](https://github.com/agentlab-in/hosted-ao/pull/45) | [#37](https://github.com/agentlab-in/hosted-ao/issues/37) |
+> | L-F `createDeviceCode` retries on any insert error | [#45](https://github.com/agentlab-in/hosted-ao/pull/45) | [#37](https://github.com/agentlab-in/hosted-ao/issues/37) |
+> | L-G `parseClaudeAuthStatus` embeds the harness's raw output | [#43](https://github.com/agentlab-in/hosted-ao/pull/43) | [#39](https://github.com/agentlab-in/hosted-ao/issues/39) |
+> | L-H the previous review's L6 is not closed | [#43](https://github.com/agentlab-in/hosted-ao/pull/43), as a documented decision rather than a relocation | [#39](https://github.com/agentlab-in/hosted-ao/issues/39) |
+>
+> Section 3 of this report, "Did the previous review's fixes close", is the record of which
+> batch 1 and 2 findings were verified closed at `a7eb9c6b2`. Those do not need re-reviewing.
+
+---
+
+# Review: the server half of batches 3 and 4 (control plane, gateway, tokens, daemon HTTP)
+
+Reviewer: AO worker `hosted-ao-24`. Read-only. Nothing was changed.
+Reviewed state: `develop` @ `a7eb9c6b2`, commits `86d9772d2` (#18), `1d242dc60` (#19),
+`793fc8dff` (#22), `ecaef6c8d` (#26), `a7eb9c6b2` (#36).
+Test suites run: `controlplane` 96 passed across 9 packages; `backend`
+`internal/vmgateway`, `internal/doctor`, `internal/httpd` 325 passed across 8 packages.
+
+## 1. Verdict
+
+Yes, safe to run on a public VM, with two caveats to fix first: the device-approval POST
+has no rate limiting at all (the limiter the code claims sits on the wrong handler), and
+`POST /device/code` is an unauthenticated unbounded permanent write. Zero critical
+findings: the device flow's core invariants (CSPRNG codes, hashed device codes,
+server-side expiry, single approval, session-validated POST, server-side poll interval)
+all hold, and every one of the previous review's H1 to H4, M1, M3, M4, M5, L1 to L5, L7
+fixes actually landed correctly.
+
+## 2. Findings, ranked by severity
+
+### Critical
+
+None. I tried to break the device flow's state machine and its token audience split and
+could not. What that means concretely is in section 5.
+
+### High
+
+---
+
+**H-A. `POST /device/decision` approves a user code with no rate limiting, so the
+enter-code limiter is bypassed by skipping the page it guards. CONFIRMED (code reading).**
+
+`controlplane/internal/device/pages.go:76` is the only call to `s.attempts.allow`, and it
+is inside `handleSubmitCode` (`POST /device`, which only renders the confirmation page).
+`handleDecision` (`POST /device/decision`, `pages.go:116-163`) reads `user_code` straight
+out of the POST form and calls `s.approve` with no limiter check and no server-side link
+back to any earlier `POST /device`. Confirmed by grep: `s.attempts` appears in exactly one
+non-test location.
+
+`controlplane/internal/device/codes.go:142-150` states the intent that was missed:
+
+> "attemptWindow and attemptsPerWindow bound how fast one signed-in account may guess user
+> codes on the enter-code page. The device code endpoint needs no equivalent because a
+> device code has 256 bits of entropy, but a user code has about 34, so the page is the
+> oracle worth closing."
+
+Two entry points reach the user code space; one got the limiter, and it is the one that
+does not change state.
+
+Failure scenario: an attacker signs in with any Google account (accounts are free), then
+POSTs `/device/decision` with `user_code=<guess>&action=approve` as fast as they like. The
+responses are fully distinguishable: 200 result page on a hit, 400 for unknown or expired
+(`statusForCodeError`, `pages.go:167-176`), 409 for already used. On a hit the code is
+approved and bound to the **attacker's** account, `registerMachine` inserts a `machines`
+row under the attacker's account (`store.go:152`), and the legitimate VM's polling client
+then receives `account_id` = attacker, `machine_id` = the attacker's machine, and an access
+token with `sub` = attacker (`endpoints.go:145-159`). `ao setup-vm` writes those into
+`machine.json`, so `ao vm serve` on the victim's VM starts accepting the attacker's tokens:
+full gateway access to the victim's machine, including `/mux`.
+
+Honest sizing: the space is 20^8 ≈ 2.6e10 and a code lives 15 minutes, so a single code is
+unlikely to fall at realistic request rates through Caddy. The finding is that the only
+control the design has against guessing does not run on the path where a guess is worth
+anything, and the `deny` branch is the same unmetered primitive (a hit kills someone else's
+setup silently, since `deny` renders the same result page whether or not it hit,
+`pages.go:129-135`).
+
+Smallest fix: move the limiter check so both handlers share it. In `handleDecision`,
+immediately after `requireAccount` returns:
+
+```go
+if !s.attempts.allow(accountID) {
+    s.renderEnterPage(w, http.StatusTooManyRequests, enterPageData{
+        Error: "Too many attempts. Wait a minute and try again.",
+    })
+    return
+}
+```
+
+Add a test mirroring `TestSubmitCode_UnknownCodeIsRejectedAndRateLimited`
+(`flow_test.go:571`) against `/device/decision`; there is currently no test on that path at
+all for rate limiting.
+
+---
+
+**H-B. `POST /device/code` is unauthenticated, unrate-limited, stores an unbounded
+attacker-chosen `machine_name`, and no code path ever deletes a `device_codes` row.
+CONFIRMED.**
+
+- `controlplane/internal/device/endpoints.go:65-104`: no auth, no limiter. `machine_name`
+  is `strings.TrimSpace(params.Get("machine_name"))` with no length check (`:77-80`).
+- `controlplane/internal/api/api.go:152-170`: `ReadParams` caps a **JSON** body at 64 KiB
+  (`http.MaxBytesReader`, `:155`) but the form branch (`:166-169`) is plain
+  `r.ParseForm()`, so a urlencoded body is capped only by net/http's 10 MiB default.
+- `controlplane/internal/device/store.go:47-71` inserts a row per request.
+- `grep -rn "DELETE FROM device_codes" controlplane/` returns nothing. `markExpired`
+  (`store.go:109-113`) only flips `status`; its doc comment says "nothing sweeps the
+  table" (`store.go:26-29`), which is accurate.
+
+Failure scenario: an internet attacker loops
+`POST /device/code` with `public_url=vm.example.com&machine_name=<10 MiB of text>`. Each
+request writes a permanent row of roughly that size into `controlplane.db`. A few hundred
+requests is gigabytes. That file sits in the same directory as the EdDSA signing keys and
+the `accounts`/`refresh_tokens` tables (`config.go:70-77`, `keys.go:49`), so when the disk
+fills, sign-in (`upsertAccount`), refresh rotation, and key rotation all start failing.
+Nothing recovers on its own because nothing deletes anything.
+
+Mitigating context, stated so it is not over-weighted: Caddy fronts this service and could
+be configured with a body limit and a rate limit. Nothing in this repo does.
+
+Smallest fix, three lines in three places:
+
+1. `endpoints.go`, after `:77`: reject a `machine_name` longer than, say, 128 runes.
+2. `api.go:166`, form branch: `r.Body = http.MaxBytesReader(w, r.Body, 1<<16)` before
+   `ParseForm`.
+3. `store.go`, inside `createDeviceCode` before the insert loop:
+   `_, _ = s.db.ExecContext(ctx, "DELETE FROM device_codes WHERE expires_at < ?", now)`.
+   That is the whole sweep: rows are useless past `expires_at` and every read already
+   rejects them.
+
+### Medium
+
+---
+
+**M-A. No CSRF token and no Origin check on the approval POST. `SameSite=Lax` is the sole
+defence, and it does not cover a same-site attacker. CONFIRMED.**
+
+`controlplane/internal/device/templates/device_confirm.html` posts to `/device/decision`
+with exactly one hidden field, `user_code`. `handleDecision` (`pages.go:116-163`) checks
+only that a session exists. `grep -rni "referer|\"Origin\"|csrf" controlplane/` finds no
+check anywhere in the service; the only hits are a doc comment and the OAuth `state`
+value. The session cookie is `http.SameSiteLaxMode` (`auth/session.go:109`), which is what
+`pages.go:113-115` cites as the defence.
+
+`SameSite` is scoped to the registrable domain, not the origin. `DefaultPublicOrigin` is
+`https://ao.agentlab.in` (`config.go:22`), so a page served from **any other host under
+`agentlab.in`** is same-site and its cross-origin POST carries the session cookie.
+
+Failure scenario: the attacker calls `POST /device/code` with
+`public_url=https://evil.example.com&machine_name=Production VM`, keeps the returned
+`device_code` and `user_code`, and hosts an auto-submitting form at any `*.agentlab.in`
+origin (or anywhere, against a client that does not enforce SameSite). A signed-in operator
+loads it. Their account approves the attacker's code. The attacker's polling client then
+receives the **victim's** `account_id` and an access token with `sub` = victim
+(`endpoints.go:152-159`), and a `machines` row named "Production VM" pointing at
+`https://evil.example.com` appears in the victim's desktop machine list
+(`listMachines`, `store.go:339-371`). If the operator ever picks it, the desktop points at
+the attacker's host.
+
+Smallest fix, one function, no new state, given the device Service holds `publicOrigin`
+already (`device.go:70`): in `handleDecision`, before `ParseForm`,
+
+```go
+if o := r.Header.Get("Origin"); o != "" && o != s.publicOrigin {
+    s.renderEnterPage(w, http.StatusForbidden, enterPageData{Error: "That request did not come from this page."})
+    return
+}
+```
+
+Browsers send `Origin` on every POST, so this closes the same-site case without touching
+the templates. A real per-session CSRF token is stronger but needs the `sessions` interface
+(`device.go:48-50`) extended to hand out a signing key, which is a larger change.
+
+---
+
+**M-B. Two concurrent exchanges of the same refresh token return HTTP 500 `server_error`
+instead of `invalid_grant`. CONFIRMED (empirically reproduced).**
+
+`controlplane/internal/tokens/refresh.go:66-118` opens a deferred transaction
+(`BeginTx(ctx, nil)`), SELECTs the row, then UPDATEs it. SQLite does **not** invoke the
+busy handler for a read-to-write upgrade whose snapshot has gone stale, so the
+`busy_timeout(5000)` in `storage/sqlite/db.go:28` does not absorb it. The raw error is not
+one of the three sentinels `api/api.go:79-87` maps to `invalid_grant`, so it falls into the
+`default` branch and becomes a 500.
+
+I reproduced the mechanism outside the repo with `modernc.org/sqlite v1.55.0`, the same four
+pragmas, and the same statement sequence (deferred tx, SELECT the row, UPDATE it, INSERT the
+replacement, commit). With 8 concurrent rotations of one row:
+
+```
+successes=1  cleanLosses=6  dirtyErrors=1
+g5: DIRTY ERROR: database is locked (5) (SQLITE_BUSY)
+```
+
+The good news is in the same line: exactly one rotation commits, so there is no
+double-rotation and no corruption. The bad news is the loser's error shape.
+
+Failure scenario: the desktop fires two refreshes at once (two windows, or a retry that
+overlaps its predecessor). One gets 200 with a rotated token. The other gets
+`500 server_error`, which any sane client treats as transient and retries with the token it
+presented, which the winner already revoked, so it now gets `invalid_grant` and forces the
+user to sign in again, even though a perfectly valid rotated token exists in the other
+window.
+
+Smallest fix: take the write lock before the read, so the loser blocks (and `busy_timeout`
+applies) instead of failing the upgrade. Add `&_txlock=immediate` to the DSN in
+`db.go:27-30`, or, scoped to this one path, map a `SQLITE_BUSY` from `RotateRefreshToken`
+onto `ErrInvalidRefreshToken` so the caller sees `invalid_grant`.
+
+The same read-then-write-in-a-deferred-tx pattern is in `device.approve`
+(`store.go:121-176`) and `device.poll` (`store.go:246-325`). There the symptom is milder:
+two browser tabs approving the same code produce a 500 "internal error" instead of the
+intended 409, and two overlapping polls produce a 500 instead of an RFC 8628 error code.
+`ao setup-vm` polls single-threaded, so poll is unlikely to hit it in practice.
+
+---
+
+**M-C. `GET /api/v1/doctor` publishes the machine's GitHub identity and token scopes, exact
+tool versions, and out-of-home binary paths, and runs six subprocesses plus a live GitHub
+API call on every request. CONFIRMED.**
+
+Enumerating what actually crosses the wire on a real Ubuntu VM, from `doctor.Run`
+(`backend/internal/doctor/doctor.go:156-193`) through the projection in
+`backend/internal/httpd/controllers/doctor.go:62-79`:
+
+| Check | Message content | Why it matters to an attacker with a token |
+|---|---|---|
+| `github-token` | `"gh token valid for <github-login> (scopes: repo, workflow, read:org)"` (`doctor.go:566-571`), or which of `AO_GITHUB_TOKEN` / `GITHUB_TOKEN` holds it | The machine's GitHub account name and the exact capability of the credential sitting on it |
+| `git` | `/usr/bin/git (version 2.43.0; supports worktrees)` (`doctor.go:387`) | Exact version for CVE targeting |
+| `tmux` | `/usr/bin/tmux (tmux 3.4)` (`doctor.go:419`) | Same |
+| `claude-code`, `codex` | path plus exact harness version (`doctor.go:488`) | Same |
+| `ao-binary` | both the running executable and the `ao` on PATH (`doctor.go:345,349`) | Install layout |
+| `claude-auth` | resolved claude path, `authMethod`, `apiProvider` (`doctor.go:240`) | Whether the harness runs on a subscription or a raw API key, and which provider |
+| `config` | `runFile=... dataDir=... port=<daemon loopback port>` (`doctor.go:166`) | The loopback port to aim a local exploit at |
+| `sqlite` | db path and exact byte size (`doctor.go:291`) | Rough activity volume |
+| `hooks-log` | a full log line, which carries a session id (`cli/hooks.go:239`) | Session identifiers |
+| `codex-launch-flags` | `FirstOutputLine` of codex's own error output (`doctor.go:517`) | Whatever codex printed |
+
+Reachable by anyone holding a valid access token for the machine, and separately by any
+Connect Mobile client on the LAN: `/api/v1/doctor` is not in `lanControlBlockedPrefixes`
+(`backend/internal/httpd/lan_listener.go:52-57`), so only the mobile password gates it
+there.
+
+Side effects, per request, with no caching and no concurrency limit: `os.MkdirAll` on the
+data dir plus a create/write/delete temp-file probe (`doctor.go:169`, `:303-322`), up to
+six `exec` probes at 2s each, and one authenticated `GET https://api.github.com/user` using
+the machine's real token (`doctor.go:530-540`). N concurrent requests multiply all of it
+and burn the operator's own GitHub rate limit.
+
+Smallest fix, in `checkGitHubToken` and the controller:
+1. `doctor.go:571`: drop the login and the scope list from the PASS message, e.g.
+   `fmt.Sprintf("%s token valid", source)`. Both are only useful locally, and `ao doctor`
+   text output can keep them behind a flag if wanted.
+2. Memoize the report in `DoctorController` behind a mutex with a short TTL (10s is enough)
+   so a burst of requests runs the probes once.
+
+---
+
+**M-D. `redactHomePaths` silently becomes a no-op when `os.UserHomeDir()` fails, and it
+only rewrites `home + separator`. CONFIRMED.**
+
+`backend/internal/httpd/controllers/doctor.go:63`: `home, _ := os.UserHomeDir()`, error
+discarded. `:91-98`: `if home == "" || home == sep { return message }`, unchanged.
+
+Failure scenario: the daemon runs under a unit that sets `AO_DATA_DIR` but not `HOME`.
+`config.Load` still succeeds (`resolveDataDir` short-circuits on `AO_DATA_DIR`,
+`backend/internal/config/config.go:324-327`), so `doctor.Run` proceeds past its first
+check, but `os.UserHomeDir` errors, `home` is `""`, and the only privacy control on this
+route does nothing. Every home path goes out verbatim:
+`/home/ubuntu/.local/bin/claude`, `/home/ubuntu/.ao/ao.db`, account name included. The
+response looks completely normal; nothing signals the defence did not run.
+
+Second, narrower gap: a message that is exactly the home directory with no trailing
+separator is never rewritten, because the replacement key is `home+sep` (`:97`). That is
+the `data-dir` check when `AO_DATA_DIR` is the home directory itself.
+
+Smallest fix: resolve the home directory once at daemon start and treat a failure as a
+reason to withhold `Message` rather than to send it unredacted; and add
+`strings.ReplaceAll(message, home, "~")` as a second pass, or compare with
+`strings.TrimSuffix` semantics.
+
+---
+
+**M-E. `normalizePublicURL` accepts `http://` for any host, not just loopback. CONFIRMED.**
+
+`controlplane/internal/device/codes.go:121-123` accepts both `http` and `https`.
+`codes_test.go:86` pins `http://127.0.0.1:8443` as valid, which shows the intent was a
+local-development affordance, but nothing restricts the scheme to a loopback host.
+
+Failure scenario: `public_url=http://vm.example.com` is accepted, stored in
+`machines.hostname` (`store.go:217`), returned by the poll response
+(`endpoints.go:158`) and by `GET /api/v1/machines` (`store.go:341`), and written into
+`machine.json`. The desktop builds its base URL from that, so the `Authorization: Bearer`
+header and the `ao_gw_token` cookie, which `TOKEN_CONTRACT.md:89` requires to be `Secure`,
+travel in the clear. `ao vm serve` only ever listens on TLS
+(`vmgateway/server.go:55-63`), so the operator gets a broken machine rather than a working
+plaintext one, but the registration itself succeeded and the desktop will try.
+
+Smallest fix, in `normalizePublicURL` after the scheme check:
+
+```go
+if u.Scheme == "http" && !isLoopbackHost(u.Hostname()) {
+    return "", fmt.Errorf("public_url %q must use https", raw)
+}
+```
+
+### Low
+
+**L-A. `corsGate` does nothing to a request with no `Origin` header, while the `/mux` and
+SSE cookie is `SameSite=None`. CONFIRMED.** `backend/internal/vmgateway/proxy.go:275-279`
+returns straight to `next` when `Origin` is empty. `cookieAuthAllowed` (`proxy.go:242-247`)
+accepts the ambient cookie on `/mux` for any method and on `GET /api/v1/events`. Browsers
+do not send `Origin` on a subresource or navigational GET, and `SameSite=None`
+(`TOKEN_CONTRACT.md:89`) means the cookie is attached cross-site. So
+`new Image().src = "https://vm.example.com/api/v1/events"` from a hostile page is an
+authenticated, proxied SSE connection held open on the daemon. There is no disclosure (the
+response is opaque, no CORS grant) and nothing state-changing, so the impact is connection
+exhaustion. Fix: on the two cookie-authenticated routes only, require an `Origin` and run
+it through the same allowlist. `EventSource` and the WebSocket handshake both send one;
+non-browser clients use the header path anyway.
+
+**L-B. A port in `publicUrl` is silently dropped on the gateway side but preserved on the
+control-plane side. CONFIRMED.** `vmgateway/config.go:184-197`: `https://vm.example.com:8443`
+reduces to `vm.example.com` (the port is lost with `u.Hostname()`), while a bare
+`vm.example.com:8443` is a fatal error. `device/codes.go:130` keeps `u.Host`, port included.
+So the control plane stores `https://vm.example.com:8443`, the desktop connects there, and
+the gateway certificates `vm.example.com` and listens on `:443` unless `--https-addr` is
+also set. Nothing checks the two agree. Fix: reject a port in `normalizeDomain` with a
+message naming `--https-addr`, or carry it into `HTTPSAddr`.
+
+**L-C. `JWKSCache.fetch` runs on the triggering request's context. CONFIRMED.**
+`vmgateway/jwks.go:136` passes the caller's `ctx` straight to `c.fetch`. A client that
+disconnects mid-refresh cancels a refresh the whole gateway shares. With a keyset already
+cached that records a 30s `failureBackoff` (`jwks.go:146`) despite the control plane being
+healthy; on a cold start it returns the error and fails that request closed. Fix:
+`context.WithTimeout(context.Background(), c.client.Timeout)` for the fetch.
+
+**L-D. A `|` in the `next` parameter breaks sign-in, and `#26` added a new caller that
+builds `next` from an attacker-influenced URL. CONFIRMED.**
+`auth/oauth.go:85` joins the flow-cookie payload with `|`; `oauth.go:120-123` requires
+exactly 4 parts after `strings.Split`. `sanitizeNext` (`:76-81`) only checks the leading
+slash. `device/pages.go:42` now feeds `r.URL.RequestURI()` into `next`, so a crafted link
+`https://ao.agentlab.in/device?user_code=A|B` sends a signed-out operator into a sign-in
+that always fails at the callback with no explanation. Denial only. Fix: reorder the
+payload to put `Next` last and use `strings.SplitN(payload, "|", 4)`.
+
+**L-E. The attempt limiter is per-account, in-memory, and never evicts. CONFIRMED.**
+`device/codes.go:159-190`. It resets on every restart, and it is bypassed linearly by using
+N Google accounts (10N guesses per minute), which the `ponytail:` comment at `:154-158`
+does not mention alongside the replication caveat it does mention. `l.seen` also keeps one
+entry per account that has ever submitted a code, with no eviction. Both are small today;
+worth a line in the comment so the next reader does not over-trust the control.
+
+**L-F. `createDeviceCode` retries on any insert error, not only a `user_code` collision.
+CONFIRMED.** `device/store.go:55-70` treats every error as a collision and redraws up to 5
+times. A `SQLITE_BUSY` or a foreign-key failure costs five wasted inserts and then reports
+only the last error. Fix: retry only when the error names a `user_code` uniqueness
+violation.
+
+**L-G. `parseClaudeAuthStatus` embeds the harness's raw output into a check message that
+crosses the wire. SUSPECTED (path not reachable with today's harness).**
+`doctor.go:269` builds `no JSON object in output %q` from the full ANSI-stripped
+`CombinedOutput`, and `doctor.go:233` puts that into the check `Message`. It only fires when
+`claude auth status --json` exits **zero** and prints no `{`, because `cmdErr` takes
+precedence when non-zero (`doctor.go:229-232`). I could not find a `claude` version that
+prints a credential on that path, so I am flagging the shape, not a live leak. Fix:
+`FirstOutputLine(out)` and a length cap instead of the whole buffer.
+
+**L-H. Previous review's L6 is not closed.** `vmgateway/config.go:199-205` still resolves
+the default `machine.json` from `os.UserHomeDir()` rather than the `AO_DATA_DIR`-honouring
+data dir, while `CertDir` right above it does honour it (`config.go:137-142`). So
+`AO_DATA_DIR=/srv/ao` moves the certificates but not `machine.json`.
+
+## 3. Did the previous review's fixes close
+
+- **H1** duplicate CORS: **closed.** `proxy.go:91` wires `ModifyResponse = dropUpstreamCORS`,
+  which deletes all six headers (`proxy.go:31-38`, `:108-113`). It covers the
+  websocket-upgrade path: `httputil.ReverseProxy` calls `modifyResponse` before
+  `handleUpgradeResponse` on a 101. The proxy-error path never touches upstream headers at
+  all, because `ErrorHandler` (`proxy.go:92-96`) writes on the gateway's own
+  `ResponseWriter`, on which `corsGate` already used `Set`, not `Add`. The fake daemon in
+  `proxy_test.go` now emits CORS headers, so the fix is tested.
+- **H2** `publicUrl` normalization: **closed.** `normalizeDomain` (`config.go:184-197`)
+  parses off a scheme and rejects anything still containing `:` or `/`. Against the four
+  cases asked about: **port** is silently dropped (see L-B), **path** is dropped by
+  `u.Hostname()`, **userinfo** is dropped by `u.Hostname()`, **IDN** works correctly
+  because `autocert.HostWhitelist` and `autocert.Manager.GetCertificate` both run
+  `idna.Lookup.ToASCII`, which also case-folds, so `VM.Example.COM` and `ünïcode.example.com`
+  both match their SNI form.
+- **H3** SSE cookie fallback: **closed.** `cookieAuthAllowed` (`proxy.go:242-247`) is
+  `path == "/mux"` or (`GET` and `path == "/api/v1/events"`), compared with `==` against
+  `r.URL.Path`, which Go has already percent-decoded and which excludes the query string.
+  A trailing slash (`/api/v1/events/`) does not match, a query string cannot widen it, and
+  no state-changing method on any other path accepts the cookie. `/mux` accepts the cookie
+  on any method, but a cross-origin POST there carries an `Origin` and is 403'd by
+  `corsGate` first; the no-Origin residue is L-A.
+- **H4** JWKS backoff: **closed.** `Get` (`jwks.go:127-154`) releases `c.mu` before
+  `c.fetch` and serves a concurrent arrival the stale keyset via the `c.refreshing` flag
+  rather than queueing it on the mutex. The failure path sets
+  `c.fetchedAt = now + failureBackoff - ttl` (`:146`), which is state on the cache, not on
+  the request, so the backoff is genuinely per-cache. Cold start still lets concurrent
+  callers each fetch; that is documented at `:125-126` and is the right trade.
+- **M1** schema comment: **closed.** `0001_init.sql:14-19` now says the audience is
+  `machines.id`, not `hostname`.
+- **M3** `DATA_DIR` required: **closed.** `config.go:101-104` fails at boot with a message
+  naming `.env.example`, `filepath.Abs` resolves it (`:105-109`), and
+  `cmd/controlplane/main.go:52-54` logs the resolved absolute dir, the active `kid`, the
+  TTL, and the public origin on every boot. Both halves of the ask landed.
+- **M4** `PUBLIC_ORIGIN` normalization: **closed.** `config.go:119` trims once;
+  `auth/auth.go:60-62` now relies on it instead of re-trimming.
+- **M5** no cross-module test: **closed.** `backend/internal/vmgateway/testdata/` holds a
+  `jwks.json` from the real `keys.Manager.JWKS()` and two tokens from the real
+  `Issuer.IssueAccessToken`, generated by `controlplane/internal/tokens/golden_test.go` and
+  consumed by `backend/internal/vmgateway/golden_test.go`, with the mirror assertion in
+  `controlplane/internal/keys/golden_test.go`. One gap left: no control-plane-audience token
+  is in the fixture set, so "the gateway rejects a control-plane token" is covered only by
+  the generic `aud` unit test, not end to end.
+- **L1** `keys.Rotate` write order: **closed.** `keys.go:161-180` writes `next.json` first,
+  `active.json` second, memory last, with the reasoning in the doc comment.
+- **L2** forwarded headers: **closed.** `stripForwardedFor` (`proxy.go:120-123`) deletes
+  `X-Real-IP` and `X-Forwarded-For` in the director, and `r.Host` is deliberately left
+  alone, which is what keeps `localControlRequest` correctly refusing.
+- **L3** preflight before allowlist: **closed.** `proxy.go:296-299` calls `isProxyablePath`
+  inside the preflight branch and 404s.
+- **L4** `/mux` header fallback: **closed.** `extractToken` (`proxy.go:216-232`) tries the
+  cookie on the allowed routes and falls through to `Authorization` everywhere.
+- **L5** `ACCESS_TOKEN_TTL` bounds: **closed.** `config.go:33-34` and `:126-129` reject
+  outside `[10m, 30m]` at load with an explanatory error. The control-plane-audience token
+  respects the same bound: `IssueControlPlaneToken` uses the same `i.accessTTL`
+  (`controlplane.go:62`) as `IssueAccessToken` (`access.go:72`), and both endpoints report
+  `AccessTokenTTL()` as `expires_in`.
+- **L6** `machine.json` vs `AO_DATA_DIR`: **not closed.** See L-H.
+- **L7** data dir 0700: **closed.** `storage/sqlite/db.go:43` and `auth/session.go:49` are
+  both `0o700`, with a test (`TestOpen_CreatesDataDirMode0700`).
+- **L8** untested rejection paths: **partially closed.** All three gateway gaps it named now
+  have tests (upstream CORS not duplicated, a failing JWKS fetch not refetched, `Resolve`
+  rejecting a URL where a hostname is required). The clone-flow gaps are untouched and are
+  outside this batch.
+- **M2** `cloneUrl` credential: not in my half (#20).
+
+### Contract drift against the previous review's section 3 table
+
+Every row of that table still matches. Of the six follow-ups it listed:
+
+1. `0001_init.sql` audience comment: closed.
+2. `PUBLIC_ORIGIN` normalization: closed.
+3. SSE Bearer transport: closed. `TOKEN_CONTRACT.md:70-84` now names the cookie for
+   `GET /api/v1/events` and states the cookie is never accepted on a state-changing method.
+4. `publicUrl` as origin vs hostname: resolved in code on both sides
+   (`device/codes.go:109-131` emits an origin, `vmgateway/config.go:184-197` reduces it) but
+   `TOKEN_CONTRACT.md` still does not state it. The reasoning lives only in two Go doc
+   comments. Worth one line in the contract before the next `setup-vm` change.
+5. Cookie name and `SameSite`: closed. `TOKEN_CONTRACT.md:86-101` names `ao_gw_token` and
+   mandates `SameSite=None; Secure` with the reasoning.
+6. Refresh TTL and rotate-on-use: closed. `TOKEN_CONTRACT.md:19-27`.
+
+New this batch, and consistent: the two-audience split is documented at
+`TOKEN_CONTRACT.md:29-51` and matches the implementation exactly, including "neither side
+accepts a list, a wildcard, or a missing `aud`" (`controlplane.go:104`, `token.go:147`).
+
+### Migrations
+
+`0002_device_code_machine.sql` is three additive `ALTER TABLE ... ADD COLUMN` on
+`device_codes`, so it composes with `0001` cleanly: the table exists, and `machines` exists
+for the `machine_id TEXT REFERENCES machines (id)` foreign key, which is genuinely enforced
+(`_pragma=foreign_keys(ON)`, `db.go:29`). `approve` inserts the machine row before it sets
+`machine_id`, inside the same transaction (`store.go:152-164`), so the ordering is right.
+
+It is **not** idempotent on its own (a second `ADD COLUMN machine_name` is a duplicate
+column error), but goose's version table means it never runs twice, and the whole
+`controlplane` suite plus every device test exercises the resulting schema. The `Down`
+migration needs SQLite 3.35+ for `DROP COLUMN`, which modernc v1.55 provides; nothing tests
+the down path (`migrate_test.go` only asserts the four tables exist and the dir mode).
+
+## 4. What I verified and found correct
+
+Does not need re-reviewing.
+
+**The device flow's security properties, read line by line:**
+
+- **`user_code` entropy and alphabet are right.** `codes.go:47-59` draws each character with
+  `crypto/rand.Int` against `big.NewInt(20)`, not a byte modulo 20, so there is no bias
+  toward the first 16 letters. The alphabet `BCDFGHJKLMNPQRSTVWXZ` (`:22`) is RFC 8628's
+  suggested set: no vowels (a code cannot spell a word), no digits, and none of `0/O`,
+  `1/I/L`, `5/S`, `8/B`. 8 characters is ~34.6 bits. `normalizeUserCode` (`:93-101`) drops
+  out-of-alphabet characters rather than rejecting, so a typed `0` and `O` both normalize to
+  a lookup that simply misses rather than to a distinguishable error.
+- **`device_code` is 32 bytes of `crypto/rand`, base64url** (`codes.go:63-69`), so 256 bits.
+  It genuinely needs no rate limit of its own.
+- **It is stored hashed, and the schema comment is accurate.** `hashCode` is SHA-256 hex
+  (`codes.go:75-78`); the insert writes `hashCode(deviceCode)` (`store.go:64`) and the poll
+  looks up `WHERE device_code = hashCode(deviceCode)` (`store.go:264`). The plaintext is
+  never written. Plain SHA-256 is the correct choice here, not bcrypt: the input is 256 bits
+  of CSPRNG output, not a password. Timing: the comparison is an indexed B-tree lookup on a
+  fixed-width digest, and since an attacker cannot choose the digest without a preimage,
+  there is nothing for a timing side channel to reveal.
+- **Polling is rate limited server side, not by trusting `slow_down`.** `poll`
+  (`store.go:246-325`) reads `last_polled_at` and returns `slow_down` when
+  `now.Sub(last) < pollInterval` (`:295-297`), inside the same transaction that advances
+  `last_polled_at` (`:299-301`), so two concurrent polls cannot both pass the gate. It
+  deliberately does not advance `last_polled_at` on a `slow_down`, so a misbehaving client
+  is throttled to one poll per interval rather than locked out permanently. Tested at
+  `flow_test.go:382`.
+- **Expiry is enforced server side on every read path**, not merely displayed: `poll`
+  (`store.go:277-289`), `lookupPending` (`:99-102`), and `approve` inside its transaction
+  (`:148-150`). `markExpired` is bookkeeping only and its failure cannot make an expired
+  code usable, which the comment states and the code backs up. Tested at `flow_test.go:413`
+  and `:438`, including the "post the decision directly, skipping the page" case.
+- **A code cannot be approved twice, including by a racing second account.** `approve`
+  re-reads the row inside the transaction, checks `status != pending`, and then guards the
+  UPDATE with `AND status = ?` plus a `RowsAffected() == 0` check (`store.go:160-170`). A
+  second approval loses cleanly with 409. Tested at `flow_test.go:463`, which additionally
+  asserts only one `machines` row exists and the binding stays with the first account.
+  My empirical SQLite check (M-B) confirms the single-winner property holds under real
+  concurrency, not just in the sequential test.
+- **The approval POST validates the session, not just the GET.** `handleDecision` calls
+  `requireAccount` first (`pages.go:117`), which goes through
+  `sessions.AccountFromRequest` → the HMAC-SHA256-signed, expiry-carrying `ao_session`
+  cookie (`auth/session.go:116-137`). A signed-out POST is redirected, not honoured, and the
+  code stays pending. Tested at `flow_test.go:506`.
+- **Following `verification_uri_complete` cannot approve anything.** The GET only renders a
+  prefilled form (`pages.go:48-55`); the confirm page is a separate POST and the approval a
+  third. Tested at `flow_test.go:601`, which asserts no machine row after reaching the page.
+- **Re-binding the same VM keeps its machine id.** `registerMachine` (`store.go:201-226`)
+  reuses the unrevoked row for `(account_id, hostname)` rather than always inserting, so a
+  re-run of `ao setup-vm` does not orphan previously minted tokens. Tested at
+  `flow_test.go:619`.
+- **`normalizePublicURL` is strict about everything except the scheme** (M-E):
+  `codes.go:109-131` rejects userinfo, query, fragment, a path, and a non-http(s) scheme,
+  and lowercases the host. Tested at `codes_test.go:80-115`.
+
+**The two-audience split, and the tests that claim to cover it:**
+
+- `IssueControlPlaneToken` sets `Aud: i.issuer` (`controlplane.go:61`), the same string as
+  `iss`, which is `cfg.PublicOrigin` (`main.go:67`). `VerifyControlPlaneToken` requires
+  **both** `claims.Iss == i.issuer` **and** `claims.Aud == i.issuer` (`:104`), so the
+  audience is pinned to this deployment's origin and a token minted by a staging control
+  plane cannot be replayed against production even if the two shared a signing key.
+- `VerifyControlPlaneToken` checks the signature strictly before it unmarshals any claim
+  (`:96-101`), pins `alg` to `EdDSA` before consulting a key (`:87-91`), rejects a missing
+  `exp` as a rejection rather than "no expiry" (`:107`), and rejects an empty `sub`
+  (`:110`). `splitJWT` (`:118-137`) rejects a fourth segment.
+- **The tests assert what they claim.** I read them rather than trusting the names.
+  `TestListMachines_RequiresAControlPlaneAudienceToken` (`machines_test.go:78-140`) sends a
+  real machine-audience token, a real refresh token, a token from a *different* control
+  plane (signed by another key), a tampered signature, an empty bearer, and a
+  session-cookie-only request, requires 401 with a `Bearer` challenge on every one, and then
+  requires 200 for the correct credential so none of it passes for the wrong reason.
+  `TestAuthenticate_AcceptsOnlyAControlPlaneAudienceBearerToken` (`api_test.go:160-206`)
+  covers the same set at the middleware level plus scheme handling.
+- **The refresh token is accepted only at the token endpoint.** It is opaque base64url and
+  fails `splitJWT` on the resource path; the only other `/api/v1` route is
+  `GET /api/v1/machines` (`device.go:111`), which goes through the same
+  `apiSvc.Authenticate` (`main.go:72`). Asserted explicitly in `machines_test.go:94-97,109`.
+- **Rotation does not leak which failure occurred.** `handleToken` (`api.go:79-87`) collapses
+  `ErrInvalidRefreshToken`, `ErrRefreshTokenRevoked`, and `ErrRefreshTokenExpired` into one
+  `invalid_grant` with one description. `TestTokenEndpoint_RejectsBadRequestsIdentically`
+  (`api_test.go:115-157`) asserts the revoked and the unknown case produce the same code and
+  that the description does not say "revoke". All three failures cost one indexed SELECT,
+  so they are not timing-separable either.
+- **Rotation itself is single-use under concurrency**, see M-B: exactly one exchange commits
+  in every run, and the loser's only problem is the error shape it gets back.
+
+**Other things read and found correct:**
+
+- `html/template` contextual escaping is in force on all four device templates
+  (`device.go:81` uses `template.ParseFS` on `html/template`), and the two
+  attacker-controlled values (`machine_name`, `machine_public_url`) appear only in element
+  text, never in an attribute or a URL context. No XSS vector.
+- No token, key, or code material reaches a log. `endpoints.go:85,134,147` log wrapped
+  errors, never the device code or the token; `pages.go:131,148,155` log the *user* code on
+  a failure path, which is short-lived and already known to the operator, and never the
+  device code. `keys.go` never formats a private key.
+- `envelope`/`api.WriteJSON` sets `Cache-Control: no-store` on every control-plane response
+  (`api.go:177`), which matters because these bodies carry bearer secrets.
+- The gateway's token verifier (`vmgateway/token.go`) is unchanged from the previous review
+  and still correct: signature before claims, `alg` pinned, signature length checked,
+  `iss`/`aud`/`sub`/`exp` all checked, `VerifyOptions` refusing to run with any of the three
+  empty, fail-closed on an empty key set.
+- The gateway's deny-by-default path allowlist is unchanged and still stronger than the LAN
+  listener's blocklist. `GET /api/v1/doctor` is inside the proxyable set by design.
+- `ao vm serve` still matches ADR 0002: separate process, `autocert.HostPolicy` scoped to the
+  one configured domain (`server.go:46`), `:80` never serving plaintext
+  (`manager.HTTPHandler(nil)`, `server.go:55`), `ReadHeaderTimeout` on both listeners and no
+  write timeout (correct for SSE and `/mux`), graceful shutdown draining both goroutines.
+- `internal/doctor` preserves the CLI contract the desktop depends on: `ClaudeHarnessName`
+  and `ClaudeAuthStatusArgs` are exported constants read by both `ao vm setup-harness`
+  (`cli/vm.go:110-114`) and the `claude-auth` check, the check `Name` is the literal
+  `"claude-auth"` (`doctor.go:207`), and `Remediation` is populated on every WARN branch of
+  that check (`doctor.go:209-214`). The `Check` JSON tags are unchanged, so
+  `ao doctor --json` output is byte-identical; the HTTP DTO is a separate projection
+  (`controllers/dto.go:793-799`).
+- Shelled-out probes that could echo a credential: `githubToken` never puts the token in a
+  message (`doctor.go:574-595`); the `gh auth token` failure path wraps an `*exec.ExitError`,
+  whose `Error()` is `"exit status N"` and not the output, so the token cannot ride out that
+  way. The one raw-output path is L-G.
+
+**Anything batch 5's remote transport will find inadequate:** two things, both already
+above. The `SameSite=None` cookie the contract mandates plus `corsGate`'s pass-through on a
+missing `Origin` (L-A) is the one place the transport story is thinner than it reads. And
+`GET /api/v1/doctor` will be called by the desktop machine card on a timer, at which point
+M-C's per-request six subprocesses and GitHub API call stop being theoretical.
+
+**Pre-existing and not caused by this work:** `go test ./internal/cli/` still has the 5
+failures the previous review recorded. None of the five commits in this batch touch
+`internal/cli/spawn.go` or the agents route.

--- a/docs/reviews/README.md
+++ b/docs/reviews/README.md
@@ -1,0 +1,21 @@
+# Preserved code-review reports
+
+Read-only review reports, copied into the repo because they were written to `/tmp` and are
+the only record of what was found, what was **confirmed** versus **suspected**, and what was
+read and found correct and therefore does not need re-reviewing.
+
+Each file carries a header giving the reviewed commit, the date, the reviewer session, and a
+table mapping every finding to the PR that fixed it. Everything below each header's
+horizontal rule is the report exactly as written.
+
+| Report | Scope | Reviewed at | Findings |
+| --- | --- | --- | --- |
+| [2026-07-30-review-batches-1-2.md](2026-07-30-review-batches-1-2.md) | Hosted AO v1 batches 1 and 2: control plane skeleton, ADR 0002, `cloneUrl`, Google login, keys and tokens, `ao vm serve` | `193f6cc52` | 17 |
+| [2026-07-30-review-batches-3-4-server.md](2026-07-30-review-batches-3-4-server.md) | Batches 3 and 4, server half: control plane, gateway, tokens, daemon HTTP | `a7eb9c6b2` | 15 |
+| [2026-07-30-review-batches-3-4-client.md](2026-07-30-review-batches-3-4-client.md) | Batches 3 and 4, client half: CLI, `ao setup-vm`, desktop auth and machines | `a7eb9c6b2` | 22 |
+
+Section 3 of the client-side report is the ranked pre-flight risk list for the fresh-VM run
+(spec task 14), which has not happened yet.
+
+For the decisions behind the work these reviews cover, see
+[../hosted-ao-v1-build-log.md](../hosted-ao-v1-build-log.md).

--- a/hosted-log.md
+++ b/hosted-log.md
@@ -1,4 +1,21 @@
-# Hosted AO log — 2026-07-27
+# Hosted AO log, 2026-07-27
+
+> **Superseded in intent, not yet replaced in fact (noted 2026-07-30).** This log records the
+> single shared pairing-secret deployment, which was the whole hosted story on 2026-07-27.
+> Hosted AO v1 (accounts, registered machines, per-machine tokens, `ao setup-vm` and
+> `ao vm serve`) replaces it, and 12 of its 15 spec tasks are merged on `develop`. **None of
+> that has run on a VM yet**, so nothing below has been re-verified against it and nothing
+> below has been overwritten with results that have not happened.
+>
+> Spec task 14 owns the replacement: run the full accounts flow on a clean Ubuntu LTS VM,
+> then write up what was actually verified. That write-up must cover, at minimum, ACME
+> issuing a certificate for the machine's domain, the RFC 8628 device flow completing against
+> real DNS, `machine.json` written and read back by the gateway, the desktop reaching the
+> machine over the gateway with a machine-audience token, and `/mux` over WSS with the
+> `ao_gw_token` cookie. Until then, treat this file as the record of the old path.
+>
+> See [`docs/hosted-ao-v1-build-log.md`](docs/hosted-ao-v1-build-log.md) and
+> [`docs/STATUS.md`](docs/STATUS.md).
 
 ## Outcome
 
@@ -43,6 +60,7 @@ The Electron app can run locally against the VM-backed AO daemon.
 ## Current limits
 
 - This is a single shared pairing-secret setup: no accounts, roles, or tenant
-  isolation yet.
+  isolation yet. Hosted AO v1 adds all three; it is not deployed here.
 - Browser-preview proxying is intentionally out of scope.
-- Keep future implementation work on this fork's `main` branch.
+- Implementation work now happens on `develop`, not `main`, and this repository
+  is no longer a fork.


### PR DESCRIPTION
Closes #49.

Documentation only. No code changes, no test changes.

## 1. The reports are preserved

The three review reports lived only in `/tmp/ao/`, which is ephemeral. They are now in `docs/reviews/`, copied **verbatim**:

| File | Scope | Reviewed at | Reviewer session | Findings |
| --- | --- | --- | --- | --- |
| `2026-07-30-review-batches-1-2.md` | batches 1 and 2 | `193f6cc52` | `hosted-ao-12` | 17 |
| `2026-07-30-review-batches-3-4-server.md` | batches 3 and 4, server half | `a7eb9c6b2` | `hosted-ao-24` | 15 |
| `2026-07-30-review-batches-3-4-client.md` | batches 3 and 4, client half | `a7eb9c6b2` | `hosted-ao-25` | 22 |

Each file gets a header block (reviewed commit, date, reviewer session, and a table mapping **every finding to the PR that fixed it**), then a horizontal rule, then the report. Everything below the rule is byte-identical to the original, verified with `diff`. Nothing was summarized, reworded, or reordered: the value is the file, the line, the failure scenario, and the smallest fix.

Two findings are recorded as **not closed by their first fix round**, because they were not:

- **L6** (batch 1 and 2, `machine.json` vs `AO_DATA_DIR`) was reported again as **L-H** by the server-side review, then closed in #43 as a **documented decision rather than a relocation**: `machine.json` stays at `~/.ao/machine.json` because deriving it from the data dir would move the file the gateway reads without moving the file `ao setup-vm` writes.
- **L-B** (a port in `publicUrl` is dropped by the gateway and kept by the control plane) is closed by **nothing**. It was not carried into #37 or #39 and no issue was filed. Recorded as an open gap rather than mapped to a PR that did not address it.

## 2. Build log

`docs/hosted-ao-v1-build-log.md`. The batch structure with the PR that closed each of the 15 spec tasks, then the decisions that are not derivable from the diff:

- **`publicUrl` is a full origin**, normalized by the gateway with `url.Parse` plus `u.Hostname()`, because the spec, the `machines.hostname` column, and the desktop all want an origin and only `autocert.HostWhitelist` wants a hostname. Includes the failure mode that made it urgent: `HostWhitelist` silently ignores what it cannot parse, so a full URL left the whitelist empty and no certificate was ever issued while the gateway logged a clean start.
- **The two-audience token split**: why it appeared mid-build (task 7 added `GET /api/v1/machines`, and a desktop install that has signed in but not yet picked a machine holds no machine id, so it could not hold a token for the one endpoint that would tell it which machines exist), and why `POST /api/v1/machines/{id}/token` is a separate endpoint rather than an `audience` parameter on the refresh grant (overloading it would rotate the refresh token on every request and reintroduce the lockout race #45 fixed).
- **The fork detachment**: exactly 3 shared commits with `Untrivial-ai/agent-orchestrator`, merge base `a1fb47000 chore: scaffold backend/ and frontend/ skeletons for rewrite`. Removed the Sync-fork hazard, the wrong-PR-base hazard, and fork-specific Actions behaviour.
- **The required-status-checks deadlock**: a skipped *job* reports success, a workflow that never *dispatches* stays pending forever, so `paths:` filters plus required contexts made docs-only PRs permanently unmergeable. Fixed in #11.
- **`AO_REMOTE_URL` and `AO_REMOTE_TOKEN` are retired last, deliberately** (task 15, gated on task 14), so remote mode is never untestable mid-build.
- Two smaller ones: the `machine.json` path decision above, and why `/api/v1/doctor` was deliberately left out of `lanControlBlockedPrefixes`.
- **The two tests that were asserting the bug**: `setupvm_plan_test.go:593` used `strings.HasPrefix(value, "\"/")`, so the assertion that existed to prove the path was absolute was passing *because of* the leading quote that made systemd reject the unit; and `TestGateway_Mux_UsesCookieNotHeader` deliberately pinned the `/mux` narrowing that finding L4 objects to.

## 3. `docs/STATUS.md`

New "Hosted AO v1" section: what is merged, then task 13 and its prerequisite (#47, #48) in flight, task 14 blocked on hardware (Ubuntu LTS VM, DNS A record, hand-created Google OAuth client), task 15 gated on 14.

**One correction against the brief.** The brief and #49 both say 9 of 15 tasks merged. The git log says **12**: batches 1 through 4 are all merged (tasks 10, 11, 12 are #32, #33, #35), and the batch 3 and 4 reviews themselves reviewed that work as merged. STATUS.md says 12, and the build log carries the full task-to-PR table so the count is checkable rather than asserted. Happy to change it if 9 meant something I have not found.

## 4. `hosted-log.md` and `deploy/hosted/README.md`

Corrected **only where now factually wrong**, with no pre-written task 14 results:

- `hosted-log.md`: a scope note saying it records the pre-accounts pairing-secret deployment and that none of hosted AO v1 has run on a VM, plus what task 14 must add. Fixed "keep future implementation work on this fork's `main` branch": the repo is no longer a fork and the base branch is `develop`.
- `deploy/hosted/README.md`: a scope note that this is the pairing-secret Caddy path, still the only path that has ever run, kept working on purpose until task 15. Corrected the "do not add a public daemon bind or a second listener" instruction, which predates ADR 0002's carve-out for `ao vm serve`, and noted that Caddy and `ao vm serve` both want `:80` and `:443` so they cannot share a VM.

## Verification

- Report bodies are byte-identical to the `/tmp` originals (`diff`, clean on all three).
- No em dashes or en dashes in any file this PR adds or changes.
- Documentation only: no file under `backend/`, `controlplane/`, or `frontend/` is touched, so nothing collides with the workers on #47 and #48.

🤖 Generated with [Claude Code](https://claude.com/claude-code)