### PR TITLE
fix(controlplane): reject a port in public_url so the two sides agree

### DIFF
--- a/backend/internal/vmgateway/config.go
+++ b/backend/internal/vmgateway/config.go
@@ -181,6 +181,15 @@ func Resolve(opts Options, dataDir string) (Config, error) {
 // issued and every TLS handshake fails while the gateway logs a clean
 // start. Reject here, loudly, at boot, whatever cannot be reduced to a
 // hostname.
+//
+// A port in the origin is dropped, not carried into HTTPSAddr: the listener
+// moves only with --https-addr/AO_VM_HTTPS_ADDR. That stays safe because the
+// other side of the publicUrl contract refuses to store an origin with a port
+// (normalizePublicURL in controlplane/internal/device/codes.go), so the desktop
+// can only ever be pointed at the port this gateway actually listens on. The
+// two normalizers are in separate Go modules, so the agreement is pinned by a
+// test on each side rather than shared code; see
+// TestNormalizeDomain_PortIsDroppedNotCarried.
 func normalizeDomain(domain, source string) (string, error) {
 	domain = strings.TrimSpace(domain)
 	if strings.Contains(domain, "://") {

--- a/backend/internal/vmgateway/config_test.go
+++ b/backend/internal/vmgateway/config_test.go
@@ -142,6 +142,43 @@ func TestResolve_MachineFilePublicURLIsReducedToHostname(t *testing.T) {
 	}
 }
 
+// This side of the publicUrl contract drops a port and keeps listening on
+// DefaultHTTPSAddr; it does not carry the port into HTTPSAddr. That is only
+// safe because the control plane refuses to store an origin with a port in the
+// first place (normalizePublicURL in controlplane/internal/device/codes.go, and
+// its TestNormalizePublicURLRejectsPort). The two normalizers are in separate
+// Go modules and cannot import each other, so this test is the pin: if either
+// side's port handling is changed without the other, a test fails here instead
+// of a VM registering fine and then showing Offline forever, with nothing in
+// the gateway log, because the desktop is calling a port nothing listens on.
+func TestNormalizeDomain_PortIsDroppedNotCarried(t *testing.T) {
+	got, err := normalizeDomain("https://vm.example.com:8443", "test")
+	if err != nil {
+		t.Fatalf("normalizeDomain: %v", err)
+	}
+	if got != "vm.example.com" {
+		t.Errorf("normalizeDomain = %q, want the bare hostname vm.example.com", got)
+	}
+
+	path := writeMachineFile(t, MachineFile{
+		MachineID: "mf-machine",
+		AccountID: "mf-account",
+		PublicURL: "https://vm.example.com:8443",
+	})
+	cfg, err := Resolve(Options{MachineFile: path}, t.TempDir())
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if cfg.HTTPSAddr != DefaultHTTPSAddr {
+		t.Errorf("HTTPSAddr = %q, want %q: the port in publicUrl is not carried into the listener", cfg.HTTPSAddr, DefaultHTTPSAddr)
+	}
+	// A bare host:port stays fatal, so the only way a port reaches the gateway
+	// is through a scheme-bearing origin the control plane will not store.
+	if _, err := normalizeDomain("vm.example.com:8443", "test"); err == nil {
+		t.Error("normalizeDomain(\"vm.example.com:8443\") = nil error, want a bare host:port rejected")
+	}
+}
+
 func TestResolve_UnusableDomainIsRejected(t *testing.T) {
 	for _, domain := range []string{
 		"https://",

--- a/controlplane/internal/device/codes.go
+++ b/controlplane/internal/device/codes.go
@@ -111,10 +111,11 @@ func normalizeUserCode(typed string) string {
 
 // normalizePublicURL turns the public URL a VM reports into the single form
 // stored in machines.hostname and handed back to the polling client: an
-// origin with no trailing slash, like https://vm.example.com. `ao vm serve`
-// reduces that origin back to a bare hostname for the certificate whitelist
-// (see backend/internal/vmgateway/config.go), so a value that is not a clean
-// origin has to be rejected here rather than stored and failed on later.
+// origin with no trailing slash and no port, like https://vm.example.com.
+// `ao vm serve` reduces that origin back to a bare hostname for the
+// certificate whitelist (see backend/internal/vmgateway/config.go), so a value
+// that is not a clean origin has to be rejected here rather than stored and
+// failed on later.
 func normalizePublicURL(raw string) (string, error) {
 	raw = strings.TrimSpace(raw)
 	if raw == "" {
@@ -143,6 +144,19 @@ func normalizePublicURL(raw string) (string, error) {
 	// registration nonetheless succeeded.
 	if u.Scheme == "http" && !isLoopbackHost(u.Hostname()) {
 		return "", fmt.Errorf("public_url %q must use https: http is accepted only for a loopback host", raw)
+	}
+	// A port is stored and served here but dropped on the other side of this
+	// contract: `ao vm serve` reduces the origin to a bare hostname
+	// (normalizeDomain in backend/internal/vmgateway/config.go) and then listens
+	// on :443 unless --https-addr is also set, which nothing checks. Registering
+	// https://vm.example.com:8443 therefore produces a machine that registers
+	// cleanly and then shows Offline forever, with nothing in the gateway log,
+	// because the desktop is calling a port the gateway never listens on. Reject
+	// it the way `ao setup-vm --domain` already does, so the two normalizers
+	// agree. Loopback is exempt: it is the local-development origin from the http
+	// affordance above, and no gateway ever serves it.
+	if u.Port() != "" && !isLoopbackHost(u.Hostname()) {
+		return "", fmt.Errorf("public_url %q must not include a port: `ao vm serve` serves the bare hostname on :443, so a port here would also need --https-addr on the VM and nothing checks the two agree", raw)
 	}
 	return u.Scheme + "://" + strings.ToLower(u.Host), nil
 }

--- a/controlplane/internal/device/codes_test.go
+++ b/controlplane/internal/device/codes_test.go
@@ -120,10 +120,47 @@ func TestNormalizePublicURL(t *testing.T) {
 		"http://vm.example.com:8443",
 		"http://203.0.113.10",
 		"http://localhost.evil.example.com",
+		// A port on a routable host: `ao vm serve` drops it and listens on :443,
+		// so storing it hands the desktop an address the gateway never answers.
+		// See TestNormalizePublicURLRejectsPort.
+		"https://vm.example.com:8443",
+		"vm.example.com:8443",
 	}
 	for _, raw := range bad {
 		if got, err := normalizePublicURL(raw); err == nil {
 			t.Errorf("normalizePublicURL(%q) = %q, want an error", raw, got)
+		}
+	}
+}
+
+// A port in public_url is the one malformed value that used to be accepted and
+// stored intact, because `ao vm serve` reduces the origin to a bare hostname
+// (normalizeDomain in backend/internal/vmgateway/config.go) and then listens on
+// :443. The machine registers, the desktop calls :8443, the gateway answers on
+// :443, and the machine shows Offline with nothing in the gateway log. The two
+// normalizers live in separate Go modules and cannot share code, so this test
+// and TestNormalizeDomain_PortIsDroppedNotCarried on the gateway side are what
+// keep them in agreement.
+func TestNormalizePublicURLRejectsPort(t *testing.T) {
+	for _, raw := range []string{"https://vm.example.com:8443", "https://vm.example.com:443", "vm.example.com:8443"} {
+		got, err := normalizePublicURL(raw)
+		if err == nil {
+			t.Errorf("normalizePublicURL(%q) = %q, want an error naming --https-addr", raw, got)
+			continue
+		}
+		// The operator's other option is a gateway told to listen there, so the
+		// error has to name the flag that would do it.
+		if !strings.Contains(err.Error(), "--https-addr") {
+			t.Errorf("normalizePublicURL(%q) error = %q, want it to name --https-addr", raw, err)
+		}
+	}
+
+	// The loopback development origins keep their port: http is only accepted
+	// for loopback, and no gateway ever serves one, so there is no second side
+	// to disagree with.
+	for _, raw := range []string{"http://127.0.0.1:8443", "http://localhost:8443", "http://[::1]:8443"} {
+		if got, err := normalizePublicURL(raw); err != nil || got != raw {
+			t.Errorf("normalizePublicURL(%q) = %q, %v; want it kept unchanged", raw, got, err)
 		}
 	}
 }


### PR DESCRIPTION
Closes #52 (server-review finding L-B).

## The problem

The two sides of the `publicUrl` contract disagreed about ports, silently:

- `controlplane/internal/device/codes.go` returned `u.Scheme + "://" + u.Host`, and `u.Host` keeps the port.
- `backend/internal/vmgateway/config.go` reduces the same origin with `u.Hostname()`, which drops it.

So a machine registered as `https://vm.example.com:8443` was stored and served that way, the desktop called :8443, and `ao vm serve` certificated `vm.example.com` and listened on :443 unless `--https-addr` was also set. Nothing checked the two agreed. On a real VM that presents as a machine that registers fine and then shows Offline forever, with nothing in the gateway log to explain it.

## The fix

Option 1 from the finding, on the control-plane side only: `normalizePublicURL` now rejects a port, with an error naming `--https-addr` as the other thing that would have to change. That matches what `normalizeSetupDomain` in `ao setup-vm` already does, so the two normalizers agree instead of one being stricter than the other. The port is not carried through to `HTTPSAddr`.

One judgment call worth flagging: loopback origins keep their port. `http://127.0.0.1:8443`, `http://localhost:8443` and `http://[::1]:8443` are already accepted by the existing http local-development affordance and its tests, no gateway ever serves one, so there is no second side for them to disagree with. Rejecting a port unconditionally would have broken local development for no safety gain.

The gateway is unchanged in behaviour. Its port handling is now pinned by a test and by a comment on `normalizeDomain` naming the control-plane rule it depends on, since the two normalizers are in separate Go modules and cannot import each other.

## Tests

- `controlplane`: `TestNormalizePublicURLRejectsPort` plus two new cases in `TestNormalizePublicURL`'s reject list. Verified both fail with the fix reverted.
- `backend/internal/vmgateway`: `TestNormalizeDomain_PortIsDroppedNotCarried` pins that a port-bearing origin reduces to the bare hostname and that `HTTPSAddr` stays `:443`, and that a bare `host:port` stays fatal. This side has no behaviour change, so this test is a pin rather than a fix-gated failure; it is what breaks if a future change to either side reopens the disagreement.

Suites run locally: `controlplane` 113 passed across 9 packages, `backend/internal/vmgateway` 84 passed. `backend/internal/cli` has pre-existing `TestSpawn*` failures (daemon HTTP 404) on a clean tree too, unrelated to this change.

## Risks

A machine that already registered with an explicit port cannot re-register until the operator drops the port. That is the intended outcome: such a machine was already broken, just silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)