### PR TITLE
feat(desktop): authenticated remote transport to a selected machine

### DIFF
--- a/docs/desktop-login-contract.md
+++ b/docs/desktop-login-contract.md
@@ -84,15 +84,26 @@ the desktop reaches for, and when.
 | --- | --- |
 | Sign in (above) | none, PKCE plus `state` |
 | `GET /api/v1/machines` | control-plane-audience access token, from `POST /api/v1/token` |
-| Talking to a chosen machine | machine-audience access token (task 13, batch 5) |
+| Talking to a chosen machine, REST | machine-audience access token in `Authorization: Bearer`, from `POST /api/v1/machines/{id}/token` |
+| Talking to a chosen machine, `/mux` and `GET /api/v1/events` | the same token, in the `ao_gw_token` cookie |
 
 Two consequences the desktop side owns:
 
 - **Sign-out discards every cached token, not just the file.**
   `frontend/src/main/ao-control-token.ts` caches a control-plane-audience access
-  token in memory, and `aoAccount:signOut` clears it alongside deleting
-  `ao-account.json`. When task 13 caches a machine-audience token, it clears there
-  too.
+  token in memory and `frontend/src/main/ao-machine-token.ts` caches a
+  machine-audience one. `aoAccount:signOut` clears both, and drops the
+  `ao_gw_token` cookie, alongside deleting `ao-account.json`.
+- **The cookie exists only because two browser APIs have no header.** The `/mux`
+  WebSocket handshake and `EventSource` cannot set `Authorization`, so the same
+  short-lived JWT travels in `ao_gw_token`, installed by the Electron main
+  process as `Secure`, `HttpOnly`, `SameSite=None`, host-only. `SameSite=None` is
+  required: `app://renderer` reaching `https://vm.example.com` is a cross-site
+  context. The gateway accepts the cookie on those two routes and nowhere else.
+- **The silent refresh emits no status.** Replacing the cookie value leaves an
+  already-open SSE stream and `/mux` session running, because the gateway reads
+  the credential at the handshake and at the SSE request and never again.
+  Publishing a status would re-point the renderer and visibly reconnect both.
 - **Every refresh exchange persists the rotated refresh token** through
   `writeStoredAccount`, before the access token it came with is handed to a caller.
   The presented token is already revoked by then, so losing the replacement would

--- a/frontend/e2e/support/fake-bridge.ts
+++ b/frontend/e2e/support/fake-bridge.ts
@@ -173,6 +173,7 @@ export async function installFakeBridge(page: Page, opts: FakeBridgeOptions = {}
 					getState: async () => signedOutAoMachines,
 					refresh: async () => signedOutAoMachines,
 					select: async () => signedOutAoMachines,
+					gatewayToken: async () => null,
 				},
 			} satisfies AoBridge;
 			(window as unknown as { ao: unknown }).ao = ao;
@@ -555,6 +556,7 @@ export async function installFakeAgent(page: Page, opts: FakeAgentOptions = {}):
 					getState: async () => signedOutAoMachines,
 					refresh: async () => signedOutAoMachines,
 					select: async () => signedOutAoMachines,
+					gatewayToken: async () => null,
 				},
 			} satisfies AoBridge;
 			(window as unknown as { ao: unknown }).ao = ao;

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -41,7 +41,7 @@ import { promisify } from "node:util";
 import { type DaemonLaunchSpec, resolveDaemonLaunch } from "./shared/daemon-launch";
 import { createListenPortScanner, defaultRunFilePath, parseRunFile } from "./shared/daemon-discovery";
 import type { DaemonStatus } from "./shared/daemon-status";
-import { machineDaemonStatus, readRemoteDaemonConfig, type RemoteDaemonConfig } from "./shared/remote-daemon";
+import { machineAuthFailedStatus, readRemoteDaemonConfig, type RemoteDaemonConfig } from "./shared/remote-daemon";
 import { attachAppShortcuts } from "./main/app-shortcuts";
 import { KEYBOARD_SHORTCUTS_HELP_CHANNEL } from "./shared/shortcuts";
 import {
@@ -65,6 +65,7 @@ import type { AoMachine } from "./shared/ao-machines";
 import { isAllowedAppExternalURL, openAllowedAppExternalURL } from "./main/external-open";
 import { buildWindowsAppMenuTemplate } from "./main/menu";
 import { createRemoteDaemonLifecycle } from "./main/remote-daemon";
+import { createMachineTransport, type MachineTransport } from "./main/machine-transport";
 
 // Globals injected at compile time by @electron-forge/plugin-vite.
 declare const MAIN_WINDOW_VITE_DEV_SERVER_URL: string | undefined;
@@ -1466,6 +1467,36 @@ function aoMachines(): ReturnType<typeof createAoMachinesController> {
 	return aoMachinesController;
 }
 
+// The authenticated transport to the active machine's gateway: the Bearer token
+// the renderer attaches to REST calls, the ao_gw_token cookie /mux and the SSE
+// stream authenticate with, and the silent refresh that keeps both current.
+let machineTransportInstance: MachineTransport | null = null;
+function machineTransport(): MachineTransport | null {
+	if (machineTransportInstance) return machineTransportInstance;
+	// Null when no control-plane credential can exist in this install: no ~/.ao
+	// state dir, or an AO_CONTROL_URL that does not parse. The machines controller
+	// already reports that as its own error, so there is nothing to add here.
+	const credential = aoMachines().credential();
+	if (!credential) return null;
+	machineTransportInstance = createMachineTransport({
+		cookies: session.defaultSession.cookies,
+		controlPlaneUrl: credential.controlPlaneUrl,
+		controlToken: credential.token,
+		onStatus: (status) => {
+			activeMachineStatus = status;
+			void startDaemon();
+		},
+		// The control plane will not mint a token for the active machine, and it
+		// answers revoked, someone else's, and never-existed identically. The list
+		// is where that resolves: refresh() drops a machine that is gone from the
+		// list and falls back to this computer, which needs no account.
+		onMachineGone: () => {
+			void aoMachines().refresh();
+		},
+	});
+	return machineTransportInstance;
+}
+
 /**
  * Re-point the app at the machine that just became active.
  *
@@ -1474,15 +1505,34 @@ function aoMachines(): ReturnType<typeof createAoMachinesController> {
  * status and the local start function is never called, whether the machine is
  * up or down. Selecting this computer clears it, and startDaemon() attaches to
  * or spawns the local daemon exactly as it always has.
+ *
+ * The transport, not this function, publishes the ready status that carries the
+ * machine's base URL, and only once it holds a token and has installed the
+ * gateway cookie.
  */
 function applyActiveMachine(machine: AoMachine | null): void {
-	activeMachineStatus = machine ? machineDaemonStatus(machine) : null;
+	// AO_REMOTE_URL is checked first in the lifecycle and wins outright, so the
+	// renderer is pointed at the env origin no matter what is selected here.
+	// Fetching a machine credential for a gateway nothing will call would be a
+	// pointless token request, and the env hatch keeps behaving exactly as before.
+	if (remoteDaemonConfig) return;
+	const transport = machineTransport();
+	if (transport) {
+		transport.setMachine(machine);
+		return;
+	}
+	activeMachineStatus = machine
+		? machineAuthFailedStatus(machine, "This computer cannot store an AO sign-in, so it has no credential to send.")
+		: null;
 	void startDaemon();
 }
 
 ipcMain.handle("aoMachines:getState", () => aoMachines().getState());
 ipcMain.handle("aoMachines:refresh", () => aoMachines().refresh());
 ipcMain.handle("aoMachines:select", (_event, machineId: string) => aoMachines().select(machineId));
+// Read from the already-built transport rather than machineTransport(), so a
+// local-only install never constructs one just to be told there is no token.
+ipcMain.handle("aoMachines:gatewayToken", () => machineTransportInstance?.token() ?? null);
 
 ipcMain.handle("updates:getStatus", (): UpdateStatus => getUpdateStatus());
 ipcMain.handle("updates:check", async (_event, options?: UpdateCheckOptions) => {

--- a/frontend/src/main/ao-account.ts
+++ b/frontend/src/main/ao-account.ts
@@ -123,8 +123,9 @@ export function createAoAccountController(deps: AoAccountControllerDeps): AoAcco
 			lastError = null;
 			// Discards the refresh token itself, not just the UI flag. The control plane
 			// keeps its own revocation list; this end stops holding the credential.
-			// Nothing else is held: no access token of either audience is cached yet. When
-			// task 13 caches a control-plane-audience token, clear it here too.
+			// The cached access tokens of both audiences, and the gateway cookie, are
+			// dropped by the same IPC handler that calls this: see aoAccount:signOut in
+			// main.ts, which then resets the machines controller.
 			if (deps.stateDir) await clearStoredAccount(deps.stateDir);
 			return currentState();
 		},

--- a/frontend/src/main/ao-control-token.ts
+++ b/frontend/src/main/ao-control-token.ts
@@ -19,9 +19,11 @@ import { readStoredAccount, writeStoredAccount, type SafeStorageLike } from "./a
  * concurrent callers share one exchange rather than racing two, where the
  * loser would have presented an already-revoked token.
  *
- * Not in scope here: the machine-audience token, the Bearer header on the
- * daemon's REST and SSE routes, the `/mux` cookie, and silent background
- * refresh. That is the remote transport, task 13.
+ * Not in scope here: the machine-audience token, the Bearer header on a
+ * machine's REST routes, the `/mux` and SSE cookie, and the silent background
+ * refresh. Those are ao-machine-token.ts and machine-transport.ts, which take
+ * the source built here rather than building a second one, because two sources
+ * would race a rotation of the same refresh token.
  */
 
 /** Refreshed this early before expiry, so a token never expires mid-request. */

--- a/frontend/src/main/ao-machine-token.test.ts
+++ b/frontend/src/main/ao-machine-token.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ControlPlaneTokenSource } from "./ao-control-token";
+import {
+	createMachineTokenSource,
+	MachineUnavailableError,
+	MACHINE_UNAVAILABLE_MESSAGE,
+	SIGN_IN_REJECTED_MESSAGE,
+	type MachineTokenSourceDeps,
+} from "./ao-machine-token";
+
+const CONTROL_PLANE_URL = "https://ao.agentlab.in";
+const CONTROL_TOKEN = "control.plane.jwt";
+const MACHINE_TOKEN = "machine.audience.jwt";
+
+const controlToken = (token: string | null = CONTROL_TOKEN): ControlPlaneTokenSource => ({
+	get: vi.fn().mockResolvedValue(token),
+	clear: vi.fn(),
+});
+
+const okBody = (extra: Record<string, unknown> = {}) =>
+	new Response(JSON.stringify({ access_token: MACHINE_TOKEN, token_type: "Bearer", expires_in: 900, ...extra }), {
+		status: 200,
+		headers: { "Content-Type": "application/json" },
+	});
+
+const errorBody = (status: number, body: Record<string, unknown>) =>
+	new Response(JSON.stringify(body), { status, headers: { "Content-Type": "application/json" } });
+
+function source(overrides: Partial<MachineTokenSourceDeps> = {}, clock = { ms: 1_000_000 }) {
+	// A fresh Response per call: a body can only be read once.
+	const fetchImpl = overrides.fetchImpl ?? vi.fn(async () => okBody());
+	return {
+		clock,
+		fetchImpl: fetchImpl as ReturnType<typeof vi.fn>,
+		tokens: createMachineTokenSource({
+			controlPlaneUrl: CONTROL_PLANE_URL,
+			machineId: "mch_1",
+			controlToken: controlToken(),
+			fetchImpl,
+			now: () => clock.ms,
+			...overrides,
+		}),
+	};
+}
+
+describe("createMachineTokenSource", () => {
+	it("mints at POST /api/v1/machines/{id}/token with the control-plane bearer and no body", async () => {
+		const { tokens, fetchImpl, clock } = source();
+
+		await expect(tokens.get()).resolves.toEqual({ token: MACHINE_TOKEN, expiresAt: clock.ms + 900_000 });
+		expect(fetchImpl).toHaveBeenCalledTimes(1);
+		const [url, init] = fetchImpl.mock.calls[0];
+		expect(url).toBe(`${CONTROL_PLANE_URL}/api/v1/machines/mch_1/token`);
+		expect(init).toMatchObject({
+			method: "POST",
+			headers: { Authorization: `Bearer ${CONTROL_TOKEN}`, Accept: "application/json" },
+		});
+		// The refresh token goes to POST /api/v1/token and nowhere else, and this
+		// endpoint takes no request body at all.
+		expect(init.body).toBeUndefined();
+	});
+
+	it("percent-encodes the machine id rather than pasting it into the path", async () => {
+		const { tokens, fetchImpl } = source({ machineId: "mch/../other" });
+
+		await tokens.get();
+
+		expect(fetchImpl.mock.calls[0][0]).toBe(`${CONTROL_PLANE_URL}/api/v1/machines/mch%2F..%2Fother/token`);
+	});
+
+	it("drives expiry off the returned expires_in, not a hardcoded fifteen minutes", async () => {
+		const { tokens, clock } = source({ fetchImpl: vi.fn(async () => okBody({ expires_in: 1800 })) });
+
+		await expect(tokens.get()).resolves.toMatchObject({ expiresAt: clock.ms + 1_800_000 });
+	});
+
+	it("falls back to the contract's default TTL when expires_in is absent or unusable", async () => {
+		for (const expiresIn of [undefined, 0, -60, "900"]) {
+			const { tokens, clock } = source({ fetchImpl: vi.fn(async () => okBody({ expires_in: expiresIn })) });
+			await expect(tokens.get()).resolves.toMatchObject({ expiresAt: clock.ms + 15 * 60_000 });
+		}
+	});
+
+	it("serves the cached token until the skew window, then mints again", async () => {
+		const clock = { ms: 1_000_000 };
+		const { tokens, fetchImpl } = source({}, clock);
+
+		await tokens.get();
+		clock.ms += 900_000 - 61_000; // still more than the skew away from expiry
+		await tokens.get();
+		expect(fetchImpl).toHaveBeenCalledTimes(1);
+
+		clock.ms += 2_000; // inside the skew window
+		await tokens.get();
+		// Nothing rotates on this endpoint, so re-minting is simply repeating the
+		// call; no persist-before-use ordering is involved.
+		expect(fetchImpl).toHaveBeenCalledTimes(2);
+	});
+
+	it("shares one mint between concurrent callers", async () => {
+		const { tokens, fetchImpl } = source();
+
+		const [a, b, c] = await Promise.all([tokens.get(), tokens.get(), tokens.get()]);
+
+		expect(fetchImpl).toHaveBeenCalledTimes(1);
+		expect(a).toEqual(b);
+		expect(b).toEqual(c);
+	});
+
+	it("mints again after clear(), so a machine switch cannot reuse the old audience", async () => {
+		const { tokens, fetchImpl } = source();
+
+		await tokens.get();
+		tokens.clear();
+		await tokens.get();
+
+		expect(fetchImpl).toHaveBeenCalledTimes(2);
+	});
+
+	it("returns null without calling the control plane when this install is signed out", async () => {
+		const fetchImpl = vi.fn();
+		const { tokens } = source({ controlToken: controlToken(null), fetchImpl });
+
+		await expect(tokens.get()).resolves.toBeNull();
+		expect(fetchImpl).not.toHaveBeenCalled();
+	});
+
+	// The control plane answers a revoked machine, another account's machine, and
+	// an unknown id identically, so nothing here may infer which it was.
+	it("turns the deliberately ambiguous 404 into MachineUnavailableError", async () => {
+		const fetchImpl = vi
+			.fn()
+			.mockResolvedValue(errorBody(404, { error: "not_found", error_description: "no such machine" }));
+		const { tokens } = source({ fetchImpl });
+
+		await expect(tokens.get()).rejects.toThrow(MachineUnavailableError);
+		await expect(tokens.get()).rejects.toThrow(MACHINE_UNAVAILABLE_MESSAGE);
+	});
+
+	it("says to sign in again when the control plane refuses the control-plane token", async () => {
+		const fetchImpl = vi.fn().mockResolvedValue(errorBody(401, { error: "invalid_token" }));
+		const { tokens } = source({ fetchImpl });
+
+		await expect(tokens.get()).rejects.toThrow(SIGN_IN_REJECTED_MESSAGE);
+	});
+
+	it("reports the status for any other failure", async () => {
+		const fetchImpl = vi.fn().mockResolvedValue(errorBody(500, { error: "server_error" }));
+		const { tokens } = source({ fetchImpl });
+
+		await expect(tokens.get()).rejects.toThrow("The control plane returned 500 issuing a machine access token.");
+	});
+
+	it("rejects a 200 that carries no access token rather than caching nothing usable", async () => {
+		const fetchImpl = vi.fn().mockResolvedValue(new Response(JSON.stringify({ token_type: "Bearer" }), { status: 200 }));
+		const { tokens } = source({ fetchImpl });
+
+		await expect(tokens.get()).rejects.toThrow("The control plane did not return a machine access token.");
+	});
+
+	it("retries after a failure instead of caching it", async () => {
+		const fetchImpl = vi
+			.fn()
+			.mockResolvedValueOnce(errorBody(500, { error: "server_error" }))
+			.mockResolvedValueOnce(okBody());
+		const { tokens } = source({ fetchImpl });
+
+		await expect(tokens.get()).rejects.toThrow(/500/);
+		await expect(tokens.get()).resolves.toMatchObject({ token: MACHINE_TOKEN });
+	});
+
+	it("keeps both tokens out of every error it raises", async () => {
+		for (const response of [errorBody(401, {}), errorBody(404, {}), errorBody(500, {})]) {
+			const { tokens } = source({ fetchImpl: vi.fn().mockResolvedValue(response) });
+			const err = await tokens.get().catch((e: unknown) => e);
+			const text = `${(err as Error).name}: ${(err as Error).message}`;
+			expect(text).not.toContain(CONTROL_TOKEN);
+			expect(text).not.toContain(MACHINE_TOKEN);
+		}
+	});
+});

--- a/frontend/src/main/ao-machine-token.ts
+++ b/frontend/src/main/ao-machine-token.ts
@@ -1,0 +1,157 @@
+import type { ControlPlaneTokenSource } from "./ao-control-token";
+
+/**
+ * The machine-audience access token for one registered machine.
+ *
+ * Every route on a machine's gateway wants an access token whose `aud` is that
+ * machine's id (controlplane/TOKEN_CONTRACT.md, "The two audiences"). The
+ * control-plane-audience token this install already holds is not one: the
+ * gateway pins `aud` to its own machine id and rejects it, correctly. So the
+ * machine token comes from `POST /api/v1/machines/{id}/token`, authenticated
+ * with the control-plane token, which is the same credential
+ * `GET /api/v1/machines` takes.
+ *
+ * That call rotates nothing and consumes nothing, so it is freely repeatable and
+ * none of ao-control-token.ts's persist-before-use machinery applies here. The
+ * refresh token is not presented on this path at all: it goes to
+ * `POST /api/v1/token` and nowhere else.
+ */
+
+/** Refreshed this early before expiry, so a token never expires mid-request. */
+const EXPIRY_SKEW_MS = 60_000;
+
+/**
+ * Fallback when the endpoint omits `expires_in`. The contract's default, but a
+ * deployment may configure 10 to 30 minutes, so a returned value always wins.
+ */
+const DEFAULT_TTL_SECONDS = 15 * 60;
+
+/** Said when the control plane will not issue a token for the active machine. */
+export const MACHINE_UNAVAILABLE_MESSAGE = "This account no longer has that machine.";
+
+/** Said when the control plane refuses this install's sign-in outright. */
+export const SIGN_IN_REJECTED_MESSAGE = "The control plane rejected this computer's sign-in. Sign in again.";
+
+/**
+ * The 404 from the token endpoint, which is deliberately the same answer for a
+ * machine that was revoked, one owned by another account, and one that never
+ * existed, so a signed-in account is not an oracle for which machine ids exist.
+ * Nothing here may infer which of the three it was: the machine list is where
+ * that gets resolved.
+ */
+export class MachineUnavailableError extends Error {
+	constructor(message = MACHINE_UNAVAILABLE_MESSAGE) {
+		super(message);
+		this.name = "MachineUnavailableError";
+	}
+}
+
+export type MachineAccessToken = {
+	token: string;
+	/** Epoch ms, from the endpoint's own `expires_in`. Drives the silent refresh. */
+	expiresAt: number;
+};
+
+export type MachineTokenSourceDeps = {
+	/** Origin of the control plane this install trusts, no trailing slash. */
+	controlPlaneUrl: string;
+	/** `machines.id`, which is also the `aud` of the token this mints. */
+	machineId: string;
+	/** The one control-plane token source in this process. See ao-machines.ts. */
+	controlToken: ControlPlaneTokenSource;
+	fetchImpl?: typeof fetch;
+	now?: () => number;
+};
+
+export type MachineTokenSource = {
+	/** A usable token, minting only when the cached one is spent. Null when signed out. */
+	get: () => Promise<MachineAccessToken | null>;
+	/**
+	 * Mint unconditionally and replace the cache.
+	 *
+	 * The silent refresh runs on a longer lead than the skew above, so it must not
+	 * go through get(): the cached token is still usable at that point, and get()
+	 * would hand it straight back, leaving the refresh with nothing new to install
+	 * and rescheduling itself into a spin. Asking for a fresh token explicitly is
+	 * what the timer actually wants.
+	 */
+	mint: () => Promise<MachineAccessToken | null>;
+	/** Drop the cached token. Called when the machine stops being active. */
+	clear: () => void;
+};
+
+type MachineTokenResponse = {
+	access_token?: unknown;
+	expires_in?: unknown;
+};
+
+export function createMachineTokenSource(deps: MachineTokenSourceDeps): MachineTokenSource {
+	const fetchImpl = deps.fetchImpl ?? fetch;
+	const now = deps.now ?? Date.now;
+
+	let cached: MachineAccessToken | null = null;
+	let inFlight: Promise<MachineAccessToken | null> | null = null;
+
+	async function mint(): Promise<MachineAccessToken | null> {
+		const controlToken = await deps.controlToken.get();
+		// Signed out. There is no credential for a registered machine without an
+		// account, and the caller turns this into a status rather than a retry.
+		if (!controlToken) return null;
+
+		const response = await fetchImpl(
+			`${deps.controlPlaneUrl}/api/v1/machines/${encodeURIComponent(deps.machineId)}/token`,
+			{
+				method: "POST",
+				headers: { Authorization: `Bearer ${controlToken}`, Accept: "application/json" },
+			},
+		);
+		if (response.status === 404) throw new MachineUnavailableError();
+		if (response.status === 401) throw new Error(SIGN_IN_REJECTED_MESSAGE);
+
+		// This body carries an access token, so nothing about it is logged.
+		let body: unknown = null;
+		try {
+			body = await response.json();
+		} catch {
+			body = null;
+		}
+		if (!response.ok) {
+			throw new Error(`The control plane returned ${response.status} issuing a machine access token.`);
+		}
+
+		const { access_token: accessToken, expires_in: expiresIn } = (body ?? {}) as MachineTokenResponse;
+		if (typeof accessToken !== "string" || !accessToken) {
+			throw new Error("The control plane did not return a machine access token.");
+		}
+		const ttlSeconds = typeof expiresIn === "number" && expiresIn > 0 ? expiresIn : DEFAULT_TTL_SECONDS;
+		cached = { token: accessToken, expiresAt: now() + ttlSeconds * 1000 };
+		return cached;
+	}
+
+	// One mint at a time. Not for safety, since nothing rotates on this endpoint,
+	// but so a burst of REST calls arriving at expiry shares one exchange instead
+	// of firing one request per call.
+	function force(): Promise<MachineAccessToken | null> {
+		if (inFlight) return inFlight;
+		const attempt = Promise.resolve()
+			.then(mint)
+			.finally(() => {
+				inFlight = null;
+			});
+		inFlight = attempt;
+		return attempt;
+	}
+
+	return {
+		async get(): Promise<MachineAccessToken | null> {
+			if (cached && cached.expiresAt - EXPIRY_SKEW_MS > now()) return cached;
+			return force();
+		},
+
+		mint: force,
+
+		clear(): void {
+			cached = null;
+		},
+	};
+}

--- a/frontend/src/main/ao-machines.test.ts
+++ b/frontend/src/main/ao-machines.test.ts
@@ -284,3 +284,39 @@ test("a bad AO_CONTROL_URL is reported, never a silent fall back to production",
 	expect(state.status).toBe("error");
 	expect(state.error).toMatch(/AO_CONTROL_URL/);
 });
+
+// The hazard: a second ControlPlaneTokenSource built elsewhere in the main
+// process would hold the same refresh token and race a rotation against this
+// one, and the loser presents an already-revoked token. The machine transport
+// therefore takes this credential rather than building its own.
+test("hands out the one control-plane credential, not a second copy of it", () => {
+	const machines = controller(fakeFetch([machineRow()]));
+
+	expect(machines.credential()).toEqual({ controlPlaneUrl: "https://ao.agentlab.in", token: signedIn });
+});
+
+test("has no credential to hand out when AO_CONTROL_URL does not parse", () => {
+	const machines = createAoMachinesController({
+		stateDir,
+		env: { AO_CONTROL_URL: "not a url" },
+		safeStorage,
+		localMachineName: "This Mac",
+		onActiveChange: (machine) => active.push(machine),
+		fetchImpl: fakeFetch([]) as unknown as typeof fetch,
+	});
+
+	expect(machines.credential()).toBeNull();
+});
+
+test("has no credential to hand out when the ~/.ao state dir is unresolvable", () => {
+	const machines = createAoMachinesController({
+		stateDir: null,
+		env: {},
+		safeStorage,
+		localMachineName: "This Mac",
+		onActiveChange: (machine) => active.push(machine),
+		fetchImpl: fakeFetch([]) as unknown as typeof fetch,
+	});
+
+	expect(machines.credential()).toBeNull();
+});

--- a/frontend/src/main/ao-machines.ts
+++ b/frontend/src/main/ao-machines.ts
@@ -77,9 +77,25 @@ export type AoMachinesControllerDeps = {
 	tokenSource?: ControlPlaneTokenSource;
 };
 
+/**
+ * The control-plane credential this process holds, handed out rather than
+ * rebuilt by the caller.
+ *
+ * There is exactly one ControlPlaneTokenSource per install, and that is load
+ * bearing: refresh tokens rotate on use, so a second source holding the same
+ * refresh token would race a rotation against this one and the loser would
+ * present an already-revoked token. See ao-control-token.ts.
+ */
+export type AoControlPlaneCredential = {
+	controlPlaneUrl: string;
+	token: ControlPlaneTokenSource;
+};
+
 export type AoMachinesController = {
 	/** Current known state. No network: the renderer can poll this freely. */
 	getState: () => AoMachinesState;
+	/** This process's one control-plane credential, or null when it cannot exist. */
+	credential: () => AoControlPlaneCredential | null;
 	/** List from the control plane and probe every machine's reachability. */
 	refresh: () => Promise<AoMachinesState>;
 	/** Make one machine active. Unknown ids are rejected rather than guessed. */
@@ -322,6 +338,7 @@ export function createAoMachinesController(deps: AoMachinesControllerDeps): AoMa
 
 	return {
 		getState: currentState,
+		credential: () => (tokenSource && !configError ? { controlPlaneUrl, token: tokenSource } : null),
 		refresh,
 
 		async select(machineId: string): Promise<AoMachinesState> {

--- a/frontend/src/main/machine-transport.test.ts
+++ b/frontend/src/main/machine-transport.test.ts
@@ -1,0 +1,444 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { AoMachine } from "../shared/ao-machines";
+import type { DaemonStatus } from "../shared/daemon-status";
+import { GATEWAY_COOKIE_NAME } from "../shared/remote-daemon";
+import type { ControlPlaneTokenSource } from "./ao-control-token";
+import { MachineUnavailableError, type MachineAccessToken, type MachineTokenSource } from "./ao-machine-token";
+import { createMachineTransport, SIGNED_OUT_REASON, type MachineTransport } from "./machine-transport";
+
+const NOW = 1_700_000_000_000;
+const TTL_MS = 900_000;
+
+const machine = (extra: Partial<AoMachine> = {}): AoMachine => ({
+	id: "mch_1",
+	name: "ao-build-01",
+	baseUrl: "https://vm.example.com",
+	local: false,
+	createdAt: null,
+	lastSeen: null,
+	reachability: "online",
+	harness: "unknown",
+	harnessCommand: null,
+	...extra,
+});
+
+const controlToken: ControlPlaneTokenSource = { get: async () => "control.plane.jwt", clear: () => undefined };
+
+/**
+ * A token source under the test's control: `mode` decides what the next call
+ * does, so a refresh can be made to succeed with a new value, fail, or report the
+ * machine gone, without a fake HTTP layer in the way.
+ *
+ * It caches like the real one (ao-machine-token.ts): `get()` reuses a token that
+ * is still comfortably valid, `mint()` always issues a new one. That split is
+ * what the transport's refresh depends on, so a fake without it would let a
+ * refresh that never actually rotates the token pass.
+ */
+function fakeTokens(clock: { ms: number }) {
+	let issued = 0;
+	let cached: MachineAccessToken | null = null;
+	const state = {
+		mode: "ok" as "ok" | "signed-out" | "gone" | "error",
+		calls: 0,
+		created: [] as string[],
+	};
+	const issue = async (): Promise<MachineAccessToken | null> => {
+		state.calls += 1;
+		if (state.mode === "signed-out") return null;
+		if (state.mode === "gone") throw new MachineUnavailableError();
+		if (state.mode === "error") throw new Error("The control plane is unreachable.");
+		issued += 1;
+		cached = { token: `machine.jwt.${issued}`, expiresAt: clock.ms + TTL_MS };
+		return cached;
+	};
+	const source: MachineTokenSource = {
+		get: async () => (cached && cached.expiresAt - 60_000 > clock.ms ? cached : issue()),
+		mint: issue,
+		clear: () => {
+			cached = null;
+		},
+	};
+	return { state, source };
+}
+
+function harness() {
+	const clock = { ms: NOW };
+	const tokens = fakeTokens(clock);
+	const set = vi.fn().mockResolvedValue(undefined);
+	const remove = vi.fn().mockResolvedValue(undefined);
+	const onStatus = vi.fn<(status: DaemonStatus | null) => void>();
+	const onMachineGone = vi.fn();
+	const createTokenSource = vi.fn((deps: { machineId: string }) => {
+		tokens.state.created.push(deps.machineId);
+		return tokens.source;
+	});
+	const transport: MachineTransport = createMachineTransport({
+		cookies: { set, remove },
+		controlPlaneUrl: "https://ao.agentlab.in",
+		controlToken,
+		onStatus,
+		onMachineGone,
+		now: () => clock.ms,
+		createTokenSource,
+	});
+	return { clock, tokens, set, remove, onStatus, onMachineGone, createTokenSource, transport };
+}
+
+/** Let the transport's own awaits settle without advancing the fake clock. */
+const settle = async (): Promise<void> => {
+	await vi.advanceTimersByTimeAsync(0);
+};
+
+beforeEach(() => {
+	vi.useFakeTimers();
+});
+
+afterEach(() => {
+	vi.useRealTimers();
+});
+
+describe("connecting to a machine", () => {
+	it("installs ao_gw_token as a Secure HttpOnly SameSite=None host-only cookie on the gateway origin", async () => {
+		const { transport, set } = harness();
+
+		transport.setMachine(machine());
+		await settle();
+
+		expect(set).toHaveBeenCalledTimes(1);
+		expect(set.mock.calls[0][0]).toEqual({
+			url: "https://vm.example.com",
+			name: GATEWAY_COOKIE_NAME,
+			value: "machine.jwt.1",
+			path: "/",
+			secure: true,
+			httpOnly: true,
+			// SameSite=None: app://renderer reaching https://vm.example.com is a
+			// cross-site context, and under the browser default the cookie is not
+			// attached to the /mux handshake or the EventSource request at all.
+			sameSite: "no_restriction",
+		});
+		// Host-only. A Domain would offer the credential to every sibling host
+		// under the same registrable domain.
+		expect(set.mock.calls[0][0]).not.toHaveProperty("domain");
+	});
+
+	// Ordering is the whole safety property: the ready status is what sets the
+	// renderer's API base URL, and it opens the SSE stream and the terminal mux
+	// immediately. Publishing it before the cookie exists makes both 401.
+	it("reports connecting first and only reports ready after the cookie is installed", async () => {
+		const { transport, onStatus, set } = harness();
+
+		transport.setMachine(machine());
+		expect(onStatus.mock.calls).toEqual([[{ state: "starting", message: "Connecting to ao-build-01…" }]]);
+		expect(set).not.toHaveBeenCalled();
+
+		await settle();
+
+		expect(onStatus).toHaveBeenLastCalledWith({
+			state: "ready",
+			baseUrl: "https://vm.example.com",
+			message: "Connected to ao-build-01",
+		});
+		expect(set).toHaveBeenCalledTimes(1);
+		expect(set.mock.invocationCallOrder[0]).toBeLessThan(onStatus.mock.invocationCallOrder[1]);
+	});
+
+	it("never puts the token in a status", async () => {
+		const { transport, onStatus } = harness();
+
+		transport.setMachine(machine());
+		await settle();
+
+		for (const [status] of onStatus.mock.calls) {
+			expect(JSON.stringify(status ?? {})).not.toContain("machine.jwt");
+		}
+	});
+
+	it.each(["offline", "unknown"] as const)(
+		"asks for no credential while a machine is %s, and hands out no base URL",
+		async (reachability) => {
+			const { transport, tokens, set, onStatus } = harness();
+
+			transport.setMachine(machine({ reachability }));
+			await settle();
+
+			expect(tokens.state.calls).toBe(0);
+			expect(set).not.toHaveBeenCalled();
+			expect(onStatus).toHaveBeenCalledTimes(1);
+			expect(onStatus.mock.calls[0][0]?.baseUrl).toBeUndefined();
+		},
+	);
+
+	it("says to sign in when this install has no account", async () => {
+		const { transport, tokens, set, onStatus } = harness();
+		tokens.state.mode = "signed-out";
+
+		transport.setMachine(machine());
+		await settle();
+
+		expect(set).not.toHaveBeenCalled();
+		expect(onStatus).toHaveBeenLastCalledWith({
+			state: "error",
+			code: "machine_auth_failed",
+			message: `Could not sign in to ao-build-01. ${SIGNED_OUT_REASON}`,
+		});
+	});
+
+	it("refreshes the machine list when the control plane will not mint a token for it", async () => {
+		const { transport, tokens, onStatus, onMachineGone } = harness();
+		tokens.state.mode = "gone";
+
+		transport.setMachine(machine());
+		await settle();
+
+		expect(onStatus).toHaveBeenLastCalledWith(
+			expect.objectContaining({ state: "error", code: "machine_auth_failed" }),
+		);
+		expect(onMachineGone).toHaveBeenCalledTimes(1);
+	});
+
+	// Nothing to protect on a first connection, so the failure is reported at once
+	// rather than retried quietly. The quiet retry is only for a refresh, where a
+	// still-valid credential is already installed.
+	it("reports a first-connection failure straight away", async () => {
+		const { transport, tokens, onStatus } = harness();
+		tokens.state.mode = "error";
+
+		transport.setMachine(machine());
+		await settle();
+
+		expect(onStatus).toHaveBeenLastCalledWith({
+			state: "error",
+			code: "machine_auth_failed",
+			message: "Could not sign in to ao-build-01. The control plane is unreachable.",
+		});
+	});
+});
+
+describe("the silent refresh", () => {
+	/**
+	 * The failure nobody notices until a VM run: a refresh that emits a status
+	 * re-runs the renderer's base-URL plumbing, which closes and rebuilds the
+	 * EventSource. See the matching assertion in
+	 * renderer/lib/event-transport.test.ts, which pins the other half: an
+	 * unchanged base URL leaves the open stream alone.
+	 */
+	it("replaces the cookie without emitting any status, so an open SSE stream is not dropped", async () => {
+		const { transport, set, onStatus, clock } = harness();
+
+		transport.setMachine(machine());
+		await settle();
+		const statusesWhileConnected = onStatus.mock.calls.length;
+
+		clock.ms += TTL_MS - 120_000;
+		await vi.advanceTimersByTimeAsync(TTL_MS - 120_000);
+
+		expect(set).toHaveBeenCalledTimes(2);
+		expect(set.mock.calls[1][0]).toMatchObject({ name: GATEWAY_COOKIE_NAME, value: "machine.jwt.2" });
+		// Nothing the renderer can observe changed, so nothing reconnects.
+		expect(onStatus).toHaveBeenCalledTimes(statusesWhileConnected);
+		// And the base URL the renderer is pointed at is still the same one.
+		expect(onStatus.mock.calls[statusesWhileConnected - 1][0]).toMatchObject({
+			state: "ready",
+			baseUrl: "https://vm.example.com",
+		});
+	});
+
+	it("keeps refreshing, so a session outlives many token lifetimes", async () => {
+		const { transport, set, onStatus, clock } = harness();
+
+		transport.setMachine(machine());
+		await settle();
+
+		for (let i = 0; i < 4; i += 1) {
+			clock.ms += TTL_MS - 120_000;
+			await vi.advanceTimersByTimeAsync(TTL_MS - 120_000);
+		}
+
+		expect(set).toHaveBeenCalledTimes(5);
+		expect(set.mock.calls[4][0]).toMatchObject({ value: "machine.jwt.5" });
+		expect(onStatus).toHaveBeenCalledTimes(2); // connecting, then ready. Nothing since.
+	});
+
+	it("schedules off the reported expiry, not a hardcoded fifteen minutes", async () => {
+		const clock = { ms: NOW };
+		const set = vi.fn().mockResolvedValue(undefined);
+		const shortTtl: MachineTokenSource = {
+			get: async () => ({ token: "machine.jwt.short", expiresAt: clock.ms + 600_000 }),
+			mint: async () => ({ token: "machine.jwt.short", expiresAt: clock.ms + 600_000 }),
+			clear: () => undefined,
+		};
+		const transport = createMachineTransport({
+			cookies: { set, remove: vi.fn().mockResolvedValue(undefined) },
+			controlPlaneUrl: "https://ao.agentlab.in",
+			controlToken,
+			onStatus: vi.fn(),
+			onMachineGone: vi.fn(),
+			now: () => clock.ms,
+			createTokenSource: () => shortTtl,
+		});
+
+		transport.setMachine(machine());
+		await settle();
+
+		// A ten minute token refreshes at eight, not at thirteen.
+		clock.ms += 480_000;
+		await vi.advanceTimersByTimeAsync(480_000);
+		expect(set).toHaveBeenCalledTimes(2);
+	});
+
+	it("stays quiet and retries while the installed token is still valid", async () => {
+		const { transport, tokens, onStatus, set, clock } = harness();
+
+		transport.setMachine(machine());
+		await settle();
+		const statusesWhileConnected = onStatus.mock.calls.length;
+
+		tokens.state.mode = "error";
+		clock.ms += TTL_MS - 120_000;
+		await vi.advanceTimersByTimeAsync(TTL_MS - 120_000);
+
+		// A control-plane outage does not disconnect a working session: the token in
+		// the cookie is good for two more minutes and the gateway serves from its
+		// stale JWKS cache.
+		expect(onStatus).toHaveBeenCalledTimes(statusesWhileConnected);
+
+		tokens.state.mode = "ok";
+		clock.ms += 30_000;
+		await vi.advanceTimersByTimeAsync(30_000);
+
+		expect(set).toHaveBeenCalledTimes(2);
+		expect(onStatus).toHaveBeenCalledTimes(statusesWhileConnected);
+	});
+
+	it("reports the failure once the installed token has actually lapsed", async () => {
+		const { transport, tokens, onStatus, clock } = harness();
+
+		transport.setMachine(machine());
+		await settle();
+
+		tokens.state.mode = "error";
+		clock.ms += TTL_MS - 120_000;
+		await vi.advanceTimersByTimeAsync(TTL_MS - 120_000);
+		// Past expiry, so the retry has nothing left to protect.
+		clock.ms += 150_000;
+		await vi.advanceTimersByTimeAsync(30_000);
+
+		expect(onStatus).toHaveBeenLastCalledWith({
+			state: "error",
+			code: "machine_auth_failed",
+			message: "Could not sign in to ao-build-01. The control plane is unreachable.",
+		});
+	});
+});
+
+describe("switching away", () => {
+	it("drops the old machine's cookie and hands the app back to the local daemon", async () => {
+		const { transport, remove, onStatus } = harness();
+
+		transport.setMachine(machine());
+		await settle();
+		transport.setMachine(null);
+		await settle();
+
+		expect(remove).toHaveBeenCalledWith("https://vm.example.com", GATEWAY_COOKIE_NAME);
+		// Null is what makes the remote lifecycle fall through to the local daemon.
+		expect(onStatus).toHaveBeenLastCalledWith(null);
+		await expect(transport.token()).resolves.toBeNull();
+	});
+
+	it("stops refreshing the machine it left", async () => {
+		const { transport, set, clock } = harness();
+
+		transport.setMachine(machine());
+		await settle();
+		transport.setMachine(null);
+		await settle();
+
+		clock.ms += TTL_MS;
+		await vi.advanceTimersByTimeAsync(TTL_MS);
+
+		expect(set).toHaveBeenCalledTimes(1);
+	});
+
+	it("mints for the new machine and drops the old cookie when switching between machines", async () => {
+		const { transport, tokens, set, remove } = harness();
+
+		transport.setMachine(machine());
+		await settle();
+		transport.setMachine(machine({ id: "mch_2", name: "ao-eu-west", baseUrl: "https://eu.example.com" }));
+		await settle();
+
+		expect(remove).toHaveBeenCalledWith("https://vm.example.com", GATEWAY_COOKIE_NAME);
+		expect(tokens.state.created).toEqual(["mch_1", "mch_2"]);
+		expect(set.mock.calls[1][0]).toMatchObject({ url: "https://eu.example.com" });
+	});
+
+	// The hazard: a slow token exchange for machine A landing after the user
+	// picked machine B would install A's cookie and publish A's base URL.
+	it("drops an acquisition that was superseded while it was in flight", async () => {
+		const clock = { ms: NOW };
+		const set = vi.fn().mockResolvedValue(undefined);
+		const onStatus = vi.fn<(status: DaemonStatus | null) => void>();
+		let release: (() => void) | undefined;
+		const blockUntilReleased = async (): Promise<MachineAccessToken> => {
+			await new Promise<void>((resolve) => {
+				release = resolve;
+			});
+			return { token: "machine.jwt.slow", expiresAt: clock.ms + TTL_MS };
+		};
+		const slow: MachineTokenSource = {
+			get: blockUntilReleased,
+			mint: blockUntilReleased,
+			clear: () => undefined,
+		};
+		const transport = createMachineTransport({
+			cookies: { set, remove: vi.fn().mockResolvedValue(undefined) },
+			controlPlaneUrl: "https://ao.agentlab.in",
+			controlToken,
+			onStatus,
+			onMachineGone: vi.fn(),
+			now: () => clock.ms,
+			createTokenSource: () => slow,
+		});
+
+		transport.setMachine(machine());
+		await settle();
+		transport.setMachine(null);
+		release?.();
+		await settle();
+
+		expect(set).not.toHaveBeenCalled();
+		expect(onStatus).toHaveBeenLastCalledWith(null);
+	});
+});
+
+describe("the REST bearer", () => {
+	it("hands out the current token for the active machine", async () => {
+		const { transport } = harness();
+
+		transport.setMachine(machine());
+		await settle();
+
+		await expect(transport.token()).resolves.toBe("machine.jwt.1");
+	});
+
+	it("is null while this computer is the active machine", async () => {
+		const { transport } = harness();
+
+		await expect(transport.token()).resolves.toBeNull();
+	});
+
+	it("is null rather than a rejection when the token cannot be obtained", async () => {
+		const { transport, tokens, clock } = harness();
+		transport.setMachine(machine());
+		await settle();
+
+		tokens.state.mode = "error";
+		clock.ms += TTL_MS; // the cached token is spent, so this has to mint and fails
+		// A rejection here would surface as an unhandled error on the IPC channel;
+		// the REST call gets a 401 from the gateway instead, which the renderer
+		// already renders through the machine's status.
+		await expect(transport.token()).resolves.toBeNull();
+	});
+});

--- a/frontend/src/main/machine-transport.ts
+++ b/frontend/src/main/machine-transport.ts
@@ -1,0 +1,255 @@
+import type { AoMachine } from "../shared/ao-machines";
+import type { DaemonStatus } from "../shared/daemon-status";
+import {
+	GATEWAY_COOKIE_NAME,
+	machineAuthFailedStatus,
+	machineConnectingStatus,
+	machineDaemonStatus,
+} from "../shared/remote-daemon";
+import type { ControlPlaneTokenSource } from "./ao-control-token";
+import {
+	createMachineTokenSource,
+	MachineUnavailableError,
+	type MachineTokenSource,
+	type MachineTokenSourceDeps,
+} from "./ao-machine-token";
+
+/**
+ * The desktop's authenticated transport to the active machine's gateway.
+ *
+ * Two credentials, because the gateway accepts two and the browser can only
+ * offer one on some routes:
+ *
+ * - `Authorization: Bearer` on REST, which the renderer attaches per request by
+ *   asking the main process for the current token over IPC. This is the only
+ *   credential the gateway takes on a state-changing route.
+ * - The `ao_gw_token` cookie for `/mux` and for `GET /api/v1/events`. Neither
+ *   the WebSocket handshake nor `EventSource` has a header API at all, so the
+ *   same JWT travels in a cookie that this module installs, and which must be
+ *   `SameSite=None` because `app://renderer` reaching `https://vm.example.com`
+ *   is a cross-site context.
+ *
+ * The `ready` status, which is what re-points the renderer at the gateway, is
+ * published only after both are in place. Ordering is the point: a base URL
+ * handed out before the cookie exists would open the SSE stream and the terminal
+ * mux against a gateway that answers 401.
+ *
+ * Tokens last fifteen minutes by default, so this also owns the silent refresh.
+ * "Silent" means no status is emitted on a successful refresh: the gateway reads
+ * the cookie at the handshake and at the SSE request and never again, so
+ * replacing its value leaves an already-open stream running, while emitting a
+ * status would re-run the renderer's base-URL plumbing and visibly reconnect it.
+ */
+
+/**
+ * Refresh this long before expiry. Taken off the expiry the endpoint reported,
+ * never off a fixed TTL: the default is fifteen minutes but a deployment may
+ * configure anywhere from ten to thirty (controlplane/TOKEN_CONTRACT.md).
+ */
+const REFRESH_LEAD_MS = 120_000;
+
+/** Floor on the refresh delay, so a short or clock-skewed TTL cannot spin. */
+const MIN_REFRESH_DELAY_MS = 5_000;
+
+/** How often to retry a failed refresh while the installed token is still good. */
+const REFRESH_RETRY_MS = 30_000;
+
+/** Said when this install has no account, so no machine token can exist. */
+export const SIGNED_OUT_REASON = "This computer is signed out of AO.";
+
+/** The subset of Electron's cookie store this module needs, so tests can fake it. */
+export type GatewayCookieStore = {
+	set: (details: Electron.CookiesSetDetails) => Promise<void>;
+	remove: (url: string, name: string) => Promise<void>;
+};
+
+export type MachineTransportDeps = {
+	cookies: GatewayCookieStore;
+	/** Origin of the control plane this install trusts, no trailing slash. */
+	controlPlaneUrl: string;
+	/** The one control-plane token source in this process. See ao-machines.ts. */
+	controlToken: ControlPlaneTokenSource;
+	/**
+	 * The app's daemon status for the active machine, or null when this computer
+	 * is the active machine. Called only when the status actually changes; a
+	 * successful silent refresh deliberately does not call it.
+	 */
+	onStatus: (status: DaemonStatus | null) => void;
+	/**
+	 * The control plane will not issue a token for the active machine. It answers
+	 * revoked, someone else's, and never-existed identically, so the reason is not
+	 * knowable here; refreshing the machine list is what resolves it.
+	 */
+	onMachineGone: () => void;
+	fetchImpl?: typeof fetch;
+	now?: () => number;
+	/** Test seam, so a transport can be driven without a real token endpoint. */
+	createTokenSource?: (deps: MachineTokenSourceDeps) => MachineTokenSource;
+};
+
+export type MachineTransport = {
+	/** Point the transport at a machine, or at null for this computer. */
+	setMachine: (machine: AoMachine | null) => void;
+	/** The gateway bearer for a REST call, or null when there is none. */
+	token: () => Promise<string | null>;
+};
+
+const errorMessage = (err: unknown): string => (err instanceof Error ? err.message : String(err));
+
+export function createMachineTransport(deps: MachineTransportDeps): MachineTransport {
+	const now = deps.now ?? Date.now;
+	const createTokenSource = deps.createTokenSource ?? createMachineTokenSource;
+
+	let target: AoMachine | null = null;
+	let tokens: MachineTokenSource | null = null;
+	let refreshTimer: ReturnType<typeof setTimeout> | undefined;
+	/** Expiry of the token currently in the cookie, or 0 when none is installed. */
+	let installedExpiresAt = 0;
+	/**
+	 * Bumped by every setMachine. An acquisition that was already in flight when
+	 * the user switched machines would otherwise land late and install machine A's
+	 * cookie, and publish machine A's base URL, while machine B is active.
+	 */
+	let generation = 0;
+
+	function stopRefresh(): void {
+		if (refreshTimer) clearTimeout(refreshTimer);
+		refreshTimer = undefined;
+	}
+
+	async function installCookie(machine: AoMachine, token: string): Promise<void> {
+		await deps.cookies.set({
+			url: machine.baseUrl,
+			name: GATEWAY_COOKIE_NAME,
+			value: token,
+			path: "/",
+			// SameSite=None is only honoured together with Secure, which is why the
+			// pair is set together. Without None the browser does not attach the
+			// cookie to the /mux handshake or the EventSource request at all, and
+			// both fail 401 with nothing to see on the client.
+			secure: true,
+			httpOnly: true,
+			sameSite: "no_restriction",
+			// No `domain`: host-only, so the credential is scoped to this gateway
+			// and never offered to a sibling host under the same registrable domain.
+		});
+	}
+
+	async function dropCookie(machine: AoMachine): Promise<void> {
+		try {
+			await deps.cookies.remove(machine.baseUrl, GATEWAY_COOKIE_NAME);
+		} catch {
+			// Best effort. Switching away from a machine, or signing out, must not
+			// leave an ambient credential behind, but a cookie jar that refuses the
+			// removal is not a reason to fail the switch. The token in it expires on
+			// its own within the fifteen minute window either way.
+		}
+	}
+
+	function scheduleRefresh(startedAt: number, expiresAt: number, delayMs?: number): void {
+		stopRefresh();
+		const delay = delayMs ?? Math.max(expiresAt - REFRESH_LEAD_MS - now(), MIN_REFRESH_DELAY_MS);
+		refreshTimer = setTimeout(() => {
+			refreshTimer = undefined;
+			void acquire(startedAt, "refresh");
+		}, delay);
+	}
+
+	/**
+	 * Get a token, install it in the cookie, and keep the refresh running.
+	 *
+	 * The reason is the whole difference between the two callers. A connect asks
+	 * for a usable token, which may be one already cached from an earlier visit to
+	 * this machine, and publishes the ready status that re-points the renderer. A
+	 * refresh asks for a genuinely fresh one, because a cached token is exactly
+	 * what it is there to replace, and publishes nothing at all.
+	 */
+	async function acquire(startedAt: number, reason: "connect" | "refresh"): Promise<void> {
+		const machine = target;
+		const source = tokens;
+		if (!machine || !source || generation !== startedAt) return;
+		const announce = reason === "connect";
+		try {
+			const minted = reason === "connect" ? await source.get() : await source.mint();
+			if (generation !== startedAt) return;
+			if (!minted) {
+				deps.onStatus(machineAuthFailedStatus(machine, SIGNED_OUT_REASON));
+				return;
+			}
+			await installCookie(machine, minted.token);
+			if (generation !== startedAt) return;
+			installedExpiresAt = minted.expiresAt;
+			// The cookie is in place before the base URL is, so the renderer cannot
+			// open the SSE stream or the terminal mux without a credential.
+			if (announce) deps.onStatus(machineDaemonStatus(machine));
+			scheduleRefresh(startedAt, minted.expiresAt);
+		} catch (err) {
+			if (generation !== startedAt) return;
+			if (err instanceof MachineUnavailableError) {
+				deps.onStatus(machineAuthFailedStatus(machine, err.message));
+				deps.onMachineGone();
+				return;
+			}
+			// The control plane going down while a user is already connected does not
+			// disconnect them (the spec's failure behaviour): the installed token is
+			// good for another couple of minutes and the gateway serves from its stale
+			// JWKS cache. So retry quietly, and report only once the credential this
+			// would have replaced has actually lapsed.
+			if (installedExpiresAt > now()) {
+				scheduleRefresh(startedAt, installedExpiresAt, REFRESH_RETRY_MS);
+				return;
+			}
+			deps.onStatus(machineAuthFailedStatus(machine, errorMessage(err)));
+		}
+	}
+
+	return {
+		setMachine(machine: AoMachine | null): void {
+			generation += 1;
+			const startedAt = generation;
+			stopRefresh();
+			const previous = target;
+			target = machine;
+			installedExpiresAt = 0;
+
+			if (previous && previous.baseUrl !== machine?.baseUrl) void dropCookie(previous);
+
+			if (!machine) {
+				tokens = null;
+				deps.onStatus(null);
+				return;
+			}
+			if (!tokens || previous?.id !== machine.id) {
+				tokens = createTokenSource({
+					controlPlaneUrl: deps.controlPlaneUrl,
+					machineId: machine.id,
+					controlToken: deps.controlToken,
+					fetchImpl: deps.fetchImpl,
+					now,
+				});
+			}
+			// Nothing to authenticate to yet, and the status already says why. A
+			// machine that is down must not be given a base URL, and must not cost a
+			// token request either.
+			if (machine.reachability !== "online") {
+				deps.onStatus(machineDaemonStatus(machine));
+				return;
+			}
+			deps.onStatus(machineConnectingStatus(machine));
+			void acquire(startedAt, "connect");
+		},
+
+		async token(): Promise<string | null> {
+			const source = tokens;
+			if (!source) return null;
+			try {
+				return (await source.get())?.token ?? null;
+			} catch {
+				// The REST call that asked for this gets a 401 from the gateway and the
+				// renderer already renders the machine's status; rejecting here would
+				// surface as an unhandled error on the IPC channel instead.
+				return null;
+			}
+		},
+	};
+}

--- a/frontend/src/main/remote-daemon.test.ts
+++ b/frontend/src/main/remote-daemon.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import type { AoMachine } from "../shared/ao-machines";
-import { machineDaemonStatus } from "../shared/remote-daemon";
+import { machineAuthFailedStatus, machineDaemonStatus } from "../shared/remote-daemon";
 import { createRemoteDaemonLifecycle, installRemoteDaemonCookie, remoteDaemonReadyStatus } from "./remote-daemon";
 
 const machine = (extra: Partial<AoMachine> = {}): AoMachine => ({
@@ -145,20 +145,36 @@ describe("an active registered machine", () => {
 		};
 	};
 
-	// TASK 13: this becomes "re-points the app at that machine's base URL", with a
-	// ready status carrying baseUrl, once the desktop can present a
-	// machine-audience token. Until then the app must not point at a machine it
-	// cannot authenticate to.
-	it("owns the app's daemon status without claiming a connection it cannot make", async () => {
+	it("re-points the app at that machine's base URL", async () => {
 		const lifecycle = createRemoteDaemonLifecycle(null, null, () => machineDaemonStatus(machine()));
 		const { localStart } = localCalls();
 
 		await expect(lifecycle.start(localStart, vi.fn())).resolves.toEqual({
-			state: "error",
-			code: "machine_transport_missing",
-			message: expect.stringContaining("cannot sign in to it yet"),
+			state: "ready",
+			baseUrl: "https://vm.example.com",
+			message: "Connected to ao-build-01",
 		});
 		expect(localStart).not.toHaveBeenCalled();
+	});
+
+	// A credential failure is still a status the remote lifecycle owns, so it
+	// cannot fall through to spawning a local daemon either.
+	it("never spawns a local daemon when it has no credential", async () => {
+		const lifecycle = createRemoteDaemonLifecycle(null, null, () =>
+			machineAuthFailedStatus(machine(), "This computer is signed out of AO."),
+		);
+		const { localRefresh, localStart, localStop, spawnLocalDaemon } = localCalls();
+		const setStatus = vi.fn();
+
+		const unauthorized = { state: "error", code: "machine_auth_failed" };
+		await expect(lifecycle.refresh(localRefresh, setStatus)).resolves.toMatchObject(unauthorized);
+		await expect(lifecycle.start(localStart, setStatus)).resolves.toMatchObject(unauthorized);
+		expect(lifecycle.stop(localStop, setStatus)).toMatchObject(unauthorized);
+
+		expect(localRefresh).not.toHaveBeenCalled();
+		expect(localStart).not.toHaveBeenCalled();
+		expect(localStop).not.toHaveBeenCalled();
+		expect(spawnLocalDaemon).not.toHaveBeenCalled();
 	});
 
 	// The hazard this guards: the app spawns a local daemon when it cannot reach

--- a/frontend/src/preload.ts
+++ b/frontend/src/preload.ts
@@ -241,6 +241,11 @@ const api = {
 		getState: () => ipcRenderer.invoke("aoMachines:getState") as Promise<AoMachinesState>,
 		refresh: () => ipcRenderer.invoke("aoMachines:refresh") as Promise<AoMachinesState>,
 		select: (machineId: string) => ipcRenderer.invoke("aoMachines:select", machineId) as Promise<AoMachinesState>,
+		// The Bearer credential for a REST call to the active machine's gateway,
+		// asked for per request so the renderer never has to reason about expiry.
+		// It is a fifteen minute token scoped to one machine; the refresh token it
+		// descends from never leaves the main process.
+		gatewayToken: () => ipcRenderer.invoke("aoMachines:gatewayToken") as Promise<string | null>,
 	},
 };
 

--- a/frontend/src/renderer/lib/api-client.test.ts
+++ b/frontend/src/renderer/lib/api-client.test.ts
@@ -1,4 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { gatewayTokenMock } = vi.hoisted(() => ({ gatewayTokenMock: vi.fn<() => Promise<string | null>>() }));
+
+vi.mock("./bridge", () => ({
+	aoBridge: { machines: { gatewayToken: gatewayTokenMock } },
+}));
+
 import {
 	apiClient,
 	apiErrorMessage,
@@ -19,6 +26,9 @@ vi.mock("./telemetry", () => ({
 const captureMock = vi.mocked(captureRendererEvent);
 
 describe("apiClient runtime base URL", () => {
+	beforeEach(() => {
+		gatewayTokenMock.mockReset().mockResolvedValue(null);
+	});
 	afterEach(() => {
 		vi.restoreAllMocks();
 		setApiBaseUrl("http://127.0.0.1:3001");
@@ -61,6 +71,49 @@ describe("apiClient runtime base URL", () => {
 		expect(fetchSpy).toHaveBeenCalledTimes(1);
 		expect(String(fetchSpy.mock.calls[0]?.[0])).toBe("https://api.ao.agentlab.in/api/v1/projects");
 		expect(fetchSpy.mock.calls[0]?.[1]).toMatchObject({ credentials: "include" });
+	});
+
+	// Bearer is the only credential the machine gateway accepts on a REST route:
+	// the ao_gw_token cookie is confined to /mux and the SSE stream, so nothing
+	// state-changing rides an ambient credential.
+	it("carries the machine bearer on a remote REST call", async () => {
+		gatewayTokenMock.mockResolvedValue("machine.audience.jwt");
+		const fetchSpy = vi
+			.spyOn(globalThis, "fetch")
+			.mockResolvedValue(new Response(JSON.stringify({ session: { id: "s1" } }), { status: 201 }));
+
+		setApiBaseUrl("https://vm.example.com");
+		await apiClient.POST("/api/v1/sessions", { body: { projectId: "p1", prompt: "hi" } });
+
+		expect(String(fetchSpy.mock.calls[0]?.[0])).toBe("https://vm.example.com/api/v1/sessions");
+		const init = fetchSpy.mock.calls[0]?.[1];
+		expect(new Headers(init?.headers).get("authorization")).toBe("Bearer machine.audience.jwt");
+		expect(init).toMatchObject({ credentials: "include" });
+	});
+
+	// AO_REMOTE_URL pairs with its own cookie and has no machine token, and it
+	// keeps working exactly as it did.
+	it("sends no Authorization header when there is no machine token", async () => {
+		gatewayTokenMock.mockResolvedValue(null);
+		const fetchSpy = vi
+			.spyOn(globalThis, "fetch")
+			.mockResolvedValue(new Response(JSON.stringify({ projects: [] }), { status: 200 }));
+
+		setApiBaseUrl("https://api.ao.agentlab.in");
+		await apiClient.GET("/api/v1/projects");
+
+		expect(new Headers(fetchSpy.mock.calls[0]?.[1]?.headers).has("authorization")).toBe(false);
+	});
+
+	it("does not ask for a machine token for a loopback daemon", async () => {
+		vi.spyOn(globalThis, "fetch").mockResolvedValue(
+			new Response(JSON.stringify({ projects: [] }), { status: 200 }),
+		);
+
+		setApiBaseUrl("http://127.0.0.1:3037");
+		await apiClient.GET("/api/v1/projects");
+
+		expect(gatewayTokenMock).not.toHaveBeenCalled();
 	});
 
 	it("prefers a ready daemon remote base URL over its loopback port", () => {

--- a/frontend/src/renderer/lib/api-client.ts
+++ b/frontend/src/renderer/lib/api-client.ts
@@ -2,6 +2,7 @@ import createClient from "openapi-fetch";
 import type { paths } from "../../api/schema";
 import type { DaemonStatus } from "../../shared/daemon-status";
 import { isRemoteDaemonBaseUrl } from "../../shared/remote-daemon";
+import { aoBridge } from "./bridge";
 import { daemonFailureMessage } from "./daemon-failure";
 import { captureRendererEvent } from "./telemetry";
 
@@ -189,10 +190,20 @@ async function runtimeFetch(input: Request): Promise<Response> {
 
 		const url = new URL(input.url);
 		const target = new URL(url.pathname + url.search + url.hash, baseUrl);
-		const credentials = isRemoteDaemonBaseUrl(baseUrl) ? "include" : input.credentials;
-		if (target.href === input.url && credentials === input.credentials) {
+		const remote = isRemoteDaemonBaseUrl(baseUrl);
+		const credentials = remote ? "include" : input.credentials;
+		// Bearer is the only credential the machine gateway accepts on a REST route:
+		// its cookie is confined to /mux and the SSE stream, so nothing
+		// state-changing rides an ambient credential (controlplane/TOKEN_CONTRACT.md).
+		// Asked for per request because the main process owns expiry and the silent
+		// refresh; null while AO_REMOTE_URL is the remote hatch, which authenticates
+		// with its own pairing cookie instead, and null in browser preview.
+		const gatewayToken = remote ? await aoBridge.machines.gatewayToken() : null;
+		if (target.href === input.url && credentials === input.credentials && !gatewayToken) {
 			return fetch(input);
 		}
+		const headers = new Headers(input.headers);
+		if (gatewayToken) headers.set("Authorization", `Bearer ${gatewayToken}`);
 
 		// Rebase onto the runtime base URL by copying fields explicitly and
 		// buffering the body. `new Request(target, input)` reads the source
@@ -203,7 +214,7 @@ async function runtimeFetch(input: Request): Promise<Response> {
 		const body = input.method === "GET" || input.method === "HEAD" ? undefined : await input.arrayBuffer();
 		return fetch(target, {
 			method: input.method,
-			headers: input.headers,
+			headers,
 			body,
 			signal: input.signal,
 			credentials,

--- a/frontend/src/renderer/lib/bridge.ts
+++ b/frontend/src/renderer/lib/bridge.ts
@@ -238,5 +238,9 @@ export const aoBridge: AoBridge =
 				previewDaemonStatusListeners.forEach((listener) => listener(status));
 				return browserPreviewMachinesState();
 			},
+			// Browser preview has no main process, so no machine token either. Null
+			// means "send no Authorization header", which is also what the
+			// AO_REMOTE_URL pairing hatch wants.
+			gatewayToken: async () => null,
 		},
 	} satisfies AoBridge);

--- a/frontend/src/renderer/lib/daemon-failure.test.ts
+++ b/frontend/src/renderer/lib/daemon-failure.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { daemonFailureTitle } from "./daemon-failure";
+import { daemonFailureHint, daemonFailureTitle } from "./daemon-failure";
 
 describe("daemonFailureTitle", () => {
 	it.each([
@@ -11,7 +11,18 @@ describe("daemonFailureTitle", () => {
 		{ code: "binary_missing" as const, title: "AO daemon binary is missing" },
 		{ code: "spawn_failed" as const, title: "AO daemon failed to start" },
 		{ code: "exited" as const, title: "AO daemon failed to start" },
+		{ code: "machine_auth_failed" as const, title: "AO could not sign in to that machine" },
 	])("returns $title for $code", ({ code, title }) => {
 		expect(daemonFailureTitle({ state: "error", code })).toBe(title);
+	});
+
+	// The wrong hint is worse than a generic one: a machine the app has no
+	// credential for is not fixed by setting AO_DAEMON_COMMAND, which is what
+	// not_configured tells the user to do.
+	it("points a credential failure at sign-in and the machine picker, not at AO_DAEMON_COMMAND", () => {
+		const hint = daemonFailureHint({ state: "error", code: "machine_auth_failed" });
+		expect(hint).toContain("Settings, Account");
+		expect(hint).toContain("Settings, Machines");
+		expect(hint).not.toContain("AO_DAEMON_COMMAND");
 	});
 });

--- a/frontend/src/renderer/lib/daemon-failure.ts
+++ b/frontend/src/renderer/lib/daemon-failure.ts
@@ -13,8 +13,8 @@ export function daemonFailureTitle(status: DaemonStatus): string {
 			return "AO daemon is not ready yet";
 		case "not_configured":
 			return "AO daemon is not configured";
-		case "machine_transport_missing":
-			return "This build cannot reach a registered machine yet";
+		case "machine_auth_failed":
+			return "AO could not sign in to that machine";
 		case "daemon_unreachable":
 			return "AO daemon is unreachable";
 		case "identity_mismatch":
@@ -39,8 +39,8 @@ export function daemonFailureHint(status: DaemonStatus): string {
 			return "The daemon has not passed its readiness check yet. Open details below for more information.";
 		case "not_configured":
 			return "Set AO_DAEMON_COMMAND or run the desktop app from a source checkout.";
-		case "machine_transport_missing":
-			return "Pick this computer under Settings, Machines to keep working.";
+		case "machine_auth_failed":
+			return "Check your sign-in under Settings, Account, or pick this computer under Settings, Machines to keep working.";
 		case "daemon_unreachable":
 		case "identity_mismatch":
 			return "Stop the conflicting daemon, then restart the desktop app.";

--- a/frontend/src/renderer/lib/event-transport.test.ts
+++ b/frontend/src/renderer/lib/event-transport.test.ts
@@ -105,6 +105,30 @@ describe("createEventTransport", () => {
 		expect(EventSourceStub.instances).toHaveLength(1);
 	});
 
+	// The other half of the silent refresh, whose main-process half is pinned in
+	// main/machine-transport.test.ts: the refresh replaces the ao_gw_token cookie
+	// and emits no status at all, so nothing here re-points and the open stream is
+	// left running. A refresh that visibly reconnected every fifteen minutes would
+	// not be silent, and that is the failure nobody notices until a VM run.
+	it("a token refresh does not drop the open SSE stream", () => {
+		getApiBaseUrlMock.mockReturnValue("https://vm.example.com");
+		createEventTransport(fakeQueryClient()).connect();
+		const stream = EventSourceStub.instances[0];
+		stream.readyState = 1; // OPEN
+		stream.onopen?.();
+
+		const onStatusHandler = onStatusMock.mock.calls[0][0] as () => void;
+		const onBaseUrlChange = subscribeApiBaseUrlMock.mock.calls[0][0] as () => void;
+		// Everything a refresh could plausibly wake, with the base URL unchanged
+		// because the machine did not move.
+		onBaseUrlChange();
+		onStatusHandler();
+
+		expect(EventSourceStub.instances).toHaveLength(1);
+		expect(stream.closed).toBe(false);
+		expect(getEventsConnectionState()).toBe("connected");
+	});
+
 	it("closes the old connection and reconnects when the base URL changes", () => {
 		createEventTransport(fakeQueryClient()).connect();
 		const first = EventSourceStub.instances[0];

--- a/frontend/src/renderer/test/setup.ts
+++ b/frontend/src/renderer/test/setup.ts
@@ -208,6 +208,7 @@ if (typeof window !== "undefined") {
 			getState: async () => signedOutAoMachines,
 			refresh: async () => signedOutAoMachines,
 			select: async () => signedOutAoMachines,
+			gatewayToken: async () => null,
 		},
 	};
 } // end if (typeof window !== "undefined")

--- a/frontend/src/shared/daemon-status.ts
+++ b/frontend/src/shared/daemon-status.ts
@@ -14,9 +14,11 @@ export type DaemonFailureCode =
 	| "not_ready"
 	| "identity_mismatch"
 	| "datadir_unwritable"
-	// TASK 13 PLACEHOLDER: a registered machine is up but this build has no
-	// credential for it. Delete this with machineTransportMissingStatus.
-	| "machine_transport_missing";
+	// A registered machine is up, but no machine-audience access token could be
+	// obtained for it: this install is signed out, the control plane refused the
+	// sign-in, or the account no longer has that machine. See
+	// main/machine-transport.ts.
+	| "machine_auth_failed";
 
 export type DaemonStatus = {
 	state: "starting" | "ready" | "stopped" | "error";

--- a/frontend/src/shared/remote-daemon.test.ts
+++ b/frontend/src/shared/remote-daemon.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it } from "vitest";
 import type { AoMachine } from "./ao-machines";
-import { isRemoteDaemonBaseUrl, machineDaemonStatus, readRemoteDaemonConfig } from "./remote-daemon";
+import {
+	GATEWAY_COOKIE_NAME,
+	isRemoteDaemonBaseUrl,
+	machineAuthFailedStatus,
+	machineDaemonStatus,
+	readRemoteDaemonConfig,
+	REMOTE_PAIRING_COOKIE_NAME,
+} from "./remote-daemon";
 
 const machine = (extra: Partial<AoMachine> = {}): AoMachine => ({
 	id: "mch_1",
@@ -82,13 +89,39 @@ describe("machineDaemonStatus", () => {
 		expect(machineDaemonStatus(machine({ reachability: "unknown" })).baseUrl).toBeUndefined();
 	});
 
-	// The regression this guards: a "ready" status here sets the renderer's API
-	// base URL, and with no machine-audience token in this build every REST call
-	// and both EventSources would 401 under a UI that says Connected.
-	it("does not hand out a base URL for a reachable machine while there is no credential for it", () => {
-		const status = machineDaemonStatus(machine({ reachability: "online" }));
-		expect(status.state).not.toBe("ready");
-		expect(status.baseUrl).toBeUndefined();
-		expect(status.message).toContain("ao-build-01");
+	it("hands the reachable machine's base URL to the renderer", () => {
+		expect(machineDaemonStatus(machine({ reachability: "online" }))).toEqual({
+			state: "ready",
+			baseUrl: "https://vm.example.com",
+			message: "Connected to ao-build-01",
+		});
+	});
+
+	// The regression this guards: a "ready" status sets the renderer's API base
+	// URL, so a machine that has not answered, or is down, must not carry one.
+	// Only main/machine-transport.ts publishes the ready case, and only once a
+	// machine-audience token is held and the ao_gw_token cookie is installed.
+	it.each(["offline", "unknown"] as const)("does not hand out a base URL while reachability is %s", (reachability) => {
+		expect(machineDaemonStatus(machine({ reachability })).baseUrl).toBeUndefined();
+	});
+});
+
+describe("machineAuthFailedStatus", () => {
+	it("names the machine and the reason without handing out a base URL", () => {
+		expect(machineAuthFailedStatus(machine(), "This computer is signed out of AO.")).toEqual({
+			state: "error",
+			code: "machine_auth_failed",
+			message: "Could not sign in to ao-build-01. This computer is signed out of AO.",
+		});
+	});
+});
+
+describe("GATEWAY_COOKIE_NAME", () => {
+	// The gateway reads this exact name (gatewayCookieName in
+	// backend/internal/vmgateway/proxy.go). A rename on either side makes /mux and
+	// the SSE stream 401 with nothing to see on the client, so it is pinned here.
+	it("is the name the VM gateway reads, and is not the AO_REMOTE_URL pairing cookie", () => {
+		expect(GATEWAY_COOKIE_NAME).toBe("ao_gw_token");
+		expect(GATEWAY_COOKIE_NAME).not.toBe(REMOTE_PAIRING_COOKIE_NAME);
 	});
 });

--- a/frontend/src/shared/remote-daemon.ts
+++ b/frontend/src/shared/remote-daemon.ts
@@ -3,6 +3,23 @@ import type { DaemonStatus } from "./daemon-status";
 
 export const REMOTE_PAIRING_COOKIE_NAME = "ao_hosted_pair";
 
+/**
+ * The VM gateway's JWT cookie, whose value is the current machine-audience
+ * access token.
+ *
+ * It exists for the two routes a browser cannot put a header on: the `/mux`
+ * WebSocket handshake, which has no header API, and the SSE stream at
+ * `GET /api/v1/events`, which the renderer opens with `EventSource`, which has
+ * none either. Every other route on the gateway takes `Authorization: Bearer`
+ * and refuses this cookie, deliberately: it is ambient, so accepting it on a
+ * state-changing method would leave the gateway's CORS origin check as the only
+ * CSRF defence.
+ *
+ * Must stay equal to `gatewayCookieName` in
+ * `backend/internal/vmgateway/proxy.go`. See `controlplane/TOKEN_CONTRACT.md`.
+ */
+export const GATEWAY_COOKIE_NAME = "ao_gw_token";
+
 export type RemoteDaemonConfig = { baseUrl: string; token: string };
 
 export function readRemoteDaemonConfig(env: Record<string, string | undefined>): RemoteDaemonConfig | null {
@@ -22,6 +39,11 @@ export function isRemoteDaemonBaseUrl(baseUrl: string): boolean {
 	return baseUrl.startsWith("https://");
 }
 
+/** Reaching a machine, before it has answered or before it is authenticated. */
+export function machineConnectingStatus(machine: AoMachine): DaemonStatus {
+	return { state: "starting", message: `Connecting to ${machine.name}…` };
+}
+
 /**
  * The app's daemon status while a registered machine is the active one.
  *
@@ -30,6 +52,13 @@ export function isRemoteDaemonBaseUrl(baseUrl: string): boolean {
  * local daemon when there is no status here at all. A remote machine being
  * down therefore cannot spawn a local daemon, because the code path that
  * spawns one is never reached rather than being skipped by a condition.
+ *
+ * The `ready` case carries the machine's base URL, which is what re-points the
+ * renderer's REST calls, its SSE stream, and the terminal mux at that gateway.
+ * Only `main/machine-transport.ts` may publish it, and only once a
+ * machine-audience token has been obtained and the `ao_gw_token` cookie is
+ * installed for that origin. Publishing it earlier would point every one of
+ * those at a gateway that answers 401 under a UI saying "Connected".
  *
  * Shared rather than main-process-only so browser preview shows the same
  * states, from the same copy, as the packaged app.
@@ -45,28 +74,21 @@ export function machineDaemonStatus(machine: AoMachine): DaemonStatus {
 				: `${machine.name} is not reachable, and has never connected to AO.`,
 		};
 	}
-	if (machine.reachability === "unknown") {
-		return { state: "starting", message: `Connecting to ${machine.name}…` };
-	}
-	return machineTransportMissingStatus(machine);
+	if (machine.reachability === "unknown") return machineConnectingStatus(machine);
+	return { state: "ready", baseUrl: machine.baseUrl, message: `Connected to ${machine.name}` };
 }
 
 /**
- * TASK 13 PLACEHOLDER. Delete this function and return
- * `{ state: "ready", baseUrl: machine.baseUrl, message: "Connected to ..." }`
- * from machineDaemonStatus when the remote transport lands.
+ * A reachable machine the app has no usable credential for.
  *
- * A reachable machine is not a usable one yet: every route on it wants a
- * machine-audience access token, and the desktop mints none (see the scope note
- * at the top of main/ao-control-token.ts). Reporting ready would point the
- * renderer at the gateway and turn every REST call and both EventSources into
- * 401s under a UI that says "Connected". Naming the missing piece is the honest
- * answer until there is a credential to send.
+ * Deliberately not a `ready` status: it carries no base URL, so nothing is
+ * pointed at a gateway that would refuse it. `reason` is the failure as
+ * reported, never a token or a cookie value.
  */
-function machineTransportMissingStatus(machine: AoMachine): DaemonStatus {
+export function machineAuthFailedStatus(machine: AoMachine, reason: string): DaemonStatus {
 	return {
 		state: "error",
-		code: "machine_transport_missing",
-		message: `${machine.name} is up, but this build cannot sign in to it yet. Reaching a registered machine needs the remote transport, which is not in this build. Use this computer for now.`,
+		code: "machine_auth_failed",
+		message: `Could not sign in to ${machine.name}. ${reason}`,
 	};
 }


### PR DESCRIPTION
Closes #48

## What

The desktop could list machines and pick one, but had no credential for the gateway, so #44 left a placeholder status saying exactly that. This is the real transport, built against `POST /api/v1/machines/{id}/token` from #47 / PR #50, **which is merged on `develop`** (1157adb40), so nothing here is provisional.

Two credentials, because the gateway accepts two and the browser can only offer one on some routes:

- **`Authorization: Bearer` on REST.** The renderer asks the main process for the current machine-audience token per request (`aoMachines:gatewayToken`) and sets the header. This is the only credential the gateway takes on a state-changing route.
- **The `ao_gw_token` cookie for `/mux` and `GET /api/v1/events`.** Neither the WebSocket handshake nor `EventSource` has a header API at all, so the same JWT travels in a cookie the Electron main process installs: `Secure`, `HttpOnly`, `SameSite=None`, host-only, `Path=/`. `SameSite=None` is required, not tidy: `app://renderer` reaching `https://vm.example.com` is a cross-site context, and under the browser default the cookie is not attached to either request and both fail 401 with nothing to see on the client.

`backend/internal/vmgateway/` is untouched. It already accepts Bearer everywhere proxyable and the cookie on those two routes only, and that asymmetry is the reason the REST path uses a header rather than widening the cookie.

## Decisions worth reviewing

- **Ordering is the safety property, not a nicety.** The cookie is installed *before* the `ready` status that carries the machine's base URL is published, because that status is what opens the SSE stream and the terminal mux. A base URL handed out first is precisely the M3 bug #44 fixed, so `machineDaemonStatus` returning `ready` is now reachable only through `main/machine-transport.ts`. `machine-transport.test.ts` pins the call order.

- **The silent refresh emits no status at all.** The gateway reads the credential at the `/mux` handshake and at the SSE request and never again, so replacing the cookie value leaves an open stream running. Emitting a status would run `applyDaemonStatus`, which calls `setApiBaseUrl(null)` for any non-`ready` state and closes the EventSource. Pinned from both sides: `main/machine-transport.test.ts` asserts the refresh replaces the cookie with **zero** \`onStatus\` calls, and `renderer/lib/event-transport.test.ts` (\"a token refresh does not drop the open SSE stream\") asserts that waking both the status and base-URL listeners with an unchanged base URL leaves the same, still-open \`EventSource\` in place.

- **The refresh forces a mint rather than going through the cache.** Worth a look, because the first version was wrong. The refresh lead (2 min) is longer than the token cache's expiry skew (1 min), so `get()` handed the still-cached token straight back, the refresh had nothing new to install, and it rescheduled itself into a 5-second spin for the last minute of every token's life. `MachineTokenSource` therefore exposes `get()` (cached if usable, for REST) and `mint()` (unconditional, for the timer). The fake in the transport test caches the same way on purpose, so a refresh that never actually rotates the token cannot pass.

- **The delay comes off the endpoint's own `expires_in`**, never a hardcoded 15 minutes, since `ACCESS_TOKEN_TTL` may be 10 to 30.

- **A failed refresh stays quiet while the installed token is still valid**, retries every 30s, and reports only once that credential has actually lapsed. This is the spec's failure behaviour: a control-plane outage does not disconnect a user who is already connected, and the VM serves from its stale JWKS cache. A first connection has nothing to protect, so it reports at once.

- **The 404 is treated as \"no longer available to you\" and refreshes the machine list.** It is byte-identical for revoked, another account's, and unknown, so nothing here infers which; `refresh()` drops a machine that is gone and falls back to this computer, which needs no account.

- **One control-plane token source, handed out rather than rebuilt.** `AoMachinesController.credential()` is new for this. A second `ControlPlaneTokenSource` would hold the same refresh token and race a rotation against the first, and the loser presents an already-revoked token, which is the lockout #45 fixed. No refresh token is presented on the machine-token path at all, and none of `ao-control-token.ts`'s persist-before-use machinery is copied, because nothing on that endpoint rotates.

## The placeholder is gone

`machineTransportMissingStatus` and the `machine_transport_missing` code are deleted. `machine_auth_failed` replaces them for the real failure (signed out, sign-in refused, machine gone), with copy that points at Settings, Account and Settings, Machines rather than at `AO_DAEMON_COMMAND`, which is what reusing `not_configured` printed. `not_configured` keeps its original meaning and its original two call sites untouched.

## AO_REMOTE_URL and AO_REMOTE_TOKEN keep working, unchanged

Not deleted, not deprecated, not routed around. `readRemoteDaemonConfig`, `REMOTE_PAIRING_COOKIE_NAME`, `installRemoteDaemonCookie`, and the lifecycle's env-first ordering are all as they were. One addition in their favour: when they are set, a machine selection returns early without fetching a credential, since the lifecycle points the renderer at the env origin regardless, so nothing would ever call that gateway. `apiClient` sends no `Authorization` header when there is no machine token, so the pairing cookie path is byte-identical.

## Preserved from #44 and #35

Structural local-daemon spawn guard (a credential failure is a status, not an absence, so the local start function is still never reached), query-cache clear on base-URL change, wrong-`state` loopback tolerance, refresh-token rotation persisted before use, and local use never requiring an account. `main/remote-daemon.test.ts` gains a case asserting a `machine_auth_failed` machine cannot spawn a local daemon either.

## Tests

`npm run typecheck`, `npm run typecheck:e2e`, and `npx vitest run` (as CI runs them): **1264 passed**, up from 1225.

New: `src/main/ao-machine-token.test.ts` (14) and `src/main/machine-transport.test.ts` (20), covering the route and bearer, no request body, percent-encoded machine id, `expires_in` honoured and defaulted, cache and shared in-flight mint, the ambiguous 404, cookie attributes including the absence of `domain`, the connect ordering, the silent refresh, the quiet retry and the eventual report, a superseded switch dropping a late acquisition, cookie removal on switch and sign-out, and that neither token appears in any error or any status.

## Shown working

`ao preview http://localhost:5199/` renders it in the browser panel. Driving the same preview build headlessly: picking `ao-build-01` now shows it **Active** with **0** failure cards (it previously rendered \"This build cannot reach a registered machine yet\"), while `ao-eu-west` still reports \"ao-eu-west is not reachable. Last seen 3 hours ago.\"

## Not done here

No change to the daemon's HTTP surface, so no `npm run api` and no `openapi.yaml` / `schema.ts` regeneration. `controlplane/` and `backend/` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)