### PR TITLE
feat(controlplane): reachability probe and a post-login landing page

### DIFF
--- a/controlplane/README.md
+++ b/controlplane/README.md
@@ -67,7 +67,33 @@ curl http://127.0.0.1:8080/healthz
 Open `http://127.0.0.1:8080/login` in a browser and sign in with Google to
 exercise the login flow end to end (see `internal/auth/` for the
 authorization-code exchange with PKCE, the `accounts` upsert, and the browser
-session cookie).
+session cookie). Sign-in lands on `/`, the landing page in `internal/home/`,
+which links to the device page. An anonymous `GET /` redirects to `/login`.
+
+## Reachability probe
+
+`ao setup-vm` preflights the VM's public ports with an off-box check: a cloud
+firewall is invisible from inside the box, so confirming 80 and 443 needs a
+host that is not that box. `internal/reachability/` serves it.
+
+```bash
+curl -s 'http://127.0.0.1:8080/api/v1/reachability?host=vm.example.com&ports=80,443'
+# {"ports":{"443":true,"80":true}}
+```
+
+It is a public service that makes an outbound connection to a caller-supplied
+target, so it is an SSRF primitive and is written as one. The hostname is
+resolved first and every resolved address is checked against the private,
+loopback, link-local (including `169.254.169.254`), CGNAT, multicast, and
+IPv6-equivalent ranges; the connection then goes to the address that was
+checked rather than to the name, so a second DNS answer cannot redirect it.
+Only 80 and 443 are ever dialled, the socket is closed without a read, and the
+endpoint is rate limited per client, per target, and globally.
+
+It is unauthenticated: `ao setup-vm` calls it during preflight, before the
+device-code binding gives the VM any credential to present. The rate limits are
+the whole budget. See the package doc in `internal/reachability/` for the
+detail.
 
 ## Device flow and machine registry
 
@@ -118,10 +144,12 @@ id or duplicating the box in the machine list.
 
 ## Control plane API
 
-Every `/api/v1` route takes one credential: an access token whose `aud` is the
-control plane's own origin. A machine-audience token is rejected, and so is a
-refresh token, which is presented only at the token endpoint. See
-`TOKEN_CONTRACT.md`, "The two audiences".
+Every `/api/v1` route that carries a credential takes one: an access token
+whose `aud` is the control plane's own origin. A machine-audience token is
+rejected, and so is a refresh token, which is presented only at the token
+endpoint. See `TOKEN_CONTRACT.md`, "The two audiences". The one route with no
+credential at all is the reachability probe above, which is called before a VM
+has one.
 
 ```bash
 # Exchange a refresh token. The refresh token rotates, so persist the

--- a/controlplane/cmd/controlplane/main.go
+++ b/controlplane/cmd/controlplane/main.go
@@ -17,7 +17,9 @@ import (
 	"github.com/agentlab-in/hosted-ao/controlplane/internal/auth"
 	"github.com/agentlab-in/hosted-ao/controlplane/internal/config"
 	"github.com/agentlab-in/hosted-ao/controlplane/internal/device"
+	"github.com/agentlab-in/hosted-ao/controlplane/internal/home"
 	"github.com/agentlab-in/hosted-ao/controlplane/internal/keys"
+	"github.com/agentlab-in/hosted-ao/controlplane/internal/reachability"
 	"github.com/agentlab-in/hosted-ao/controlplane/internal/server"
 	"github.com/agentlab-in/hosted-ao/controlplane/internal/storage/sqlite"
 	"github.com/agentlab-in/hosted-ao/controlplane/internal/tokens"
@@ -74,6 +76,17 @@ func main() {
 		log.Fatalf("init device flow: %v", err)
 	}
 	deviceSvc.Register(mux)
+
+	homeSvc, err := home.NewService(authSvc)
+	if err != nil {
+		log.Fatalf("init landing page: %v", err)
+	}
+	homeSvc.Register(mux)
+
+	// Unauthenticated by necessity: ao setup-vm probes this during preflight,
+	// before the device-code binding gives the VM any credential. See the
+	// package doc for the controls that stand in for authentication.
+	reachability.NewService().Register(mux)
 
 	// LISTEN_ADDR defaults to loopback (127.0.0.1:8080): this service sits
 	// behind Caddy on the same box, which terminates TLS and reverse-proxies

--- a/controlplane/internal/home/home.go
+++ b/controlplane/internal/home/home.go
@@ -1,0 +1,75 @@
+// Package home serves the control plane's landing page at "/".
+//
+// It exists because sign-in has to land somewhere. Google returns the operator
+// to /auth/google/callback, which redirects to the flow's `next`, and that
+// defaults to "/": with nothing registered there, a successful sign-in ended
+// on a 404, which reads as a broken service at the exact moment the operator
+// has just proved it is not.
+//
+// It is deliberately not a dashboard. The control plane's job is binding a
+// machine to an account, so the page says what to do next and links to the one
+// page that does it.
+package home
+
+import (
+	"embed"
+	"fmt"
+	"html/template"
+	"log"
+	"net/http"
+)
+
+//go:embed templates/*.html
+var templatesFS embed.FS
+
+// sessions is the slice of the auth service this package needs: who is signed
+// in on the current browser request. An interface, for the same reason the
+// device flow uses one, so the landing page does not pull in the OAuth client.
+type sessions interface {
+	AccountFromRequest(r *http.Request) (accountID string, ok bool)
+}
+
+// Service serves the landing page.
+type Service struct {
+	sessions sessions
+	tmpl     *template.Template
+}
+
+// NewService builds the landing page service.
+func NewService(s sessions) (*Service, error) {
+	tmpl, err := template.ParseFS(templatesFS, "templates/*.html")
+	if err != nil {
+		return nil, fmt.Errorf("parse home templates: %w", err)
+	}
+	return &Service{sessions: s, tmpl: tmpl}, nil
+}
+
+// Register wires the landing page onto mux. This is the one call the rest of
+// the control plane needs to know about.
+//
+// The pattern is "/{$}", which matches the root path exactly. A bare "/" would
+// match every path no other handler claims, turning every genuine 404 into
+// this page.
+func (s *Service) Register(mux *http.ServeMux) {
+	mux.HandleFunc("GET /{$}", s.handleHome)
+}
+
+// handleHome renders the landing page for a signed-in operator, and sends
+// everyone else to sign in.
+//
+// The unauthenticated case is a redirect to /login, not a 404 and not a public
+// page: "/" is the address a person types, the only thing they can usefully do
+// here needs an account, and /login already sends them back to "/" afterwards
+// because that is its default `next`.
+func (s *Service) handleHome(w http.ResponseWriter, r *http.Request) {
+	if _, ok := s.sessions.AccountFromRequest(r); !ok {
+		http.Redirect(w, r, "/login", http.StatusFound)
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	if err := s.tmpl.ExecuteTemplate(w, "home.html", nil); err != nil {
+		log.Printf("home: render landing page: %v", err)
+		http.Error(w, "internal error", http.StatusInternalServerError)
+	}
+}

--- a/controlplane/internal/home/home_test.go
+++ b/controlplane/internal/home/home_test.go
@@ -1,0 +1,71 @@
+package home
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// fakeSessions signs a request in, or does not.
+type fakeSessions struct{ signedIn bool }
+
+func (f fakeSessions) AccountFromRequest(*http.Request) (string, bool) {
+	return "account-1", f.signedIn
+}
+
+func newTestMux(t *testing.T, signedIn bool) *http.ServeMux {
+	t.Helper()
+	svc, err := NewService(fakeSessions{signedIn: signedIn})
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	mux := http.NewServeMux()
+	svc.Register(mux)
+	return mux
+}
+
+func get(mux *http.ServeMux, path string) *httptest.ResponseRecorder {
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, httptest.NewRequest(http.MethodGet, path, nil))
+	return w
+}
+
+// TestSignedInLandingPage is the whole point of the page: sign-in redirects to
+// "/", and "/" must not 404.
+func TestSignedInLandingPage(t *testing.T) {
+	w := get(newTestMux(t, true), "/")
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	if ct := w.Header().Get("Content-Type"); !strings.HasPrefix(ct, "text/html") {
+		t.Fatalf("Content-Type = %q, want text/html", ct)
+	}
+	// The useful next step, which is the only reason this page exists.
+	if !strings.Contains(w.Body.String(), `href="/device"`) {
+		t.Fatalf("landing page does not link to /device:\n%s", w.Body.String())
+	}
+}
+
+// TestUnauthenticatedRedirectsToLogin: the deliberate choice for an anonymous
+// GET /. Not a 404, and not a public page, because everything reachable from
+// here needs an account.
+func TestUnauthenticatedRedirectsToLogin(t *testing.T) {
+	w := get(newTestMux(t, false), "/")
+
+	if w.Code != http.StatusFound {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusFound)
+	}
+	if got := w.Header().Get("Location"); got != "/login" {
+		t.Fatalf("Location = %q, want /login", got)
+	}
+}
+
+// TestOnlyMatchesRoot guards the "/{$}" pattern: a bare "/" would claim every
+// path no other handler registered and turn real 404s into this page.
+func TestOnlyMatchesRoot(t *testing.T) {
+	if w := get(newTestMux(t, true), "/no-such-page"); w.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", w.Code)
+	}
+}

--- a/controlplane/internal/home/templates/home.html
+++ b/controlplane/internal/home/templates/home.html
@@ -1,0 +1,76 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>AO</title>
+  {{/*
+    Inline styling, kept in step with internal/auth/templates/signin.html and
+    internal/device/templates/device_style.html so sign-in, this page, and
+    approval look like one service. Inline rather than a served stylesheet:
+    the control plane has no static file route.
+  */}}
+  <style>
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      background: #0b0d12;
+      color: #e6e8eb;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      min-height: 100vh;
+      margin: 0;
+    }
+    .card {
+      background: #151821;
+      border: 1px solid #262b36;
+      border-radius: 12px;
+      padding: 2.5rem;
+      width: 360px;
+      text-align: center;
+    }
+    h1 {
+      font-size: 1.25rem;
+      margin: 0 0 1rem;
+    }
+    p.hint {
+      color: #9aa4b2;
+      font-size: 0.875rem;
+      margin: 0 0 1.25rem;
+    }
+    p.hint:last-child {
+      margin: 1.25rem 0 0;
+    }
+    code {
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      word-break: break-all;
+    }
+    .button {
+      display: block;
+      width: 100%;
+      box-sizing: border-box;
+      background: #3b82f6;
+      border: 1px solid #3b82f6;
+      color: #fff;
+      text-decoration: none;
+      padding: 0.75rem 1rem;
+      border-radius: 8px;
+      font-size: 1rem;
+      font-weight: 600;
+      cursor: pointer;
+    }
+    .button:hover {
+      background: #2563eb;
+      border-color: #2563eb;
+    }
+  </style>
+</head>
+<body>
+  <div class="card">
+    <h1>You are signed in</h1>
+    <p class="hint">Connect a VM to this account to run agents on it from anywhere.</p>
+    <a class="button" href="/device">Connect a machine</a>
+    <p class="hint">No VM yet? Run <code>sudo ao setup-vm --domain your.domain</code> on an Ubuntu VM, then enter the code it prints.</p>
+  </div>
+</body>
+</html>

--- a/controlplane/internal/reachability/addr.go
+++ b/controlplane/internal/reachability/addr.go
@@ -1,0 +1,104 @@
+package reachability
+
+import "net/netip"
+
+// blockedPrefix is one special-purpose range this service refuses to connect
+// to, with the reason the refusal is reported and logged under.
+type blockedPrefix struct {
+	prefix netip.Prefix
+	reason string
+}
+
+// blockedPrefixes are the special-purpose ranges the net/netip predicates in
+// denyReason do not already cover. Everything here is either unroutable on the
+// public internet or a range whose reachability from this service says nothing
+// about whether a VM is reachable from the internet, so refusing costs a real
+// caller nothing.
+//
+// The IPv6 entries that embed an IPv4 address (6to4, Teredo, NAT64,
+// IPv4-compatible) are blocked wholesale rather than decoded: an attacker
+// picks the embedded address, so decoding one to re-check it is a second
+// parser to get wrong for a range nobody legitimately probes.
+var blockedPrefixes = []blockedPrefix{
+	{netip.MustParsePrefix("0.0.0.0/8"), "this-network"},
+	// 169.254.0.0/16 is also link-local, which denyReason rejects before it
+	// reaches this table. It is listed anyway because 169.254.169.254 is the
+	// cloud metadata endpoint: this is the one range where a refactor that
+	// loosens a predicate must still fail closed.
+	{netip.MustParsePrefix("169.254.0.0/16"), "link-local (cloud metadata)"},
+	{netip.MustParsePrefix("100.64.0.0/10"), "carrier-grade NAT"},
+	{netip.MustParsePrefix("192.0.0.0/24"), "IETF protocol assignments"},
+	{netip.MustParsePrefix("192.0.2.0/24"), "documentation"},
+	{netip.MustParsePrefix("198.18.0.0/15"), "benchmarking"},
+	{netip.MustParsePrefix("198.51.100.0/24"), "documentation"},
+	{netip.MustParsePrefix("203.0.113.0/24"), "documentation"},
+	// 240.0.0.0/4 is reserved and contains 255.255.255.255.
+	{netip.MustParsePrefix("240.0.0.0/4"), "reserved"},
+	// ::/8 covers ::1, ::, the IPv4-compatible ::a.b.c.d form, and the NAT64
+	// well-known prefix 64:ff9b::/96.
+	{netip.MustParsePrefix("::/8"), "IPv6 reserved"},
+	{netip.MustParsePrefix("100::/64"), "IPv6 discard-only"},
+	// 2001::/23 is the IETF protocol assignments block, which contains Teredo
+	// (2001::/32) and ORCHIDv2.
+	{netip.MustParsePrefix("2001::/23"), "IETF protocol assignments"},
+	{netip.MustParsePrefix("2001:db8::/32"), "documentation"},
+	{netip.MustParsePrefix("2002::/16"), "6to4"},
+}
+
+// denyReason reports why addr must not be connected to, or "" if it is a
+// public destination this service may probe.
+//
+// The check is on a resolved address, never on the hostname the caller sent:
+// the string tells you nothing, and the address is what the connection
+// actually goes to. The caller must then dial this exact address rather than
+// the name, or a second DNS answer can point the connection somewhere this
+// function never saw.
+func denyReason(addr netip.Addr) string {
+	// An IPv4 address that arrived as ::ffff:169.254.169.254 is the same
+	// destination as 169.254.169.254, and the IPv4 predicates and prefixes
+	// below only recognise it once it is unmapped.
+	addr = addr.Unmap()
+
+	switch {
+	case !addr.IsValid():
+		return "not an IP address"
+	case addr.IsLoopback():
+		return "loopback"
+	case addr.IsUnspecified():
+		return "unspecified"
+	case addr.IsLinkLocalUnicast(), addr.IsLinkLocalMulticast():
+		return "link-local"
+	case addr.IsInterfaceLocalMulticast(), addr.IsMulticast():
+		return "multicast"
+	case addr.IsPrivate():
+		// RFC 1918 for IPv4, and fc00::/7 unique local for IPv6.
+		return "private"
+	case !addr.IsGlobalUnicast():
+		return "not a global unicast address"
+	}
+
+	for _, b := range blockedPrefixes {
+		if b.prefix.Contains(addr) {
+			return b.reason
+		}
+	}
+	return ""
+}
+
+// selectTarget picks the address to probe, or reports why the whole request is
+// refused.
+//
+// One blocked address in the answer refuses the request outright rather than
+// being skipped over: a name that resolves to both a public address and an
+// internal one is a rebinding attempt, not a host worth being helpful about.
+func selectTarget(addrs []netip.Addr) (netip.Addr, string) {
+	if len(addrs) == 0 {
+		return netip.Addr{}, "did not resolve to any address"
+	}
+	for _, addr := range addrs {
+		if reason := denyReason(addr); reason != "" {
+			return netip.Addr{}, "resolves to a " + reason + " address"
+		}
+	}
+	return addrs[0].Unmap(), ""
+}

--- a/controlplane/internal/reachability/limiter.go
+++ b/controlplane/internal/reachability/limiter.go
@@ -1,0 +1,84 @@
+package reachability
+
+import (
+	"sync"
+	"time"
+)
+
+// maxTrackedKeys bounds the memory one window may hold. Unlike the device
+// flow's per-account limiter, the keys here are caller-supplied (a client
+// address and a target hostname), so the map cannot be left to grow.
+//
+// ponytail: expired entries are swept only when the map reaches this cap, so
+// the common path stays O(1) and a burst of fresh keys costs one full sweep
+// rather than one per request. If the sweep does not free anything, a key that
+// is not already tracked is refused rather than admitted: a flood of fresh
+// keys degrades into refusing new callers, which resolves on its own within
+// one window, instead of into unbounded memory. If the control plane is ever
+// replicated, move this to a shared store: each replica otherwise grants the
+// full allowance.
+const maxTrackedKeys = 4096
+
+// window is a fixed-window rate limiter keyed by an arbitrary string, in the
+// shape of the device flow's attemptLimiter but with expiry sweeping and a
+// bound on how many keys it will track.
+type window struct {
+	mu    sync.Mutex
+	limit int
+	per   time.Duration
+	seen  map[string][]time.Time
+	clock func() time.Time
+}
+
+func newWindow(limit int, per time.Duration) *window {
+	return &window{limit: limit, per: per, seen: make(map[string][]time.Time), clock: time.Now}
+}
+
+// allow records one request against key and reports whether it is within the
+// allowance. A refused request is not recorded, so the allowance itself bounds
+// how fast the map can grow.
+func (w *window) allow(key string) bool {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	now := w.clock()
+	cutoff := now.Add(-w.per)
+
+	times, tracked := w.seen[key]
+	times = live(times, cutoff)
+	if len(times) >= w.limit {
+		w.seen[key] = times
+		return false
+	}
+	if !tracked && len(w.seen) >= maxTrackedKeys {
+		w.sweep(cutoff)
+		if len(w.seen) >= maxTrackedKeys {
+			return false
+		}
+	}
+	w.seen[key] = append(times, now)
+	return true
+}
+
+// sweep drops every key whose requests have all aged out.
+func (w *window) sweep(cutoff time.Time) {
+	for k, times := range w.seen {
+		if kept := live(times, cutoff); len(kept) == 0 {
+			delete(w.seen, k)
+		} else {
+			w.seen[k] = kept
+		}
+	}
+}
+
+// live returns the timestamps still inside the window, reusing the backing
+// array.
+func live(times []time.Time, cutoff time.Time) []time.Time {
+	kept := times[:0]
+	for _, t := range times {
+		if t.After(cutoff) {
+			kept = append(kept, t)
+		}
+	}
+	return kept
+}

--- a/controlplane/internal/reachability/reachability.go
+++ b/controlplane/internal/reachability/reachability.go
@@ -1,0 +1,274 @@
+// Package reachability serves the off-box port check `ao setup-vm` runs
+// during preflight: a cloud firewall is invisible from inside the VM, so
+// confirming that 80 and 443 accept connections needs a host that is not that
+// VM, and this control plane is the one such host setup-vm already depends on.
+//
+// # This endpoint is an SSRF primitive
+//
+// It is a public service that makes an outbound TCP connection to a
+// caller-supplied target. Written naively it is a port scanner and an
+// internal-network probe running from inside our own cloud account, with
+// 169.254.169.254 (the instance metadata endpoint) as the first thing anyone
+// points it at. The controls, all of which are load bearing:
+//
+//   - The hostname is resolved first and every resolved address is checked
+//     against denyReason; the connection then goes to the address that was
+//     checked, not to the name, so a second DNS answer cannot redirect it.
+//   - Only ports 80 and 443, the two the CLI asks about. There is no port
+//     parameter that reaches the dialer.
+//   - Connect and close. No TLS handshake, no read, no redirect to follow, and
+//     nothing about what answered is reported back beyond the boolean.
+//   - A short per-connect timeout, and three rate limits: per client, per
+//     target, and one global cap, because this endpoint turns one small
+//     request into outbound connections.
+//
+// The endpoint is unauthenticated. `ao setup-vm` calls it during preflight,
+// before the device-code binding that gives the VM any credential at all, so
+// there is nothing it could present. The rate limits are therefore the whole
+// budget, and they are set low.
+package reachability
+
+import (
+	"context"
+	"errors"
+	"log"
+	"net"
+	"net/http"
+	"net/netip"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/agentlab-in/hosted-ao/controlplane/internal/api"
+)
+
+const (
+	// connectTimeout bounds one TCP connect. A filtered port is the slow case
+	// and it fails by timing out, so this plus dnsTimeout is what the caller
+	// waits for: two ports plus resolution stays inside the 10s budget
+	// setup-vm gives the whole request.
+	connectTimeout = 2 * time.Second
+	dnsTimeout     = 3 * time.Second
+
+	// rateWindow and the three allowances below meter this endpoint. One
+	// `ao setup-vm` run calls it once, so a handful per minute is generous for
+	// the real caller and small for anyone using it as a scanner. globalPerWindow
+	// is the ceiling on outbound connections regardless of who asks: the per
+	// client limit alone cannot bound it, because the client key is only as
+	// good as the address the request arrives with.
+	rateWindow         = time.Minute
+	clientPerWindow    = 6
+	targetPerWindow    = 6
+	globalPerWindow    = 60
+	globalRateLimitKey = "*"
+
+	// maxHostLength is the longest DNS name that can exist, per RFC 1035.
+	maxHostLength = 253
+)
+
+// probePorts are the only ports this service will connect to, in the order
+// they are reported. The CLI asks about exactly these two.
+var probePorts = []uint16{80, 443}
+
+// Service owns the reachability endpoint. resolve and dial are fields so tests
+// can drive the refusal paths without DNS or a network.
+type Service struct {
+	resolve func(ctx context.Context, host string) ([]netip.Addr, error)
+	dial    func(ctx context.Context, addr string) (net.Conn, error)
+
+	clients *window
+	targets *window
+	global  *window
+}
+
+// NewService builds the reachability service with the real resolver and
+// dialer.
+func NewService() *Service {
+	dialer := &net.Dialer{Timeout: connectTimeout}
+	return &Service{
+		resolve: func(ctx context.Context, host string) ([]netip.Addr, error) {
+			return net.DefaultResolver.LookupNetIP(ctx, "ip", host)
+		},
+		dial: func(ctx context.Context, addr string) (net.Conn, error) {
+			return dialer.DialContext(ctx, "tcp", addr)
+		},
+		clients: newWindow(clientPerWindow, rateWindow),
+		targets: newWindow(targetPerWindow, rateWindow),
+		global:  newWindow(globalPerWindow, rateWindow),
+	}
+}
+
+// Register wires the reachability endpoint onto mux. This is the one call the
+// rest of the control plane needs to know about.
+func (s *Service) Register(mux *http.ServeMux) {
+	mux.HandleFunc("GET /api/v1/reachability", s.handleReachability)
+}
+
+// response is the body `ao setup-vm` parses: a map of port to whether a TCP
+// connect from here succeeded. The contract is set by the CLI, which reads
+// {"ports":{"80":true,"443":false}} and treats a port it did not get back as
+// unknown rather than closed. Nothing else is reported: what answered on the
+// port is the caller's business and none of ours to relay.
+type response struct {
+	Ports map[string]bool `json:"ports"`
+}
+
+func (s *Service) handleReachability(w http.ResponseWriter, r *http.Request) {
+	host, ok := normalizeHost(r.URL.Query().Get("host"))
+	if !ok {
+		api.WriteError(w, http.StatusBadRequest, "invalid_request", "host must be a hostname or IP address")
+		return
+	}
+	ports, err := parsePorts(r.URL.Query().Get("ports"))
+	if err != nil {
+		api.WriteError(w, http.StatusBadRequest, "invalid_request", err.Error())
+		return
+	}
+
+	// Metered before the resolver runs: DNS is outbound work too, and the
+	// global window is what bounds this endpoint as an amplifier.
+	if !s.global.allow(globalRateLimitKey) || !s.clients.allow(clientKey(r)) || !s.targets.allow(host) {
+		api.WriteError(w, http.StatusTooManyRequests, "slow_down", "too many reachability checks, try again in a minute")
+		return
+	}
+
+	resolveCtx, cancel := context.WithTimeout(r.Context(), dnsTimeout)
+	defer cancel()
+	addrs, err := s.resolve(resolveCtx, host)
+	if err != nil || len(addrs) == 0 {
+		api.WriteError(w, http.StatusBadRequest, "invalid_request", "host could not be resolved")
+		return
+	}
+
+	target, refusal := selectTarget(addrs)
+	if refusal != "" {
+		// Worth a line: a caller pointing this at internal space is the abuse
+		// case the endpoint exists inside of. The host is logged, the client is
+		// not, since behind the proxy it is a header.
+		log.Printf("reachability: refused %q, it %s", host, refusal)
+		api.WriteError(w, http.StatusBadRequest, "invalid_request", "host "+refusal+", which this check will not connect to")
+		return
+	}
+
+	open := make(map[string]bool, len(ports))
+	for _, port := range ports {
+		open[strconv.Itoa(int(port))] = s.connects(r.Context(), target, port)
+	}
+	api.WriteJSON(w, http.StatusOK, response{Ports: open})
+}
+
+// connects reports whether a TCP connection to target completes. It dials the
+// validated address, never the hostname, so the destination cannot differ from
+// the one selectTarget approved. The connection is closed immediately: nothing
+// is written, nothing is read, and no TLS handshake is attempted, so a port
+// that answers gives up no banner and this never becomes a content fetcher.
+func (s *Service) connects(ctx context.Context, target netip.Addr, port uint16) bool {
+	dialCtx, cancel := context.WithTimeout(ctx, connectTimeout)
+	defer cancel()
+
+	conn, err := s.dial(dialCtx, netip.AddrPortFrom(target, port).String())
+	if err != nil {
+		return false
+	}
+	_ = conn.Close()
+	return true
+}
+
+// normalizeHost validates the caller's target and returns it in the canonical
+// form used both for resolution and as the per-target rate limit key.
+//
+// This is input validation only. It is not a security boundary: whether the
+// target is allowed is decided on the resolved address, in denyReason.
+func normalizeHost(raw string) (string, bool) {
+	host := strings.TrimSuffix(strings.TrimSpace(raw), ".")
+	if host == "" || len(host) > maxHostLength {
+		return "", false
+	}
+
+	if addr, err := netip.ParseAddr(host); err == nil {
+		// A zone ("fe80::1%eth0") only names a local interface, so a target
+		// carrying one is never a public VM.
+		if addr.Zone() != "" {
+			return "", false
+		}
+		return addr.Unmap().String(), true
+	}
+
+	for _, label := range strings.Split(host, ".") {
+		if len(label) == 0 || len(label) > 63 || label[0] == '-' || label[len(label)-1] == '-' {
+			return "", false
+		}
+		for i := 0; i < len(label); i++ {
+			c := label[i]
+			switch {
+			case c >= 'a' && c <= 'z', c >= 'A' && c <= 'Z', c >= '0' && c <= '9', c == '-':
+			default:
+				return "", false
+			}
+		}
+	}
+	return strings.ToLower(host), true
+}
+
+// parsePorts reads the CLI's `ports` parameter. It is a filter over probePorts
+// and never a way to name a new one: anything outside 80 and 443 is refused
+// rather than silently dropped, so a caller cannot mistake this endpoint's
+// answer for a general port scan it did not get.
+func parsePorts(raw string) ([]uint16, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return probePorts, nil
+	}
+
+	asked := make(map[uint16]bool, len(probePorts))
+	for _, field := range strings.Split(raw, ",") {
+		port, err := strconv.ParseUint(strings.TrimSpace(field), 10, 16)
+		if err != nil || !slices.Contains(probePorts, uint16(port)) {
+			return nil, errOnlyProbePorts
+		}
+		asked[uint16(port)] = true
+	}
+
+	// Emitted in probePorts order rather than the caller's, so the answer is
+	// the same shape however the query was written.
+	ports := make([]uint16, 0, len(asked))
+	for _, port := range probePorts {
+		if asked[port] {
+			ports = append(ports, port)
+		}
+	}
+	return ports, nil
+}
+
+// errOnlyProbePorts is the single answer for every unsupported ports value: a
+// caller learns that this endpoint checks 80 and 443, and nothing about what
+// else it might have been willing to try.
+var errOnlyProbePorts = errors.New("ports may only name 80 and 443")
+
+// clientKey is the per-client rate limit key.
+//
+// In production this service listens on loopback behind Caddy, so RemoteAddr
+// is always the proxy and the real caller is the last entry of
+// X-Forwarded-For, which the proxy appends itself. That entry is only trusted
+// when the request actually arrived over loopback; on a directly exposed
+// listener the header is caller-controlled and is ignored.
+func clientKey(r *http.Request) string {
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		host = r.RemoteAddr
+	}
+	peer, err := netip.ParseAddr(host)
+	if err != nil || !peer.IsLoopback() {
+		return host
+	}
+	if fwd := r.Header.Get("X-Forwarded-For"); fwd != "" {
+		if i := strings.LastIndex(fwd, ","); i >= 0 {
+			fwd = fwd[i+1:]
+		}
+		if forwarded := strings.TrimSpace(fwd); forwarded != "" {
+			return forwarded
+		}
+	}
+	return host
+}

--- a/controlplane/internal/reachability/reachability_test.go
+++ b/controlplane/internal/reachability/reachability_test.go
@@ -1,0 +1,409 @@
+package reachability
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/netip"
+	"net/url"
+	"slices"
+	"strconv"
+	"testing"
+	"time"
+)
+
+// fakeConn stands in for a connected socket. It records reads so a test can
+// assert this service never touches the body of whatever answered.
+type fakeConn struct {
+	net.Conn
+	reads  int
+	closed bool
+}
+
+func (c *fakeConn) Read(b []byte) (int, error) { c.reads++; return 0, io.EOF }
+func (c *fakeConn) Close() error               { c.closed = true; return nil }
+
+// recorder captures what a request made the service do off-box.
+type recorder struct {
+	resolved []string
+	dialed   []string
+	conns    []*fakeConn
+	open     map[string]bool
+}
+
+// newTestService builds a Service whose resolver answers with addrs and whose
+// dialer succeeds only for the "ip:port" strings in open, so every path can be
+// exercised without DNS or a network.
+func newTestService(addrs []netip.Addr, open map[string]bool) (*Service, *recorder) {
+	rec := &recorder{open: open}
+	return &Service{
+		resolve: func(_ context.Context, host string) ([]netip.Addr, error) {
+			rec.resolved = append(rec.resolved, host)
+			if len(addrs) == 0 {
+				return nil, errors.New("no such host")
+			}
+			return addrs, nil
+		},
+		dial: func(_ context.Context, addr string) (net.Conn, error) {
+			rec.dialed = append(rec.dialed, addr)
+			if !rec.open[addr] {
+				return nil, errors.New("connection refused")
+			}
+			conn := &fakeConn{}
+			rec.conns = append(rec.conns, conn)
+			return conn, nil
+		},
+		clients: newWindow(clientPerWindow, rateWindow),
+		targets: newWindow(targetPerWindow, rateWindow),
+		global:  newWindow(globalPerWindow, rateWindow),
+	}, rec
+}
+
+// probe issues one request the way ao setup-vm does.
+func probe(s *Service, query string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/reachability?"+query, nil)
+	req.RemoteAddr = "203.0.113.9:54321"
+	w := httptest.NewRecorder()
+	s.handleReachability(w, req)
+	return w
+}
+
+func hostQuery(host string) string {
+	return url.Values{"host": {host}, "ports": {"80,443"}}.Encode()
+}
+
+func addrs(t *testing.T, raw ...string) []netip.Addr {
+	t.Helper()
+	out := make([]netip.Addr, 0, len(raw))
+	for _, s := range raw {
+		addr, err := netip.ParseAddr(s)
+		if err != nil {
+			t.Fatalf("parse %q: %v", s, err)
+		}
+		out = append(out, addr)
+	}
+	return out
+}
+
+// TestRefusesBlockedAddressClasses is the test that matters on this endpoint.
+// One case per blocked class, each asserting the request is refused *and* that
+// no connection was attempted, so a later refactor that loosens one predicate
+// cannot quietly reopen a class.
+func TestRefusesBlockedAddressClasses(t *testing.T) {
+	cases := []struct {
+		name string
+		addr string
+	}{
+		// The one an SSRF goes for first. Also covered by the link-local
+		// predicate, and listed in blockedPrefixes as well, on purpose.
+		{"cloud metadata", "169.254.169.254"},
+		{"cloud metadata as IPv4-mapped IPv6", "::ffff:169.254.169.254"},
+		{"loopback IPv4", "127.0.0.1"},
+		{"loopback IPv4 outside 127.0.0.1", "127.10.20.30"},
+		{"loopback IPv6", "::1"},
+		{"link-local IPv6", "fe80::1"},
+		{"RFC 1918 10/8", "10.0.0.5"},
+		{"RFC 1918 172.16/12", "172.16.0.5"},
+		{"RFC 1918 192.168/16", "192.168.1.5"},
+		{"unique local IPv6", "fd00::1"},
+		{"carrier-grade NAT", "100.64.0.1"},
+		{"multicast IPv4", "224.0.0.1"},
+		{"multicast IPv6", "ff02::1"},
+		{"interface-local multicast IPv6", "ff01::1"},
+		{"unspecified IPv4", "0.0.0.0"},
+		{"unspecified IPv6", "::"},
+		{"this-network", "0.1.2.3"},
+		{"broadcast", "255.255.255.255"},
+		{"reserved 240/4", "240.1.2.3"},
+		{"benchmarking", "198.18.0.1"},
+		{"IETF protocol assignments IPv4", "192.0.0.1"},
+		{"documentation IPv4", "192.0.2.1"},
+		{"documentation IPv4 TEST-NET-2", "198.51.100.1"},
+		{"documentation IPv4 TEST-NET-3", "203.0.113.1"},
+		{"documentation IPv6", "2001:db8::1"},
+		{"IPv4-compatible IPv6", "::7f00:1"},
+		{"NAT64 well-known prefix", "64:ff9b::a9fe:a9fe"},
+		{"6to4", "2002:a9fe:a9fe::1"},
+		{"Teredo", "2001::a9fe:a9fe"},
+		{"IPv6 discard-only", "100::1"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s, rec := newTestService(addrs(t, tc.addr), nil)
+
+			w := probe(s, hostQuery("vm.example.com"))
+
+			if w.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want %d (body %s)", w.Code, http.StatusBadRequest, w.Body.String())
+			}
+			if len(rec.dialed) != 0 {
+				t.Fatalf("connected to %v, want no connection at all", rec.dialed)
+			}
+		})
+	}
+}
+
+// TestRefusesMixedAnswer covers the DNS rebinding shape: a name that resolves
+// to a public address alongside an internal one is refused outright, in either
+// order, rather than the public one being picked out and the rest ignored.
+func TestRefusesMixedAnswer(t *testing.T) {
+	for _, answer := range [][]string{
+		{"93.184.216.34", "169.254.169.254"},
+		{"169.254.169.254", "93.184.216.34"},
+	} {
+		s, rec := newTestService(addrs(t, answer...), nil)
+
+		w := probe(s, hostQuery("vm.example.com"))
+
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("answer %v: status = %d, want %d", answer, w.Code, http.StatusBadRequest)
+		}
+		if len(rec.dialed) != 0 {
+			t.Fatalf("answer %v: connected to %v, want no connection", answer, rec.dialed)
+		}
+	}
+}
+
+// TestProbesResolvedAddress checks the wire contract ao setup-vm parses, and
+// that the connection goes to the address that was validated rather than to
+// the hostname, which is what stops a second DNS answer redirecting it.
+func TestProbesResolvedAddress(t *testing.T) {
+	s, rec := newTestService(addrs(t, "93.184.216.34"), map[string]bool{"93.184.216.34:80": true})
+
+	w := probe(s, hostQuery("vm.example.com"))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body %s)", w.Code, w.Body.String())
+	}
+	var body struct {
+		Ports map[string]bool `json:"ports"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode %s: %v", w.Body.String(), err)
+	}
+	if len(body.Ports) != 2 || !body.Ports["80"] || body.Ports["443"] {
+		t.Fatalf("ports = %v, want {80:true 443:false}", body.Ports)
+	}
+	if got, want := rec.dialed, []string{"93.184.216.34:80", "93.184.216.34:443"}; !slices.Equal(got, want) {
+		t.Fatalf("dialed %v, want %v", got, want)
+	}
+	if len(rec.conns) != 1 {
+		t.Fatalf("opened %d connections, want 1", len(rec.conns))
+	}
+	// Connect only: nothing is read off the socket, so no banner can reach the
+	// caller, and it is closed straight away.
+	if rec.conns[0].reads != 0 {
+		t.Fatalf("read from the probed port %d times, want 0", rec.conns[0].reads)
+	}
+	if !rec.conns[0].closed {
+		t.Fatal("probe connection was left open")
+	}
+}
+
+func TestProbesIPv6TargetWithBrackets(t *testing.T) {
+	s, rec := newTestService(addrs(t, "2606:2800:220:1::1"), nil)
+
+	if w := probe(s, hostQuery("vm.example.com")); w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	if got, want := rec.dialed, []string{"[2606:2800:220:1::1]:80", "[2606:2800:220:1::1]:443"}; !slices.Equal(got, want) {
+		t.Fatalf("dialed %v, want %v", got, want)
+	}
+}
+
+func TestRejectsBadRequests(t *testing.T) {
+	cases := []struct {
+		name  string
+		query string
+	}{
+		{"no host", "ports=80,443"},
+		{"empty host", "host=&ports=80,443"},
+		{"host with a scheme", "host=" + url.QueryEscape("http://vm.example.com")},
+		{"host with a port", "host=" + url.QueryEscape("vm.example.com:8080")},
+		{"host with a path", "host=" + url.QueryEscape("vm.example.com/admin")},
+		{"host with an IPv6 zone", "host=" + url.QueryEscape("fe80::1%25eth0")},
+		{"port that is not 80 or 443", "host=vm.example.com&ports=22"},
+		{"port smuggled alongside a real one", "host=vm.example.com&ports=80,22"},
+		{"port out of range", "host=vm.example.com&ports=99999"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s, rec := newTestService(addrs(t, "93.184.216.34"), nil)
+
+			if w := probe(s, tc.query); w.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want %d", w.Code, http.StatusBadRequest)
+			}
+			if len(rec.dialed) != 0 {
+				t.Fatalf("connected to %v, want no connection", rec.dialed)
+			}
+		})
+	}
+}
+
+func TestUnresolvableHostIsNotAProbe(t *testing.T) {
+	s, rec := newTestService(nil, nil)
+
+	if w := probe(s, hostQuery("nope.example.com")); w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+	if len(rec.dialed) != 0 {
+		t.Fatalf("connected to %v, want no connection", rec.dialed)
+	}
+}
+
+func TestDefaultsToBothPorts(t *testing.T) {
+	s, rec := newTestService(addrs(t, "93.184.216.34"), nil)
+
+	if w := probe(s, "host=vm.example.com"); w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	if got, want := rec.dialed, []string{"93.184.216.34:80", "93.184.216.34:443"}; !slices.Equal(got, want) {
+		t.Fatalf("dialed %v, want %v", got, want)
+	}
+}
+
+func TestSingleRequestedPortIsHonoured(t *testing.T) {
+	s, rec := newTestService(addrs(t, "93.184.216.34"), nil)
+
+	w := probe(s, "host=vm.example.com&ports=443")
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	if got, want := rec.dialed, []string{"93.184.216.34:443"}; !slices.Equal(got, want) {
+		t.Fatalf("dialed %v, want %v", got, want)
+	}
+}
+
+// TestRateLimited proves the endpoint stops making outbound connections once a
+// caller is over the allowance. It is unauthenticated, so this is the whole
+// budget.
+func TestRateLimited(t *testing.T) {
+	s, rec := newTestService(addrs(t, "93.184.216.34"), nil)
+
+	for i := range clientPerWindow {
+		if w := probe(s, hostQuery("vm.example.com")); w.Code != http.StatusOK {
+			t.Fatalf("request %d: status = %d, want 200", i+1, w.Code)
+		}
+	}
+	dialedWhileAllowed := len(rec.dialed)
+
+	w := probe(s, hostQuery("vm.example.com"))
+	if w.Code != http.StatusTooManyRequests {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusTooManyRequests)
+	}
+	if len(rec.dialed) != dialedWhileAllowed {
+		t.Fatalf("a refused request still connected: %v", rec.dialed[dialedWhileAllowed:])
+	}
+}
+
+func TestNormalizeHost(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+		ok   bool
+	}{
+		{"vm.example.com", "vm.example.com", true},
+		{" VM.Example.com. ", "vm.example.com", true},
+		{"93.184.216.34", "93.184.216.34", true},
+		{"::ffff:93.184.216.34", "93.184.216.34", true},
+		{"2606:2800:220:1::1", "2606:2800:220:1::1", true},
+		{"", "", false},
+		{"vm..example.com", "", false},
+		{"-vm.example.com", "", false},
+		{"vm.example.com:443", "", false},
+		{"fe80::1%eth0", "", false},
+	}
+	for _, tc := range cases {
+		got, ok := normalizeHost(tc.in)
+		if ok != tc.ok || got != tc.want {
+			t.Errorf("normalizeHost(%q) = %q, %v, want %q, %v", tc.in, got, ok, tc.want, tc.ok)
+		}
+	}
+}
+
+// TestClientKeyBehindProxy: in production this listens on loopback behind
+// Caddy, so every RemoteAddr is the proxy and the real caller is the last
+// X-Forwarded-For entry, which Caddy appends. The header is only trusted from
+// loopback, so a direct caller cannot pick its own rate limit bucket.
+func TestClientKeyBehindProxy(t *testing.T) {
+	cases := []struct {
+		name       string
+		remoteAddr string
+		forwarded  string
+		want       string
+	}{
+		{"loopback proxy uses the appended entry", "127.0.0.1:8080", "198.51.100.7", "198.51.100.7"},
+		{"a spoofed prefix does not win", "127.0.0.1:8080", "10.0.0.1, 198.51.100.7", "198.51.100.7"},
+		{"no header, loopback peer", "127.0.0.1:8080", "", "127.0.0.1"},
+		{"direct caller's header is ignored", "198.51.100.7:1234", "203.0.113.1", "198.51.100.7"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/reachability", nil)
+			req.RemoteAddr = tc.remoteAddr
+			if tc.forwarded != "" {
+				req.Header.Set("X-Forwarded-For", tc.forwarded)
+			}
+			if got := clientKey(req); got != tc.want {
+				t.Fatalf("clientKey = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestWindow(t *testing.T) {
+	now := time.Now()
+	w := newWindow(2, time.Minute)
+	w.clock = func() time.Time { return now }
+
+	if !w.allow("a") || !w.allow("a") {
+		t.Fatal("the first two requests should be inside the allowance")
+	}
+	if w.allow("a") {
+		t.Fatal("the third request should be refused")
+	}
+	if !w.allow("b") {
+		t.Fatal("a different key has its own allowance")
+	}
+
+	now = now.Add(2 * time.Minute)
+	if !w.allow("a") {
+		t.Fatal("the window should have expired")
+	}
+	if len(w.seen["a"]) != 1 {
+		t.Fatalf("expired requests were not dropped: %v", w.seen["a"])
+	}
+}
+
+// TestWindowBoundsMemory: the keys here are caller-supplied, so past the cap a
+// new key is refused rather than admitted.
+func TestWindowBoundsMemory(t *testing.T) {
+	now := time.Now()
+	w := newWindow(1, time.Minute)
+	w.clock = func() time.Time { return now }
+
+	for i := range maxTrackedKeys {
+		if !w.allow(strconv.Itoa(i)) {
+			t.Fatalf("key %d should be within the cap", i)
+		}
+	}
+	if w.allow("one too many") {
+		t.Fatal("a new key past the cap should be refused")
+	}
+
+	// Once the tracked keys age out the cap releases itself, so a burst cannot
+	// lock new callers out for longer than one window.
+	now = now.Add(2 * time.Minute)
+	if !w.allow("one too many") {
+		t.Fatal("the cap should release once the window has passed")
+	}
+	if len(w.seen) != 1 {
+		t.Fatalf("the sweep left %d keys, want 1", len(w.seen))
+	}
+}


### PR DESCRIPTION
Closes #56
Closes #58

Two gaps that both end on a 404.

## The reachability probe (#56)

`ao setup-vm` preflights the VM's public ports against `/api/v1/reachability`, which did not exist, so a fresh setup only got past preflight with `--reachability-probe-url ""`. That is review finding H2 in `docs/reviews/2026-07-30-review-batches-3-4-client.md`; the earlier fix only stopped the CLI implying the check had run. This serves it.

The response shape is the one `parseSetupReachability` in `backend/internal/cli/setupvm_plan.go` already parses, `{"ports":{"80":true,"443":false}}`, read from `?host=<domain>&ports=80,443`. No CLI change is needed and none was made.

### It is an SSRF primitive, and is written as one

A public service making an outbound connection to a caller-supplied target. The controls, all load bearing:

- **The resolved address is what is checked, never the string.** Refused: loopback, link-local (including **169.254.169.254**, the cloud metadata endpoint), RFC 1918, CGNAT, multicast, unspecified, the reserved and documentation ranges, and the IPv6 equivalents (`::1`, `fc00::/7`, `fe80::/10`, `ff00::/8`). The IPv6 forms that embed an IPv4 address (v4-mapped, v4-compatible, 6to4, Teredo, NAT64) are refused wholesale, because an attacker picks the embedded address.
- **One blocked address anywhere in the answer refuses the whole request**, and the connection then goes to the address that was validated, never to the hostname, so a second DNS answer cannot redirect it.
- **Only 80 and 443.** `ports` filters those two; it cannot name a third, and an unsupported value is a 400 rather than a silent drop.
- **Connect and close.** No TLS handshake, no read, no redirect to follow, and nothing about what answered comes back beyond the boolean.
- **Two second connect timeout, three second DNS timeout**, comfortably inside the CLI's 10s budget for the whole request.
- **Rate limited three ways**: 6/min per client, 6/min per target host, 60/min globally. The global one is the actual bound on outbound connections, since the client key is only as good as the address the request arrives with. Behind Caddy that key is the last `X-Forwarded-For` entry, which the proxy appends, and it is trusted only when the request arrived over loopback.

### Probe auth: unauthenticated, deliberately

`ao setup-vm` calls this during preflight, **before** the device-code binding gives the VM any credential, so there is nothing it could present. Requiring auth would mean either shipping a shared secret in the CLI or moving the check after binding, where it no longer preflights anything. The rate limits are therefore the whole budget, which is why they are set low and why there is a global cap on top of the per-caller ones.

### Tests

One test per blocked address class, each asserting both the 400 **and** that no connection was attempted, so a later refactor that loosens one predicate cannot quietly reopen a class. 169.254.169.254 is a named case, as is its `::ffff:` form. Plus the mixed-answer (rebinding) refusal, the dialed-address assertion, a check that the socket is never read from, the port filter, and the rate limit.

## The landing page (#58)

Sign-in redirects to `/`, which 404'd. `internal/home` now serves a small authenticated page there with the one useful next step, connecting a machine, styled to match the sign-in and device pages.

**An unauthenticated GET / redirects to `/login`** rather than 404ing or serving a public page: everything reachable from here needs an account, and `/login`'s default `next` brings the operator straight back. The route is registered as `"/{$}"`, not `"/"`, so it claims the root path only and real 404s stay 404s (there is a test for that).

## Scope

Both features live in their own package and register through one call, so the desktop OAuth work landing in `controlplane/` at the same time touches nothing here beyond two lines of `main.go`. Nothing in `backend/` or `frontend/` changed.

## Verification

`gofmt -l .`, `go build ./...`, `go vet ./...`, and `go test -race ./...` all clean in `controlplane/` (172 tests across 11 packages).

## Known follow-ups

- The rate limiter is in-memory, so it bounds one process. The control plane is a single instance today; if it is ever replicated, each replica grants the full allowance and this needs a shared store. Marked with a `ponytail:` comment.