### PR TITLE
feat(controlplane): desktop OAuth authorize and token endpoints

### DIFF
--- a/controlplane/README.md
+++ b/controlplane/README.md
@@ -95,6 +95,57 @@ device-code binding gives the VM any credential to present. The rate limits are
 the whole budget. See the package doc in `internal/reachability/` for the
 detail.
 
+## Desktop sign-in
+
+The desktop app signs in with an RFC 8252 loopback authorization-code exchange
+with PKCE, implemented in `internal/desktopauth/`. The wire contract is
+[`docs/desktop-login-contract.md`](../docs/desktop-login-contract.md) and the
+client half is `frontend/src/main/ao-pkce.ts`.
+
+```
+GET /oauth/desktop/authorize
+  ?response_type=code&client_id=ao-desktop
+  &redirect_uri=http://127.0.0.1:<ephemeral>/callback
+  &code_challenge=<base64url SHA-256 of the verifier>
+  &code_challenge_method=S256&state=<CSPRNG>
+```
+
+Opened in the system browser. It reuses `internal/auth`'s Google sign-in and
+session (a signed-out request is sent to `/auth/google/login?next=` pointing
+back here), then redirects to the loopback listener with a one-time `code` and
+the `state` unmodified.
+
+```bash
+curl -s http://127.0.0.1:8080/oauth/desktop/token \
+  -d grant_type=authorization_code -d client_id=ao-desktop \
+  -d code=... -d code_verifier=... \
+  -d redirect_uri=http://127.0.0.1:54321/callback
+# {"refresh_token":"...","account":{"id":"...","email":"..."}}
+```
+
+No access token comes back: login yields identity plus the refresh token, and
+every access token comes from `POST /api/v1/token`.
+
+Three things about this endpoint are load-bearing, because it is the only
+public unauthenticated entry point that ends in a ninety-day credential.
+
+- **The redirect target is proven loopback before it is used at all**, for a
+  code or for an error. `127.0.0.1` and `[::1]` on any port, per RFC 8252
+  section 7.3, and nothing else: not `localhost`, which is a name whose
+  resolution is not this service's decision, and not any other host, which
+  would make this an open redirect that hands out accounts. A refused redirect
+  URI, an unknown `client_id`, and a missing `state` are shown to the operator
+  in the browser rather than redirected anywhere (RFC 6749 section 4.1.2.1).
+- **The code is bound at issue to the PKCE challenge, the redirect URI, and
+  the account**, and the exchange re-checks all three against the stored row.
+- **The code is consumed in the same transaction that inserts the refresh
+  token**, so no interleaving of a replay mints a second one.
+
+An unknown code, an expired one, a replayed one, a mismatched `redirect_uri`,
+and a wrong verifier are one `invalid_grant` with one description, the way the
+refresh token endpoint collapses its three failures: the distinctions are
+exactly the oracle someone holding a stolen code would want.
+
 ## Device flow and machine registry
 
 `ao setup-vm` binds a VM to an account with the RFC 8628 device authorization

--- a/controlplane/cmd/controlplane/main.go
+++ b/controlplane/cmd/controlplane/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/agentlab-in/hosted-ao/controlplane/internal/api"
 	"github.com/agentlab-in/hosted-ao/controlplane/internal/auth"
 	"github.com/agentlab-in/hosted-ao/controlplane/internal/config"
+	"github.com/agentlab-in/hosted-ao/controlplane/internal/desktopauth"
 	"github.com/agentlab-in/hosted-ao/controlplane/internal/device"
 	"github.com/agentlab-in/hosted-ao/controlplane/internal/home"
 	"github.com/agentlab-in/hosted-ao/controlplane/internal/keys"
@@ -76,6 +77,11 @@ func main() {
 		log.Fatalf("init device flow: %v", err)
 	}
 	deviceSvc.Register(mux)
+
+	// The desktop app's own sign-in: the loopback PKCE exchange in
+	// docs/desktop-login-contract.md. It reuses authSvc's Google flow and
+	// session rather than standing up a second one.
+	desktopauth.NewService(db, issuer, authSvc).Register(mux)
 
 	homeSvc, err := home.NewService(authSvc)
 	if err != nil {

--- a/controlplane/internal/desktopauth/authorize_test.go
+++ b/controlplane/internal/desktopauth/authorize_test.go
@@ -1,0 +1,430 @@
+package desktopauth
+
+import (
+	"database/sql"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/agentlab-in/hosted-ao/controlplane/internal/keys"
+	"github.com/agentlab-in/hosted-ao/controlplane/internal/storage/sqlite"
+	"github.com/agentlab-in/hosted-ao/controlplane/internal/tokens"
+)
+
+const (
+	accountA   = "account-a"
+	emailA     = "account-a@example.test"
+	testOrigin = "https://ao.test"
+
+	// signInHeader is how a test says "this request carries account X's
+	// browser session", standing in for the signed cookie the auth package
+	// issues. An absent or empty header is a signed-out request.
+	signInHeader = "X-Test-Account"
+
+	// testRedirectURI is the shape the desktop actually sends: loopback, an
+	// ephemeral port, and the listener's /callback path.
+	testRedirectURI = "http://127.0.0.1:54321/callback"
+
+	// testVerifier is one fixed PKCE verifier, so a test can name the right
+	// one and the wrong one without generating either.
+	testVerifier  = "kQ7XmR3nZv1sLpTdWy8cHfJb0aOeUgN4iM2rV6xB9zA"
+	wrongVerifier = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+
+	// testState is what the app asks to have echoed back, unmodified.
+	testState = "5jZ0qLwT2nX8vBcR4mHsKdYpUe1gAfN7iO3rQ6tVxZ0"
+)
+
+// oauthError is the error envelope both endpoints return, written by
+// api.WriteError.
+type oauthError struct {
+	Error            string `json:"error"`
+	ErrorDescription string `json:"error_description"`
+}
+
+// testSessions stands in for auth.Service on the sessions interface.
+type testSessions struct{}
+
+func (testSessions) AccountFromRequest(r *http.Request) (string, bool) {
+	id := r.Header.Get(signInHeader)
+	return id, id != ""
+}
+
+type harness struct {
+	t   *testing.T
+	svc *Service
+	mux *http.ServeMux
+	db  *sql.DB
+}
+
+func newHarness(t *testing.T) *harness {
+	t.Helper()
+
+	db, err := sqlite.Open(t.TempDir())
+	if err != nil {
+		t.Fatalf("sqlite.Open() unexpected error: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	if _, err := db.Exec(
+		`INSERT INTO accounts (id, google_subject, email, created_at) VALUES (?, ?, ?, ?)`,
+		accountA, "google-"+accountA, emailA, time.Now().UTC(),
+	); err != nil {
+		t.Fatalf("seed account: %v", err)
+	}
+
+	km, err := keys.Load(t.TempDir())
+	if err != nil {
+		t.Fatalf("keys.Load() unexpected error: %v", err)
+	}
+
+	svc := NewService(db, tokens.NewIssuer(km, db, testOrigin, 15*time.Minute), testSessions{})
+	mux := http.NewServeMux()
+	svc.Register(mux)
+
+	return &harness{t: t, svc: svc, mux: mux, db: db}
+}
+
+// authorizeQuery is a complete, valid authorization request, which each test
+// then breaks in exactly one place.
+func authorizeQuery() url.Values {
+	return url.Values{
+		"response_type":         {"code"},
+		"client_id":             {desktopClientID},
+		"redirect_uri":          {testRedirectURI},
+		"code_challenge":        {challengeFor(testVerifier)},
+		"code_challenge_method": {"S256"},
+		"state":                 {testState},
+	}
+}
+
+// authorize sends an authorization request. account, when non-empty, signs it
+// in as that account.
+func (h *harness) authorize(account string, q url.Values) *httptest.ResponseRecorder {
+	h.t.Helper()
+
+	req := httptest.NewRequest(http.MethodGet, "/oauth/desktop/authorize?"+q.Encode(), nil)
+	if account != "" {
+		req.Header.Set(signInHeader, account)
+	}
+	rec := httptest.NewRecorder()
+	h.mux.ServeHTTP(rec, req)
+	return rec
+}
+
+// location requires a redirect and returns the parsed Location.
+func (h *harness) location(rec *httptest.ResponseRecorder) *url.URL {
+	h.t.Helper()
+
+	if rec.Code != http.StatusFound {
+		h.t.Fatalf("status = %d, want 302, body: %s", rec.Code, rec.Body)
+	}
+	u, err := url.Parse(rec.Header().Get("Location"))
+	if err != nil {
+		h.t.Fatalf("parse Location %q: %v", rec.Header().Get("Location"), err)
+	}
+	return u
+}
+
+// codeFrom runs a signed-in authorization request and returns the code it
+// redirected back with.
+func (h *harness) codeFrom(q url.Values) string {
+	h.t.Helper()
+
+	loc := h.location(h.authorize(accountA, q))
+	code := loc.Query().Get("code")
+	if code == "" {
+		h.t.Fatalf("authorize redirected to %q with no code", loc)
+	}
+	return code
+}
+
+func TestAuthorize_RedirectsToTheLoopbackListenerWithACodeAndTheStateUnmodified(t *testing.T) {
+	h := newHarness(t)
+
+	loc := h.location(h.authorize(accountA, authorizeQuery()))
+
+	if got, want := loc.Scheme+"://"+loc.Host+loc.Path, testRedirectURI; got != want {
+		t.Errorf("redirected to %q, want %q", got, want)
+	}
+	if got := loc.Query().Get("state"); got != testState {
+		t.Errorf("state = %q, want it echoed unmodified as %q", got, testState)
+	}
+	if got := loc.Query().Get("code"); got == "" {
+		t.Error("no code in the redirect")
+	}
+	if got := loc.Query().Get("error"); got != "" {
+		t.Errorf("error = %q, want none", got)
+	}
+}
+
+// The code travels in a Location header, so nothing between here and the
+// browser may keep a copy of it.
+func TestAuthorize_SuccessIsNotCacheable(t *testing.T) {
+	h := newHarness(t)
+
+	rec := h.authorize(accountA, authorizeQuery())
+	if got := rec.Header().Get("Cache-Control"); got != "no-store" {
+		t.Errorf("Cache-Control = %q, want no-store", got)
+	}
+}
+
+// The stored code is a hash. A leak of controlplane.db must not hand over a
+// live authorization code.
+func TestAuthorize_StoresOnlyTheHashOfTheCode(t *testing.T) {
+	h := newHarness(t)
+
+	code := h.codeFrom(authorizeQuery())
+
+	var stored, redirectURI, challenge, account string
+	if err := h.db.QueryRow(
+		`SELECT code_hash, redirect_uri, code_challenge, account_id FROM desktop_auth_codes`,
+	).Scan(&stored, &redirectURI, &challenge, &account); err != nil {
+		t.Fatalf("read stored code: %v", err)
+	}
+	if stored == code {
+		t.Error("the plaintext authorization code was stored")
+	}
+	if stored != hashCode(code) {
+		t.Error("the stored value is not the hash of the issued code")
+	}
+	// The three bindings the exchange re-checks are all fixed here.
+	if redirectURI != testRedirectURI {
+		t.Errorf("stored redirect_uri = %q, want %q", redirectURI, testRedirectURI)
+	}
+	if challenge != challengeFor(testVerifier) {
+		t.Errorf("stored code_challenge = %q, want the request's challenge", challenge)
+	}
+	if account != accountA {
+		t.Errorf("stored account_id = %q, want %q", account, accountA)
+	}
+}
+
+func TestAuthorize_SignedOutGoesThroughGoogleAndComesBack(t *testing.T) {
+	h := newHarness(t)
+
+	q := authorizeQuery()
+	loc := h.location(h.authorize("", q))
+
+	if loc.Path != googleLoginPath {
+		t.Fatalf("signed-out authorize went to %q, want %q", loc.Path, googleLoginPath)
+	}
+	next, err := url.Parse(loc.Query().Get("next"))
+	if err != nil {
+		t.Fatalf("parse next: %v", err)
+	}
+	if next.Path != "/oauth/desktop/authorize" {
+		t.Errorf("next path = %q, want the authorize endpoint", next.Path)
+	}
+	// Every parameter has to survive the round trip, or the request that comes
+	// back after Google is not the one the app made.
+	for key, want := range q {
+		if got := next.Query().Get(key); got != want[0] {
+			t.Errorf("next lost %s: got %q, want %q", key, got, want[0])
+		}
+	}
+	// And it must be a same-site path, or the auth package's sanitizeNext
+	// discards it and the operator lands on "/" after signing in.
+	if raw := loc.Query().Get("next"); len(raw) == 0 || raw[0] != '/' {
+		t.Errorf("next = %q, want a relative path", raw)
+	}
+	if n := h.codeCount(); n != 0 {
+		t.Errorf("a signed-out request issued %d codes, want 0", n)
+	}
+}
+
+// The redirect URI is the one parameter that, wrong, hands an account to
+// whoever crafted the link. None of these may produce a redirect at all.
+func TestAuthorize_RefusesARedirectURIThatIsNotLoopback(t *testing.T) {
+	cases := []struct {
+		name        string
+		redirectURI string
+	}{
+		{"a remote host", "http://evil.example/callback"},
+		{"https on a remote host", "https://evil.example/callback"},
+		{"a host that merely starts with the loopback literal", "http://127.0.0.1.evil.example/callback"},
+		{"localhost, which is a name and not an address", "http://localhost:54321/callback"},
+		{"an address that is not the loopback", "http://10.0.0.5:54321/callback"},
+		{"the wildcard address", "http://0.0.0.0:54321/callback"},
+		{"credentials smuggled into the authority", "http://127.0.0.1@evil.example/callback"},
+		{"a port smuggled into the authority", "http://127.0.0.1:54321@evil.example/callback"},
+		{"a backslash where the authority ends", `http://127.0.0.1\@evil.example/callback`},
+		{"a newline, which would otherwise reach a Location header", "http://127.0.0.1:54321/callback\r\nX-Evil: 1"},
+		{"a NUL", "http://127.0.0.1:54321/callback\x00"},
+		{"a scheme-relative reference", "//evil.example/callback"},
+		{"a relative path", "/callback"},
+		{"a non-http scheme", "aodesktop://callback"},
+		{"https on the loopback", "https://127.0.0.1:54321/callback"},
+		{"a query of its own", "http://127.0.0.1:54321/callback?next=http://evil.example"},
+		{"a fragment", "http://127.0.0.1:54321/callback#x"},
+		{"an unparseable URL", "http://127.0.0.1:notaport/callback"},
+		{"empty", ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newHarness(t)
+
+			q := authorizeQuery()
+			q.Set("redirect_uri", tc.redirectURI)
+			rec := h.authorize(accountA, q)
+
+			if rec.Code != http.StatusBadRequest {
+				t.Errorf("status = %d, want 400", rec.Code)
+			}
+			if loc := rec.Header().Get("Location"); loc != "" {
+				t.Errorf("redirected to %q, want no redirect at all", loc)
+			}
+			if n := h.codeCount(); n != 0 {
+				t.Errorf("issued %d codes for a refused redirect URI, want 0", n)
+			}
+		})
+	}
+}
+
+// RFC 8252 section 7.3: the app gets whatever ephemeral port the OS handed it,
+// so every port has to work, and so does the IPv6 loopback.
+func TestAuthorize_AcceptsAnyLoopbackPort(t *testing.T) {
+	for _, redirectURI := range []string{
+		"http://127.0.0.1:1/callback",
+		"http://127.0.0.1:65535/callback",
+		"http://127.0.0.1/callback",
+		"http://[::1]:49152/callback",
+	} {
+		t.Run(redirectURI, func(t *testing.T) {
+			h := newHarness(t)
+
+			q := authorizeQuery()
+			q.Set("redirect_uri", redirectURI)
+			loc := h.location(h.authorize(accountA, q))
+
+			if got := loc.Query().Get("code"); got == "" {
+				t.Errorf("no code redirecting to %q", redirectURI)
+			}
+		})
+	}
+}
+
+func TestAuthorize_RefusesAnUnknownClient(t *testing.T) {
+	h := newHarness(t)
+
+	q := authorizeQuery()
+	q.Set("client_id", "not-ao-desktop")
+	rec := h.authorize(accountA, q)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", rec.Code)
+	}
+	if loc := rec.Header().Get("Location"); loc != "" {
+		t.Errorf("redirected to %q, want no redirect", loc)
+	}
+}
+
+// A callback with no state is one the app rejects before reading it, so
+// redirecting would leave the user with a browser that did nothing. It is
+// refused where the operator can see it instead.
+func TestAuthorize_RefusesAMissingState(t *testing.T) {
+	for _, name := range []string{"absent", "empty"} {
+		t.Run(name, func(t *testing.T) {
+			h := newHarness(t)
+
+			q := authorizeQuery()
+			if name == "absent" {
+				q.Del("state")
+			} else {
+				q.Set("state", "")
+			}
+			rec := h.authorize(accountA, q)
+
+			if rec.Code != http.StatusBadRequest {
+				t.Errorf("status = %d, want 400", rec.Code)
+			}
+			if loc := rec.Header().Get("Location"); loc != "" {
+				t.Errorf("redirected to %q, want no redirect", loc)
+			}
+			if n := h.codeCount(); n != 0 {
+				t.Errorf("issued %d codes without a state, want 0", n)
+			}
+		})
+	}
+}
+
+// Once the redirect target is proven, the app is told what went wrong, and
+// every such answer carries the state so the app can tell it apart from a
+// stray hit on its port.
+func TestAuthorize_ReportsABadRequestToTheAppWithItsState(t *testing.T) {
+	cases := []struct {
+		name   string
+		mutate func(url.Values)
+		want   string
+	}{
+		{"a response type other than code", func(q url.Values) { q.Set("response_type", "token") }, "unsupported_response_type"},
+		{"a missing response type", func(q url.Values) { q.Del("response_type") }, "unsupported_response_type"},
+		{"plain PKCE", func(q url.Values) { q.Set("code_challenge_method", "plain") }, "invalid_request"},
+		{"a missing challenge method", func(q url.Values) { q.Del("code_challenge_method") }, "invalid_request"},
+		{"a missing challenge", func(q url.Values) { q.Del("code_challenge") }, "invalid_request"},
+		{"a challenge that is not a SHA-256 digest", func(q url.Values) { q.Set("code_challenge", "too-short") }, "invalid_request"},
+		{"a challenge that is not base64url", func(q url.Values) { q.Set("code_challenge", "++++/////+++++++++++++++++++++++++++++++++++") }, "invalid_request"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newHarness(t)
+
+			q := authorizeQuery()
+			tc.mutate(q)
+			loc := h.location(h.authorize(accountA, q))
+
+			if got := loc.Query().Get("error"); got != tc.want {
+				t.Errorf("error = %q, want %q", got, tc.want)
+			}
+			if got := loc.Query().Get("state"); got != testState {
+				t.Errorf("state = %q, want %q", got, testState)
+			}
+			if got := loc.Query().Get("code"); got != "" {
+				t.Errorf("a rejected request still carried a code")
+			}
+			if n := h.codeCount(); n != 0 {
+				t.Errorf("issued %d codes for a rejected request, want 0", n)
+			}
+		})
+	}
+}
+
+// The app compares state byte for byte, so anything the control plane does to
+// it in transit ends the sign-in.
+func TestAuthorize_EchoesAStateWithURLSignificantCharactersUnmodified(t *testing.T) {
+	h := newHarness(t)
+
+	state := "a b&c=d?e#f/g+h%i"
+	q := authorizeQuery()
+	q.Set("state", state)
+	loc := h.location(h.authorize(accountA, q))
+
+	if got := loc.Query().Get("state"); got != state {
+		t.Errorf("state = %q, want %q", got, state)
+	}
+}
+
+func TestAuthorize_EachRequestGetsItsOwnCode(t *testing.T) {
+	h := newHarness(t)
+
+	first := h.codeFrom(authorizeQuery())
+	second := h.codeFrom(authorizeQuery())
+
+	if first == second {
+		t.Error("two authorization requests produced the same code")
+	}
+}
+
+// codeCount is how many authorization codes are live.
+func (h *harness) codeCount() int {
+	h.t.Helper()
+
+	var n int
+	if err := h.db.QueryRow(`SELECT COUNT(*) FROM desktop_auth_codes`).Scan(&n); err != nil {
+		h.t.Fatalf("count authorization codes: %v", err)
+	}
+	return n
+}

--- a/controlplane/internal/desktopauth/desktopauth.go
+++ b/controlplane/internal/desktopauth/desktopauth.go
@@ -1,0 +1,162 @@
+// Package desktopauth implements the desktop app's sign-in: the RFC 8252
+// loopback authorization-code exchange with PKCE that
+// docs/desktop-login-contract.md specifies and frontend/src/main/ao-pkce.ts
+// already calls. GET /oauth/desktop/authorize drives the browser through the
+// auth package's existing Google session and hands a one-time code back to the
+// app's loopback listener; POST /oauth/desktop/token trades that code for the
+// account and a new refresh token.
+//
+// This is the control plane's only public, unauthenticated entry point that
+// ends in a ninety-day credential, so three things carry the whole flow and
+// none of them may be relaxed:
+//
+//   - The redirect target is proven to be a loopback address before it is ever
+//     used, including to report an error. Any other host would make this an
+//     open redirect that hands out accounts.
+//   - The code is bound at issue time to the PKCE challenge, the redirect URI,
+//     and the account, and all three are re-checked at the token endpoint
+//     against the stored row, never against the token request.
+//   - The code is deleted in the same transaction that inserts the refresh
+//     token, so no interleaving of a replay can mint a second one.
+//
+// Nothing here logs a code, a verifier, or a token.
+package desktopauth
+
+import (
+	"database/sql"
+	"net"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/agentlab-in/hosted-ao/controlplane/internal/tokens"
+)
+
+const (
+	// desktopClientID is the one client this flow serves. The desktop app is a
+	// public client, so this identifies it and authenticates nothing; PKCE does
+	// the work a client secret would.
+	desktopClientID = "ao-desktop"
+
+	// authCodeTTL bounds how long an issued code stays redeemable. The desktop
+	// exchanges it the instant its loopback listener receives the redirect, so
+	// this only has to cover a slow hop through the browser. RFC 6749 section
+	// 4.1.2 recommends a maximum of ten minutes; half of that is plenty and
+	// halves the window in which a leaked code is worth anything.
+	authCodeTTL = 5 * time.Minute
+
+	// googleLoginPath is the auth package's existing Google sign-in entry
+	// point. The authorize endpoint sends a signed-out browser through it with
+	// ?next= pointing back at itself, so there is one Google flow and one
+	// session cookie in this service, not two.
+	googleLoginPath = "/auth/google/login"
+)
+
+// sessions is the slice of the auth service this package needs: who is signed
+// in on the current browser request. An interface so the login exchange does
+// not import the whole auth service, and so tests can sign a request in
+// without standing up an OAuth client.
+type sessions interface {
+	AccountFromRequest(r *http.Request) (accountID string, ok bool)
+}
+
+// Service owns the two desktop login endpoints.
+type Service struct {
+	db       *sql.DB
+	issuer   *tokens.Issuer
+	sessions sessions
+	limiter  *windowLimiter
+}
+
+// NewService builds the desktop login Service. issuer mints the refresh token
+// the exchange returns; s identifies the operator signed in on the browser
+// request that reaches the authorize endpoint.
+func NewService(db *sql.DB, issuer *tokens.Issuer, s sessions) *Service {
+	return &Service{db: db, issuer: issuer, sessions: s, limiter: newWindowLimiter()}
+}
+
+// Register wires this package's two routes onto mux. One call, so this flow
+// merges alongside the rest of the control plane without either touching the
+// other's files.
+func (s *Service) Register(mux *http.ServeMux) {
+	mux.HandleFunc("GET /oauth/desktop/authorize", s.handleAuthorize)
+	mux.HandleFunc("POST /oauth/desktop/token", s.handleToken)
+}
+
+const (
+	// tokenWindow and tokenAttemptsPerWindow bound how fast one caller may hit
+	// the token endpoint. Guessing a code is not the threat that motivates this
+	// (a code is 256 bits and lives five minutes); the endpoint opens a write
+	// transaction per call while unauthenticated, so the point is to keep one
+	// caller from making that everybody's problem. The allowance is well past
+	// what a human retrying a sign-in produces.
+	tokenWindow            = time.Minute
+	tokenAttemptsPerWindow = 20
+)
+
+// windowLimiter is a fixed-window counter keyed by caller.
+//
+// The whole map is dropped at each window boundary rather than swept per key,
+// so memory is bounded by the distinct callers seen inside one window and an
+// attacker cycling addresses cannot grow it without bound. That costs a caller
+// straddling a boundary a fresh allowance, which for a limit this coarse is not
+// worth a sliding window.
+//
+// ponytail: in-memory, so it bounds one process. The control plane is a single
+// instance today (one Caddy site on one box); if it is ever replicated, move
+// this to a shared store or each replica grants the full allowance.
+type windowLimiter struct {
+	mu     sync.Mutex
+	start  time.Time
+	counts map[string]int
+	clock  func() time.Time
+}
+
+func newWindowLimiter() *windowLimiter {
+	return &windowLimiter{counts: make(map[string]int), clock: time.Now}
+}
+
+// allow records an attempt for key and reports whether it is within the
+// window's allowance.
+func (l *windowLimiter) allow(key string) bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	now := l.clock()
+	if now.Sub(l.start) >= tokenWindow {
+		l.start = now
+		l.counts = make(map[string]int)
+	}
+	l.counts[key]++
+	return l.counts[key] <= tokenAttemptsPerWindow
+}
+
+// clientKey identifies the caller for rate limiting.
+//
+// The control plane sits behind Caddy on the same box, so every request's
+// RemoteAddr is the loopback and keying on it alone would collapse the whole
+// internet into one bucket: one caller could then spend everybody's allowance.
+// When the immediate peer is that loopback proxy, the last X-Forwarded-For hop
+// is used instead, because Caddy appends the address it actually saw to
+// whatever the client sent. The last entry is therefore the one value in that
+// header a client cannot forge; the earlier ones are attacker text and are
+// ignored. When the peer is not the loopback there is no proxy in front, so
+// the header is ignored entirely.
+func clientKey(r *http.Request) string {
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		host = r.RemoteAddr
+	}
+	if ip := net.ParseIP(host); ip == nil || !ip.IsLoopback() {
+		return host
+	}
+	fwd := r.Header.Get("X-Forwarded-For")
+	if i := strings.LastIndex(fwd, ","); i >= 0 {
+		fwd = fwd[i+1:]
+	}
+	if fwd = strings.TrimSpace(fwd); fwd != "" {
+		return fwd
+	}
+	return host
+}

--- a/controlplane/internal/desktopauth/endpoints.go
+++ b/controlplane/internal/desktopauth/endpoints.go
@@ -1,0 +1,197 @@
+package desktopauth
+
+import (
+	"errors"
+	"log"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/agentlab-in/hosted-ao/controlplane/internal/api"
+)
+
+// authorizationCodeGrantType is the grant this exchange accepts, and the only
+// one. It is required rather than defaulted: the one client sends it, and a
+// token endpoint that guesses what an unlabelled request meant is a token
+// endpoint that can be surprised.
+const authorizationCodeGrantType = "authorization_code"
+
+// handleAuthorize is the authorization endpoint the desktop app opens in the
+// system browser. It validates the request, drives the browser through the
+// auth package's Google sign-in if there is no session yet, and redirects back
+// to the app's loopback listener with a one-time code and the app's own state.
+//
+// The order of the checks is the security property, not a style choice. The
+// client and the redirect target are settled first, because until the redirect
+// URI is proven to be loopback there is no address this endpoint may send
+// anything to, not a code and not an error either. RFC 6749 section 4.1.2.1
+// says exactly that: with an invalid client or redirect URI, inform the user
+// and do not redirect. Everything after that point can be reported to the app,
+// because by then the only place a report can go is the app's own machine.
+//
+// One residual risk this shape carries, from the contract rather than from
+// this code: a browser that already holds a session completes the flow with no
+// interaction, so any local process that can open a URL can run its own
+// authorization request against the signed-in operator's browser and receive a
+// code on its own loopback port. RFC 8252 section 8.10 treats that as inherent
+// to native app loopback flows, PKCE does not help because such a caller picks
+// its own verifier, and the defence is that the process is already running as
+// the user. Adding a confirmation step would change the documented contract
+// the desktop is built against, so it is not done here.
+func (s *Service) handleAuthorize(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query()
+
+	if q.Get("client_id") != desktopClientID {
+		refuse(w, "This sign-in link is not for the AO desktop app.")
+		return
+	}
+	redirectURI, err := validateLoopbackRedirect(q.Get("redirect_uri"))
+	if err != nil {
+		// The reason is safe to show: it is a property of the link the user
+		// followed, not of any account, and a desktop build with the wrong
+		// redirect URI is otherwise a silent hang.
+		refuse(w, "This sign-in link cannot be completed: "+err.Error()+
+			". The AO desktop app receives sign-in on a loopback address on this computer, and nowhere else.")
+		return
+	}
+	state := q.Get("state")
+	if !validState(state) {
+		// Also not redirected, even though the target is now proven. The app
+		// checks state before it reads anything else out of the callback, so a
+		// redirect carrying no state is one it would ignore, leaving the user
+		// with a browser that did nothing and a listener that times out.
+		refuse(w, "This sign-in link is missing the value that ties it to the app's request, so it cannot be completed.")
+		return
+	}
+
+	if rt := q.Get("response_type"); rt != "code" {
+		redirectError(w, r, redirectURI, state, "unsupported_response_type", "this endpoint issues authorization codes only")
+		return
+	}
+	if m := q.Get("code_challenge_method"); m != "S256" {
+		redirectError(w, r, redirectURI, state, "invalid_request", "code_challenge_method must be S256")
+		return
+	}
+	challenge := q.Get("code_challenge")
+	if !validS256Challenge(challenge) {
+		redirectError(w, r, redirectURI, state, "invalid_request", "code_challenge must be the base64url SHA-256 of the code verifier")
+		return
+	}
+
+	accountID, ok := s.sessions.AccountFromRequest(r)
+	if !ok {
+		// Back here once Google has signed the operator in, with the request
+		// intact. RequestURI is this endpoint's own path and query, so it
+		// survives the auth package's same-site check on ?next=.
+		http.Redirect(w, r, googleLoginPath+"?next="+url.QueryEscape(r.URL.RequestURI()), http.StatusFound)
+		return
+	}
+
+	code, err := s.createCode(r.Context(), accountID, redirectURI, challenge, time.Now().UTC())
+	if err != nil {
+		log.Printf("desktopauth: issue authorization code: %v", err)
+		redirectError(w, r, redirectURI, state, "server_error", "the control plane could not issue an authorization code")
+		return
+	}
+	redirectBack(w, r, redirectURI, url.Values{"code": {code}, "state": {state}})
+}
+
+// tokenResponse is the exchange's success body, exactly as
+// docs/desktop-login-contract.md specifies it: identity plus the refresh
+// token, and no access token. Every access token comes from a later exchange
+// at POST /api/v1/token.
+type tokenResponse struct {
+	RefreshToken string         `json:"refresh_token"`
+	Account      accountSummary `json:"account"`
+}
+
+type accountSummary struct {
+	ID    string `json:"id"`
+	Email string `json:"email"`
+}
+
+// handleToken exchanges an authorization code for the account and a new
+// refresh token.
+//
+// Every way the exchange itself can fail collapses into one invalid_grant with
+// one description, following the precedent api.handleToken sets for refresh
+// tokens: an unknown code, an expired one, a replayed one, a mismatched
+// redirect URI, and a wrong verifier are indistinguishable from out here. The
+// distinctions are exactly the oracle an attacker holding a stolen code would
+// want, and the app has nothing useful to do with any of them.
+func (s *Service) handleToken(w http.ResponseWriter, r *http.Request) {
+	if !s.limiter.allow(clientKey(r)) {
+		api.WriteError(w, http.StatusTooManyRequests, "slow_down", "too many token requests, try again shortly")
+		return
+	}
+
+	params, err := api.ReadParams(w, r)
+	if err != nil {
+		api.WriteError(w, http.StatusBadRequest, "invalid_request", "could not parse the request body")
+		return
+	}
+	if params.Get("grant_type") != authorizationCodeGrantType {
+		api.WriteError(w, http.StatusBadRequest, "unsupported_grant_type", "expected grant_type "+authorizationCodeGrantType)
+		return
+	}
+	if params.Get("client_id") != desktopClientID {
+		api.WriteError(w, http.StatusBadRequest, "invalid_client", "unknown client_id")
+		return
+	}
+	code := strings.TrimSpace(params.Get("code"))
+	verifier := strings.TrimSpace(params.Get("code_verifier"))
+	redirectURI := strings.TrimSpace(params.Get("redirect_uri"))
+	if code == "" || verifier == "" || redirectURI == "" {
+		api.WriteError(w, http.StatusBadRequest, "invalid_request", "code, code_verifier, and redirect_uri are all required")
+		return
+	}
+
+	res, err := s.redeem(r.Context(), code, verifier, redirectURI, time.Now().UTC())
+	if err != nil {
+		if errors.Is(err, errInvalidCode) {
+			api.WriteError(w, http.StatusBadRequest, "invalid_grant", "the authorization code is not valid, sign in again")
+			return
+		}
+		log.Printf("desktopauth: redeem authorization code: %v", err)
+		api.WriteError(w, http.StatusInternalServerError, "server_error", "could not complete the sign-in")
+		return
+	}
+
+	api.WriteJSON(w, http.StatusOK, tokenResponse{
+		RefreshToken: res.RefreshToken,
+		Account:      accountSummary{ID: res.AccountID, Email: res.Email},
+	})
+}
+
+// redirectBack sends the browser to the app's loopback listener.
+//
+// validateLoopbackRedirect has already refused a redirect URI carrying a query
+// or a fragment, so appending "?" here cannot collide with one. no-store
+// because the Location this writes carries the authorization code.
+func redirectBack(w http.ResponseWriter, r *http.Request, redirectURI string, params url.Values) {
+	w.Header().Set("Cache-Control", "no-store")
+	http.Redirect(w, r, redirectURI+"?"+params.Encode(), http.StatusFound)
+}
+
+// redirectError reports a failure to the app through its loopback listener,
+// carrying the state so the app can tell this is the answer to its own
+// request rather than a stray hit on its port.
+func redirectError(w http.ResponseWriter, r *http.Request, redirectURI, state, code, description string) {
+	redirectBack(w, r, redirectURI, url.Values{
+		"error":             {code},
+		"error_description": {description},
+		"state":             {state},
+	})
+}
+
+// refuse ends an authorization request that cannot be reported to the app,
+// because the client or the redirect target is not one this endpoint will use.
+// The operator is looking at this in a browser, so it is plain text they can
+// read, not the JSON error envelope the token endpoint returns.
+func refuse(w http.ResponseWriter, message string) {
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	w.Header().Set("Cache-Control", "no-store")
+	w.WriteHeader(http.StatusBadRequest)
+	_, _ = w.Write([]byte(message + "\n"))
+}

--- a/controlplane/internal/desktopauth/request.go
+++ b/controlplane/internal/desktopauth/request.go
@@ -1,0 +1,96 @@
+package desktopauth
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"errors"
+	"net/url"
+)
+
+// maxStateLen caps the state the app asks to have echoed back. state is
+// opaque to this service and only the app interprets it, so the only thing
+// worth enforcing is that it exists and cannot be used to push an unbounded
+// string through a Location header. The contract's own state is 32 CSPRNG
+// bytes base64url, which is 43 characters.
+const maxStateLen = 512
+
+var (
+	errRedirectMissing     = errors.New("redirect_uri is required")
+	errRedirectMalformed   = errors.New("redirect_uri is not a URL")
+	errRedirectNotHTTP     = errors.New("redirect_uri must use the http scheme")
+	errRedirectNotLoopback = errors.New("redirect_uri host must be 127.0.0.1 or [::1]")
+	errRedirectHasUser     = errors.New("redirect_uri must not carry userinfo")
+	errRedirectHasQuery    = errors.New("redirect_uri must not carry a query")
+	errRedirectHasFragment = errors.New("redirect_uri must not carry a fragment")
+)
+
+// validateLoopbackRedirect returns raw unchanged if it is a redirect target
+// this endpoint may send an account to, and an error naming the reason if it
+// is not.
+//
+// RFC 8252 section 7.3: a native app receives its redirect on a loopback
+// listener bound to an ephemeral port, so the port is whatever the OS handed
+// the app that run and cannot be registered in advance. The port is therefore
+// the only part left free. The host is pinned to the two loopback literals and
+// nothing else: "localhost" is refused because it is a name, and section 8.3
+// warns that what it resolves to is not this service's decision. Anything
+// beyond that is an open redirect on a public endpoint that ends in a refresh
+// token, which is an account handed to whoever crafted the link.
+//
+// The value is returned verbatim rather than normalized, because the token
+// endpoint compares it to what the app sends there by simple string equality,
+// per RFC 6749 section 4.1.3, and a normalization applied on one side and not
+// the other would break that comparison.
+func validateLoopbackRedirect(raw string) (string, error) {
+	if raw == "" {
+		return "", errRedirectMissing
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return "", errRedirectMalformed
+	}
+	// http, not https: RFC 8252 section 7.3 has the loopback interface serve
+	// plaintext, and the app could not present a certificate for 127.0.0.1
+	// anyway. The redirect never leaves the machine.
+	if u.Scheme != "http" {
+		return "", errRedirectNotHTTP
+	}
+	if u.User != nil {
+		return "", errRedirectHasUser
+	}
+	if host := u.Hostname(); host != "127.0.0.1" && host != "::1" {
+		return "", errRedirectNotLoopback
+	}
+	// url.Parse already rejects a non-numeric port, so any port that parsed
+	// here is acceptable per section 7.3.
+	if u.RawQuery != "" || u.ForceQuery {
+		return "", errRedirectHasQuery
+	}
+	if u.Fragment != "" {
+		return "", errRedirectHasFragment
+	}
+	return raw, nil
+}
+
+// validState reports whether state is one this endpoint can echo back.
+func validState(state string) bool {
+	return state != "" && len(state) <= maxStateLen
+}
+
+// validS256Challenge reports whether challenge is a well-formed S256 PKCE
+// challenge: base64url, unpadded, of exactly one SHA-256 digest (RFC 7636
+// section 4.2). Checking the shape here means a client that sent something
+// else finds out at the authorization request rather than at the exchange,
+// where every failure is deliberately indistinguishable.
+func validS256Challenge(challenge string) bool {
+	raw, err := base64.RawURLEncoding.DecodeString(challenge)
+	return err == nil && len(raw) == sha256.Size
+}
+
+// challengeFor returns the S256 challenge a verifier produces, in the same
+// encoding validS256Challenge accepts, so the exchange compares like with
+// like.
+func challengeFor(verifier string) string {
+	sum := sha256.Sum256([]byte(verifier))
+	return base64.RawURLEncoding.EncodeToString(sum[:])
+}

--- a/controlplane/internal/desktopauth/store.go
+++ b/controlplane/internal/desktopauth/store.go
@@ -1,0 +1,175 @@
+package desktopauth
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/subtle"
+	"database/sql"
+	"encoding/base64"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// authCodeBytes is the entropy of an authorization code before base64url
+// encoding: 32 bytes is 256 bits, the same as a device code and a refresh
+// token, so the code itself is not guessable and the exchange's rate limit is
+// about load rather than brute force.
+const authCodeBytes = 32
+
+// errInvalidCode is every reason an exchange can fail: no such code, expired,
+// already redeemed, wrong redirect URI, wrong verifier. They are one error on
+// purpose, so the endpoint above cannot accidentally tell them apart. See
+// handleToken.
+var errInvalidCode = errors.New("authorization code is not valid")
+
+// newAuthCode returns a fresh authorization code, the bearer secret that
+// travels back through the browser to the app's loopback listener.
+func newAuthCode() (string, error) {
+	buf := make([]byte, authCodeBytes)
+	if _, err := rand.Read(buf); err != nil {
+		return "", fmt.Errorf("generate authorization code: %w", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(buf), nil
+}
+
+// hashCode is how a code is stored and looked up. The plaintext is never
+// written to the database, so a leak of controlplane.db hands over no live
+// codes, and the lookup compares a fixed-width digest rather than the secret.
+func hashCode(plaintext string) string {
+	sum := sha256.Sum256([]byte(plaintext))
+	return hex.EncodeToString(sum[:])
+}
+
+// createCode issues an authorization code bound to accountID, redirectURI, and
+// challenge, and returns the plaintext. Only the hash is stored, so the
+// returned value cannot be recovered afterwards.
+func (s *Service) createCode(ctx context.Context, accountID, redirectURI, challenge string, now time.Time) (string, error) {
+	code, err := newAuthCode()
+	if err != nil {
+		return "", err
+	}
+
+	s.sweepExpired(ctx, now)
+
+	if _, err := s.db.ExecContext(ctx,
+		`INSERT INTO desktop_auth_codes
+		   (code_hash, account_id, redirect_uri, code_challenge, created_at, expires_at)
+		 VALUES (?, ?, ?, ?, ?, ?)`,
+		hashCode(code), accountID, redirectURI, challenge, now, now.Add(authCodeTTL),
+	); err != nil {
+		return "", fmt.Errorf("insert authorization code: %w", err)
+	}
+	return code, nil
+}
+
+// sweepExpired deletes codes that are past their expiry. It runs on the issue
+// path because that is where the table grows, and one DELETE over an indexed
+// comparison is cheaper than the row it is about to insert. An expired row
+// carries nothing: redeem rejects one regardless, so deleting it changes no
+// answer this service gives. A failure is logged and swallowed, because a
+// sweep that did not run must not fail the sign-in that triggered it.
+func (s *Service) sweepExpired(ctx context.Context, now time.Time) {
+	if _, err := s.db.ExecContext(ctx, `DELETE FROM desktop_auth_codes WHERE expires_at < ?`, now); err != nil {
+		log.Printf("desktopauth: sweep expired authorization codes: %v", err)
+	}
+}
+
+// redeemed is what a successful exchange yields: the account the code was
+// bound to, and the refresh token issued for it.
+type redeemed struct {
+	AccountID    string
+	Email        string
+	RefreshToken string
+}
+
+// redeem verifies a presented code against everything it was bound to,
+// consumes it, and issues the refresh token, all in one transaction.
+//
+// The consume and the issue commit together or not at all, which is the whole
+// point: two requests presenting the same code both open an immediate write
+// transaction (see the _txlock=immediate reasoning in storage/sqlite), so they
+// serialize, the first deletes the row and inserts a refresh token, and the
+// second finds nothing and mints none. A crash between the two leaves the code
+// intact rather than spent, which is recoverable; the reverse would not be.
+//
+// A failed verifier or redirect URI does not consume the code. The code alone
+// is useless without the verifier, so burning it on a bad attempt would only
+// give anyone who intercepted the code a way to deny the real client its
+// sign-in.
+//
+// Every failure returns errInvalidCode, including an unknown code. The caller
+// must not be able to learn which of the checks it failed.
+func (s *Service) redeem(ctx context.Context, code, verifier, redirectURI string, now time.Time) (redeemed, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return redeemed{}, fmt.Errorf("begin redemption tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	var (
+		accountID       string
+		storedRedirect  string
+		storedChallenge string
+		expiresAt       time.Time
+	)
+	hash := hashCode(code)
+	err = tx.QueryRowContext(ctx,
+		`SELECT account_id, redirect_uri, code_challenge, expires_at
+		   FROM desktop_auth_codes WHERE code_hash = ?`, hash,
+	).Scan(&accountID, &storedRedirect, &storedChallenge, &expiresAt)
+	if errors.Is(err, sql.ErrNoRows) {
+		return redeemed{}, errInvalidCode
+	}
+	if err != nil {
+		return redeemed{}, fmt.Errorf("look up authorization code: %w", err)
+	}
+
+	if !now.Before(expiresAt) {
+		return redeemed{}, errInvalidCode
+	}
+	// Simple string comparison, per RFC 6749 section 4.1.3: the value the app
+	// sends here must be the one it asked with, byte for byte.
+	if subtle.ConstantTimeCompare([]byte(storedRedirect), []byte(redirectURI)) != 1 {
+		return redeemed{}, errInvalidCode
+	}
+	// RFC 7636 section 4.6. Constant time because the comparison is cheap and
+	// the alternative is reasoning about whether a challenge is secret enough
+	// for an early exit to be harmless.
+	if subtle.ConstantTimeCompare([]byte(storedChallenge), []byte(challengeFor(verifier))) != 1 {
+		return redeemed{}, errInvalidCode
+	}
+
+	res, err := tx.ExecContext(ctx, `DELETE FROM desktop_auth_codes WHERE code_hash = ?`, hash)
+	if err != nil {
+		return redeemed{}, fmt.Errorf("consume authorization code: %w", err)
+	}
+	// Belt to the transaction's braces: if the row is gone by now, someone else
+	// redeemed it and this request must mint nothing.
+	if n, _ := res.RowsAffected(); n != 1 {
+		return redeemed{}, errInvalidCode
+	}
+
+	var email string
+	if err := tx.QueryRowContext(ctx, `SELECT email FROM accounts WHERE id = ?`, accountID).Scan(&email); err != nil {
+		return redeemed{}, fmt.Errorf("look up account for authorization code: %w", err)
+	}
+
+	// The contract carries no install identifier through the login exchange, so
+	// each completed sign-in is its own install: a fresh id here means revoking
+	// one desktop's refresh token chain never touches another's.
+	refreshToken, err := s.issuer.IssueRefreshTokenTx(ctx, tx, accountID, uuid.NewString())
+	if err != nil {
+		return redeemed{}, fmt.Errorf("issue refresh token: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return redeemed{}, fmt.Errorf("commit redemption: %w", err)
+	}
+	return redeemed{AccountID: accountID, Email: email, RefreshToken: refreshToken}, nil
+}

--- a/controlplane/internal/desktopauth/token_test.go
+++ b/controlplane/internal/desktopauth/token_test.go
@@ -1,0 +1,465 @@
+package desktopauth
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// tokenForm is a complete, valid exchange for code, which each test then
+// breaks in exactly one place.
+func tokenForm(code string) url.Values {
+	return url.Values{
+		"grant_type":    {authorizationCodeGrantType},
+		"client_id":     {desktopClientID},
+		"code":          {code},
+		"code_verifier": {testVerifier},
+		"redirect_uri":  {testRedirectURI},
+	}
+}
+
+// exchange posts a token request and returns the raw recorder.
+func (h *harness) exchange(form url.Values) *httptest.ResponseRecorder {
+	h.t.Helper()
+
+	req := httptest.NewRequest(http.MethodPost, "/oauth/desktop/token", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec := httptest.NewRecorder()
+	h.mux.ServeHTTP(rec, req)
+	return rec
+}
+
+// exchangeOK posts a token request and requires a 200, returning the decoded
+// body.
+func (h *harness) exchangeOK(form url.Values) tokenResponse {
+	h.t.Helper()
+
+	rec := h.exchange(form)
+	if rec.Code != http.StatusOK {
+		h.t.Fatalf("POST token status = %d, want 200, body: %s", rec.Code, rec.Body)
+	}
+	var resp tokenResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		h.t.Fatalf("decode token response: %v", err)
+	}
+	return resp
+}
+
+// rejects requires the exchange to fail with the collapsed invalid_grant, and
+// returns the description so a caller can check every failure shares one.
+func (h *harness) rejects(form url.Values) string {
+	h.t.Helper()
+
+	rec := h.exchange(form)
+	if rec.Code != http.StatusBadRequest {
+		h.t.Fatalf("status = %d, want 400, body: %s", rec.Code, rec.Body)
+	}
+	var body oauthError
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		h.t.Fatalf("decode error body: %v", err)
+	}
+	if body.Error != "invalid_grant" {
+		h.t.Errorf("error = %q, want invalid_grant", body.Error)
+	}
+	return body.ErrorDescription
+}
+
+// refreshTokenCount is how many refresh tokens exist. The number that matters
+// after a replay is one.
+func (h *harness) refreshTokenCount() int {
+	h.t.Helper()
+
+	var n int
+	if err := h.db.QueryRow(`SELECT COUNT(*) FROM refresh_tokens`).Scan(&n); err != nil {
+		h.t.Fatalf("count refresh tokens: %v", err)
+	}
+	return n
+}
+
+func TestToken_ExchangesTheCodeForTheAccountAndARefreshToken(t *testing.T) {
+	h := newHarness(t)
+
+	resp := h.exchangeOK(tokenForm(h.codeFrom(authorizeQuery())))
+
+	if resp.Account.ID != accountA {
+		t.Errorf("account.id = %q, want %q", resp.Account.ID, accountA)
+	}
+	if resp.Account.Email != emailA {
+		t.Errorf("account.email = %q, want %q", resp.Account.Email, emailA)
+	}
+	if resp.RefreshToken == "" {
+		t.Fatal("no refresh token in the response")
+	}
+	if n := h.refreshTokenCount(); n != 1 {
+		t.Errorf("refresh token rows = %d, want 1", n)
+	}
+	// The contract is explicit: login yields identity plus the refresh token
+	// and nothing else. Every access token comes from POST /api/v1/token.
+	if body := h.exchangeBody(t); strings.Contains(body, "access_token") {
+		t.Errorf("the exchange returned an access token: %s", body)
+	}
+}
+
+// exchangeBody runs one more exchange and returns its raw body, so a test can
+// assert on fields the response struct does not have.
+func (h *harness) exchangeBody(t *testing.T) string {
+	t.Helper()
+
+	rec := h.exchange(tokenForm(h.codeFrom(authorizeQuery())))
+	return rec.Body.String()
+}
+
+// The refresh token is a bearer credential for ninety days. Only its hash may
+// reach disk, and the response must not be cached.
+func TestToken_StoresOnlyTheHashOfTheRefreshToken(t *testing.T) {
+	h := newHarness(t)
+
+	resp := h.exchangeOK(tokenForm(h.codeFrom(authorizeQuery())))
+
+	var stored string
+	if err := h.db.QueryRow(`SELECT token_hash FROM refresh_tokens`).Scan(&stored); err != nil {
+		t.Fatalf("read refresh token row: %v", err)
+	}
+	if stored == resp.RefreshToken {
+		t.Error("the plaintext refresh token was stored")
+	}
+}
+
+func TestToken_ResponseIsNotCacheable(t *testing.T) {
+	h := newHarness(t)
+
+	rec := h.exchange(tokenForm(h.codeFrom(authorizeQuery())))
+	if got := rec.Header().Get("Cache-Control"); got != "no-store" {
+		t.Errorf("Cache-Control = %q, want no-store", got)
+	}
+}
+
+// A replayed code must mint nothing. The code is consumed in the same
+// transaction that issues the refresh token, so the second attempt finds no
+// row and there is still exactly one refresh token.
+func TestToken_ARepliedCodeMintsNothing(t *testing.T) {
+	h := newHarness(t)
+	form := tokenForm(h.codeFrom(authorizeQuery()))
+
+	first := h.exchangeOK(form)
+	h.rejects(form)
+
+	if n := h.refreshTokenCount(); n != 1 {
+		t.Errorf("refresh token rows after a replay = %d, want 1", n)
+	}
+	if n := h.codeCount(); n != 0 {
+		t.Errorf("authorization codes after redemption = %d, want 0", n)
+	}
+	// And the one row that survives is the token the first exchange handed
+	// out, not a second one the replay slipped in: it still rotates.
+	if _, _, _, err := h.svc.issuer.RotateRefreshToken(context.Background(), first.RefreshToken); err != nil {
+		t.Errorf("the refresh token from the first exchange no longer works: %v", err)
+	}
+}
+
+// The same replay, raced. Whatever the interleaving, one caller wins and one
+// refresh token exists.
+func TestToken_ConcurrentRedemptionsOfOneCodeMintOneRefreshToken(t *testing.T) {
+	h := newHarness(t)
+	form := tokenForm(h.codeFrom(authorizeQuery()))
+
+	const attempts = 4
+	var (
+		wg    sync.WaitGroup
+		mu    sync.Mutex
+		codes []int
+	)
+	for range attempts {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			rec := h.exchange(form)
+			mu.Lock()
+			codes = append(codes, rec.Code)
+			mu.Unlock()
+		}()
+	}
+	wg.Wait()
+
+	won := 0
+	for _, c := range codes {
+		switch c {
+		case http.StatusOK:
+			won++
+		case http.StatusBadRequest:
+		default:
+			t.Errorf("unexpected status %d, want 200 or 400", c)
+		}
+	}
+	if won != 1 {
+		t.Errorf("%d of %d concurrent redemptions succeeded, want exactly 1", won, attempts)
+	}
+	if n := h.refreshTokenCount(); n != 1 {
+		t.Errorf("refresh token rows = %d, want 1", n)
+	}
+}
+
+// Every way the exchange can fail is one invalid_grant with one description.
+// An unknown code, an expired one, a replayed one, a mismatched redirect URI,
+// and a wrong verifier must be indistinguishable, or this endpoint is an
+// oracle for whoever holds a stolen code.
+func TestToken_EveryFailureIsTheSameInvalidGrant(t *testing.T) {
+	descriptions := map[string]string{}
+
+	cases := []struct {
+		name string
+		form func(h *harness) url.Values
+	}{
+		{"an unknown code", func(h *harness) url.Values {
+			return tokenForm("nosuchcodenosuchcodenosuchcodenosuchcode")
+		}},
+		{"a wrong verifier", func(h *harness) url.Values {
+			f := tokenForm(h.codeFrom(authorizeQuery()))
+			f.Set("code_verifier", wrongVerifier)
+			return f
+		}},
+		{"a redirect URI that is not the one the code was issued for", func(h *harness) url.Values {
+			f := tokenForm(h.codeFrom(authorizeQuery()))
+			f.Set("redirect_uri", "http://127.0.0.1:54322/callback")
+			return f
+		}},
+		{"the same redirect URI spelled differently", func(h *harness) url.Values {
+			f := tokenForm(h.codeFrom(authorizeQuery()))
+			f.Set("redirect_uri", testRedirectURI+"/")
+			return f
+		}},
+		{"a replayed code", func(h *harness) url.Values {
+			f := tokenForm(h.codeFrom(authorizeQuery()))
+			h.exchangeOK(f)
+			return f
+		}},
+		{"an expired code", func(h *harness) url.Values {
+			return tokenForm(h.expiredCode())
+		}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newHarness(t)
+			// After the setup, not before: the replayed-code case spends a code
+			// legitimately on its way to arranging the replay.
+			form := tc.form(h)
+			before := h.refreshTokenCount()
+
+			descriptions[tc.name] = h.rejects(form)
+
+			if got := h.refreshTokenCount(); got != before {
+				t.Errorf("a rejected exchange minted %d refresh tokens", got-before)
+			}
+		})
+	}
+
+	var seen string
+	for name, descr := range descriptions {
+		if seen == "" {
+			seen = descr
+			continue
+		}
+		if descr != seen {
+			t.Errorf("%s answered %q, want the same description as every other failure, %q", name, descr, seen)
+		}
+	}
+}
+
+// A bad verifier or redirect URI must not consume the code: the code alone is
+// useless without the verifier, so burning it on a failed attempt would only
+// let anyone who intercepted it deny the real app its sign-in.
+func TestToken_AFailedAttemptDoesNotBurnTheCode(t *testing.T) {
+	h := newHarness(t)
+	form := tokenForm(h.codeFrom(authorizeQuery()))
+
+	wrong := tokenForm(form.Get("code"))
+	wrong.Set("code_verifier", wrongVerifier)
+	h.rejects(wrong)
+
+	if n := h.codeCount(); n != 1 {
+		t.Fatalf("authorization codes after a failed attempt = %d, want 1", n)
+	}
+	if resp := h.exchangeOK(form); resp.RefreshToken == "" {
+		t.Error("the real exchange did not complete after a failed attempt")
+	}
+}
+
+// An expired code is refused even before the sweep has removed its row.
+func TestToken_RefusesAnExpiredCode(t *testing.T) {
+	h := newHarness(t)
+
+	h.rejects(tokenForm(h.expiredCode()))
+
+	if n := h.refreshTokenCount(); n != 0 {
+		t.Errorf("an expired code minted %d refresh tokens, want 0", n)
+	}
+}
+
+// expiredCode issues a code whose whole lifetime is already in the past.
+func (h *harness) expiredCode() string {
+	h.t.Helper()
+
+	past := time.Now().UTC().Add(-authCodeTTL - time.Minute)
+	code, err := h.svc.createCode(context.Background(), accountA, testRedirectURI, challengeFor(testVerifier), past)
+	if err != nil {
+		h.t.Fatalf("create expired code: %v", err)
+	}
+	return code
+}
+
+func TestToken_SweepsExpiredCodes(t *testing.T) {
+	h := newHarness(t)
+	h.expiredCode()
+
+	if n := h.codeCount(); n != 1 {
+		t.Fatalf("expired codes before a sweep = %d, want 1", n)
+	}
+	// Issuing the next code sweeps.
+	h.codeFrom(authorizeQuery())
+
+	if n := h.codeCount(); n != 1 {
+		t.Errorf("codes after the sweep = %d, want only the fresh one", n)
+	}
+}
+
+// A malformed request is told what is wrong, because none of it depends on a
+// credential. Only the exchange itself collapses.
+func TestToken_RejectsAMalformedRequest(t *testing.T) {
+	cases := []struct {
+		name   string
+		mutate func(url.Values)
+		want   string
+	}{
+		{"a missing grant type", func(f url.Values) { f.Del("grant_type") }, "unsupported_grant_type"},
+		{"the wrong grant type", func(f url.Values) { f.Set("grant_type", "refresh_token") }, "unsupported_grant_type"},
+		{"an unknown client", func(f url.Values) { f.Set("client_id", "not-ao-desktop") }, "invalid_client"},
+		{"a missing client", func(f url.Values) { f.Del("client_id") }, "invalid_client"},
+		{"a missing code", func(f url.Values) { f.Del("code") }, "invalid_request"},
+		{"a missing verifier", func(f url.Values) { f.Del("code_verifier") }, "invalid_request"},
+		{"a missing redirect URI", func(f url.Values) { f.Del("redirect_uri") }, "invalid_request"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newHarness(t)
+			form := tokenForm(h.codeFrom(authorizeQuery()))
+			tc.mutate(form)
+
+			rec := h.exchange(form)
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want 400, body: %s", rec.Code, rec.Body)
+			}
+			var body oauthError
+			if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+				t.Fatalf("decode error body: %v", err)
+			}
+			if body.Error != tc.want {
+				t.Errorf("error = %q, want %q", body.Error, tc.want)
+			}
+			// Nothing that failed validation may have touched the code.
+			if n := h.codeCount(); n != 1 {
+				t.Errorf("authorization codes = %d, want the unspent one", n)
+			}
+		})
+	}
+}
+
+// A code issued for one account never yields another account's refresh token:
+// the identity comes from the stored row, and the token request carries no
+// account at all.
+func TestToken_BindsTheRefreshTokenToTheCodesOwnAccount(t *testing.T) {
+	h := newHarness(t)
+
+	resp := h.exchangeOK(tokenForm(h.codeFrom(authorizeQuery())))
+
+	var account string
+	if err := h.db.QueryRow(`SELECT account_id FROM refresh_tokens`).Scan(&account); err != nil {
+		t.Fatalf("read refresh token row: %v", err)
+	}
+	if account != accountA {
+		t.Errorf("refresh token account = %q, want %q", account, accountA)
+	}
+	if resp.Account.ID != account {
+		t.Errorf("response account %q does not match the token's account %q", resp.Account.ID, account)
+	}
+}
+
+func TestToken_RateLimitsTheEndpoint(t *testing.T) {
+	h := newHarness(t)
+
+	// Unknown codes, so nothing is spent: this measures the limiter, not the
+	// exchange.
+	form := tokenForm("nosuchcodenosuchcodenosuchcodenosuchcode")
+	limited := false
+	for range tokenAttemptsPerWindow + 1 {
+		if h.exchange(form).Code == http.StatusTooManyRequests {
+			limited = true
+		}
+	}
+	if !limited {
+		t.Errorf("no request was limited within %d attempts", tokenAttemptsPerWindow+1)
+	}
+}
+
+// Behind the loopback reverse proxy this service runs under, every RemoteAddr
+// is the proxy, so one caller must not be able to spend everybody's allowance.
+// Caddy appends the address it saw, so the last hop is the one entry a client
+// cannot forge.
+func TestClientKey(t *testing.T) {
+	tests := []struct {
+		name       string
+		remoteAddr string
+		forwarded  string
+		want       string
+	}{
+		{"a direct caller", "198.51.100.7:4021", "", "198.51.100.7"},
+		{"a direct caller cannot forge a hop", "198.51.100.7:4021", "203.0.113.9", "198.51.100.7"},
+		{"behind the local proxy", "127.0.0.1:8080", "203.0.113.9", "203.0.113.9"},
+		{"the client's spoofed hops are ignored", "127.0.0.1:8080", "1.2.3.4, 5.6.7.8, 203.0.113.9", "203.0.113.9"},
+		{"the proxy sent no header", "127.0.0.1:8080", "", "127.0.0.1"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, "/oauth/desktop/token", nil)
+			req.RemoteAddr = tt.remoteAddr
+			if tt.forwarded != "" {
+				req.Header.Set("X-Forwarded-For", tt.forwarded)
+			}
+			if got := clientKey(req); got != tt.want {
+				t.Errorf("clientKey() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestWindowLimiter_ResetsOnTheNextWindow(t *testing.T) {
+	now := time.Now()
+	l := newWindowLimiter()
+	l.clock = func() time.Time { return now }
+
+	for i := range tokenAttemptsPerWindow {
+		if !l.allow("a") {
+			t.Fatalf("attempt %d refused inside the allowance", i+1)
+		}
+	}
+	if l.allow("a") {
+		t.Error("the attempt past the allowance was permitted")
+	}
+	// A different caller has its own allowance.
+	if !l.allow("b") {
+		t.Error("a second caller was refused on the first caller's count")
+	}
+
+	now = now.Add(tokenWindow)
+	if !l.allow("a") {
+		t.Error("the allowance did not reset on the next window")
+	}
+}

--- a/controlplane/internal/storage/sqlite/migrate_test.go
+++ b/controlplane/internal/storage/sqlite/migrate_test.go
@@ -7,8 +7,8 @@ import (
 )
 
 // TestOpen_CreatesAllTables is the runnable check for the schema: it fails if
-// a future migration change breaks one of the four tables the control plane
-// depends on.
+// a future migration change breaks one of the tables the control plane depends
+// on.
 func TestOpen_CreatesAllTables(t *testing.T) {
 	db, err := Open(t.TempDir())
 	if err != nil {
@@ -16,7 +16,7 @@ func TestOpen_CreatesAllTables(t *testing.T) {
 	}
 	defer db.Close()
 
-	for _, table := range []string{"accounts", "machines", "device_codes", "refresh_tokens"} {
+	for _, table := range []string{"accounts", "machines", "device_codes", "refresh_tokens", "desktop_auth_codes"} {
 		var count int
 		if err := db.QueryRow("SELECT count(*) FROM " + table).Scan(&count); err != nil {
 			t.Errorf("querying table %q: %v", table, err)

--- a/controlplane/internal/storage/sqlite/migrations/0003_desktop_auth_codes.sql
+++ b/controlplane/internal/storage/sqlite/migrations/0003_desktop_auth_codes.sql
@@ -1,0 +1,34 @@
+-- +goose Up
+-- +goose StatementBegin
+
+-- desktop_auth_codes backs the desktop app's authorization-code exchange
+-- (docs/desktop-login-contract.md). One row is one code in flight, and it is
+-- deleted the moment it is redeemed, in the same transaction that inserts the
+-- refresh token it yields, so a replayed code finds nothing and mints nothing.
+--
+-- code_hash is the SHA-256 of the opaque code, never the code itself: it is a
+-- bearer secret for the seconds between the loopback redirect and the token
+-- request, so a database leak must not hand over live codes, and the lookup is
+-- a fixed-width comparison. This mirrors device_codes.device_code.
+--
+-- redirect_uri and code_challenge are stored because the token endpoint has to
+-- prove the caller is the same client that asked: the exchange re-checks the
+-- redirect URI byte-for-byte and the PKCE verifier against this challenge, and
+-- account_id is the identity the code is bound to. All three are fixed at
+-- authorization time and none of them are taken from the token request.
+CREATE TABLE desktop_auth_codes (
+    code_hash      TEXT PRIMARY KEY,
+    account_id     TEXT NOT NULL REFERENCES accounts (id),
+    redirect_uri   TEXT NOT NULL,
+    code_challenge TEXT NOT NULL,
+    created_at     TIMESTAMP NOT NULL,
+    expires_at     TIMESTAMP NOT NULL
+);
+CREATE INDEX idx_desktop_auth_codes_expires ON desktop_auth_codes (expires_at);
+
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP TABLE desktop_auth_codes;
+-- +goose StatementEnd

--- a/controlplane/internal/tokens/refresh.go
+++ b/controlplane/internal/tokens/refresh.go
@@ -37,17 +37,38 @@ var (
 	ErrRefreshTokenExpired = errors.New("refresh token expired")
 )
 
+// execer is the write half shared by *sql.DB and *sql.Tx, so one insert
+// serves both the standalone issue path and a caller's transaction.
+type execer interface {
+	ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error)
+}
+
 // IssueRefreshToken mints a new opaque refresh token bound to accountID and
 // installID, stores only its hash in refresh_tokens, and returns the
 // plaintext token. The plaintext is never stored and cannot be recovered
 // once returned.
 func (i *Issuer) IssueRefreshToken(ctx context.Context, accountID, installID string) (string, error) {
+	return issueRefreshToken(ctx, i.db, accountID, installID)
+}
+
+// IssueRefreshTokenTx is IssueRefreshToken inside a transaction the caller
+// already owns, so consuming a one-time credential and issuing the refresh
+// token it yields commit together or not at all.
+//
+// The desktop login exchange needs exactly that: it deletes the authorization
+// code and inserts this row in one commit, so a replay of the same code cannot
+// mint a second refresh token no matter how the two requests interleave.
+func (i *Issuer) IssueRefreshTokenTx(ctx context.Context, tx *sql.Tx, accountID, installID string) (string, error) {
+	return issueRefreshToken(ctx, tx, accountID, installID)
+}
+
+func issueRefreshToken(ctx context.Context, db execer, accountID, installID string) (string, error) {
 	plaintext, err := randomToken()
 	if err != nil {
 		return "", err
 	}
 	now := time.Now().UTC()
-	_, err = i.db.ExecContext(ctx,
+	_, err = db.ExecContext(ctx,
 		`INSERT INTO refresh_tokens (id, account_id, install_id, token_hash, created_at, expires_at)
 		 VALUES (?, ?, ?, ?, ?, ?)`,
 		uuid.NewString(), accountID, installID, hashToken(plaintext), now, now.Add(DefaultRefreshTokenTTL),


### PR DESCRIPTION
Closes #55.

The deployed control plane registers only `/login`, `/auth/google/login`, and
`/auth/google/callback`. The desktop opens `GET /oauth/desktop/authorize` and gets a
404, so **desktop sign-in does not work at all against a real deployment**. The desktop
half was built against `docs/desktop-login-contract.md` and said so; this is the control
plane half of that same contract, implemented as written and not redesigned.

## What this adds

`controlplane/internal/desktopauth`, registered with one call from `main.go`.

- **`GET /oauth/desktop/authorize`** validates the `ao-desktop` client, an RFC 8252
  loopback redirect URI, S256 PKCE, and `state`; sends a signed-out browser through
  `internal/auth`'s existing Google flow with `?next=` pointing back here; then redirects
  to the loopback listener with a one-time `code` and the `state` unmodified.
- **`POST /oauth/desktop/token`** verifies the code, the verifier, and the redirect URI,
  consumes the code, and returns the account plus a new opaque refresh token. No access
  token, per the contract: every access token comes from `POST /api/v1/token`.

It reuses the auth package from #12 rather than standing up a parallel OAuth stack: same
Google login, same session cookie, same `accounts` rows, same `api.ReadParams` /
`api.WriteError` conventions, same `tokens.Issuer`.

## Security

This is the only public, unauthenticated entry point that ends in a ninety-day
credential, so three properties carry it.

- **The redirect target is proven loopback before it is used for anything**, including to
  report an error. `127.0.0.1` and `[::1]` on any port per RFC 8252 section 7.3, and
  nothing else: not `localhost` (a name, whose resolution is not this service's decision,
  section 8.3), not any other host, not `https`, not a URI carrying userinfo, a query, or
  a fragment. A refused redirect URI, an unknown `client_id`, and a missing `state` are
  shown to the operator in the browser rather than redirected anywhere, which is RFC 6749
  section 4.1.2.1 and is what keeps this from being an open redirect that hands out
  accounts.
- **The code is bound at issue to the PKCE challenge, the redirect URI, and the account**,
  and the exchange re-checks all three against the stored row, never against the token
  request. The redirect URI is compared byte for byte per RFC 6749 section 4.1.3.
- **The code is deleted in the same transaction that inserts the refresh token**, so no
  interleaving of a replay mints a second one. `tokens` gains `IssueRefreshTokenTx` for
  that, mirroring `RotateRefreshToken`, and the `_txlock=immediate` reasoning from #45
  applies unchanged: the losing side of a race waits and then reads committed state.

Also: every exchange failure is one `invalid_grant` with one description, the way
`api.handleToken` collapses its three; codes are 256 bits from a CSPRNG, stored only as a
SHA-256 hash and swept on the issue path; nothing logs a code, a verifier, or a token; the
token endpoint is rate limited per caller, resolving the real client behind the loopback
reverse proxy from the **last** `X-Forwarded-For` hop, which is the one entry in that
header a client cannot forge when exactly one trusted proxy appends to it.

One residual risk is documented in `handleAuthorize` rather than fixed: a browser that
already holds a session completes the flow with no interaction, so any local process that
can open a URL can run its own authorization request and receive a code on its own
loopback port. RFC 8252 section 8.10 treats that as inherent to native app loopback flows,
PKCE does not help because such a caller picks its own verifier, and adding a confirmation
step would change the contract the desktop is already built against.

## Tests

`controlplane/internal/desktopauth`, weighted to the rejection paths.

Authorize: 20 refused redirect URIs (remote host, `localhost`, `0.0.0.0`, a host that
merely starts with `127.0.0.1`, userinfo smuggling, a backslash authority, `https`, a
non-`http` scheme, a query, a fragment, a scheme-relative reference, a relative path, a
newline that would otherwise reach a `Location` header, a NUL, an unparseable port, empty)
each asserted to produce a 400 with **no `Location` header at all** and no code issued;
four accepted loopback ports including `[::1]`; unknown client; missing and empty `state`;
seven malformed requests redirected back to the app with the right OAuth error **and** the
state; a state full of URL-significant characters echoed byte for byte; the signed-out
round trip asserted to preserve every parameter through `?next=`; only the hash stored.

Token: replayed code (mints nothing, one refresh token survives and still rotates);
**four concurrent redemptions of one code under `-race`, exactly one winning**; expired
code; wrong verifier; mismatched redirect URI; the same redirect URI spelled differently;
unknown code; all six asserted to share one identical `error_description`; a failed
attempt asserted not to burn the code; seven malformed requests; the rate limiter and its
window reset; `clientKey` against forged and genuine `X-Forwarded-For`.

## Verified

- `gofmt -l .` clean, `go vet ./...` clean, `go test -race ./...` green (182 tests).
- The real binary: routes registered, signed-out authorize 302s to `/auth/google/login`
  with the full request in `?next=`, a remote redirect URI 400s with no `Location`, an
  unknown code answers `invalid_grant`, and the server log contains no secret.
- The `?next=` round trip through the auth package end to end: the signed `ao_oauth_flow`
  cookie carries the authorize URL back verbatim, so the browser returns here with every
  parameter intact after Google.

## Scope

`controlplane/` only. `main.go` gains one import and one `Register` call, `server.go` is
untouched, and everything else is the new package, one migration, one `tokens` helper, one
line in `migrate_test.go`, and a README section. `docs/desktop-login-contract.md` is
unchanged: nothing in it turned out to be wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)