### PR TITLE
feat(desktop): clone a project from a Git URL

### DIFF
--- a/frontend/e2e/clone-url.spec.ts
+++ b/frontend/e2e/clone-url.spec.ts
@@ -1,0 +1,112 @@
+import { expect, test, type Page } from "@playwright/test";
+import { installFakeBridge } from "./support/fake-bridge";
+
+// CLONE-* RENDERER SMOKE (renderer slice, issue #59).
+//
+// Scope: `dev:web` + fake bridge, with the daemon's two REST answers stubbed at
+// the network. Unlike the vitest coverage of the same flow, this drives the
+// real generated API client, so it locks the wire shape the clone step sends
+// (`cloneUrl`, never `path`) and the remediation the daemon's error envelope
+// turns into on screen. It does NOT exercise a real clone: that boundary is the
+// daemon's, covered by backend tests.
+
+const AGENT_CATALOG = {
+	supported: [{ id: "claude-code", label: "Claude Code" }],
+	installed: [{ id: "claude-code", label: "Claude Code", authStatus: "authorized" }],
+	authorized: [{ id: "claude-code", label: "Claude Code", authStatus: "authorized" }],
+};
+
+const CLONE_AUTH_FAILED = {
+	error: "invalid_request",
+	code: "CLONE_AUTH_FAILED",
+	message:
+		"No git credentials on this machine. For an https:// URL, run `gh auth login`. For an SSH URL, add a deploy key or start an SSH agent, then try again.",
+	requestId: "req_clone_demo",
+};
+
+// Demo capture for `ao preview`, off in CI: waits out the modal's open
+// animation so the shot is not a half-faded frame.
+async function shot(page: Page, name: string): Promise<void> {
+	if (!process.env.AO_CLONE_SHOTS) return;
+	await page.waitForTimeout(400);
+	await page.screenshot({ path: `${process.env.AO_CLONE_SHOTS}/${name}.png` });
+}
+
+/**
+ * Answers the two daemon calls the clone step makes, captures the create body,
+ * and can hold the create call open the way a real clone does.
+ */
+async function stubDaemon(page: Page, cloneMs = 0): Promise<{ body: () => unknown }> {
+	let createBody: unknown = null;
+	await page.route("**/api/v1/agents", (route) =>
+		route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(AGENT_CATALOG) }),
+	);
+	await page.route("**/api/v1/projects", async (route) => {
+		if (route.request().method() !== "POST") return route.fallback();
+		createBody = route.request().postDataJSON();
+		if (cloneMs > 0) await new Promise((resolve) => setTimeout(resolve, cloneMs));
+		return route.fulfill({
+			status: 400,
+			contentType: "application/json",
+			body: JSON.stringify(CLONE_AUTH_FAILED),
+		});
+	});
+	return { body: () => createBody };
+}
+
+/** Picker → clone step → agent sheet → submit, the whole clone branch. */
+async function submitClone(page: Page, url: string): Promise<void> {
+	await page.getByRole("button", { name: "New project" }).click();
+	await page.getByRole("button", { name: "Clone from a Git URL" }).click();
+	await page.getByRole("dialog", { name: "Clone a repository" }).getByLabel("Repository URL").fill(url);
+	await page.getByRole("button", { name: "Continue" }).click();
+	await page.getByRole("button", { name: "Clone and start" }).click();
+}
+
+test("renderer: clone by URL sends only a clone URL and surfaces the daemon's remediation @P0 @CLONE", async ({
+	page,
+}) => {
+	await installFakeBridge(page, { daemonPort: 8080 });
+	const created = await stubDaemon(page);
+	await page.goto("/");
+
+	await page.getByRole("button", { name: "New project" }).click();
+	await page.getByRole("button", { name: "Clone from a Git URL" }).click();
+
+	const cloneDialog = page.getByRole("dialog", { name: "Clone a repository" });
+	await expect(cloneDialog).toBeVisible();
+	await shot(page, "clone-field");
+
+	// A URL the daemon would reject never leaves the field.
+	await cloneDialog.getByLabel("Repository URL").fill("github.com/agentlab-in");
+	await expect(cloneDialog.getByRole("button", { name: "Continue" })).toBeDisabled();
+
+	await cloneDialog.getByLabel("Repository URL").fill("https://github.com/agentlab-in/hosted-ao.git");
+	await cloneDialog.getByRole("button", { name: "Continue" }).click();
+	await page.getByRole("button", { name: "Clone and start" }).click();
+
+	const alert = page.getByRole("alert");
+	await expect(alert).toContainText("Git credentials needed on this machine");
+	await expect(alert.getByText("gh auth login")).toBeVisible();
+	await expect(cloneDialog.getByLabel("Repository URL")).toHaveValue("https://github.com/agentlab-in/hosted-ao.git");
+	await shot(page, "clone-error");
+
+	expect(created.body()).toMatchObject({ cloneUrl: "https://github.com/agentlab-in/hosted-ao.git" });
+	expect(created.body()).not.toHaveProperty("path");
+});
+
+test("renderer: a clone in flight keeps reporting itself rather than freezing @P0 @CLONE", async ({ page }) => {
+	await installFakeBridge(page, { daemonPort: 8080 });
+	// A clone takes as long as it takes; the daemon answers only at the end.
+	await stubDaemon(page, 4000);
+	await page.goto("/");
+
+	await submitClone(page, "https://github.com/agentlab-in/hosted-ao.git");
+
+	const progress = page.getByRole("status").filter({ hasText: "Cloning agentlab-in/hosted-ao" });
+	await expect(progress).toBeVisible();
+	await expect(page.getByRole("button", { name: "Cloning..." })).toBeDisabled();
+	await shot(page, "clone-progress");
+	// The elapsed counter is the liveness signal, so it has to actually move.
+	await expect(progress).toContainText("0:02", { timeout: 4000 });
+});

--- a/frontend/src/renderer/components/CreateProjectAgentSheet.tsx
+++ b/frontend/src/renderer/components/CreateProjectAgentSheet.tsx
@@ -5,6 +5,7 @@ import { memo, useEffect, useState } from "react";
 import type { components } from "../../api/schema";
 import { agentsQueryKey, agentsQueryOptions, refreshAgents } from "../hooks/useAgentsQuery";
 import { AGENT_OPTIONS } from "../lib/agent-options";
+import { cloneUrlLabel } from "../lib/clone-url";
 import { cn } from "../lib/utils";
 import { buildIntake, type IntakeForm, IntakeFields, intakeNeedsRule } from "./IntakeFields";
 import type { ProjectKind } from "../types/workspace";
@@ -33,6 +34,10 @@ function agentLabelCompare(a: AgentInfo, b: AgentInfo): number {
 }
 
 type CreateProjectAgentSheetProps = {
+	// Set instead of `path` when the project is being cloned by URL. The daemon
+	// clones synchronously (no job model, no progress channel), so submitting
+	// can take minutes and the sheet has to keep saying so.
+	cloneUrl?: string | null;
 	error?: string | null;
 	isCreating: boolean;
 	isInitializing?: boolean;
@@ -85,6 +90,7 @@ function projectSheetError(error: string): SheetError {
 }
 
 export function CreateProjectAgentSheet({
+	cloneUrl = null,
 	error,
 	isCreating,
 	isInitializing = false,
@@ -157,7 +163,7 @@ export function CreateProjectAgentSheet({
 								{kind === "workspace" ? "Workspace agents" : "Project agents"}
 							</Dialog.Title>
 							<Dialog.Description className="mt-1 break-all text-xs text-[var(--color-text-agents-sheet-description)]">
-								{path ?? ""}
+								{path ?? cloneUrl ?? ""}
 							</Dialog.Description>
 						</div>
 						<Dialog.Close asChild>
@@ -256,6 +262,8 @@ export function CreateProjectAgentSheet({
 							/>
 						</div>
 
+						{cloneUrl !== null && isCreating && <CloneProgress url={cloneUrl} />}
+
 						{repositorySetupNeeded && (
 							<div className="rounded-lg border border-[var(--color-border-agents-sheet)] bg-[var(--color-bg-agents-sheet-control)]/80 px-3 py-2.5 text-xs leading-body-md text-[var(--color-text-agents-sheet-description)]">
 								If this folder needs Git setup, AO will initialize it and create the first commit before starting.
@@ -308,16 +316,62 @@ export function CreateProjectAgentSheet({
 								{isInitializing
 									? "Setting up..."
 									: isCreating
-										? "Creating..."
-										: kind === "workspace"
-											? "Create workspace and start"
-											: "Create and start"}
+										? cloneUrl !== null
+											? "Cloning..."
+											: "Creating..."
+										: cloneUrl !== null
+											? "Clone and start"
+											: kind === "workspace"
+												? "Create workspace and start"
+												: "Create and start"}
 							</Button>
 						</div>
 					</form>
 				</Dialog.Content>
 			</Dialog.Portal>
 		</Dialog.Root>
+	);
+}
+
+function formatElapsed(totalSeconds: number): string {
+	const minutes = Math.floor(totalSeconds / 60);
+	return `${minutes}:${String(totalSeconds % 60).padStart(2, "0")}`;
+}
+
+/**
+ * Liveness for a synchronous clone. There is no progress to report (the daemon
+ * runs `git clone` to completion and answers once), so the honest signal is an
+ * elapsed counter plus an indeterminate bar: the window is working, not hung.
+ */
+function CloneProgress({ url }: { url: string }) {
+	const [elapsedSeconds, setElapsedSeconds] = useState(0);
+	useEffect(() => {
+		const startedAt = Date.now();
+		const timer = window.setInterval(() => setElapsedSeconds(Math.floor((Date.now() - startedAt) / 1000)), 1000);
+		return () => window.clearInterval(timer);
+	}, []);
+
+	return (
+		<div
+			className="space-y-2 rounded-lg border border-[var(--color-border-agents-sheet)] bg-[var(--color-bg-agents-sheet-control)]/80 px-3 py-2.5"
+			role="status"
+			aria-live="polite"
+		>
+			<div className="flex items-center justify-between gap-3 text-xs leading-body-md">
+				<span className="min-w-0 truncate font-medium text-[var(--color-text-agents-sheet-title)]">
+					Cloning {cloneUrlLabel(url)}...
+				</span>
+				<span className="shrink-0 font-mono tabular-nums text-[var(--color-text-agents-sheet-description)]">
+					{formatElapsed(elapsedSeconds)}
+				</span>
+			</div>
+			<div className="h-1 overflow-hidden rounded-full bg-[var(--color-bg-agents-sheet)]">
+				<div className="clone-progress-bar" />
+			</div>
+			<p className="text-xs leading-body-md text-[var(--color-text-agents-sheet-description)]">
+				A large repository can take a few minutes. Keep this window open.
+			</p>
+		</div>
 	);
 }
 

--- a/frontend/src/renderer/components/CreateProjectFlow.test.tsx
+++ b/frontend/src/renderer/components/CreateProjectFlow.test.tsx
@@ -1,0 +1,149 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { agentsQueryKey } from "../hooks/useAgentsQuery";
+import { CreateProjectFlow, type CreateProjectInput } from "./CreateProjectFlow";
+
+type CreateProjectHandler = (input: CreateProjectInput) => Promise<void>;
+
+function renderFlow(onCreateProject: CreateProjectHandler) {
+	const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+	const agent = { id: "claude-code", label: "claude-code", authStatus: "authorized" };
+	queryClient.setQueryData(agentsQueryKey, { supported: [agent], installed: [agent], authorized: [agent] });
+	render(
+		<QueryClientProvider client={queryClient}>
+			<CreateProjectFlow mode="choose" onCreateProject={onCreateProject} onInitializeProject={vi.fn()}>
+				{({ choosePath }) => (
+					<button type="button" onClick={choosePath}>
+						New project
+					</button>
+				)}
+			</CreateProjectFlow>
+		</QueryClientProvider>,
+	);
+}
+
+/** Open the picker, take the clone branch, and land on the URL step. */
+async function openCloneStep(user: ReturnType<typeof userEvent.setup>) {
+	await user.click(screen.getByRole("button", { name: "New project" }));
+	await user.click(screen.getByRole("button", { name: "Clone from a Git URL" }));
+	return screen.getByRole("dialog", { name: "Clone a repository" });
+}
+
+function cloneFailure(code: string, message: string): Error & { code?: string } {
+	const failure = new Error(`${message} (${code})`) as Error & { code?: string };
+	failure.code = code;
+	return failure;
+}
+
+describe("CreateProjectFlow clone by URL", () => {
+	it("sends a clone URL and never a path alongside it", async () => {
+		const user = userEvent.setup();
+		const onCreateProject = vi.fn().mockResolvedValue(undefined) as CreateProjectHandler;
+		renderFlow(onCreateProject);
+
+		await openCloneStep(user);
+		await user.type(screen.getByLabelText("Repository URL"), "https://github.com/agentlab-in/hosted-ao.git");
+		await user.click(screen.getByRole("button", { name: "Continue" }));
+
+		await user.click(await screen.findByRole("button", { name: "Clone and start" }));
+
+		await waitFor(() => expect(onCreateProject).toHaveBeenCalledTimes(1));
+		expect(onCreateProject).toHaveBeenCalledWith({
+			cloneUrl: "https://github.com/agentlab-in/hosted-ao.git",
+			workerAgent: "claude-code",
+			orchestratorAgent: "claude-code",
+			trackerIntake: undefined,
+		});
+		expect(vi.mocked(onCreateProject).mock.calls[0][0]).not.toHaveProperty("path");
+	});
+
+	it("blocks a URL the daemon would reject, and says what a good one looks like", async () => {
+		const user = userEvent.setup();
+		const onCreateProject = vi.fn().mockResolvedValue(undefined) as CreateProjectHandler;
+		renderFlow(onCreateProject);
+
+		const dialog = await openCloneStep(user);
+		expect(within(dialog).getByRole("button", { name: "Continue" })).toBeDisabled();
+
+		await user.type(within(dialog).getByLabelText("Repository URL"), "github.com/owner");
+		await user.tab();
+
+		expect(
+			within(dialog).getByText("Use an https:// or ssh git remote URL that names an owner and a repository."),
+		).toBeInTheDocument();
+		expect(within(dialog).getByRole("button", { name: "Continue" })).toBeDisabled();
+		expect(onCreateProject).not.toHaveBeenCalled();
+	});
+
+	it("shows the daemon's auth remediation on the URL step, with the URL kept for a retry", async () => {
+		const user = userEvent.setup();
+		const onCreateProject = vi
+			.fn()
+			.mockRejectedValue(
+				cloneFailure(
+					"CLONE_AUTH_FAILED",
+					"No git credentials on this machine. For an https:// URL, run `gh auth login`. For an SSH URL, add a deploy key or start an SSH agent, then try again.",
+				),
+			) as CreateProjectHandler;
+		renderFlow(onCreateProject);
+
+		await openCloneStep(user);
+		await user.type(screen.getByLabelText("Repository URL"), "https://github.com/agentlab-in/private-repo.git");
+		await user.click(screen.getByRole("button", { name: "Continue" }));
+		await user.click(await screen.findByRole("button", { name: "Clone and start" }));
+
+		const alert = await screen.findByRole("alert");
+		expect(alert).toHaveTextContent("Git credentials needed on this machine");
+		expect(alert).toHaveTextContent("run gh auth login");
+		expect(within(alert).getByText("gh auth login").tagName).toBe("CODE");
+		// The code is not repeated raw at the user, and the URL survives for a retry.
+		expect(alert).not.toHaveTextContent("CLONE_AUTH_FAILED");
+		expect(screen.getByLabelText("Repository URL")).toHaveValue("https://github.com/agentlab-in/private-repo.git");
+	});
+
+	it("titles every clone failure code rather than falling back to the raw message", async () => {
+		const user = userEvent.setup();
+		const onCreateProject = vi
+			.fn()
+			.mockRejectedValue(
+				cloneFailure("CLONE_TIMEOUT", "Clone timed out after 5m0s. Check your network connection and try again."),
+			) as CreateProjectHandler;
+		renderFlow(onCreateProject);
+
+		await openCloneStep(user);
+		await user.type(screen.getByLabelText("Repository URL"), "https://github.com/agentlab-in/hosted-ao.git");
+		await user.click(screen.getByRole("button", { name: "Continue" }));
+		await user.click(await screen.findByRole("button", { name: "Clone and start" }));
+
+		const alert = await screen.findByRole("alert");
+		expect(alert).toHaveTextContent("Clone timed out");
+		expect(alert).toHaveTextContent("Check your network connection and try again.");
+	});
+
+	it("keeps saying the clone is running while the daemon is still cloning", async () => {
+		const user = userEvent.setup();
+		let finishClone = () => undefined as void;
+		const onCreateProject = vi.fn().mockImplementation(
+			() =>
+				new Promise<void>((resolve) => {
+					finishClone = () => resolve();
+				}),
+		) as CreateProjectHandler;
+		renderFlow(onCreateProject);
+
+		await openCloneStep(user);
+		await user.type(screen.getByLabelText("Repository URL"), "https://github.com/agentlab-in/hosted-ao.git");
+		await user.click(screen.getByRole("button", { name: "Continue" }));
+		await user.click(await screen.findByRole("button", { name: "Clone and start" }));
+
+		const progress = await screen.findByRole("status");
+		expect(progress).toHaveTextContent("Cloning agentlab-in/hosted-ao...");
+		expect(progress).toHaveTextContent("A large repository can take a few minutes.");
+		expect(screen.getByRole("button", { name: "Cloning..." })).toBeDisabled();
+
+		finishClone();
+		await waitFor(() => expect(screen.queryByRole("status")).not.toBeInTheDocument());
+	});
+});

--- a/frontend/src/renderer/components/CreateProjectFlow.tsx
+++ b/frontend/src/renderer/components/CreateProjectFlow.tsx
@@ -1,14 +1,23 @@
 import * as Dialog from "@radix-ui/react-dialog";
-import { CheckCircle2, ChevronRight, Folder, FolderPlus, X, XCircle } from "lucide-react";
+import { CheckCircle2, ChevronRight, CloudDownload, Folder, FolderPlus, TriangleAlert, X, XCircle } from "lucide-react";
 import { useEffect, useRef, useState, type ReactNode } from "react";
 import type { ImportFolderScan } from "../../preload";
 import { aoBridge } from "../lib/bridge";
+import { cloneErrorPresentation, parseCloneUrl } from "../lib/clone-url";
 import { cn } from "../lib/utils";
 import type { ProjectKind } from "../types/workspace";
 import { CreateProjectAgentSheet, type CreateProjectAgentSelection } from "./CreateProjectAgentSheet";
 import { Button } from "./ui/button";
+import { Input } from "./ui/input";
+import { Label } from "./ui/label";
 
-export type CreateProjectInput = { path: string; asWorkspace?: boolean } & CreateProjectAgentSelection;
+// A local folder and a clone URL are mutually exclusive on the daemon (it
+// answers PATH_AND_CLONE_URL_CONFLICT when both arrive). Modelling the source
+// as a union means the UI cannot express the conflict at all: the two are
+// separate branches of the flow, and nothing can send both.
+export type CreateProjectSource = { path: string; cloneUrl?: never } | { cloneUrl: string; path?: never };
+
+export type CreateProjectInput = CreateProjectSource & { asWorkspace?: boolean } & CreateProjectAgentSelection;
 
 type CreateProjectFlowMode = ProjectKind | "choose";
 
@@ -38,8 +47,16 @@ export function CreateProjectFlow({
 	openSignal?: number;
 }) {
 	const [error, setError] = useState<string | null>(null);
+	const [errorCode, setErrorCode] = useState<string | null>(null);
 	const [modePickerOpen, setModePickerOpen] = useState(false);
 	const [folderPickerOpen, setFolderPickerOpen] = useState(false);
+	const [cloneDialogOpen, setCloneDialogOpen] = useState(false);
+	// The field's text, kept across a failed clone so a retry (after `gh auth
+	// login`, say) does not start from an empty input.
+	const [cloneUrl, setCloneUrl] = useState("");
+	// Set once the URL is confirmed: the agent sheet is open and this is what
+	// gets cloned on submit.
+	const [pendingCloneUrl, setPendingCloneUrl] = useState<string | null>(null);
 	const [selectedKind, setSelectedKind] = useState<ProjectKind>(mode === "workspace" ? "workspace" : "single_repo");
 	const [selectedPath, setSelectedPath] = useState<string | null>(null);
 	const [validationScan, setValidationScan] = useState<ImportFolderScan | null>(null);
@@ -57,8 +74,27 @@ export function CreateProjectFlow({
 		void chooseDirectory(kind);
 	};
 
+	const openCloneStep = () => {
+		setError(null);
+		setErrorCode(null);
+		setValidationScan(null);
+		setRepositorySetup(null);
+		setSelectedKind("single_repo");
+		setModePickerOpen(false);
+		setCloneDialogOpen(true);
+	};
+
+	const confirmCloneUrl = (url: string) => {
+		setError(null);
+		setErrorCode(null);
+		setCloneUrl(url);
+		setCloneDialogOpen(false);
+		setPendingCloneUrl(url);
+	};
+
 	const chooseDirectory = async (kind: ProjectKind) => {
 		setError(null);
+		setErrorCode(null);
 		setValidationScan(null);
 		setRepositorySetup(null);
 		setSelectedKind(kind);
@@ -101,26 +137,43 @@ export function CreateProjectFlow({
 	}, [openSignal]);
 
 	const createProject = async (selection: CreateProjectAgentSelection) => {
-		if (!selectedPath) return;
+		const path = selectedPath;
+		const clone = pendingCloneUrl;
+		if (path === null && clone === null) return;
 		setError(null);
+		setErrorCode(null);
 		setIsCreating(true);
 		try {
-			if (selectedKind === "single_repo" && repositorySetup) {
+			if (path !== null && selectedKind === "single_repo" && repositorySetup) {
 				setIsCreating(false);
 				setIsInitializing(true);
-				await onInitializeProject(selectedPath);
+				await onInitializeProject(path);
 				setRepositorySetup(null);
 				setIsInitializing(false);
 				setIsCreating(true);
 			}
-			await onCreateProject({ path: selectedPath, asWorkspace: selectedKind === "workspace", ...selection });
-			setSelectedPath(null);
+			if (clone !== null) {
+				await onCreateProject({ cloneUrl: clone, ...selection });
+				setPendingCloneUrl(null);
+				setCloneUrl("");
+			} else if (path !== null) {
+				await onCreateProject({ path, asWorkspace: selectedKind === "workspace", ...selection });
+				setSelectedPath(null);
+			}
 		} catch (err) {
 			const code = err instanceof Error && "code" in err ? (err.code as string | undefined) : undefined;
 			const message = err instanceof Error ? err.message : "Could not add project";
-			if (selectedKind === "single_repo" && isRepositorySetupRecoveryCode(code)) setRepositorySetup(code);
 			setError(message);
-			if (hasModePicker) {
+			setErrorCode(code ?? null);
+			if (clone !== null) {
+				// Back to the URL step: every clone failure is fixed there, either
+				// by editing the URL or by fixing credentials and retrying it.
+				setPendingCloneUrl(null);
+				setCloneDialogOpen(true);
+				return;
+			}
+			if (selectedKind === "single_repo" && isRepositorySetupRecoveryCode(code)) setRepositorySetup(code);
+			if (hasModePicker && selectedPath !== null) {
 				if (shouldScanCreateFailure(message)) {
 					try {
 						const scan = await aoBridge.app.scanImportFolder({
@@ -164,8 +217,8 @@ export function CreateProjectFlow({
 				})}
 			{hasModePicker && embedded && !modePickerOpen && (
 				<div className="flex w-full flex-col items-center gap-3">
-					<ImportModePicker disabled={isBusy} onSelect={openFolderStep} />
-					{error && !folderPickerOpen && selectedPath === null && (
+					<ImportModePicker disabled={isBusy} onSelect={openFolderStep} onCloneFromUrl={openCloneStep} />
+					{error && !folderPickerOpen && !cloneDialogOpen && selectedPath === null && (
 						<p className="text-caption leading-body text-error" role="status">
 							{error}
 						</p>
@@ -179,6 +232,31 @@ export function CreateProjectFlow({
 						open={modePickerOpen}
 						onOpenChange={(open) => !isBusy && setModePickerOpen(open)}
 						onSelect={openFolderStep}
+						onCloneFromUrl={openCloneStep}
+					/>
+					<CloneProjectDialog
+						disabled={isBusy}
+						error={error ? cloneErrorPresentation(errorCode ?? undefined, error) : null}
+						open={cloneDialogOpen}
+						url={cloneUrl}
+						onUrlChange={setCloneUrl}
+						onBack={() => {
+							setError(null);
+							setErrorCode(null);
+							setCloneDialogOpen(false);
+							if (!embedded) {
+								window.requestAnimationFrame(() => setModePickerOpen(true));
+							}
+						}}
+						onOpenChange={(open) => {
+							if (isBusy) return;
+							setCloneDialogOpen(open);
+							if (!open) {
+								setError(null);
+								setErrorCode(null);
+							}
+						}}
+						onSubmit={confirmCloneUrl}
 					/>
 					<CreateProjectFolderDialog
 						disabled={isBusy}
@@ -208,20 +286,23 @@ export function CreateProjectFlow({
 				</>
 			)}
 			<CreateProjectAgentSheet
-				error={error}
+				cloneUrl={pendingCloneUrl}
+				error={pendingCloneUrl === null ? error : null}
 				isCreating={isCreating}
 				isInitializing={isInitializing}
 				kind={selectedKind}
 				onOpenChange={(open) => {
 					if (!open) {
 						setSelectedPath(null);
-						if (!folderPickerOpen) {
+						setPendingCloneUrl(null);
+						if (!folderPickerOpen && !cloneDialogOpen) {
 							setError(null);
+							setErrorCode(null);
 						}
 					}
 				}}
 				onSubmit={createProject}
-				open={selectedPath !== null}
+				open={selectedPath !== null || pendingCloneUrl !== null}
 				path={selectedPath}
 				repositorySetupNeeded={repositorySetup !== null}
 			/>
@@ -257,11 +338,13 @@ function shouldScanCreateFailure(message: string): boolean {
 
 function CreateProjectModeDialog({
 	disabled,
+	onCloneFromUrl,
 	onOpenChange,
 	onSelect,
 	open,
 }: {
 	disabled: boolean;
+	onCloneFromUrl: () => void;
 	onOpenChange: (open: boolean) => void;
 	onSelect: (kind: ProjectKind) => void;
 	open: boolean;
@@ -271,7 +354,13 @@ function CreateProjectModeDialog({
 			<Dialog.Portal>
 				<Dialog.Overlay className="dialog-overlay data-[state=open]:animate-overlay-in" />
 				<Dialog.Content className="fixed left-1/2 top-1/2 z-overlay w-[min(var(--size-import-modal-max),calc(100vw-24px))] -translate-x-1/2 -translate-y-1/2 border-0 bg-transparent p-0 shadow-none outline-none data-[state=open]:animate-modal-in">
-					<ImportModePicker disabled={disabled} onClose={() => onOpenChange(false)} onSelect={onSelect} dialog />
+					<ImportModePicker
+						disabled={disabled}
+						onCloneFromUrl={onCloneFromUrl}
+						onClose={() => onOpenChange(false)}
+						onSelect={onSelect}
+						dialog
+					/>
 				</Dialog.Content>
 			</Dialog.Portal>
 		</Dialog.Root>
@@ -282,11 +371,13 @@ function CreateProjectModeDialog({
 function ImportModePicker({
 	dialog = false,
 	disabled,
+	onCloneFromUrl,
 	onClose,
 	onSelect,
 }: {
 	dialog?: boolean;
 	disabled: boolean;
+	onCloneFromUrl: () => void;
 	onClose?: () => void;
 	onSelect: (kind: ProjectKind) => void;
 }) {
@@ -321,6 +412,22 @@ function ImportModePicker({
 					kind="single_repo"
 					onClick={() => onSelect("single_repo")}
 				/>
+			</div>
+			{/* Third source, deliberately quieter than the two cards: both of those
+			    import something already on this machine, this one fetches it first. */}
+			<div className="relative z-[2] flex flex-col items-center gap-1.5 self-stretch border-t border-[var(--color-border-import-modal)] pt-6 text-center">
+				<button
+					type="button"
+					className="inline-flex items-center gap-2 rounded-md px-2 py-1 text-[14px] font-semibold text-[var(--color-text-import-title)] underline-offset-4 transition-colors hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/60 disabled:pointer-events-none disabled:opacity-50"
+					disabled={disabled}
+					onClick={onCloneFromUrl}
+				>
+					<CloudDownload className="size-4 shrink-0" aria-hidden="true" />
+					Clone from a Git URL
+				</button>
+				<p className="text-[13px] font-normal leading-5 text-[var(--color-text-import-muted)]">
+					Not on this machine yet? AO clones the repository first, then imports it as a project.
+				</p>
 			</div>
 			{onClose && (
 				<button
@@ -565,6 +672,188 @@ function CreateProjectFolderDialog({
 				</Dialog.Content>
 			</Dialog.Portal>
 		</Dialog.Root>
+	);
+}
+
+/**
+ * Clone-by-URL step, and the surface every clone failure comes back to: the
+ * daemon's remediation always resolves here, either by editing the URL or by
+ * fixing credentials on the machine and submitting the same URL again.
+ */
+function CloneProjectDialog({
+	disabled,
+	error,
+	onBack,
+	onOpenChange,
+	onSubmit,
+	onUrlChange,
+	open,
+	url,
+}: {
+	disabled: boolean;
+	error: { title: string; message: string } | null;
+	onBack: () => void;
+	onOpenChange: (open: boolean) => void;
+	onSubmit: (url: string) => void;
+	onUrlChange: (url: string) => void;
+	open: boolean;
+	url: string;
+}) {
+	// Validity is checked as you type, but only reported once the field has been
+	// left or a submit was attempted: no red text while typing a valid URL.
+	const [touched, setTouched] = useState(false);
+	useEffect(() => {
+		if (!open) setTouched(false);
+	}, [open]);
+
+	const target = parseCloneUrl(url);
+	const invalid = touched && url.trim() !== "" && target === null;
+
+	return (
+		<Dialog.Root open={open} onOpenChange={onOpenChange}>
+			<Dialog.Portal>
+				<Dialog.Overlay className="dialog-overlay data-[state=open]:animate-overlay-in" />
+				<Dialog.Content className="fixed left-1/2 top-1/2 z-overlay flex max-h-[calc(100svh-24px)] w-[min(var(--size-import-folder-dialog),calc(100vw-24px))] -translate-x-1/2 -translate-y-1/2 flex-col overflow-hidden rounded-welcome-panel border border-[var(--color-border-import-modal)] bg-[var(--color-bg-import-modal)] p-0 text-[var(--color-text-import-title)] shadow-[var(--shadow-import-modal)] data-[state=open]:animate-modal-in">
+					<form
+						className="flex min-h-0 flex-col"
+						onSubmit={(event) => {
+							event.preventDefault();
+							setTouched(true);
+							if (!disabled && target) onSubmit(url.trim());
+						}}
+					>
+						<div className="flex shrink-0 items-start gap-3 border-b border-[var(--color-border-import-modal)] px-4 py-4 sm:gap-4 sm:px-6 sm:py-5">
+							<button
+								type="button"
+								className="grid size-8 shrink-0 place-items-center rounded-lg border border-[var(--color-border-import-modal)] text-[var(--color-text-import-muted)] transition hover:bg-[var(--color-bg-import-card-hover)] hover:text-[var(--color-text-import-title)] disabled:pointer-events-none disabled:opacity-50"
+								aria-label="Back to import type"
+								disabled={disabled}
+								onClick={onBack}
+							>
+								<ChevronRight className="size-4 rotate-180" aria-hidden="true" />
+							</button>
+							<div className="min-w-0 flex-1">
+								<Dialog.Title className="text-[18px] font-semibold text-[var(--color-text-import-title)]">
+									Clone a repository
+								</Dialog.Title>
+								<Dialog.Description className="mt-1 max-w-[440px] text-[13px] font-medium leading-5 text-[var(--color-text-import-muted)]">
+									AO clones the repository onto the machine running it, then imports the clone as a project.
+								</Dialog.Description>
+							</div>
+							<Dialog.Close asChild>
+								<button
+									type="button"
+									className="grid size-7 shrink-0 place-items-center rounded-md text-[var(--color-text-import-muted)] transition hover:bg-[var(--color-bg-import-card-hover)] hover:text-[var(--color-text-import-title)] disabled:pointer-events-none disabled:opacity-50"
+									aria-label="Close clone dialog"
+									disabled={disabled}
+								>
+									<X className="size-4" aria-hidden="true" />
+								</button>
+							</Dialog.Close>
+						</div>
+
+						<div className="min-h-0 space-y-4 overflow-y-auto px-4 py-4 sm:px-6 sm:py-6">
+							<div className="flex flex-col gap-1.5">
+								<Label
+									htmlFor="cloneProjectUrl"
+									className="text-[12px] font-medium text-[var(--color-text-import-muted)]"
+								>
+									Repository URL
+								</Label>
+								<Input
+									id="cloneProjectUrl"
+									autoFocus
+									autoComplete="off"
+									autoCorrect="off"
+									autoCapitalize="off"
+									spellCheck={false}
+									aria-invalid={invalid || undefined}
+									aria-describedby="cloneProjectUrlHint"
+									className="font-mono text-[13px]"
+									disabled={disabled}
+									placeholder="https://github.com/owner/repo.git"
+									value={url}
+									onBlur={() => setTouched(true)}
+									onChange={(event) => onUrlChange(event.target.value)}
+								/>
+								<p
+									id="cloneProjectUrlHint"
+									className={cn(
+										"text-[12px] leading-5",
+										invalid ? "text-destructive" : "text-[var(--color-text-import-muted)]",
+									)}
+								>
+									{invalid
+										? "Use an https:// or ssh git remote URL that names an owner and a repository."
+										: "https:// or ssh, for example git@github.com:owner/repo.git"}
+								</p>
+							</div>
+
+							{/* Standing expectation-setting, dropped once a real failure is on
+							    screen: the daemon's own remediation supersedes it. */}
+							{!error && (
+								<div className="rounded-lg border border-[var(--color-border-import-modal)] bg-[var(--color-bg-import-card)] px-4 py-3 text-[12px] leading-5 text-[var(--color-text-import-muted)]">
+									A large repository can take a few minutes to clone. A private one needs git credentials on that
+									machine: run <RemediationText text="`gh auth login`" /> there first.
+								</div>
+							)}
+
+							{error && (
+								<div
+									role="alert"
+									className="flex gap-2 rounded-lg border border-destructive/40 bg-destructive/10 px-4 py-3 text-[12px] leading-5"
+								>
+									<TriangleAlert className="mt-0.5 size-4 shrink-0 text-destructive" aria-hidden="true" />
+									<div className="min-w-0 space-y-1">
+										<p className="font-semibold text-destructive">{error.title}</p>
+										<p className="text-[var(--color-text-import-muted)]">
+											<RemediationText text={error.message} />
+										</p>
+									</div>
+								</div>
+							)}
+						</div>
+
+						<div className="flex shrink-0 flex-col gap-3 border-t border-[var(--color-border-import-modal)] px-4 py-4 sm:flex-row sm:items-center sm:justify-between sm:px-6">
+							<p className="text-[12px] font-medium text-[var(--color-text-import-muted)]">
+								{target ? `Clones ${target.owner}/${target.repo}` : "Paste the repository's git remote URL"}
+							</p>
+							<div className="flex flex-wrap items-center justify-end gap-2 sm:gap-3">
+								<Button type="button" variant="outline" disabled={disabled} onClick={() => onOpenChange(false)}>
+									Cancel
+								</Button>
+								<Button type="submit" variant="primary" disabled={disabled || target === null}>
+									Continue
+								</Button>
+							</div>
+						</div>
+					</form>
+				</Dialog.Content>
+			</Dialog.Portal>
+		</Dialog.Root>
+	);
+}
+
+/**
+ * The daemon writes its remediation with the command in backticks ("run `gh
+ * auth login`"). Render those spans as code so the thing to copy is obvious.
+ */
+export function RemediationText({ text }: { text: string }) {
+	return (
+		<>
+			{text.split(/`([^`]+)`/).map((part, index) =>
+				index % 2 === 1 ? (
+					<code
+						key={`${index}:${part}`}
+						className="rounded bg-[var(--color-bg-import-chip)] px-1 py-0.5 font-mono text-[11px] text-[var(--color-text-import-title)]"
+					>
+						{part}
+					</code>
+				) : (
+					part
+				),
+			)}
+		</>
 	);
 }
 

--- a/frontend/src/renderer/components/Sidebar.test.tsx
+++ b/frontend/src/renderer/components/Sidebar.test.tsx
@@ -3,6 +3,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { CreateProjectInput } from "./CreateProjectFlow";
 import { Sidebar } from "./Sidebar";
 import type { WorkspaceSession, WorkspaceSummary } from "../types/workspace";
 import { agentsQueryKey } from "../hooks/useAgentsQuery";
@@ -94,13 +95,6 @@ function sidebarPR(overrides: Partial<WorkspaceSession["prs"][number]> = {}): Wo
 	};
 }
 
-type CreateProjectInput = {
-	path: string;
-	workerAgent: string;
-	orchestratorAgent: string;
-	trackerIntake?: unknown;
-	asWorkspace?: boolean;
-};
 type CreateProjectHandler = (input: CreateProjectInput) => Promise<void>;
 type InitializeProjectHandler = (path: string) => Promise<void>;
 type RemoveProjectHandler = (projectId: string) => Promise<void>;

--- a/frontend/src/renderer/lib/clone-url.test.ts
+++ b/frontend/src/renderer/lib/clone-url.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { cloneErrorPresentation, cloneUrlLabel, parseCloneUrl } from "./clone-url";
+
+describe("parseCloneUrl", () => {
+	it.each([
+		["https://github.com/agentlab-in/hosted-ao.git", "agentlab-in", "hosted-ao"],
+		["https://github.com/agentlab-in/hosted-ao", "agentlab-in", "hosted-ao"],
+		["https://github.com/agentlab-in/hosted-ao/", "agentlab-in", "hosted-ao"],
+		["git@github.com:agentlab-in/hosted-ao.git", "agentlab-in", "hosted-ao"],
+		["ssh://git@github.com/agentlab-in/hosted-ao.git", "agentlab-in", "hosted-ao"],
+		["https://gitlab.com/group/sub/repo.git", "sub", "repo"],
+		["  https://github.com/owner/repo.git  ", "owner", "repo"],
+	])("accepts %s", (raw, owner, repo) => {
+		expect(parseCloneUrl(raw)).toEqual({ owner, repo });
+	});
+
+	it.each([
+		[""],
+		["   "],
+		["github.com/owner/repo"],
+		["https://github.com/repo"],
+		["https://github.com/"],
+		["not a url at all"],
+		["https://github.com/../repo.git"],
+		["https://github.com/owner/re po.git"],
+	])("rejects %s", (raw) => {
+		expect(parseCloneUrl(raw)).toBeNull();
+	});
+});
+
+describe("cloneUrlLabel", () => {
+	it("shortens a parseable URL to owner/repo", () => {
+		expect(cloneUrlLabel("https://github.com/agentlab-in/hosted-ao.git")).toBe("agentlab-in/hosted-ao");
+	});
+
+	it("falls back to the raw value", () => {
+		expect(cloneUrlLabel(" mystery ")).toBe("mystery");
+	});
+});
+
+describe("cloneErrorPresentation", () => {
+	it("titles the auth failure and keeps the daemon's remediation intact", () => {
+		const daemonMessage =
+			"No git credentials on this machine. For an https:// URL, run `gh auth login`. For an SSH URL, add a deploy key or start an SSH agent, then try again.";
+
+		expect(cloneErrorPresentation("CLONE_AUTH_FAILED", `${daemonMessage} (CLONE_AUTH_FAILED)`)).toEqual({
+			title: "Git credentials needed on this machine",
+			message: daemonMessage,
+		});
+	});
+
+	it("falls back to a generic title for an unmapped code", () => {
+		expect(cloneErrorPresentation("SOMETHING_ELSE", "Boom")).toEqual({
+			title: "Could not clone the repository",
+			message: "Boom",
+		});
+	});
+
+	it("never renders an empty body", () => {
+		expect(cloneErrorPresentation("CLONE_FAILED", "(CLONE_FAILED)").message).toBe("Check the URL and try again.");
+	});
+});

--- a/frontend/src/renderer/lib/clone-url.ts
+++ b/frontend/src/renderer/lib/clone-url.ts
@@ -1,0 +1,87 @@
+// Clone-by-URL support for the project creation flow.
+//
+// `parseCloneUrl` mirrors the daemon's own parser
+// (backend/internal/service/project/clone.go `parseCloneURL`) so a URL the
+// daemon would reject as CLONE_URL_INVALID is caught in the field, before a
+// round trip that can take minutes. Keep the two in sync: the daemon stays the
+// authority, this is only an early exit.
+
+// scp-like git remote syntax, e.g. "git@github.com:owner/repo.git" — a form no
+// URL parser recognizes as having a scheme and host.
+const SCP_LIKE_CLONE_URL = /^[\w.-]+@[\w.-]+:(.+)$/;
+
+// A parsed owner/repo segment becomes a single path component of the clone
+// destination on the daemon, so it is restricted the same way there.
+const SAFE_DIR_COMPONENT = /^[A-Za-z0-9._-]+$/;
+
+export type CloneTarget = { owner: string; repo: string };
+
+/** Owner and repository of a git remote URL, or null when it is not one. */
+export function parseCloneUrl(raw: string): CloneTarget | null {
+	const value = raw.trim();
+	if (value === "") return null;
+
+	let pathPart: string | null = null;
+	try {
+		pathPart = new URL(value).pathname;
+	} catch {
+		pathPart = SCP_LIKE_CLONE_URL.exec(value)?.[1] ?? null;
+	}
+	if (pathPart === null) return null;
+
+	const segments = pathPart
+		.replace(/^\/+/, "")
+		.replace(/\/+$/, "")
+		.replace(/\.git$/, "")
+		.split("/");
+	const repo = segments[segments.length - 1];
+	const owner = segments[segments.length - 2];
+	if (segments.length < 2 || !SAFE_DIR_COMPONENT.test(owner) || !SAFE_DIR_COMPONENT.test(repo)) return null;
+	return { owner, repo };
+}
+
+/** "owner/repo" for display, falling back to the raw URL when unparseable. */
+export function cloneUrlLabel(raw: string): string {
+	const target = parseCloneUrl(raw);
+	return target ? `${target.owner}/${target.repo}` : raw.trim();
+}
+
+// The daemon returns remediation-shaped clone failures rather than raw git
+// output: the message already tells the user what to do (run `gh auth login`,
+// accept a host key, pick a different URL). Each code only needs a heading, so
+// the user sees what went wrong before reading the fix. Mirrors
+// backend/internal/service/project/clone.go.
+const CLONE_ERROR_TITLES: Record<string, string> = {
+	CLONE_AUTH_FAILED: "Git credentials needed on this machine",
+	CLONE_URL_INVALID: "Check the repository URL",
+	CLONE_REPO_NOT_FOUND: "Repository not found",
+	CLONE_HOST_NOT_FOUND: "Could not reach the git host",
+	CLONE_HOST_KEY_UNVERIFIED: "SSH host key not recognized",
+	CLONE_TIMEOUT: "Clone timed out",
+	CLONE_DESTINATION_EXISTS: "Already cloned on this machine",
+	CLONE_DEST_UNAVAILABLE: "Could not prepare the clone destination",
+	CLONE_NOT_CONFIGURED: "Cloning by URL is unavailable here",
+	CLONE_FAILED: "Could not clone the repository",
+	// Structurally unreachable from the UI (a folder and a URL are separate
+	// branches of the flow), kept so a future regression reads as a bug rather
+	// than as an unexplained failure.
+	PATH_AND_CLONE_URL_CONFLICT: "Choose a folder or a URL, not both",
+	// Registration failures that can still land on a clone that itself worked.
+	PATH_ALREADY_REGISTERED: "Already registered as a project",
+	ID_ALREADY_REGISTERED: "Project id already in use",
+};
+
+export type CloneErrorPresentation = { title: string; message: string };
+
+/**
+ * Heading plus remediation text for a failed clone. `apiErrorMessage` appends
+ * "(CODE)" when the daemon message does not already name the code; that suffix
+ * is dropped here because the heading now carries the meaning.
+ */
+export function cloneErrorPresentation(code: string | undefined, message: string): CloneErrorPresentation {
+	const trimmed = message.replace(/\s*\(([A-Z0-9_]+)\)\s*$/, "").trim();
+	return {
+		title: CLONE_ERROR_TITLES[code ?? ""] ?? "Could not clone the repository",
+		message: trimmed || "Check the URL and try again.",
+	};
+}

--- a/frontend/src/renderer/lib/shell-context.ts
+++ b/frontend/src/renderer/lib/shell-context.ts
@@ -1,5 +1,5 @@
 import { createContext, useContext } from "react";
-import type { components } from "../../api/schema";
+import type { CreateProjectInput } from "../components/CreateProjectFlow";
 import type { useDaemonStatus } from "../hooks/useDaemonStatus";
 
 // Shared state the persistent _shell layout owns and route content reads. The
@@ -7,13 +7,7 @@ import type { useDaemonStatus } from "../hooks/useDaemonStatus";
 // it lives in the shell and is handed down here rather than re-run per route.
 export type ShellContextValue = {
 	daemonStatus: ReturnType<typeof useDaemonStatus>;
-	createProject: (input: {
-		path: string;
-		workerAgent: string;
-		orchestratorAgent: string;
-		trackerIntake?: components["schemas"]["TrackerIntakeConfig"];
-		asWorkspace?: boolean;
-	}) => Promise<void>;
+	createProject: (input: CreateProjectInput) => Promise<void>;
 	initializeProjectRepository: (path: string) => Promise<void>;
 };
 

--- a/frontend/src/renderer/routes/_shell.tsx
+++ b/frontend/src/renderer/routes/_shell.tsx
@@ -2,6 +2,7 @@ import { createFileRoute, Outlet, useMatchRoute, useNavigate, useParams } from "
 import { useQueryClient } from "@tanstack/react-query";
 import { type CSSProperties, useCallback, useEffect, useRef, useState } from "react";
 import { CommandPalette } from "../components/CommandPalette";
+import type { CreateProjectInput } from "../components/CreateProjectFlow";
 import { CenterPanelShell } from "../components/CenterPanelShell";
 import { DaemonFailureBanner } from "../components/DaemonFailureBanner";
 import { NotificationRuntime } from "../components/NotificationCenter";
@@ -202,26 +203,25 @@ function ShellLayout() {
 	);
 
 	const createProject = useCallback(
-		async (input: {
-			path: string;
-			workerAgent: string;
-			orchestratorAgent: string;
-			trackerIntake?: components["schemas"]["TrackerIntakeConfig"];
-			asWorkspace?: boolean;
-		}) => {
+		async (input: CreateProjectInput) => {
 			void addRendererExceptionStep("Project add requested", {
 				source: "project-add",
 				operation: "project_add",
 				surface: "project_board",
 			});
-			void captureRendererEvent("ao.renderer.project_add_requested");
+			void captureRendererEvent("ao.renderer.project_add_requested", {
+				source: input.cloneUrl ? "clone_url" : "local_path",
+			});
 			const status = await refreshDaemonStatus();
 			if (status.state !== "ready" || !status.port) {
 				throw new Error(status.message || "AO daemon is not ready.");
 			}
 			const { data, error } = await apiClient.POST("/api/v1/projects", {
 				body: {
-					path: input.path,
+					// Exactly one source, never both: the daemon rejects the pair with
+					// PATH_AND_CLONE_URL_CONFLICT, and CreateProjectInput makes the
+					// pair unrepresentable upstream of here.
+					...(input.cloneUrl ? { cloneUrl: input.cloneUrl } : { path: input.path }),
 					asWorkspace: input.asWorkspace || undefined,
 					config: createProjectConfig(input),
 				},

--- a/frontend/src/renderer/styles.css
+++ b/frontend/src/renderer/styles.css
@@ -911,6 +911,28 @@ select {
 	}
 }
 
+/* Indeterminate bar for the synchronous clone in the create-project sheet.
+ * The daemon reports no progress (it runs `git clone` to completion and then
+ * answers), so this only says "still working"; the elapsed counter beside it
+ * carries the real signal, which is why reduced motion can drop the travel and
+ * settle for a dimmed full bar. */
+.clone-progress-bar {
+	height: 100%;
+	width: 34%;
+	border-radius: inherit;
+	background: var(--color-accent);
+	animation: clone-progress 1.4s ease-in-out infinite;
+}
+
+@keyframes clone-progress {
+	from {
+		transform: translateX(-110%);
+	}
+	to {
+		transform: translateX(310%);
+	}
+}
+
 /* ── Global resize state (sidebar drag) ─────────────────────────────────── */
 body.is-resizing-x {
 	cursor: col-resize;
@@ -948,6 +970,12 @@ body.is-resizing-x [data-slot="sidebar-container"] {
 	[data-slot="command-dialog-overlay"],
 	[data-slot="command-dialog-content"] {
 		animation: none;
+	}
+
+	.clone-progress-bar {
+		animation: none;
+		width: 100%;
+		opacity: 0.45;
 	}
 }
 


### PR DESCRIPTION
Closes #59.

`POST /api/v1/projects` has accepted `cloneUrl` since #6, but the desktop had no input for it, so the capability was API-only and invisible. The import picker now offers a third source below the Workspace/Project cards: **Clone from a Git URL**.

Frontend only. No API, backend, or control-plane change; `cloneUrl` was already in `frontend/src/api/schema.ts`.

## The conflict is unrepresentable, not just reported

A folder and a URL are separate branches of the flow, and `CreateProjectInput` is now a union (`{ path } | { cloneUrl }`), so nothing in the UI can send both. `PATH_AND_CLONE_URL_CONFLICT` still has a title in the error map, so a future regression reads as a bug rather than an unexplained failure.

## Validation and error presentation

- `parseCloneUrl` mirrors the daemon's own parser (`backend/internal/service/project/clone.go`), so a URL it would reject as `CLONE_URL_INVALID` is caught in the field, before a round trip that can take minutes. Continue stays disabled until the URL parses; the hint only turns red once the field is left or a submit is attempted.
- Every other clone failure returns to the URL step, where the remediation resolves. The daemon's code becomes a heading (`CLONE_AUTH_FAILED` &rarr; "Git credentials needed on this machine") and its message is shown verbatim, with backticked commands rendered as code, so a private repo on a fresh VM is told to run `gh auth login`, which is exactly what the daemon says. The URL is kept, so the retry after signing in is one click.
- Codes mapped: `CLONE_AUTH_FAILED`, `CLONE_URL_INVALID`, `CLONE_REPO_NOT_FOUND`, `CLONE_HOST_NOT_FOUND`, `CLONE_HOST_KEY_UNVERIFIED`, `CLONE_TIMEOUT`, `CLONE_DESTINATION_EXISTS`, `CLONE_DEST_UNAVAILABLE`, `CLONE_NOT_CONFIGURED`, `CLONE_FAILED`, `PATH_AND_CLONE_URL_CONFLICT`, plus the registration conflicts a successful clone can still land on.

## Not frozen while a large repo clones

The clone is synchronous by design (no job model, no progress channel), so the create sheet reports the repository being cloned, an elapsed counter that ticks, and an indeterminate bar; the submit button reads "Cloning...". There is no real progress to fake. Reduced motion drops the bar's travel and keeps the counter.

## Design

Built from `components/ui/*` primitives (Input, Label, Button) and the existing import-dialog chrome, tokens, and error language, per DESIGN.md's clone-agent-orchestrator banner. The two Figma mode cards are untouched; the clone entry is a quieter third source beneath them.

## Tests

- `src/renderer/lib/clone-url.test.ts` — parser parity with the daemon (https, ssh, scp-like, nested paths, traversal and whitespace rejects) and the error presentation.
- `src/renderer/components/CreateProjectFlow.test.tsx` — sends `cloneUrl` and never `path`, blocks a URL the daemon would reject, shows the auth remediation on the URL step with the URL kept, titles other codes, and keeps reporting an in-flight clone.
- `e2e/clone-url.spec.ts` (`@P0`, renderer smoke) — the same flow through the real generated API client with the daemon's two REST answers stubbed, locking the wire shape and the on-screen remediation, plus the in-flight state.

`npm run typecheck`, `npm run typecheck:e2e`, `npx vitest run` (1289 passed), and `npm run test:e2e:renderer` (22 passed) are green locally.

## Risks and follow-ups

- Progress is elapsed time only. Real progress needs the job model the brief rules out.
- A credential embedded in the URL is passed through to the daemon as before; the persistence side of that is #17/#20 territory, not this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)