### PR TITLE
fix(vm-gateway): honor AO_ALLOWED_ORIGINS

### DIFF
--- a/backend/internal/cli/vm.go
+++ b/backend/internal/cli/vm.go
@@ -88,7 +88,7 @@ func (c *commandContext) runVMServe(cmd *cobra.Command, opts vmgateway.Options) 
 		Skew:     vmgateway.DefaultSkew,
 	}
 	jwks := vmgateway.NewJWKSCache(gwCfg.JWKSURL, nil)
-	handler, err := vmgateway.NewHandler(gwCfg.DaemonAddr, jwks, verify, config.DefaultAllowedOrigins, log)
+	handler, err := vmgateway.NewHandler(gwCfg.DaemonAddr, jwks, verify, cfg.AllowedOrigins, log)
 	if err != nil {
 		return fmt.Errorf("build gateway handler: %w", err)
 	}


### PR DESCRIPTION
## Summary

- `ao vm serve` used `config.DefaultAllowedOrigins` hardcoded; the env var
  `AO_ALLOWED_ORIGINS` had no effect on the gateway even though the daemon
  already respects it.
- Passing `cfg.AllowedOrigins` from the already-loaded config lets operators
  add dev origins (or anything else) without a rebuild.

Closes #64

## Test plan

- [x] Verified on the deployed test VM: after setting
  `AO_ALLOWED_ORIGINS=app://renderer,http://localhost:5173,http://localhost:5174`
  on the systemd unit, the dev renderer can talk to the gateway; unknown
  origins still get 403.
- [ ] Unit test covering the config wiring.