### PR TITLE
fix(desktop): accept remote-ready status when creating a project

### DIFF
--- a/frontend/src/renderer/routes/_shell.tsx
+++ b/frontend/src/renderer/routes/_shell.tsx
@@ -213,7 +213,9 @@ function ShellLayout() {
 				source: input.cloneUrl ? "clone_url" : "local_path",
 			});
 			const status = await refreshDaemonStatus();
-			if (status.state !== "ready" || !status.port) {
+			// A remote machine's daemon status has baseUrl (and no port); a local
+			// daemon's has port (and no baseUrl). Accept either as ready.
+			if (status.state !== "ready" || (!status.port && !status.baseUrl)) {
 				throw new Error(status.message || "AO daemon is not ready.");
 			}
 			const { data, error } = await apiClient.POST("/api/v1/projects", {


### PR DESCRIPTION
## Summary

- `createProject` in the shell route required `status.port`, which is only set
  for the local daemon; a reachable remote machine's status carries `baseUrl`
  instead. Every remote clone and remote session spawn threw before any fetch
  went out — DevTools Network showed nothing.
- Accept `baseUrl` as sufficient too.

Closes #65

## Test plan

- [x] Signed in against the deployed control plane, selected the test VM,
  cloned `https://github.com/agentlab-in/journal` end to end.
- [ ] Regression test for the shell route's readiness gate.