### PR TITLE
docs: replace hosted-log.md with the end-to-end verification

### DIFF
--- a/hosted-log.md
+++ b/hosted-log.md
@@ -1,66 +1,73 @@
-# Hosted AO log, 2026-07-27
+# Hosted AO log, 2026-07-31
 
-> **Superseded in intent, not yet replaced in fact (noted 2026-07-30).** This log records the
-> single shared pairing-secret deployment, which was the whole hosted story on 2026-07-27.
-> Hosted AO v1 (accounts, registered machines, per-machine tokens, `ao setup-vm` and
-> `ao vm serve`) replaces it, and 12 of its 15 spec tasks are merged on `develop`. **None of
-> that has run on a VM yet**, so nothing below has been re-verified against it and nothing
-> below has been overwritten with results that have not happened.
->
-> Spec task 14 owns the replacement: run the full accounts flow on a clean Ubuntu LTS VM,
-> then write up what was actually verified. That write-up must cover, at minimum, ACME
-> issuing a certificate for the machine's domain, the RFC 8628 device flow completing against
-> real DNS, `machine.json` written and read back by the gateway, the desktop reaching the
-> machine over the gateway with a machine-audience token, and `/mux` over WSS with the
-> `ao_gw_token` cookie. Until then, treat this file as the record of the old path.
->
-> See [`docs/hosted-ao-v1-build-log.md`](docs/hosted-ao-v1-build-log.md) and
-> [`docs/STATUS.md`](docs/STATUS.md).
+Hosted AO v1 verified end to end on a real user-owned VM. From a signed-out
+desktop:
 
-## Outcome
+1. Sign in with Google against `https://ao.agentlab.in` (system browser, PKCE,
+   loopback redirect).
+2. The account's registered machines appear in the app; select the remote one.
+3. Add a project by Git URL (`https://github.com/agentlab-in/journal`) and the
+   daemon on the VM clones it.
 
-The first hosted AO slice is live for testing at `https://api.ao.agentlab.in`.
-The Electron app can run locally against the VM-backed AO daemon.
+Everything travels over `https://vm-test.ao.agentlab.in` with a machine-audience
+JWT: `Authorization: Bearer` for REST, `ao_gw_token` cookie for `/mux` and SSE.
 
 ## Architecture
 
-- AO daemon runs on the Azure VM as `hosted-ao.service`, bound only to
-  `127.0.0.1:3001`.
-- Caddy runs as the public TLS edge at `api.ao.agentlab.in`.
-- Caddy requires the `ao_hosted_pair` cookie for app requests and proxies REST,
-  SSE, and terminal mux traffic to the loopback daemon.
-- Electron remote mode uses `AO_REMOTE_URL` and `AO_REMOTE_TOKEN`; the token is
-  installed as a Secure, HttpOnly, host-only cookie, so the renderer never sees
-  it.
-- Browser CORS preflights are allowed without the pairing cookie; all actual
-  app requests require it. Loopback-only control routes are blocked by Caddy.
-
-## VM preparation
-
-- DNS: `api.ao.agentlab.in` points to `YOUR_VM_PUBLIC_IP`.
-- Azure inbound TCP 80/443 is enabled; Caddy obtained a trusted Let's Encrypt
-  certificate.
-- `tmux 3.4` is installed.
-- Claude Code is installed for `azureuser` but still requires user
-  authentication.
-- Caddy's systemd override avoids its default `--environ` flag so the pairing
-  token is not written to the journal.
+- Control plane at `https://ao.agentlab.in` on the Azure VM: Go binary at
+  `/opt/ao-controlplane/controlplane`, systemd unit `ao-controlplane.service`,
+  Caddy in front for TLS. Owns Google login, RFC 8628 device flow, machines
+  registry, EdDSA JWKS, refresh-token exchange.
+- User VM (GCP `ao-test-vm` in this test): the `ao` binary runs both the
+  loopback daemon on `127.0.0.1:3001` (`ao-daemon.service`) and the public TLS
+  gateway (`ao-gateway.service`, `ao vm serve`) bound on `:80` and `:443`. The
+  gateway verifies AO tokens against the JWKS, checks `aud`/`sub`, and
+  reverse-proxies authenticated requests to the loopback daemon.
+- Desktop app: signed-in state under `~/.ao/hosted/dev/ao-account.json`
+  (safeStorage-encrypted refresh token), active machine in `ao-machine.json`,
+  data root `~/.ao/hosted/*` (isolated from the upstream AO build).
 
 ## Verified
 
-- Unpaired health request: `401`.
-- Paired health request: `200`.
-- Credentialed CORS preflight: `204` with credential support.
-- Bare unauthenticated `OPTIONS`: `401`.
-- `/shutdown` through the public proxy: `404`.
-- SSE stream: `200 text/event-stream`.
-- Terminal mux WebSocket upgrade: `101`.
-- Electron dev app successfully connected to the hosted backend.
+- Control plane: `/oauth/desktop/authorize` 302, `/oauth/desktop/token` 400 on
+  bad grant, `/api/v1/machines` 401 unauth, `/api/v1/token` 400 on invalid
+  refresh, `/api/v1/reachability` 200, `/login` 200, `/` 302.
+- Gateway on the user VM: TLS 1.3 with a Let's Encrypt cert for
+  `vm-test.ao.agentlab.in`, deny-by-default 404 on `/healthz`, 401 on
+  `/api/v1/*` without a token, 401 on the SSE stream without the cookie, CORS
+  preflight 204 with `Access-Control-Allow-Origin: app://renderer`.
+- Desktop end to end: Google sign-in through the loopback callback, machine
+  list populated from the account, machine-audience token exchange, remote
+  clone of a public Git URL onto the VM.
+- Claude Code auth on the VM: `ao doctor` reports `PASS claude-auth` for the
+  daemon user; `claude --print` under that user completes.
 
-## Current limits
+## Operator notes
 
-- This is a single shared pairing-secret setup: no accounts, roles, or tenant
-  isolation yet. Hosted AO v1 adds all three; it is not deployed here.
-- Browser-preview proxying is intentionally out of scope.
-- Implementation work now happens on `develop`, not `main`, and this repository
-  is no longer a fork.
+- Redeploying the control plane: cross-compile
+  `GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o /tmp/controlplane ./cmd/controlplane`
+  from `controlplane/`, `scp` to the Azure VM, `install -m 0755` to
+  `/opt/ao-controlplane/controlplane`, `systemctl restart ao-controlplane`.
+  Signing keys live under `/var/lib/ao-controlplane` and survive restarts, so
+  already-issued tokens keep verifying.
+- Restoring a user VM from a boot-disk snapshot is safe: `machine.json`, the
+  systemd units, the cached ACME cert, and the daemon's SQLite state all come
+  back. Only the DNS A record has to be re-pointed at the new external IP.
+- Claude Code auth is per Unix user. If the interactive login runs under a
+  different user than the daemon (easy to do over GCP browser SSH, which uses
+  the operator's Google login as the Linux user), copy `~/.claude/` to the
+  daemon user, `chown -R`, and `ao doctor` flips to PASS.
+
+## Bugs found during verification
+
+Patched locally, not yet merged:
+
+- [#64](https://github.com/agentlab-in/hosted-ao/issues/64): `ao vm serve`
+  hardcodes `DefaultAllowedOrigins` instead of honoring `AO_ALLOWED_ORIGINS`.
+  Blocks `npm run dev`, worked around on the test VM with a systemd
+  `Environment=` override.
+- [#65](https://github.com/agentlab-in/hosted-ao/issues/65): `createProject`
+  in `frontend/src/renderer/routes/_shell.tsx` requires `status.port`, which is
+  only set for the local daemon. Every remote clone and remote session spawn
+  threw before any fetch went out. Local one-line fix accepts `status.baseUrl`
+  as ready too.


### PR DESCRIPTION
## Summary

- Rewrites the hosted log to record the 2026-07-31 v1 flow: Google sign-in,
  machine registry, per-machine tokens, remote clone onto a user-owned VM.
- Adds architecture, verified checks, operator notes for redeploy and
  snapshot restore, and links to the bugs found during verification (#64,
  #65).
- Drops the older shared-pairing-secret section; it is kept in git history if
  ever needed.

## Test plan

- [x] File renders in GitHub markdown preview.
- [x] Links (#64, #65) resolve.