### PR TITLE
feat: account fleet page and retire env-var pairing (task 15)

### DIFF
--- a/controlplane/README.md
+++ b/controlplane/README.md
@@ -67,8 +67,10 @@ curl http://127.0.0.1:8080/healthz
 Open `http://127.0.0.1:8080/login` in a browser and sign in with Google to
 exercise the login flow end to end (see `internal/auth/` for the
 authorization-code exchange with PKCE, the `accounts` upsert, and the browser
-session cookie). Sign-in lands on `/`, the landing page in `internal/home/`,
-which links to the device page. An anonymous `GET /` redirects to `/login`.
+session cookie). Sign-in lands on `/`, the account home page in
+`internal/home/`: it lists machines bound to the account, unbinds them, and
+points at `/device` plus `ao setup-vm` when the list is empty. An anonymous
+`GET /` redirects to `/login`.
 
 ## Reachability probe
 
@@ -218,6 +220,12 @@ curl -s http://127.0.0.1:8080/api/v1/machines -H 'Authorization: Bearer <access 
 curl -s -X POST http://127.0.0.1:8080/api/v1/machines/<machine id>/token \
   -H 'Authorization: Bearer <access token>'
 # {"access_token":"...","token_type":"Bearer","expires_in":900}
+
+# Unbind (revoke) a machine. It drops out of the list and cannot mint tokens.
+curl -s -o /dev/null -w '%{http_code}\n' -X DELETE \
+  http://127.0.0.1:8080/api/v1/machines/<machine id> \
+  -H 'Authorization: Bearer <access token>'
+# 204
 ```
 
 The token that comes back has `aud` = `machines.id` and `sub` = the account

--- a/controlplane/cmd/controlplane/main.go
+++ b/controlplane/cmd/controlplane/main.go
@@ -83,7 +83,28 @@ func main() {
 	// session rather than standing up a second one.
 	desktopauth.NewService(db, issuer, authSvc).Register(mux)
 
-	homeSvc, err := home.NewService(authSvc)
+	// Account home lists and unbinds machines. Bridged without home importing
+	// device: same registry, browser session instead of bearer tokens.
+	homeSvc, err := home.NewService(authSvc, home.Adapt(
+		func(ctx context.Context, accountID string) ([]home.Machine, error) {
+			ms, err := deviceSvc.ListMachines(ctx, accountID)
+			if err != nil {
+				return nil, err
+			}
+			out := make([]home.Machine, len(ms))
+			for i, m := range ms {
+				out[i] = home.Machine{
+					ID:        m.ID,
+					Name:      m.Name,
+					PublicURL: m.PublicURL,
+					CreatedAt: m.CreatedAt,
+					LastSeen:  m.LastSeen,
+				}
+			}
+			return out, nil
+		},
+		deviceSvc.RevokeMachine,
+	), cfg.PublicOrigin)
 	if err != nil {
 		log.Fatalf("init landing page: %v", err)
 	}

--- a/controlplane/internal/device/device.go
+++ b/controlplane/internal/device/device.go
@@ -107,9 +107,10 @@ func (s *Service) Register(mux *http.ServeMux) {
 	mux.HandleFunc("POST /device", s.handleSubmitCode)
 	mux.HandleFunc("POST /device/decision", s.handleDecision)
 
-	// The machine registry API the desktop reads.
+	// The machine registry API the desktop and the account home page use.
 	mux.HandleFunc("GET /api/v1/machines", s.handleListMachines)
 	mux.HandleFunc("POST /api/v1/machines/{id}/token", s.handleMachineToken)
+	mux.HandleFunc("DELETE /api/v1/machines/{id}", s.handleRevokeMachine)
 }
 
 // verificationURI is the absolute URL of the enter-code page.

--- a/controlplane/internal/device/flow_test.go
+++ b/controlplane/internal/device/flow_test.go
@@ -930,7 +930,7 @@ func assertNoMachines(t *testing.T, db *sql.DB) {
 
 // listMachines calls the machines API with a bearer token and returns the
 // decoded list.
-func (h *harness) listMachines(bearer string) []machine {
+func (h *harness) listMachines(bearer string) []Machine {
 	h.t.Helper()
 
 	rec := h.listMachinesRaw(bearer)

--- a/controlplane/internal/device/machine_token_test.go
+++ b/controlplane/internal/device/machine_token_test.go
@@ -38,16 +38,16 @@ func (h *harness) machineToken(machineID, bearer string) machineTokenResponse {
 	return resp
 }
 
-// revokeMachine sets revoked_at on a machine, as a future revoke endpoint will.
+// revokeMachine sets revoked_at on a machine through the public API.
 func (h *harness) revokeMachine(machineID string) {
 	h.t.Helper()
 
-	res, err := h.db.Exec(`UPDATE machines SET revoked_at = CURRENT_TIMESTAMP WHERE id = ?`, machineID)
-	if err != nil {
-		h.t.Fatalf("revoke machine: %v", err)
-	}
-	if n, _ := res.RowsAffected(); n != 1 {
-		h.t.Fatalf("revoke machine affected %d rows, want 1", n)
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/machines/"+machineID, nil)
+	req.Header.Set("Authorization", "Bearer "+h.controlPlaneToken(accountA))
+	rec := httptest.NewRecorder()
+	h.mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusNoContent {
+		h.t.Fatalf("DELETE machine status = %d, want 204, body: %s", rec.Code, rec.Body)
 	}
 }
 

--- a/controlplane/internal/device/machines.go
+++ b/controlplane/internal/device/machines.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"time"
 
 	"github.com/agentlab-in/hosted-ao/controlplane/internal/api"
 )
@@ -15,7 +16,7 @@ import (
 // bare array so a later addition (paging, a revoked list) does not have to
 // break the shape.
 type machinesResponse struct {
-	Machines []machine `json:"machines"`
+	Machines []Machine `json:"machines"`
 }
 
 // handleListMachines serves the account's registered machines to the desktop.
@@ -31,7 +32,7 @@ func (s *Service) handleListMachines(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	machines, err := s.listMachines(r.Context(), accountID)
+	machines, err := s.ListMachines(r.Context(), accountID)
 	if err != nil {
 		log.Printf("device: list machines: %v", err)
 		api.WriteError(w, http.StatusInternalServerError, "server_error", "could not list machines")
@@ -99,6 +100,32 @@ func (s *Service) handleMachineToken(w http.ResponseWriter, r *http.Request) {
 		TokenType:   "Bearer",
 		ExpiresIn:   int(s.issuer.AccessTokenTTL().Seconds()),
 	})
+}
+
+// handleRevokeMachine unbinds a machine from the calling account.
+//
+// Sets revoked_at; the row stays as a tombstone so history is not rewritten.
+// Same not-found story as the token endpoint for foreign, missing, and already
+// revoked ids.
+func (s *Service) handleRevokeMachine(w http.ResponseWriter, r *http.Request) {
+	accountID, ok := s.apiAuth(r)
+	if !ok {
+		api.Unauthorized(w)
+		return
+	}
+
+	machineID := r.PathValue("id")
+	revoked, err := s.RevokeMachine(r.Context(), accountID, machineID, time.Now().UTC())
+	if err != nil {
+		log.Printf("device: revoke machine: %v", err)
+		api.WriteError(w, http.StatusInternalServerError, "server_error", "could not unbind the machine")
+		return
+	}
+	if !revoked {
+		notFound(w)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
 }
 
 // notFound is the answer to a machine id this account may not have a token

--- a/controlplane/internal/device/machines_test.go
+++ b/controlplane/internal/device/machines_test.go
@@ -75,6 +75,48 @@ func TestListMachines_ScopedToTheTokensAccount(t *testing.T) {
 	}
 }
 
+func TestRevokeMachine_RemovesFromListAndBlocksTokens(t *testing.T) {
+	h := newHarness(t)
+	machineID := h.bindMachine(accountA, testPublicURL, "prod vm")
+	credential := h.controlPlaneToken(accountA)
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/machines/"+machineID, nil)
+	req.Header.Set("Authorization", "Bearer "+credential)
+	rec := httptest.NewRecorder()
+	h.mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("DELETE status = %d, want 204, body: %s", rec.Code, rec.Body)
+	}
+
+	if listed := h.listMachines(credential); len(listed) != 0 {
+		t.Fatalf("list after revoke: %d machines, want 0", len(listed))
+	}
+	if rec := h.machineTokenRaw(machineID, credential); rec.Code != http.StatusNotFound {
+		t.Fatalf("token after revoke: status = %d, want 404", rec.Code)
+	}
+
+	// Second DELETE is the same not-found as an unknown id.
+	req2 := httptest.NewRequest(http.MethodDelete, "/api/v1/machines/"+machineID, nil)
+	req2.Header.Set("Authorization", "Bearer "+credential)
+	rec2 := httptest.NewRecorder()
+	h.mux.ServeHTTP(rec2, req2)
+	if rec2.Code != http.StatusNotFound {
+		t.Fatalf("second DELETE status = %d, want 404", rec2.Code)
+	}
+}
+
+func TestRevokeMachine_RequiresControlPlaneToken(t *testing.T) {
+	h := newHarness(t)
+	machineID := h.bindMachine(accountA, testPublicURL, "prod vm")
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/machines/"+machineID, nil)
+	rec := httptest.NewRecorder()
+	h.mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("unauthenticated DELETE status = %d, want 401", rec.Code)
+	}
+}
+
 func TestListMachines_RequiresAControlPlaneAudienceToken(t *testing.T) {
 	h := newHarness(t)
 	machineID := h.bindMachine(accountA, testPublicURL, "prod vm")

--- a/controlplane/internal/device/store.go
+++ b/controlplane/internal/device/store.go
@@ -364,8 +364,8 @@ func (s *Service) poll(ctx context.Context, deviceCode string, now time.Time) (p
 	}
 }
 
-// machine is one row of the list-machines response.
-type machine struct {
+// Machine is one row of the list-machines response and the account home page.
+type Machine struct {
 	ID        string     `json:"id"`
 	Name      string     `json:"name"`
 	PublicURL string     `json:"public_url"`
@@ -373,10 +373,11 @@ type machine struct {
 	LastSeen  *time.Time `json:"last_seen"`
 }
 
-// listMachines returns the account's unrevoked machines, newest first. A
-// revoked machine is omitted rather than flagged: the desktop must not offer
-// it, and nothing in the current UI has a use for its tombstone.
-func (s *Service) listMachines(ctx context.Context, accountID string) ([]machine, error) {
+// ListMachines returns the account's unrevoked machines, newest first. A
+// revoked machine is omitted rather than flagged: the desktop and the account
+// home page must not offer it, and nothing in the current UI has a use for its
+// tombstone.
+func (s *Service) ListMachines(ctx context.Context, accountID string) ([]Machine, error) {
 	rows, err := s.db.QueryContext(ctx,
 		`SELECT id, name, hostname, created_at, last_seen
 		   FROM machines
@@ -389,10 +390,10 @@ func (s *Service) listMachines(ctx context.Context, accountID string) ([]machine
 
 	// Non-nil so an account with no machines serializes as [] rather than
 	// null, which a JSON client would otherwise have to special-case.
-	out := []machine{}
+	out := []Machine{}
 	for rows.Next() {
 		var (
-			m        machine
+			m        Machine
 			lastSeen sql.NullTime
 		)
 		if err := rows.Scan(&m.ID, &m.Name, &m.PublicURL, &m.CreatedAt, &lastSeen); err != nil {
@@ -408,4 +409,26 @@ func (s *Service) listMachines(ctx context.Context, accountID string) ([]machine
 		return nil, fmt.Errorf("iterate machines: %w", err)
 	}
 	return out, nil
+}
+
+// RevokeMachine sets revoked_at on one of accountID's live machines.
+//
+// A revoked machine no longer appears in the list, cannot mint a machine
+// token, and cannot re-bind under the same machines.id until a new bind
+// inserts a fresh row. Returns false when no live row matched (missing,
+// foreign, or already revoked), without distinguishing those cases.
+func (s *Service) RevokeMachine(ctx context.Context, accountID, machineID string, now time.Time) (bool, error) {
+	res, err := s.db.ExecContext(ctx,
+		`UPDATE machines SET revoked_at = ?
+		  WHERE id = ? AND account_id = ? AND revoked_at IS NULL`,
+		now, machineID, accountID,
+	)
+	if err != nil {
+		return false, fmt.Errorf("revoke machine %q: %w", machineID, err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return false, fmt.Errorf("revoke machine %q rows affected: %w", machineID, err)
+	}
+	return n > 0, nil
 }

--- a/controlplane/internal/home/adapter.go
+++ b/controlplane/internal/home/adapter.go
@@ -1,0 +1,28 @@
+package home
+
+import (
+	"context"
+	"time"
+)
+
+// Adapt wraps list and revoke functions as a Machines implementation so main
+// can bridge device.Service without home importing device.
+func Adapt(
+	list func(ctx context.Context, accountID string) ([]Machine, error),
+	revoke func(ctx context.Context, accountID, machineID string, now time.Time) (bool, error),
+) Machines {
+	return machinesFuncs{list: list, revoke: revoke}
+}
+
+type machinesFuncs struct {
+	list   func(ctx context.Context, accountID string) ([]Machine, error)
+	revoke func(ctx context.Context, accountID, machineID string, now time.Time) (bool, error)
+}
+
+func (m machinesFuncs) ListMachines(ctx context.Context, accountID string) ([]Machine, error) {
+	return m.list(ctx, accountID)
+}
+
+func (m machinesFuncs) RevokeMachine(ctx context.Context, accountID, machineID string, now time.Time) (bool, error) {
+	return m.revoke(ctx, accountID, machineID, now)
+}

--- a/controlplane/internal/home/home.go
+++ b/controlplane/internal/home/home.go
@@ -1,75 +1,182 @@
-// Package home serves the control plane's landing page at "/".
+// Package home serves the control plane's account landing page at "/".
 //
-// It exists because sign-in has to land somewhere. Google returns the operator
-// to /auth/google/callback, which redirects to the flow's `next`, and that
-// defaults to "/": with nothing registered there, a successful sign-in ended
-// on a 404, which reads as a broken service at the exact moment the operator
-// has just proved it is not.
-//
-// It is deliberately not a dashboard. The control plane's job is binding a
-// machine to an account, so the page says what to do next and links to the one
-// page that does it.
+// After sign-in the operator lands here. The page lists machines bound to the
+// account, lets them unbind one, and points at the device flow and setup-vm
+// when the list is empty. It is not a second AO board: sessions and terminals
+// stay on each machine's daemon.
 package home
 
 import (
+	"context"
 	"embed"
 	"fmt"
 	"html/template"
 	"log"
 	"net/http"
+	"time"
 )
 
 //go:embed templates/*.html
 var templatesFS embed.FS
 
 // sessions is the slice of the auth service this package needs: who is signed
-// in on the current browser request. An interface, for the same reason the
-// device flow uses one, so the landing page does not pull in the OAuth client.
+// in on the current browser request.
 type sessions interface {
 	AccountFromRequest(r *http.Request) (accountID string, ok bool)
 }
 
-// Service serves the landing page.
-type Service struct {
-	sessions sessions
-	tmpl     *template.Template
+// Machine is one registered VM shown on the account home page.
+type Machine struct {
+	ID        string
+	Name      string
+	PublicURL string
+	CreatedAt time.Time
+	LastSeen  *time.Time
 }
 
-// NewService builds the landing page service.
-func NewService(s sessions) (*Service, error) {
-	tmpl, err := template.ParseFS(templatesFS, "templates/*.html")
+// Machines is the registry this page reads and mutates. device.Service is the
+// production implementation.
+type Machines interface {
+	ListMachines(ctx context.Context, accountID string) ([]Machine, error)
+	RevokeMachine(ctx context.Context, accountID, machineID string, now time.Time) (bool, error)
+}
+
+// Service serves the account home page.
+type Service struct {
+	sessions     sessions
+	machines     Machines
+	publicOrigin string
+	tmpl         *template.Template
+}
+
+// NewService builds the account home page service.
+func NewService(s sessions, m Machines, publicOrigin string) (*Service, error) {
+	tmpl, err := template.New("").Funcs(template.FuncMap{
+		"formatTime": formatTime,
+		"formatSeen": formatSeen,
+	}).ParseFS(templatesFS, "templates/*.html")
 	if err != nil {
 		return nil, fmt.Errorf("parse home templates: %w", err)
 	}
-	return &Service{sessions: s, tmpl: tmpl}, nil
+	return &Service{
+		sessions:     s,
+		machines:     m,
+		publicOrigin: publicOrigin,
+		tmpl:         tmpl,
+	}, nil
 }
 
-// Register wires the landing page onto mux. This is the one call the rest of
-// the control plane needs to know about.
+// Register wires the account home routes onto mux.
 //
-// The pattern is "/{$}", which matches the root path exactly. A bare "/" would
-// match every path no other handler claims, turning every genuine 404 into
-// this page.
+// GET /{$} matches the root path exactly. A bare "/" would claim every path no
+// other handler registered and turn real 404s into this page.
 func (s *Service) Register(mux *http.ServeMux) {
 	mux.HandleFunc("GET /{$}", s.handleHome)
+	mux.HandleFunc("POST /machines/unbind", s.handleUnbind)
 }
 
-// handleHome renders the landing page for a signed-in operator, and sends
-// everyone else to sign in.
-//
-// The unauthenticated case is a redirect to /login, not a 404 and not a public
-// page: "/" is the address a person types, the only thing they can usefully do
-// here needs an account, and /login already sends them back to "/" afterwards
-// because that is its default `next`.
+type pageData struct {
+	Machines []Machine
+	Flash    string
+	Error    string
+}
+
 func (s *Service) handleHome(w http.ResponseWriter, r *http.Request) {
-	if _, ok := s.sessions.AccountFromRequest(r); !ok {
+	accountID, ok := s.sessions.AccountFromRequest(r)
+	if !ok {
 		http.Redirect(w, r, "/login", http.StatusFound)
 		return
 	}
 
-	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	if err := s.tmpl.ExecuteTemplate(w, "home.html", nil); err != nil {
-		log.Printf("home: render landing page: %v", err)
+	machines, err := s.machines.ListMachines(r.Context(), accountID)
+	if err != nil {
+		log.Printf("home: list machines: %v", err)
 		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
 	}
+
+	flash := r.URL.Query().Get("unbound")
+	s.render(w, http.StatusOK, pageData{
+		Machines: machines,
+		Flash:    flash,
+	})
+}
+
+// handleUnbind revokes a machine from the signed-in account via a browser form.
+//
+// Session cookie plus same-origin check (same pattern as the device approval
+// POSTs). On success redirects to / so a refresh does not re-POST.
+func (s *Service) handleUnbind(w http.ResponseWriter, r *http.Request) {
+	accountID, ok := s.sessions.AccountFromRequest(r)
+	if !ok {
+		http.Redirect(w, r, "/login", http.StatusFound)
+		return
+	}
+	if !s.sameOrigin(w, r) {
+		return
+	}
+	if err := r.ParseForm(); err != nil {
+		http.Error(w, "bad request", http.StatusBadRequest)
+		return
+	}
+	machineID := r.FormValue("machine_id")
+	if machineID == "" {
+		http.Error(w, "machine_id is required", http.StatusBadRequest)
+		return
+	}
+
+	revoked, err := s.machines.RevokeMachine(r.Context(), accountID, machineID, time.Now().UTC())
+	if err != nil {
+		log.Printf("home: unbind machine: %v", err)
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+	if !revoked {
+		// Same soft landing as an already-revoked row: re-render the list.
+		machines, listErr := s.machines.ListMachines(r.Context(), accountID)
+		if listErr != nil {
+			log.Printf("home: list machines after failed unbind: %v", listErr)
+			http.Error(w, "internal error", http.StatusInternalServerError)
+			return
+		}
+		s.render(w, http.StatusNotFound, pageData{
+			Machines: machines,
+			Error:    "That machine is not on this account (it may already be unbound).",
+		})
+		return
+	}
+
+	http.Redirect(w, r, "/?unbound=1", http.StatusSeeOther)
+}
+
+// sameOrigin rejects a browser POST that did not come from this control plane.
+// Missing Origin is allowed (curl, tests); a present wrong Origin is not.
+func (s *Service) sameOrigin(w http.ResponseWriter, r *http.Request) bool {
+	if o := r.Header.Get("Origin"); o != "" && o != s.publicOrigin {
+		http.Error(w, "That request did not come from this page.", http.StatusForbidden)
+		return false
+	}
+	return true
+}
+
+func (s *Service) render(w http.ResponseWriter, status int, data pageData) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.WriteHeader(status)
+	if err := s.tmpl.ExecuteTemplate(w, "home.html", data); err != nil {
+		log.Printf("home: render landing page: %v", err)
+	}
+}
+
+func formatTime(t time.Time) string {
+	if t.IsZero() {
+		return ""
+	}
+	return t.UTC().Format("2006-01-02")
+}
+
+func formatSeen(t *time.Time) string {
+	if t == nil || t.IsZero() {
+		return "never"
+	}
+	return t.UTC().Format("2006-01-02 15:04 UTC")
 }

--- a/controlplane/internal/home/home_test.go
+++ b/controlplane/internal/home/home_test.go
@@ -1,11 +1,17 @@
 package home
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 )
+
+const testOrigin = "https://ao.agentlab.in"
 
 // fakeSessions signs a request in, or does not.
 type fakeSessions struct{ signedIn bool }
@@ -14,9 +20,38 @@ func (f fakeSessions) AccountFromRequest(*http.Request) (string, bool) {
 	return "account-1", f.signedIn
 }
 
-func newTestMux(t *testing.T, signedIn bool) *http.ServeMux {
+// fakeMachines is an in-memory registry for the home page tests.
+type fakeMachines struct {
+	mu       sync.Mutex
+	machines []Machine
+}
+
+func (f *fakeMachines) ListMachines(context.Context, string) ([]Machine, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]Machine, len(f.machines))
+	copy(out, f.machines)
+	return out, nil
+}
+
+func (f *fakeMachines) RevokeMachine(_ context.Context, _, machineID string, _ time.Time) (bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for i, m := range f.machines {
+		if m.ID == machineID {
+			f.machines = append(f.machines[:i], f.machines[i+1:]...)
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func newTestMux(t *testing.T, signedIn bool, m Machines) *http.ServeMux {
 	t.Helper()
-	svc, err := NewService(fakeSessions{signedIn: signedIn})
+	if m == nil {
+		m = &fakeMachines{}
+	}
+	svc, err := NewService(fakeSessions{signedIn: signedIn}, m, testOrigin)
 	if err != nil {
 		t.Fatalf("NewService: %v", err)
 	}
@@ -34,7 +69,7 @@ func get(mux *http.ServeMux, path string) *httptest.ResponseRecorder {
 // TestSignedInLandingPage is the whole point of the page: sign-in redirects to
 // "/", and "/" must not 404.
 func TestSignedInLandingPage(t *testing.T) {
-	w := get(newTestMux(t, true), "/")
+	w := get(newTestMux(t, true, nil), "/")
 
 	if w.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200", w.Code)
@@ -42,9 +77,41 @@ func TestSignedInLandingPage(t *testing.T) {
 	if ct := w.Header().Get("Content-Type"); !strings.HasPrefix(ct, "text/html") {
 		t.Fatalf("Content-Type = %q, want text/html", ct)
 	}
-	// The useful next step, which is the only reason this page exists.
 	if !strings.Contains(w.Body.String(), `href="/device"`) {
 		t.Fatalf("landing page does not link to /device:\n%s", w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "No machines yet") {
+		t.Fatalf("empty state missing setup copy:\n%s", w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "ao setup-vm") {
+		t.Fatalf("empty state missing setup-vm command:\n%s", w.Body.String())
+	}
+}
+
+func TestSignedInListsMachines(t *testing.T) {
+	reg := &fakeMachines{machines: []Machine{{
+		ID:        "mch-1",
+		Name:      "prod vm",
+		PublicURL: "https://vm.example.com",
+		CreatedAt: time.Date(2026, 7, 30, 0, 0, 0, 0, time.UTC),
+	}}}
+	w := get(newTestMux(t, true, reg), "/")
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, "prod vm") {
+		t.Fatalf("machine name missing:\n%s", body)
+	}
+	if !strings.Contains(body, "https://vm.example.com") {
+		t.Fatalf("public URL missing:\n%s", body)
+	}
+	if !strings.Contains(body, `name="machine_id" value="mch-1"`) {
+		t.Fatalf("unbind form missing machine id:\n%s", body)
+	}
+	if strings.Contains(body, "No machines yet") {
+		t.Fatalf("empty state shown with machines present:\n%s", body)
 	}
 }
 
@@ -52,7 +119,7 @@ func TestSignedInLandingPage(t *testing.T) {
 // GET /. Not a 404, and not a public page, because everything reachable from
 // here needs an account.
 func TestUnauthenticatedRedirectsToLogin(t *testing.T) {
-	w := get(newTestMux(t, false), "/")
+	w := get(newTestMux(t, false, nil), "/")
 
 	if w.Code != http.StatusFound {
 		t.Fatalf("status = %d, want %d", w.Code, http.StatusFound)
@@ -65,7 +132,77 @@ func TestUnauthenticatedRedirectsToLogin(t *testing.T) {
 // TestOnlyMatchesRoot guards the "/{$}" pattern: a bare "/" would claim every
 // path no other handler registered and turn real 404s into this page.
 func TestOnlyMatchesRoot(t *testing.T) {
-	if w := get(newTestMux(t, true), "/no-such-page"); w.Code != http.StatusNotFound {
+	if w := get(newTestMux(t, true, nil), "/no-such-page"); w.Code != http.StatusNotFound {
 		t.Fatalf("status = %d, want 404", w.Code)
+	}
+}
+
+func TestUnbindRemovesMachineAndRedirects(t *testing.T) {
+	reg := &fakeMachines{machines: []Machine{{
+		ID:        "mch-1",
+		Name:      "prod vm",
+		PublicURL: "https://vm.example.com",
+		CreatedAt: time.Now().UTC(),
+	}}}
+	mux := newTestMux(t, true, reg)
+
+	form := url.Values{"machine_id": {"mch-1"}}
+	req := httptest.NewRequest(http.MethodPost, "/machines/unbind", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Origin", testOrigin)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("status = %d, want %d, body: %s", w.Code, http.StatusSeeOther, w.Body)
+	}
+	if got := w.Header().Get("Location"); got != "/?unbound=1" {
+		t.Fatalf("Location = %q, want /?unbound=1", got)
+	}
+	listed, _ := reg.ListMachines(context.Background(), "account-1")
+	if len(listed) != 0 {
+		t.Fatalf("machines left after unbind: %+v", listed)
+	}
+
+	// Flash on the following GET.
+	home := get(mux, "/?unbound=1")
+	if !strings.Contains(home.Body.String(), "Machine unbound") {
+		t.Fatalf("flash missing after unbind:\n%s", home.Body.String())
+	}
+}
+
+func TestUnbindRejectsCrossOrigin(t *testing.T) {
+	reg := &fakeMachines{machines: []Machine{{ID: "mch-1", Name: "prod", PublicURL: "https://vm.example.com"}}}
+	mux := newTestMux(t, true, reg)
+
+	form := url.Values{"machine_id": {"mch-1"}}
+	req := httptest.NewRequest(http.MethodPost, "/machines/unbind", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Origin", "https://evil.example")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", w.Code)
+	}
+	listed, _ := reg.ListMachines(context.Background(), "account-1")
+	if len(listed) != 1 {
+		t.Fatalf("cross-origin POST must not unbind; machines = %+v", listed)
+	}
+}
+
+func TestUnbindUnknownMachine(t *testing.T) {
+	mux := newTestMux(t, true, &fakeMachines{})
+	form := url.Values{"machine_id": {"nope"}}
+	req := httptest.NewRequest(http.MethodPost, "/machines/unbind", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "not on this account") {
+		t.Fatalf("error copy missing:\n%s", w.Body.String())
 	}
 }

--- a/controlplane/internal/home/templates/home.html
+++ b/controlplane/internal/home/templates/home.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>AO</title>
+  <title>Your machines - AO</title>
   {{/*
     Inline styling, kept in step with internal/auth/templates/signin.html and
     internal/device/templates/device_style.html so sign-in, this page, and
@@ -16,34 +16,85 @@
       background: #0b0d12;
       color: #e6e8eb;
       display: flex;
-      align-items: center;
+      align-items: flex-start;
       justify-content: center;
       min-height: 100vh;
       margin: 0;
+      padding: 2rem 1rem;
+      box-sizing: border-box;
     }
     .card {
       background: #151821;
       border: 1px solid #262b36;
       border-radius: 12px;
-      padding: 2.5rem;
-      width: 360px;
-      text-align: center;
+      padding: 2rem;
+      width: 100%;
+      max-width: 520px;
     }
     h1 {
       font-size: 1.25rem;
-      margin: 0 0 1rem;
+      margin: 0 0 0.5rem;
     }
     p.hint {
       color: #9aa4b2;
       font-size: 0.875rem;
       margin: 0 0 1.25rem;
+      line-height: 1.45;
     }
     p.hint:last-child {
-      margin: 1.25rem 0 0;
+      margin-bottom: 0;
     }
     code {
       font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
       word-break: break-all;
+      font-size: 0.8em;
+    }
+    .flash {
+      background: #13251a;
+      border: 1px solid #1f6f3a;
+      color: #9ae6b4;
+      border-radius: 8px;
+      padding: 0.65rem 0.85rem;
+      font-size: 0.875rem;
+      margin: 0 0 1rem;
+    }
+    .error {
+      background: #2a1515;
+      border: 1px solid #7f1d1d;
+      color: #fca5a5;
+      border-radius: 8px;
+      padding: 0.65rem 0.85rem;
+      font-size: 0.875rem;
+      margin: 0 0 1rem;
+    }
+    .machines {
+      list-style: none;
+      margin: 0 0 1.25rem;
+      padding: 0;
+    }
+    .machine {
+      border: 1px solid #262b36;
+      border-radius: 8px;
+      padding: 0.9rem 1rem;
+      margin: 0 0 0.65rem;
+      text-align: left;
+    }
+    .machine:last-child {
+      margin-bottom: 0;
+    }
+    .machine-name {
+      font-weight: 600;
+      margin: 0 0 0.25rem;
+      font-size: 0.95rem;
+    }
+    .machine-meta {
+      color: #9aa4b2;
+      font-size: 0.8rem;
+      margin: 0 0 0.75rem;
+      line-height: 1.4;
+    }
+    .machine-meta code {
+      color: #c5cbd3;
     }
     .button {
       display: block;
@@ -58,19 +109,107 @@
       font-size: 1rem;
       font-weight: 600;
       cursor: pointer;
+      text-align: center;
     }
     .button:hover {
       background: #2563eb;
       border-color: #2563eb;
     }
+    .button.secondary {
+      background: transparent;
+      border-color: #262b36;
+      color: #9aa4b2;
+      margin-top: 0.65rem;
+    }
+    .button.secondary:hover {
+      border-color: #3b4252;
+      color: #e6e8eb;
+    }
+    .button.danger {
+      background: transparent;
+      border-color: #7f1d1d;
+      color: #fca5a5;
+      font-size: 0.85rem;
+      padding: 0.45rem 0.75rem;
+      width: auto;
+      display: inline-block;
+    }
+    .button.danger:hover {
+      background: #2a1515;
+      border-color: #991b1b;
+      color: #fecaca;
+    }
+    .empty {
+      border: 1px dashed #262b36;
+      border-radius: 8px;
+      padding: 1.25rem;
+      margin: 0 0 1.25rem;
+      text-align: left;
+    }
+    .empty p {
+      margin: 0 0 0.75rem;
+      color: #9aa4b2;
+      font-size: 0.875rem;
+      line-height: 1.45;
+    }
+    .empty p:last-child {
+      margin-bottom: 0;
+    }
+    .empty ol {
+      margin: 0.5rem 0 0;
+      padding-left: 1.2rem;
+      color: #9aa4b2;
+      font-size: 0.875rem;
+      line-height: 1.5;
+    }
   </style>
 </head>
 <body>
   <div class="card">
-    <h1>You are signed in</h1>
-    <p class="hint">Connect a VM to this account to run agents on it from anywhere.</p>
+    <h1>Your machines</h1>
+    <p class="hint">VMs bound to this AO account. The desktop app lists the same set; pick one there to run agents on it.</p>
+
+    {{if .Flash}}
+    <p class="flash">Machine unbound. It will no longer accept tokens for this account.</p>
+    {{end}}
+    {{if .Error}}
+    <p class="error">{{.Error}}</p>
+    {{end}}
+
+    {{if .Machines}}
+    <ul class="machines">
+      {{range .Machines}}
+      <li class="machine">
+        <p class="machine-name">{{.Name}}</p>
+        <p class="machine-meta">
+          <code>{{.PublicURL}}</code><br>
+          Bound {{formatTime .CreatedAt}} · Last seen {{formatSeen .LastSeen}}
+        </p>
+        <form method="post" action="/machines/unbind" onsubmit="return confirm('Unbind {{.Name}}? The desktop will stop being able to reach it until you run setup-vm again.');">
+          <input type="hidden" name="machine_id" value="{{.ID}}">
+          <button type="submit" class="button danger">Unbind</button>
+        </form>
+      </li>
+      {{end}}
+    </ul>
+    {{else}}
+    <div class="empty">
+      <p><strong style="color:#e6e8eb">No machines yet.</strong></p>
+      <p>On an Ubuntu LTS VM with a public DNS name pointed at it:</p>
+      <ol>
+        <li>Open ports <code>80</code> and <code>443</code> on the cloud firewall and host firewall.</li>
+        <li>Run <code>sudo ao setup-vm --domain your.domain</code>.</li>
+        <li>Open the link it prints (or enter the code on <a href="/device" style="color:#93c5fd">/device</a>) while signed in here.</li>
+        <li>Sign the harness in as the <em>daemon</em> Unix user, then check with <code>ao doctor</code>.</li>
+      </ol>
+      <p>After bind, open the AO desktop, sign in, and pick the machine.</p>
+    </div>
+    {{end}}
+
     <a class="button" href="/device">Connect a machine</a>
-    <p class="hint">No VM yet? Run <code>sudo ao setup-vm --domain your.domain</code> on an Ubuntu VM, then enter the code it prints.</p>
+    {{if .Machines}}
+    <p class="hint" style="margin-top:1.25rem">New box? Run <code>sudo ao setup-vm --domain your.domain</code>, then enter the code via Connect a machine.</p>
+    {{end}}
   </div>
 </body>
 </html>

--- a/deploy/hosted/README.md
+++ b/deploy/hosted/README.md
@@ -1,97 +1,34 @@
-# Hosted AO proxy
+# Hosted AO proxy (retired)
 
-> **Scope note (2026-07-30).** This file documents the **pairing-secret Caddy proxy**, the
-> pre-accounts hosted path. It is still the only path that has ever run on a VM, and it keeps
-> working on purpose: spec task 15 removes `AO_REMOTE_URL`, `AO_REMOTE_TOKEN`, and the
-> `ao_hosted_pair` secret only after the fresh-VM run (task 14) passes, so remote mode is
-> never untestable mid-build.
->
-> The replacement is `ao setup-vm` plus `ao vm serve`: per-account registered machines and
-> short-lived per-machine JWTs instead of one shared secret, and the `ao` binary itself
-> holding `:80` and `:443` instead of Caddy. It is merged but **unrun**; task 14 owns
-> standing it up on a clean Ubuntu LTS VM and writing the deployment guide for it. Do not
-> read the accounts path out of this file, and do not add results here that have not
-> happened. See [`docs/adr/0002-hosted-public-gateway.md`](../../docs/adr/0002-hosted-public-gateway.md)
-> and [`docs/hosted-ao-v1-build-log.md`](../../docs/hosted-ao-v1-build-log.md).
+> **Retired by spec task 15.** The pairing-secret Caddy path
+> (`AO_REMOTE_URL`, `AO_REMOTE_TOKEN`, `ao_hosted_pair` / `AO_HOSTED_PAIR_TOKEN`)
+> is no longer supported. Remote mode is accounts only: bind a VM with
+> `ao setup-vm`, sign in on the desktop against the control plane, and pick the
+> machine. The desktop carries short-lived machine-audience JWTs; the VM runs
+> `ao vm serve` on `:80` and `:443`.
 
-This deployment exposes the AO daemon on a VM through Caddy at
-`https://api.ao.agentlab.in`. The daemon remains loopback-only on
-`127.0.0.1:3001`; Caddy is the only public listener and permits requests only
-when their `ao_hosted_pair` cookie exactly matches `AO_HOSTED_PAIR_TOKEN`.
+## What to use instead
 
-## VM setup
+| Concern | Path |
+| --- | --- |
+| Control plane (login, device flow, machines) | `https://ao.agentlab.in` and `controlplane/` + `deploy/controlplane/` |
+| User VM public edge | `ao setup-vm` installs `ao-daemon` + `ao-gateway` (`ao vm serve`) |
+| Desktop remote | Sign in → machine picker → machine-audience token (no env pairing) |
+| Development hatch | `AO_CONTROL_URL` selects which control plane to trust; it never skips auth |
 
-Install the supplied `Caddyfile` as `/etc/caddy/Caddyfile`. Create the pairing
-secret once, store it in a root-readable systemd environment file, and use the
-same value as the local desktop's `AO_REMOTE_TOKEN`.
+## Historical files in this directory
 
-```bash
-# VM: create a URL-safe pairing secret once and store it in a root-readable env file.
-openssl rand -base64 32 | tr '+/' '-_' | tr -d '='
+`Caddyfile` is kept only so old deployments can be recognized and torn down.
+Do not install it on a new VM. Caddy and `ao vm serve` both want `:80`/`:443`,
+so they cannot share a host.
 
-# VM: run the existing daemon only on loopback.
-AO_PORT=3001 ao daemon
+To retire a leftover pairing proxy on an existing box:
 
-# VM: validate with the same root-only environment file that systemd loads.
-sudo sh -c 'set -a; . /etc/caddy/hosted-ao.env; caddy validate --adapter caddyfile --config /etc/caddy/Caddyfile'
-sudo systemctl reload caddy
+1. Stop and disable the Caddy unit that served `api.ao.agentlab.in` with the
+   pairing cookie matcher.
+2. Ensure `ao-gateway.service` (`ao vm serve`) is the public listener.
+3. Remove any desktop launch wrappers that still export `AO_REMOTE_URL` /
+   `AO_REMOTE_TOKEN`.
 
-# Mac: launch the desktop build in remote mode.
-AO_REMOTE_URL=https://api.ao.agentlab.in AO_REMOTE_TOKEN="$AO_HOSTED_PAIR_TOKEN" npm run dev
-```
-
-Do not put the generated secret in shell history, logs, or this repository. Its
-URL-safe form (`A-Z`, `a-z`, `0-9`, `-`, and `_`) is safe to use literally in
-the Caddy cookie-matching regular expression. Create `/etc/caddy/hosted-ao.env`
-with mode `600`, owned by `root`, containing
-`AO_HOSTED_PAIR_TOKEN=<generated-secret>`. Configure Caddy with this systemd
-drop-in:
-
-```ini
-# /etc/systemd/system/caddy.service.d/hosted-ao.conf
-[Service]
-EnvironmentFile=/etc/caddy/hosted-ao.env
-ExecStart=
-ExecStart=/usr/bin/caddy run --config /etc/caddy/Caddyfile
-```
-
-Then run `sudo systemctl daemon-reload && sudo systemctl restart caddy`. The
-`ExecStart` replacement deliberately removes Ubuntu's default `--environ` flag,
-which would otherwise write the pairing secret to Caddy's journal. Caddy still
-retains access to its certificate storage for TLS issuance and renewal.
-The supplied Caddyfile uses Caddy's `{$AO_HOSTED_PAIR_TOKEN}` parse-time
-substitution, which is required for the cookie regular-expression matcher.
-
-Create an A record for `api.ao.agentlab.in` that points to `YOUR_VM_PUBLIC_IP`.
-Allow TCP ports 80 and 443 through both the Azure NSG and the VM host firewall.
-Do not expose port 3001. Do not add a public daemon bind, a second daemon
-listener, or a proxy route for a browser preview server. The one permitted
-network-facing bind besides this proxy is `ao vm serve`, the VM gateway, which
-is a separate process from the daemon and is covered by ADR 0002; that carve-out
-is in `AGENTS.md` and does not widen anything here. Caddy and `ao vm serve` both
-want `:80` and `:443`, so they cannot run on the same VM at the same time.
-
-`app://renderer` is already the Go daemon's default allowed CORS origin. Do
-not set `AO_ALLOWED_ORIGINS` on the VM in a way that overwrites that default.
-
-## Manual end-to-end smoke test
-
-After copying the Caddyfile to the VM and exporting a non-secret test token in
-the Caddy service environment, validate the configuration without starting
-deployment services:
-
-```bash
-sudo sh -c 'set -a; . /etc/caddy/hosted-ao.env; caddy validate --adapter caddyfile --config /etc/caddy/Caddyfile'
-```
-
-Expected: Caddy reports that the configuration is valid. Do not print the
-token in terminal output.
-
-Then perform these checks in order:
-
-1. `curl -i https://api.ao.agentlab.in/healthz` returns `401` without the cookie.
-2. `curl -i --cookie "ao_hosted_pair=$AO_HOSTED_PAIR_TOKEN" https://api.ao.agentlab.in/healthz` returns the daemon health response.
-3. Start the local Electron app with the two remote variables and verify the sidebar displays a project stored on the VM.
-4. Change a VM session through the AO API or CLI and verify the desktop board refreshes without a manual reload; this verifies the credentialed SSE connection.
-5. Open that session's terminal in Electron, type `pwd`, and verify the output reports the VM workspace path; this verifies the WSS mux and pairing cookie on the upgrade request.
-6. Quit the app, start it with no remote variables, and verify a local daemon is discovered or started as before.
+Architecture: [`docs/adr/0002-hosted-public-gateway.md`](../../docs/adr/0002-hosted-public-gateway.md).
+Verification writeup: [`hosted-log.md`](../../hosted-log.md).

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -85,47 +85,66 @@ surface (`npm run sqlc`, `npm run api`).
 
 ## Hosted AO v1: accounts and registered machines
 
-Tracked separately because it lives on `develop`, not `main`, and because it is not
-usable end to end yet. Spec:
+Lives on `develop` (not yet the story on `main`). Spec:
 [`superpowers/specs/2026-07-29-hosted-ao-v1-accounts-and-machines.md`](superpowers/specs/2026-07-29-hosted-ao-v1-accounts-and-machines.md).
 Decisions, the PR-per-task table, and the review history:
 [`hosted-ao-v1-build-log.md`](hosted-ao-v1-build-log.md).
+Real-VM verification writeup: [`../hosted-log.md`](../hosted-log.md)
+([#68](https://github.com/agentlab-in/hosted-ao/pull/68)).
 
-**12 of the 15 spec tasks are merged into `develop`** (batches 1 through 4), plus
-`GET /api/v1/doctor` ([#36](https://github.com/agentlab-in/hosted-ao/pull/36)), which was
-added mid-build so the desktop could read remote machine readiness.
+**Tasks 1 through 14 are done.** Batches 1 through 4 plus batch 5 transport and the
+fresh-VM run are on `develop`. Mid-build additions that stayed:
+`GET /api/v1/doctor` ([#36](https://github.com/agentlab-in/hosted-ao/pull/36)),
+`POST /api/v1/machines/{id}/token` ([#50](https://github.com/agentlab-in/hosted-ao/pull/50)),
+desktop OAuth authorize/token ([#62](https://github.com/agentlab-in/hosted-ao/pull/62)),
+reachability probe and post-login landing ([#61](https://github.com/agentlab-in/hosted-ao/pull/61)).
+Verification fixes that closed the two e2e blockers:
+gateway honors `AO_ALLOWED_ORIGINS` ([#66](https://github.com/agentlab-in/hosted-ao/pull/66)),
+remote project create accepts `status.baseUrl`
+([#67](https://github.com/agentlab-in/hosted-ao/pull/67)).
 
-Merged:
+### Shipped on `develop`
 
-- **Control plane** (`controlplane/`): Google login with PKCE, EdDSA signing keys and JWKS,
-  access and refresh token issuance with rotation, the RFC 8628 device flow, the machine
-  registry, and the authenticated `GET /api/v1/machines`.
+- **Control plane** (`controlplane/`, live at `https://ao.agentlab.in`): Google login with
+  PKCE, desktop OAuth authorize/token, EdDSA signing keys and JWKS, access and refresh
+  token issuance with rotation, the RFC 8628 device flow, the machine registry,
+  authenticated `GET /api/v1/machines`, machine-audience token mint at
+  `POST /api/v1/machines/{id}/token`, off-box reachability probe, post-login landing page.
 - **VM gateway** (`ao vm serve`): ACME TLS, JWT verification against the control plane's
   JWKS, machine allowlist, reverse proxy to the loopback daemon, deny-by-default path
-  allowlist, CORS preflight handling.
+  allowlist, CORS preflight handling (including `AO_ALLOWED_ORIGINS`).
 - **CLI**: `ao setup-vm` (Ubuntu preflight, dependency install, systemd units for daemon and
   gateway, device binding, `machine.json`), `ao vm setup-harness claude`, `ao whoami`, and
   `cloneUrl` on `POST /api/v1/projects`.
-- **Desktop**: AO account login through the system browser, the machine list, picker, and
-  switching.
+- **Desktop**: AO account login through the system browser, machine list / picker /
+  switching, authenticated remote transport (Bearer on REST and SSE, JWT-valued
+  `ao_gw_token` cookie for `/mux`, silent refresh), remote project create by Git URL.
+- **State isolation**: hosted desktop and daemon state default under `~/.ao/hosted`
+  ([#60](https://github.com/agentlab-in/hosted-ao/pull/60)) so they never fight the
+  upstream agent-orchestrator install over `~/.ao`.
 
-Still open, in spec order:
+### Verified end to end (2026-07-31)
 
-- **Task 13, desktop authenticated remote transport**
-  ([#48](https://github.com/agentlab-in/hosted-ao/issues/48)): in flight. Bearer tokens on
-  REST and SSE, the JWT-valued `ao_gw_token` cookie for `/mux`, and silent refresh. Its
-  prerequisite, `POST /api/v1/machines/{id}/token`
-  ([#47](https://github.com/agentlab-in/hosted-ao/issues/47)), is in flight alongside it:
-  nothing currently mints a machine-audience token for a desktop install, so the remote
-  transport has no credential to carry. Until both land, picking a machine in the desktop
-  reports a not-ready state on purpose.
-- **Task 14, fresh-VM end-to-end verification and docs**: blocked on hardware. It needs an
-  Ubuntu LTS VM, a DNS A record pointing at it, and a hand-created Google OAuth client. No
-  part of the hosted stack has run on a real VM yet: the gateway has never obtained a
-  certificate, and the device flow has never run against real DNS.
-- **Task 15, retire the env-var pairing path**: gated on task 14 passing. `AO_REMOTE_URL`,
-  `AO_REMOTE_TOKEN`, and the `ao_hosted_pair` shared secret are removed only once accounts
-  are proven end to end, so remote mode is never untestable mid-build.
+On a real user-owned VM (`vm-test.ao.agentlab.in`), from a signed-out desktop:
+
+1. Google sign-in against `https://ao.agentlab.in`
+2. Account machines listed; remote machine selected
+3. Project cloned by Git URL onto the VM over the machine-audience JWT path
+4. Claude harness auth on the VM reported `PASS` via `ao doctor`
+
+Details, operator redeploy notes, and snapshot restore behavior:
+[`../hosted-log.md`](../hosted-log.md).
+
+### Task 15 and account home (done)
+
+- **Env-var pairing path retired.** `AO_REMOTE_URL`, `AO_REMOTE_TOKEN`, and the
+  `ao_hosted_pair` cookie are gone from the desktop. Remote is accounts only.
+  `AO_CONTROL_URL` remains the development hatch (which control plane to trust; never
+  skips authentication). `deploy/hosted/` documents the old Caddy pairing proxy as
+  retired.
+- **Account home on the control plane** (`GET /`): lists machines bound to the signed-in
+  account, unbind via `POST /machines/unbind` (session + same-origin), and empty-state
+  setup copy for `ao setup-vm`. API unbind: `DELETE /api/v1/machines/{id}`.
 
 Three code-review reports covering batches 1 through 4 are preserved in
 [`reviews/`](reviews/), with every finding mapped to the PR that fixed it.

--- a/docs/hosted-ao-v1-build-log.md
+++ b/docs/hosted-ao-v1-build-log.md
@@ -31,9 +31,9 @@ independent and were built in parallel by separate AO workers.
 | 10. `ao setup-vm`, part two | 4 | [#32](https://github.com/agentlab-in/hosted-ao/pull/32) | [#29](https://github.com/agentlab-in/hosted-ao/issues/29) | merged |
 | 11. `ao vm setup-harness claude` | 4 | [#33](https://github.com/agentlab-in/hosted-ao/pull/33) | [#30](https://github.com/agentlab-in/hosted-ao/issues/30) | merged |
 | 12. Desktop: machine list | 4 | [#35](https://github.com/agentlab-in/hosted-ao/pull/35) | [#31](https://github.com/agentlab-in/hosted-ao/issues/31) | merged |
-| 13. Desktop: authenticated remote transport | 5 | not opened | [#48](https://github.com/agentlab-in/hosted-ao/issues/48) | in flight |
-| 14. Fresh-VM end-to-end verification and docs | 5 | not opened | not filed | blocked on hardware |
-| 15. Retire the env-var pairing path | 5 | not opened | not filed | gated on task 14 |
+| 13. Desktop: authenticated remote transport | 5 | [#54](https://github.com/agentlab-in/hosted-ao/pull/54) | [#48](https://github.com/agentlab-in/hosted-ao/issues/48) | merged |
+| 14. Fresh-VM end-to-end verification and docs | 5 | [#68](https://github.com/agentlab-in/hosted-ao/pull/68) | not filed | done (see `hosted-log.md`) |
+| 15. Retire the env-var pairing path | 5 | (this change) | not filed | done; accounts-only remote + account home fleet page |
 
 Two pieces of work were added mid-build and are not spec tasks:
 

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -42,7 +42,7 @@ import { type DaemonLaunchSpec, resolveDaemonLaunch } from "./shared/daemon-laun
 import { createListenPortScanner, defaultRunFilePath, parseRunFile } from "./shared/daemon-discovery";
 import { STATE_ROOT_SEGMENTS } from "./shared/state-root";
 import type { DaemonStatus } from "./shared/daemon-status";
-import { machineAuthFailedStatus, readRemoteDaemonConfig, type RemoteDaemonConfig } from "./shared/remote-daemon";
+import { machineAuthFailedStatus } from "./shared/remote-daemon";
 import { attachAppShortcuts } from "./main/app-shortcuts";
 import { KEYBOARD_SHORTCUTS_HELP_CHANNEL } from "./shared/shortcuts";
 import {
@@ -110,29 +110,12 @@ let daemonProcess: ChildProcess | null = null;
 let daemonStoppingProcess: ChildProcess | null = null;
 let daemonStartPromise: Promise<DaemonStatus> | null = null;
 let daemonStartEpoch = 0;
-let remoteDaemonConfigurationFailureStatus: DaemonStatus | null = null;
-const remoteDaemonConfig: RemoteDaemonConfig | null = (() => {
-	try {
-		return readRemoteDaemonConfig(process.env);
-	} catch {
-		remoteDaemonConfigurationFailureStatus = {
-			state: "error",
-			message: "Remote daemon configuration is invalid.",
-			code: "not_configured",
-		};
-		return null;
-	}
-})();
 // The active registered machine's status, or null when this computer is the
 // active machine. Held here rather than read from the machines controller so
 // the lifecycle can be built before the state dir is resolved, and so a remote
 // machine restored at boot is in force before the first startDaemon() call.
 let activeMachineStatus: DaemonStatus | null = null;
-const remoteDaemonLifecycle = createRemoteDaemonLifecycle(
-	remoteDaemonConfig,
-	remoteDaemonConfigurationFailureStatus,
-	() => activeMachineStatus,
-);
+const remoteDaemonLifecycle = createRemoteDaemonLifecycle(() => activeMachineStatus);
 let daemonStatus: DaemonStatus = remoteDaemonLifecycle.currentStatus() ?? { state: "stopped" };
 let daemonOutput = "";
 let browserViewHost: BrowserViewHost | null = null;
@@ -1528,11 +1511,6 @@ function machineTransport(): MachineTransport | null {
  * gateway cookie.
  */
 function applyActiveMachine(machine: AoMachine | null): void {
-	// AO_REMOTE_URL is checked first in the lifecycle and wins outright, so the
-	// renderer is pointed at the env origin no matter what is selected here.
-	// Fetching a machine credential for a gateway nothing will call would be a
-	// pointless token request, and the env hatch keeps behaving exactly as before.
-	if (remoteDaemonConfig) return;
 	const transport = machineTransport();
 	if (transport) {
 		transport.setMachine(machine);
@@ -1679,12 +1657,6 @@ app.whenReady().then(async () => {
 
 	registerRendererProtocol();
 	applyRuntimeAppIcon();
-	if (remoteDaemonConfig) {
-		const remoteStatus = await remoteDaemonLifecycle.installCookie(session.defaultSession.cookies);
-		if (remoteStatus) {
-			setDaemonStatus(remoteStatus);
-		}
-	}
 	// Before the first startDaemon(): a machine chosen in a previous run must be
 	// active by the time anything can start a daemon, or the app would spawn a
 	// local one on behalf of a remote machine. restore() reads the remembered

--- a/frontend/src/main/remote-daemon.test.ts
+++ b/frontend/src/main/remote-daemon.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import type { AoMachine } from "../shared/ao-machines";
 import { machineAuthFailedStatus, machineDaemonStatus } from "../shared/remote-daemon";
-import { createRemoteDaemonLifecycle, installRemoteDaemonCookie, remoteDaemonReadyStatus } from "./remote-daemon";
+import { createRemoteDaemonLifecycle } from "./remote-daemon";
 
 const machine = (extra: Partial<AoMachine> = {}): AoMachine => ({
 	id: "mch_1",
@@ -14,118 +14,6 @@ const machine = (extra: Partial<AoMachine> = {}): AoMachine => ({
 	harness: "unknown",
 	harnessCommand: null,
 	...extra,
-});
-
-describe("installRemoteDaemonCookie", () => {
-	it("installs the pairing secret as a secure HttpOnly remote-origin cookie", async () => {
-		const set = vi.fn().mockResolvedValue(undefined);
-
-		await installRemoteDaemonCookie({ set }, {
-			baseUrl: "https://api.ao.agentlab.in",
-			token: "dGVzdF9wYWlyaW5nLXNlY3JldA",
-		});
-
-		expect(set).toHaveBeenCalledWith(expect.objectContaining({
-			url: "https://api.ao.agentlab.in",
-			name: "ao_hosted_pair",
-			value: "dGVzdF9wYWlyaW5nLXNlY3JldA",
-			httpOnly: true,
-			secure: true,
-			sameSite: "no_restriction",
-			path: "/",
-		}));
-		expect(set.mock.calls[0]?.[0]).not.toHaveProperty("domain");
-	});
-
-	it("propagates cookie store failures", async () => {
-		const error = new Error("cookie store unavailable");
-		const set = vi.fn().mockRejectedValue(error);
-
-		await expect(installRemoteDaemonCookie({ set }, {
-			baseUrl: "https://api.ao.agentlab.in",
-			token: "dGVzdF9wYWlyaW5nLXNlY3JldA",
-		})).rejects.toThrow(error);
-	});
-});
-
-describe("createRemoteDaemonLifecycle", () => {
-	it("returns remote-ready statuses without entering local lifecycle dependencies", async () => {
-		const resolveDaemonLaunch = vi.fn();
-		const inspectExistingDaemon = vi.fn();
-		const spawnDaemon = vi.fn();
-		const establishSupervisorLink = vi.fn();
-		const setStatus = vi.fn();
-		const lifecycle = createRemoteDaemonLifecycle({
-			baseUrl: "https://api.ao.agentlab.in",
-			token: "dGVzdF9wYWlyaW5nLXNlY3JldA",
-		});
-
-		const localRefresh = vi.fn(async () => {
-			resolveDaemonLaunch();
-			inspectExistingDaemon();
-			return { state: "stopped" as const };
-		});
-		const localStart = vi.fn(async () => {
-			resolveDaemonLaunch();
-			inspectExistingDaemon();
-			spawnDaemon();
-			establishSupervisorLink();
-			return { state: "stopped" as const };
-		});
-		const localStop = vi.fn(() => {
-			establishSupervisorLink();
-			return { state: "stopped" as const };
-		});
-
-		const expected = { state: "ready" as const, baseUrl: "https://api.ao.agentlab.in", message: "Connected to remote daemon" };
-		await expect(lifecycle.refresh(localRefresh, setStatus)).resolves.toEqual(expected);
-		await expect(lifecycle.start(localStart, setStatus)).resolves.toEqual(expected);
-		expect(lifecycle.stop(localStop, setStatus)).toEqual(expected);
-		expect(localRefresh).not.toHaveBeenCalled();
-		expect(localStart).not.toHaveBeenCalled();
-		expect(localStop).not.toHaveBeenCalled();
-		expect(resolveDaemonLaunch).not.toHaveBeenCalled();
-		expect(inspectExistingDaemon).not.toHaveBeenCalled();
-		expect(spawnDaemon).not.toHaveBeenCalled();
-		expect(establishSupervisorLink).not.toHaveBeenCalled();
-	});
-
-	it("keeps local lifecycle dependencies untouched when cookie installation fails", async () => {
-		const setStatus = vi.fn();
-		const localRefresh = vi.fn(async () => ({ state: "stopped" as const }));
-		const localStart = vi.fn(async () => ({ state: "stopped" as const }));
-		const localStop = vi.fn(() => ({ state: "stopped" as const }));
-		const lifecycle = createRemoteDaemonLifecycle({
-			baseUrl: "https://api.ao.agentlab.in",
-			token: "dGVzdF9wYWlyaW5nLXNlY3JldA",
-		});
-
-		await expect(lifecycle.installCookie({
-			set: vi.fn().mockRejectedValue(new Error("cookie store unavailable")),
-		})).resolves.toEqual({
-			state: "error",
-			message: "Could not configure remote daemon authentication.",
-			code: "not_configured",
-		});
-		await expect(lifecycle.refresh(localRefresh, setStatus)).resolves.toEqual({
-			state: "error",
-			message: "Could not configure remote daemon authentication.",
-			code: "not_configured",
-		});
-		await expect(lifecycle.start(localStart, setStatus)).resolves.toEqual({
-			state: "error",
-			message: "Could not configure remote daemon authentication.",
-			code: "not_configured",
-		});
-		expect(lifecycle.stop(localStop, setStatus)).toEqual({
-			state: "error",
-			message: "Could not configure remote daemon authentication.",
-			code: "not_configured",
-		});
-		expect(localRefresh).not.toHaveBeenCalled();
-		expect(localStart).not.toHaveBeenCalled();
-		expect(localStop).not.toHaveBeenCalled();
-	});
 });
 
 describe("an active registered machine", () => {
@@ -146,7 +34,7 @@ describe("an active registered machine", () => {
 	};
 
 	it("re-points the app at that machine's base URL", async () => {
-		const lifecycle = createRemoteDaemonLifecycle(null, null, () => machineDaemonStatus(machine()));
+		const lifecycle = createRemoteDaemonLifecycle(() => machineDaemonStatus(machine()));
 		const { localStart } = localCalls();
 
 		await expect(lifecycle.start(localStart, vi.fn())).resolves.toEqual({
@@ -160,7 +48,7 @@ describe("an active registered machine", () => {
 	// A credential failure is still a status the remote lifecycle owns, so it
 	// cannot fall through to spawning a local daemon either.
 	it("never spawns a local daemon when it has no credential", async () => {
-		const lifecycle = createRemoteDaemonLifecycle(null, null, () =>
+		const lifecycle = createRemoteDaemonLifecycle(() =>
 			machineAuthFailedStatus(machine(), "This computer is signed out of AO."),
 		);
 		const { localRefresh, localStart, localStop, spawnLocalDaemon } = localCalls();
@@ -183,7 +71,7 @@ describe("an active registered machine", () => {
 	// machine is active, so being down cannot reach them by any path.
 	it("never spawns a local daemon when it is unreachable", async () => {
 		const down = machine({ reachability: "offline", lastSeen: "2026-07-30T09:00:00Z" });
-		const lifecycle = createRemoteDaemonLifecycle(null, null, () => machineDaemonStatus(down));
+		const lifecycle = createRemoteDaemonLifecycle(() => machineDaemonStatus(down));
 		const { localRefresh, localStart, localStop, spawnLocalDaemon } = localCalls();
 		const setStatus = vi.fn();
 
@@ -203,29 +91,10 @@ describe("an active registered machine", () => {
 	});
 
 	it("hands back to the local daemon only when this computer is the active machine", async () => {
-		const lifecycle = createRemoteDaemonLifecycle(null, null, () => null);
+		const lifecycle = createRemoteDaemonLifecycle(() => null);
 		const { localStart } = localCalls();
 
 		await expect(lifecycle.start(localStart, vi.fn())).resolves.toEqual({ state: "stopped" });
 		expect(localStart).toHaveBeenCalledTimes(1);
-	});
-
-	it("does not displace AO_REMOTE_URL, which keeps behaving exactly as before", async () => {
-		const config = { baseUrl: "https://api.ao.agentlab.in", token: "dGVzdF9wYWlyaW5nLXNlY3JldA" };
-		const lifecycle = createRemoteDaemonLifecycle(config, null, () => machineDaemonStatus(machine()));
-
-		await expect(lifecycle.start(vi.fn(), vi.fn())).resolves.toEqual(remoteDaemonReadyStatus(config));
-	});
-});
-
-describe("remoteDaemonReadyStatus", () => {
-	it("returns a ready status without exposing the pairing token", () => {
-		expect(remoteDaemonReadyStatus({ baseUrl: "https://api.ao.agentlab.in", token: "secret" }))
-			.toEqual({ state: "ready", baseUrl: "https://api.ao.agentlab.in", message: "Connected to remote daemon" });
-	});
-
-	it("omits the token field even when the supplied config has one", () => {
-		expect(remoteDaemonReadyStatus({ baseUrl: "https://api.ao.agentlab.in", token: "secret" }))
-			.not.toHaveProperty("token");
 	});
 });

--- a/frontend/src/main/remote-daemon.ts
+++ b/frontend/src/main/remote-daemon.ts
@@ -1,46 +1,20 @@
-import { REMOTE_PAIRING_COOKIE_NAME, type RemoteDaemonConfig } from "../shared/remote-daemon";
 import type { DaemonStatus } from "../shared/daemon-status";
-
-type CookieStore = {
-	set: (details: Electron.CookiesSetDetails) => Promise<void>;
-};
 
 type SetDaemonStatus = (status: DaemonStatus) => void;
 
-const remoteDaemonCookieFailureStatus = (): DaemonStatus => ({
-	state: "error",
-	message: "Could not configure remote daemon authentication.",
-	code: "not_configured",
-});
-
-export async function installRemoteDaemonCookie(store: CookieStore, config: RemoteDaemonConfig): Promise<void> {
-	await store.set({
-		url: config.baseUrl,
-		name: REMOTE_PAIRING_COOKIE_NAME,
-		value: config.token,
-		path: "/",
-		secure: true,
-		httpOnly: true,
-		sameSite: "no_restriction",
-	});
-}
-
-export function remoteDaemonReadyStatus(config: RemoteDaemonConfig): DaemonStatus {
-	return { state: "ready", baseUrl: config.baseUrl, message: "Connected to remote daemon" };
-}
-
+/**
+ * Daemon lifecycle when remote may mean "an account machine is active".
+ *
+ * Remote is only the registered-machine path: the active machine's status, or
+ * null when this computer is the active machine (local daemon). The old
+ * AO_REMOTE_URL / AO_REMOTE_TOKEN pairing hatch is gone (spec task 15).
+ */
 export function createRemoteDaemonLifecycle(
-	config: RemoteDaemonConfig | null,
-	initialFailureStatus: DaemonStatus | null = null,
 	// The active registered machine's status, or null when this computer is the
-	// active machine. AO_REMOTE_URL is checked first so the env pairing hatch
-	// keeps behaving exactly as it did before machines existed.
+	// active machine.
 	activeMachineStatus: () => DaemonStatus | null = () => null,
 ) {
-	let failureStatus = initialFailureStatus;
-
-	const currentStatus = (): DaemonStatus | null =>
-		failureStatus ?? (config ? remoteDaemonReadyStatus(config) : activeMachineStatus());
+	const currentStatus = (): DaemonStatus | null => activeMachineStatus();
 	const applyRemoteStatus = (setStatus: SetDaemonStatus): DaemonStatus | null => {
 		const status = currentStatus();
 		if (status) setStatus(status);
@@ -49,15 +23,6 @@ export function createRemoteDaemonLifecycle(
 
 	return {
 		currentStatus,
-		async installCookie(store: CookieStore): Promise<DaemonStatus | null> {
-			if (!config || failureStatus) return currentStatus();
-			try {
-				await installRemoteDaemonCookie(store, config);
-			} catch {
-				failureStatus = remoteDaemonCookieFailureStatus();
-			}
-			return currentStatus();
-		},
 		async refresh(localRefresh: () => Promise<DaemonStatus>, setStatus: SetDaemonStatus): Promise<DaemonStatus> {
 			return applyRemoteStatus(setStatus) ?? localRefresh();
 		},

--- a/frontend/src/renderer/lib/api-client.test.ts
+++ b/frontend/src/renderer/lib/api-client.test.ts
@@ -57,7 +57,7 @@ describe("apiClient runtime base URL", () => {
 		expect(seen).toEqual([{ url: "http://127.0.0.1:3037/api/v1/projects", credentials: "same-origin" }]);
 	});
 
-	it("rebases remote API calls and includes the pairing cookie", async () => {
+	it("rebases remote API calls with credentials included for the gateway cookie", async () => {
 		const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
 			new Response(JSON.stringify({ projects: [] }), {
 				status: 200,
@@ -65,11 +65,11 @@ describe("apiClient runtime base URL", () => {
 			}),
 		);
 
-		setApiBaseUrl("https://api.ao.agentlab.in");
+		setApiBaseUrl("https://vm.example.com");
 		await apiClient.GET("/api/v1/projects");
 
 		expect(fetchSpy).toHaveBeenCalledTimes(1);
-		expect(String(fetchSpy.mock.calls[0]?.[0])).toBe("https://api.ao.agentlab.in/api/v1/projects");
+		expect(String(fetchSpy.mock.calls[0]?.[0])).toBe("https://vm.example.com/api/v1/projects");
 		expect(fetchSpy.mock.calls[0]?.[1]).toMatchObject({ credentials: "include" });
 	});
 
@@ -91,15 +91,13 @@ describe("apiClient runtime base URL", () => {
 		expect(init).toMatchObject({ credentials: "include" });
 	});
 
-	// AO_REMOTE_URL pairs with its own cookie and has no machine token, and it
-	// keeps working exactly as it did.
 	it("sends no Authorization header when there is no machine token", async () => {
 		gatewayTokenMock.mockResolvedValue(null);
 		const fetchSpy = vi
 			.spyOn(globalThis, "fetch")
 			.mockResolvedValue(new Response(JSON.stringify({ projects: [] }), { status: 200 }));
 
-		setApiBaseUrl("https://api.ao.agentlab.in");
+		setApiBaseUrl("https://vm.example.com");
 		await apiClient.GET("/api/v1/projects");
 
 		expect(new Headers(fetchSpy.mock.calls[0]?.[1]?.headers).has("authorization")).toBe(false);
@@ -117,9 +115,9 @@ describe("apiClient runtime base URL", () => {
 	});
 
 	it("prefers a ready daemon remote base URL over its loopback port", () => {
-		applyDaemonStatus({ state: "ready", baseUrl: "https://api.ao.agentlab.in", port: 3001 });
+		applyDaemonStatus({ state: "ready", baseUrl: "https://vm.example.com", port: 3001 });
 
-		expect(getApiBaseUrl()).toBe("https://api.ao.agentlab.in");
+		expect(getApiBaseUrl()).toBe("https://vm.example.com");
 	});
 
 	it("rebases POSTs without Request-as-init, preserving method, body, and headers", async () => {

--- a/frontend/src/renderer/lib/api-client.ts
+++ b/frontend/src/renderer/lib/api-client.ts
@@ -196,8 +196,7 @@ async function runtimeFetch(input: Request): Promise<Response> {
 		// its cookie is confined to /mux and the SSE stream, so nothing
 		// state-changing rides an ambient credential (controlplane/TOKEN_CONTRACT.md).
 		// Asked for per request because the main process owns expiry and the silent
-		// refresh; null while AO_REMOTE_URL is the remote hatch, which authenticates
-		// with its own pairing cookie instead, and null in browser preview.
+		// refresh. Null when no machine is selected (local daemon) or in browser preview.
 		const gatewayToken = remote ? await aoBridge.machines.gatewayToken() : null;
 		if (target.href === input.url && credentials === input.credentials && !gatewayToken) {
 			return fetch(input);

--- a/frontend/src/renderer/lib/bridge.ts
+++ b/frontend/src/renderer/lib/bridge.ts
@@ -238,9 +238,8 @@ export const aoBridge: AoBridge =
 				previewDaemonStatusListeners.forEach((listener) => listener(status));
 				return browserPreviewMachinesState();
 			},
-			// Browser preview has no main process, so no machine token either. Null
-			// means "send no Authorization header", which is also what the
-			// AO_REMOTE_URL pairing hatch wants.
+			// Browser preview has no main process, so no machine token either.
+			// Null means "send no Authorization header".
 			gatewayToken: async () => null,
 		},
 	} satisfies AoBridge);

--- a/frontend/src/shared/remote-daemon.test.ts
+++ b/frontend/src/shared/remote-daemon.test.ts
@@ -5,8 +5,6 @@ import {
 	isRemoteDaemonBaseUrl,
 	machineAuthFailedStatus,
 	machineDaemonStatus,
-	readRemoteDaemonConfig,
-	REMOTE_PAIRING_COOKIE_NAME,
 } from "./remote-daemon";
 
 const machine = (extra: Partial<AoMachine> = {}): AoMachine => ({
@@ -22,53 +20,9 @@ const machine = (extra: Partial<AoMachine> = {}): AoMachine => ({
 	...extra,
 });
 
-describe("readRemoteDaemonConfig", () => {
-	it("returns a normalized remote config for an HTTPS origin and URL-safe token", () => {
-		expect(readRemoteDaemonConfig({
-			AO_REMOTE_URL: "https://api.ao.agentlab.in/",
-			AO_REMOTE_TOKEN: "dGVzdF9wYWlyaW5nLXNlY3JldA",
-		})).toEqual({
-			baseUrl: "https://api.ao.agentlab.in",
-			token: "dGVzdF9wYWlyaW5nLXNlY3JldA",
-		});
-	});
-
-	it("rejects a partial remote configuration without returning a local fallback", () => {
-		expect(() => readRemoteDaemonConfig({ AO_REMOTE_URL: "https://api.ao.agentlab.in" }))
-			.toThrow("AO_REMOTE_URL and AO_REMOTE_TOKEN must be set together");
-	});
-
-	it("returns null when neither remote variable is set", () => {
-		expect(readRemoteDaemonConfig({})).toBeNull();
-	});
-
-	it("rejects token-only input", () => {
-		expect(() => readRemoteDaemonConfig({ AO_REMOTE_TOKEN: "token" }))
-			.toThrow("AO_REMOTE_URL and AO_REMOTE_TOKEN must be set together");
-	});
-
-	it.each([
-		["http://api.ao.agentlab.in", "HTTP URLs"],
-		["https://api.ao.agentlab.in/path", "URL paths"],
-		["https://api.ao.agentlab.in?query=1", "query strings"],
-		["https://api.ao.agentlab.in?", "bare query delimiters"],
-		["https://api.ao.agentlab.in#fragment", "fragments"],
-		["https://api.ao.agentlab.in#", "bare fragment delimiters"],
-		["https://user:pass@api.ao.agentlab.in", "credentials"],
-	])("rejects %s (%s)", (url) => {
-		expect(() => readRemoteDaemonConfig({ AO_REMOTE_URL: url, AO_REMOTE_TOKEN: "token" }))
-			.toThrow("AO_REMOTE_URL must be an HTTPS origin without a path, query, fragment, or credentials");
-	});
-
-	it.each([["token with space"], ["token/with/slash"]])("rejects URL-unsafe token %s", (token) => {
-		expect(() => readRemoteDaemonConfig({ AO_REMOTE_URL: "https://api.ao.agentlab.in", AO_REMOTE_TOKEN: token }))
-			.toThrow("AO_REMOTE_TOKEN must be URL-safe base64");
-	});
-});
-
 describe("isRemoteDaemonBaseUrl", () => {
 	it("recognizes HTTPS remote origins", () => {
-		expect(isRemoteDaemonBaseUrl("https://api.ao.agentlab.in")).toBe(true);
+		expect(isRemoteDaemonBaseUrl("https://vm.example.com")).toBe(true);
 	});
 
 	it("does not recognize loopback HTTP", () => {
@@ -120,8 +74,7 @@ describe("GATEWAY_COOKIE_NAME", () => {
 	// The gateway reads this exact name (gatewayCookieName in
 	// backend/internal/vmgateway/proxy.go). A rename on either side makes /mux and
 	// the SSE stream 401 with nothing to see on the client, so it is pinned here.
-	it("is the name the VM gateway reads, and is not the AO_REMOTE_URL pairing cookie", () => {
+	it("is the name the VM gateway reads", () => {
 		expect(GATEWAY_COOKIE_NAME).toBe("ao_gw_token");
-		expect(GATEWAY_COOKIE_NAME).not.toBe(REMOTE_PAIRING_COOKIE_NAME);
 	});
 });

--- a/frontend/src/shared/remote-daemon.ts
+++ b/frontend/src/shared/remote-daemon.ts
@@ -1,8 +1,6 @@
 import { formatLastSeen, type AoMachine } from "./ao-machines";
 import type { DaemonStatus } from "./daemon-status";
 
-export const REMOTE_PAIRING_COOKIE_NAME = "ao_hosted_pair";
-
 /**
  * The VM gateway's JWT cookie, whose value is the current machine-audience
  * access token.
@@ -19,21 +17,6 @@ export const REMOTE_PAIRING_COOKIE_NAME = "ao_hosted_pair";
  * `backend/internal/vmgateway/proxy.go`. See `controlplane/TOKEN_CONTRACT.md`.
  */
 export const GATEWAY_COOKIE_NAME = "ao_gw_token";
-
-export type RemoteDaemonConfig = { baseUrl: string; token: string };
-
-export function readRemoteDaemonConfig(env: Record<string, string | undefined>): RemoteDaemonConfig | null {
-	const rawURL = env.AO_REMOTE_URL?.trim() ?? "";
-	const token = env.AO_REMOTE_TOKEN?.trim() ?? "";
-	if (!rawURL && !token) return null;
-	if (!rawURL || !token) throw new Error("AO_REMOTE_URL and AO_REMOTE_TOKEN must be set together");
-	if (!/^[A-Za-z0-9_-]+$/.test(token)) throw new Error("AO_REMOTE_TOKEN must be URL-safe base64");
-	const url = new URL(rawURL);
-	if (url.protocol !== "https:" || url.pathname !== "/" || rawURL.includes("?") || rawURL.includes("#") || url.username || url.password) {
-		throw new Error("AO_REMOTE_URL must be an HTTPS origin without a path, query, fragment, or credentials");
-	}
-	return { baseUrl: url.origin, token };
-}
 
 export function isRemoteDaemonBaseUrl(baseUrl: string): boolean {
 	return baseUrl.startsWith("https://");


### PR DESCRIPTION
## Summary

- Retire the env-var remote pairing path (`AO_REMOTE_URL`, `AO_REMOTE_TOKEN`, `ao_hosted_pair`). Remote mode is accounts only; `AO_CONTROL_URL` remains the control-plane hatch.
- Account home at control plane `GET /` lists machines, unbinds via `POST /machines/unbind`, and shows setup-vm empty state. API: `DELETE /api/v1/machines/{id}`.
- Update STATUS, hosted deploy docs (pairing proxy retired), and control plane README.

## Deploy note

The fleet page is served by the **control plane** on `ao.agentlab.in` (Azure), not the user VM gateway. Redeploy the control plane binary for this to go live. User VMs do not need a redeploy for this change.

## Test plan

- [x] `cd controlplane && go test ./...`
- [x] Vitest: remote-daemon + api-client
- [ ] After control plane redeploy: sign in at ao.agentlab.in, see machine list / empty setup, unbind works
- [ ] Desktop remote still works via machine picker (no env pairing)