### PR TITLE
feat(desktop): show cloud and local sessions together behind a Cloud toggle

### DIFF
--- a/frontend/e2e/support/fake-bridge.ts
+++ b/frontend/e2e/support/fake-bridge.ts
@@ -174,6 +174,9 @@ export async function installFakeBridge(page: Page, opts: FakeBridgeOptions = {}
 					refresh: async () => signedOutAoMachines,
 					select: async () => signedOutAoMachines,
 					gatewayToken: async () => null,
+					// Signed out, so there is no peer daemon to list. Matches the
+					// rest of this harness: no main process, so no second daemon.
+					peerWorkspaces: async () => ({ state: "unavailable" as const, reason: "This computer is signed out of AO." }),
 				},
 			} satisfies AoBridge;
 			(window as unknown as { ao: unknown }).ao = ao;
@@ -557,6 +560,9 @@ export async function installFakeAgent(page: Page, opts: FakeAgentOptions = {}):
 					refresh: async () => signedOutAoMachines,
 					select: async () => signedOutAoMachines,
 					gatewayToken: async () => null,
+					// Signed out, so there is no peer daemon to list. Matches the
+					// rest of this harness: no main process, so no second daemon.
+					peerWorkspaces: async () => ({ state: "unavailable" as const, reason: "This computer is signed out of AO." }),
 				},
 			} satisfies AoBridge;
 			(window as unknown as { ao: unknown }).ao = ao;

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -62,6 +62,7 @@ import { keepDaemonAlive, shouldLinkOnAttach } from "./main/daemon-owner";
 import { readMigrationState, updateMigration, writeAppStateMarker, type MigrationState } from "./main/app-state";
 import { createAoAccountController } from "./main/ao-account";
 import { createAoMachinesController } from "./main/ao-machines";
+import { createPeerWorkspacesController } from "./main/peer-workspaces";
 import type { AoMachine } from "./shared/ao-machines";
 import { isAllowedAppExternalURL, openAllowedAppExternalURL } from "./main/external-open";
 import { buildWindowsAppMenuTemplate } from "./main/menu";
@@ -1448,6 +1449,12 @@ ipcMain.handle("aoAccount:signOut", async () => {
 	return state;
 });
 
+// "This Mac" on macOS, per the spec. The other platforms get a label that is
+// not wrong for them. Shared by the machines controller and the peer
+// workspaces controller so the local machine's display name cannot drift
+// between the two.
+const LOCAL_MACHINE_NAME = process.platform === "darwin" ? "This Mac" : "This computer";
+
 // The machine list and which machine is active. This computer is machine zero
 // and is always offered; everything below is only about reaching a machine the
 // account has registered.
@@ -1459,12 +1466,35 @@ function aoMachines(): ReturnType<typeof createAoMachinesController> {
 		stateDir: runFile ? path.dirname(runFile) : null,
 		env: process.env,
 		safeStorage,
-		// "This Mac" on macOS, per the spec. The other platforms get a label that
-		// is not wrong for them.
-		localMachineName: process.platform === "darwin" ? "This Mac" : "This computer",
+		localMachineName: LOCAL_MACHINE_NAME,
 		onActiveChange: applyActiveMachine,
 	});
 	return aoMachinesController;
+}
+
+// Read-only view of the daemon that is NOT the app's active one (the
+// "peer"), so the UI can list its projects and sessions alongside the active
+// one's. Fully independent of machineTransport(): a peer never opens /mux or
+// the SSE stream, so it needs no cookie and must never touch the one
+// target/one token machinery in machine-transport.ts.
+let peerWorkspacesController: ReturnType<typeof createPeerWorkspacesController> | null = null;
+function peerWorkspaces(): ReturnType<typeof createPeerWorkspacesController> {
+	if (peerWorkspacesController) return peerWorkspacesController;
+	peerWorkspacesController = createPeerWorkspacesController({
+		getMachinesState: () => aoMachines().getState(),
+		credential: () => aoMachines().credential(),
+		localMachineName: LOCAL_MACHINE_NAME,
+		readLocalRunFile: async () => {
+			const rfp = runFilePath();
+			if (!rfp) return null;
+			try {
+				return await readFile(rfp, "utf8");
+			} catch {
+				return null;
+			}
+		},
+	});
+	return peerWorkspacesController;
 }
 
 // The authenticated transport to the active machine's gateway: the Bearer token
@@ -1528,6 +1558,7 @@ ipcMain.handle("aoMachines:select", (_event, machineId: string) => aoMachines().
 // Read from the already-built transport rather than machineTransport(), so a
 // local-only install never constructs one just to be told there is no token.
 ipcMain.handle("aoMachines:gatewayToken", () => machineTransportInstance?.token() ?? null);
+ipcMain.handle("aoMachines:peerWorkspaces", () => peerWorkspaces().get());
 
 ipcMain.handle("updates:getStatus", (): UpdateStatus => getUpdateStatus());
 ipcMain.handle("updates:check", async (_event, options?: UpdateCheckOptions) => {

--- a/frontend/src/main/peer-workspaces.test.ts
+++ b/frontend/src/main/peer-workspaces.test.ts
@@ -1,0 +1,393 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { LOCAL_MACHINE_ID, type AoMachine, type AoMachinesState } from "../shared/ao-machines";
+import type { ControlPlaneTokenSource } from "./ao-control-token";
+import type { MachineAccessToken, MachineTokenSource } from "./ao-machine-token";
+import { MachineUnavailableError } from "./ao-machine-token";
+import type { AoControlPlaneCredential } from "./ao-machines";
+import { SIGNED_OUT_REASON } from "./machine-transport";
+import { buildPeerProjects, createPeerWorkspacesController, type PeerWorkspacesDeps } from "./peer-workspaces";
+
+const REMOTE_MACHINE: AoMachine = {
+	id: "mch_1",
+	name: "ao-build-01",
+	baseUrl: "https://vm.example.com",
+	local: false,
+	createdAt: null,
+	lastSeen: null,
+	reachability: "online",
+	harness: "unknown",
+	harnessCommand: null,
+};
+
+const localState = (extra: Partial<AoMachinesState> = {}): AoMachinesState => ({
+	status: "ready",
+	machines: [
+		{
+			id: LOCAL_MACHINE_ID,
+			name: "This Mac",
+			baseUrl: "",
+			local: true,
+			createdAt: null,
+			lastSeen: null,
+			reachability: "online",
+			harness: "unknown",
+			harnessCommand: null,
+		},
+	],
+	activeMachineId: LOCAL_MACHINE_ID,
+	...extra,
+});
+
+const remoteState = (): AoMachinesState => ({
+	...localState(),
+	machines: [...localState().machines, REMOTE_MACHINE],
+	activeMachineId: REMOTE_MACHINE.id,
+});
+
+const projectsResponse = (...projects: Array<Record<string, unknown>>) =>
+	new Response(JSON.stringify({ projects }), { status: 200, headers: { "Content-Type": "application/json" } });
+
+const sessionsResponse = (...sessions: Array<Record<string, unknown>>) =>
+	new Response(JSON.stringify({ sessions }), { status: 200, headers: { "Content-Type": "application/json" } });
+
+const project = (extra: Record<string, unknown> = {}) => ({ id: "proj_1", name: "widgets", ...extra });
+const session = (extra: Record<string, unknown> = {}) => ({
+	id: "sess_1",
+	projectId: "proj_1",
+	displayName: "Fix the thing",
+	status: "working",
+	activity: { state: "active", lastActivityAt: "2026-08-01T00:00:00Z" },
+	branch: "sess/1",
+	harness: "claude-code",
+	kind: "worker",
+	updatedAt: "2026-08-01T00:00:00Z",
+	...extra,
+});
+
+/** A fetch that answers /api/v1/projects and /api/v1/sessions on any origin. */
+function fakeFetch(projects: Array<Record<string, unknown>>, sessions: Array<Record<string, unknown>>) {
+	return vi.fn(async (input: string) => {
+		const url = String(input);
+		if (url.endsWith("/api/v1/projects")) return projectsResponse(...projects);
+		if (url.endsWith("/api/v1/sessions")) return sessionsResponse(...sessions);
+		throw new Error(`unexpected url: ${url}`);
+	});
+}
+
+const MACHINE_TOKEN = "machine.audience.jwt";
+
+/** A MachineTokenSource under the test's control, mirroring machine-transport.test.ts's fakeTokens. */
+function fakeTokenSource() {
+	const state = { mode: "ok" as "ok" | "signed-out" | "gone" | "error", created: [] as string[] };
+	const token: MachineAccessToken = { token: MACHINE_TOKEN, expiresAt: Date.now() + 900_000 };
+	const source: MachineTokenSource = {
+		get: async () => {
+			if (state.mode === "signed-out") return null;
+			if (state.mode === "gone") throw new MachineUnavailableError();
+			if (state.mode === "error") throw new Error("The control plane is unreachable.");
+			return token;
+		},
+		mint: async () => token,
+		clear: () => undefined,
+	};
+	return { state, source };
+}
+
+function credential(): AoControlPlaneCredential {
+	const controlToken: ControlPlaneTokenSource = { get: async () => "control.plane.jwt", clear: () => undefined };
+	return { controlPlaneUrl: "https://ao.agentlab.in", token: controlToken };
+}
+
+function harness(overrides: Partial<PeerWorkspacesDeps> = {}) {
+	const tokens = fakeTokenSource();
+	const createTokenSource = vi.fn((deps: { machineId: string }) => {
+		tokens.state.created.push(deps.machineId);
+		return tokens.source;
+	});
+	const readLocalRunFile = vi.fn(async () => null as string | null);
+	const deps: PeerWorkspacesDeps = {
+		getMachinesState: () => localState(),
+		credential: () => credential(),
+		localMachineName: "This Mac",
+		readLocalRunFile,
+		fetchImpl: fakeFetch([project()], [session()]) as unknown as typeof fetch,
+		createTokenSource,
+		...overrides,
+	};
+	return { deps, tokens, readLocalRunFile, controller: createPeerWorkspacesController(deps) };
+}
+
+describe("buildPeerProjects", () => {
+	it("shapes projects and sessions to the peer contract, grouping sessions by project", () => {
+		const projects = buildPeerProjects({ projects: [project()] }, { sessions: [session()] });
+
+		expect(projects).toEqual([
+			{
+				id: "proj_1",
+				name: "widgets",
+				sessions: [
+					{
+						id: "sess_1",
+						title: "Fix the thing",
+						status: "working",
+						activity: "active",
+						branch: "sess/1",
+						harness: "claude-code",
+						kind: "worker",
+						updatedAt: "2026-08-01T00:00:00Z",
+					},
+				],
+			},
+		]);
+	});
+
+	it("falls back to the id as title when displayName is blank", () => {
+		const projects = buildPeerProjects({ projects: [project()] }, { sessions: [session({ displayName: "" })] });
+		expect(projects[0]?.sessions[0]?.title).toBe("sess_1");
+	});
+
+	it("drops unusable rows instead of failing the whole list", () => {
+		const projects = buildPeerProjects(
+			{ projects: [project(), { name: "no id" }] },
+			{ sessions: [session(), { id: "orphan" }, "garbage"] },
+		);
+		expect(projects).toHaveLength(1);
+		expect(projects[0]?.sessions).toHaveLength(1);
+	});
+
+	it("gives a session a home even when its project id is missing from the projects list", () => {
+		const projects = buildPeerProjects({ projects: [] }, { sessions: [session({ projectId: "proj_orphan" })] });
+		expect(projects).toEqual([expect.objectContaining({ id: "proj_orphan", name: "proj_orphan" })]);
+	});
+
+	it("tolerates a malformed body instead of throwing", () => {
+		expect(buildPeerProjects(null, undefined)).toEqual([]);
+		expect(buildPeerProjects("garbage", { sessions: "garbage" })).toEqual([]);
+	});
+});
+
+const REMOTE_ACTIVE_STATE: AoMachinesState = {
+	...localState(),
+	machines: [...localState().machines, REMOTE_MACHINE],
+	// The registered machine is in the list but NOT active: this computer is
+	// active, which is what makes the registered machine the peer.
+	activeMachineId: LOCAL_MACHINE_ID,
+};
+
+describe("remote peer (this computer is active)", () => {
+	it("fetches the registered machine's projects and sessions with a Bearer token and no cookie", async () => {
+		const { controller, deps } = harness({ getMachinesState: () => REMOTE_ACTIVE_STATE });
+
+		const result = await controller.get();
+
+		expect(result).toEqual({
+			state: "ok",
+			machineId: REMOTE_MACHINE.id,
+			machineName: REMOTE_MACHINE.name,
+			isRemote: true,
+			projects: [
+				{
+					id: "proj_1",
+					name: "widgets",
+					sessions: [expect.objectContaining({ id: "sess_1", title: "Fix the thing" })],
+				},
+			],
+		});
+		const fetchMock = deps.fetchImpl as ReturnType<typeof vi.fn>;
+		expect(fetchMock.mock.calls[0][1]).toMatchObject({
+			headers: { Authorization: `Bearer ${MACHINE_TOKEN}`, Accept: "application/json" },
+		});
+		// No cookie is ever installed for a peer: it never opens /mux or SSE.
+		for (const [, init] of fetchMock.mock.calls) {
+			expect(JSON.stringify(init)).not.toMatch(/cookie/i);
+		}
+	});
+
+	it("mints from a second, independent token source, not machine-transport's", async () => {
+		const { tokens, controller } = harness({ getMachinesState: () => REMOTE_ACTIVE_STATE });
+
+		await controller.get();
+
+		expect(tokens.state.created).toEqual([REMOTE_MACHINE.id]);
+	});
+
+	it("returns unavailable when no registered machine is online", async () => {
+		const { controller } = harness({ getMachinesState: () => localState() });
+
+		await expect(controller.get()).resolves.toEqual({
+			state: "unavailable",
+			reason: "No other machine is online for this account.",
+		});
+	});
+
+	it("returns unavailable when signed out, without calling fetch", async () => {
+		const { deps, controller } = harness({ getMachinesState: () => REMOTE_ACTIVE_STATE, credential: () => null });
+
+		await expect(controller.get()).resolves.toEqual({ state: "unavailable", reason: SIGNED_OUT_REASON });
+		expect(deps.fetchImpl).not.toHaveBeenCalled();
+	});
+
+	it("returns unavailable, not a throw, when the peer is offline", async () => {
+		const failingFetch = vi.fn(async () => {
+			throw new Error("connect ECONNREFUSED");
+		});
+		const { controller } = harness({
+			getMachinesState: () => REMOTE_ACTIVE_STATE,
+			fetchImpl: failingFetch as unknown as typeof fetch,
+		});
+
+		await expect(controller.get()).resolves.toEqual({
+			state: "unavailable",
+			reason: `${REMOTE_MACHINE.name} is not reachable.`,
+		});
+	});
+});
+
+describe("local peer (a registered machine is active)", () => {
+	it("reads the loopback daemon's port from running.json and fetches it unauthenticated", async () => {
+		const readLocalRunFile = vi.fn(async () => JSON.stringify({ pid: 123, port: 4123 }));
+		const { controller, deps } = harness({
+			getMachinesState: () => remoteState(),
+			readLocalRunFile,
+		});
+
+		const result = await controller.get();
+
+		expect(result).toEqual({
+			state: "ok",
+			machineId: LOCAL_MACHINE_ID,
+			machineName: "This Mac",
+			isRemote: false,
+			projects: [
+				{
+					id: "proj_1",
+					name: "widgets",
+					sessions: [expect.objectContaining({ id: "sess_1" })],
+				},
+			],
+		});
+		const [url, init] = (deps.fetchImpl as ReturnType<typeof vi.fn>).mock.calls[0];
+		expect(url).toBe("http://127.0.0.1:4123/api/v1/projects");
+		expect(init).not.toHaveProperty("headers.Authorization");
+	});
+
+	it("never hardcodes 3001: the port comes from running.json", async () => {
+		const readLocalRunFile = vi.fn(async () => JSON.stringify({ pid: 1, port: 9999 }));
+		const { controller, deps } = harness({ getMachinesState: () => remoteState(), readLocalRunFile });
+
+		await controller.get();
+
+		const urls = (deps.fetchImpl as ReturnType<typeof vi.fn>).mock.calls.map((call) => call[0]);
+		expect(urls).toEqual(["http://127.0.0.1:9999/api/v1/projects", "http://127.0.0.1:9999/api/v1/sessions"]);
+	});
+
+	it("returns unavailable when no local daemon is running", async () => {
+		const { controller } = harness({ getMachinesState: () => remoteState(), readLocalRunFile: async () => null });
+
+		await expect(controller.get()).resolves.toEqual({
+			state: "unavailable",
+			reason: "This computer's local AO daemon is not running.",
+		});
+	});
+
+	it("returns unavailable when running.json cannot be parsed", async () => {
+		const { controller } = harness({
+			getMachinesState: () => remoteState(),
+			readLocalRunFile: async () => "not json",
+		});
+
+		await expect(controller.get()).resolves.toEqual({
+			state: "unavailable",
+			reason: "This computer's local AO daemon is not running.",
+		});
+	});
+
+	it("returns unavailable when readLocalRunFile rejects", async () => {
+		const { controller } = harness({
+			getMachinesState: () => remoteState(),
+			readLocalRunFile: async () => {
+				throw new Error("EPERM");
+			},
+		});
+
+		await expect(controller.get()).resolves.toEqual({
+			state: "unavailable",
+			reason: "This computer's local AO daemon is not running.",
+		});
+	});
+});
+
+describe("timeouts", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+	});
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("aborts a peer fetch that never answers, rather than hanging the UI", async () => {
+		const hangingFetch = vi.fn(
+			(_url: string, init?: RequestInit) =>
+				new Promise((_resolve, reject) => {
+					init?.signal?.addEventListener("abort", () => reject(new Error("aborted")));
+				}),
+		);
+		const { controller } = harness({
+			getMachinesState: () => remoteState(),
+			readLocalRunFile: async () => JSON.stringify({ pid: 1, port: 4123 }),
+			fetchImpl: hangingFetch as unknown as typeof fetch,
+			timeoutMs: 2_000,
+		});
+
+		const pending = controller.get();
+		await vi.advanceTimersByTimeAsync(2_000);
+
+		await expect(pending).resolves.toEqual({
+			state: "unavailable",
+			reason: "This computer's local AO daemon is not reachable.",
+		});
+	});
+});
+
+describe("token safety", () => {
+	it("never puts the token value in a returned reason", async () => {
+		const failingFetch = vi.fn(async () => {
+			throw new Error("connect ECONNREFUSED");
+		});
+		const { controller } = harness({
+			getMachinesState: () => REMOTE_ACTIVE_STATE,
+			fetchImpl: failingFetch as unknown as typeof fetch,
+		});
+
+		const result = await controller.get();
+
+		expect(JSON.stringify(result)).not.toContain(MACHINE_TOKEN);
+		expect(JSON.stringify(result)).not.toContain("control.plane.jwt");
+	});
+
+	it("never puts the token value in an unavailable reason for a local-peer timeout either", async () => {
+		vi.useFakeTimers();
+		try {
+			const hangingFetch = vi.fn(
+				(_url: string, init?: RequestInit) =>
+					new Promise((_resolve, reject) => {
+						init?.signal?.addEventListener("abort", () => reject(new Error("aborted")));
+					}),
+			);
+			const { controller } = harness({
+				getMachinesState: () => remoteState(),
+				readLocalRunFile: async () => JSON.stringify({ pid: 1, port: 4123 }),
+				fetchImpl: hangingFetch as unknown as typeof fetch,
+				timeoutMs: 2_000,
+			});
+
+			const pending = controller.get();
+			await vi.advanceTimersByTimeAsync(2_000);
+			const result = await pending;
+
+			expect(JSON.stringify(result)).not.toContain(MACHINE_TOKEN);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+});

--- a/frontend/src/main/peer-workspaces.ts
+++ b/frontend/src/main/peer-workspaces.ts
@@ -1,0 +1,236 @@
+import { LOCAL_MACHINE_ID, type AoMachine, type AoMachinesState } from "../shared/ao-machines";
+import { parseRunFile } from "../shared/daemon-discovery";
+import type { PeerProject, PeerSession, PeerWorkspacesResult } from "../shared/peer-workspaces";
+import type { AoControlPlaneCredential } from "./ao-machines";
+import {
+	createMachineTokenSource,
+	type MachineTokenSource,
+	type MachineTokenSourceDeps,
+} from "./ao-machine-token";
+import { SIGNED_OUT_REASON } from "./machine-transport";
+
+/**
+ * Read-only "peer" workspaces: the projects and sessions of the daemon that is
+ * NOT the app's active one, so the UI can list them alongside the active
+ * daemon's without touching `machine-transport.ts`'s one target/one token
+ * machinery at all.
+ *
+ * Peer, relative to `AoMachinesState.activeMachineId`:
+ *   - active is this computer -> peer is the account's online registered
+ *     machine, if the account has one and it is reachable.
+ *   - active is a registered machine -> peer is this computer's local
+ *     loopback daemon.
+ *
+ * A remote peer is reached with a second, independent machine-audience token
+ * source (never `createMachineTransport`'s), Bearer-only: no cookie is
+ * installed, because a peer never opens `/mux` or the SSE stream. A local peer
+ * is reached unauthenticated, like every other loopback caller. Every failure
+ * mode collapses to `{state:"unavailable", reason}`: this never throws across
+ * IPC, and `reason` is always a fixed, human-readable string, never a token,
+ * a cookie value, or a raw error message that could carry one.
+ */
+
+/** A dead or slow peer must not hang the UI; a few seconds is plenty for two loopback-scale GETs. */
+const DEFAULT_TIMEOUT_MS = 5_000;
+
+export type PeerWorkspacesDeps = {
+	/** Current machine list and which one is active. No network; read from ao-machines.ts's cache. */
+	getMachinesState: () => AoMachinesState;
+	/** This process's one control-plane credential, or null when it cannot exist. See ao-machines.ts. */
+	credential: () => AoControlPlaneCredential | null;
+	/** Display name for machine zero, the same one the machines list already uses (e.g. "This Mac"). */
+	localMachineName: string;
+	/**
+	 * This computer's own running.json contents, or null when it cannot be read
+	 * (no file, no permission, home dir unresolvable). Never throws.
+	 */
+	readLocalRunFile: () => Promise<string | null>;
+	fetchImpl?: typeof fetch;
+	timeoutMs?: number;
+	/** Test seam, so a controller can be driven without a real token endpoint. */
+	createTokenSource?: (deps: MachineTokenSourceDeps) => MachineTokenSource;
+};
+
+export type PeerWorkspacesController = {
+	get: () => Promise<PeerWorkspacesResult>;
+};
+
+function unavailable(reason: string): PeerWorkspacesResult {
+	return { state: "unavailable", reason };
+}
+
+type RawSessionRow = {
+	id?: unknown;
+	projectId?: unknown;
+	displayName?: unknown;
+	status?: unknown;
+	activity?: unknown;
+	branch?: unknown;
+	harness?: unknown;
+	kind?: unknown;
+	updatedAt?: unknown;
+};
+
+function parseSessionRow(raw: unknown): { projectId: string; session: PeerSession } | null {
+	if (!raw || typeof raw !== "object") return null;
+	const row = raw as RawSessionRow;
+	const id = typeof row.id === "string" ? row.id.trim() : "";
+	const projectId = typeof row.projectId === "string" ? row.projectId.trim() : "";
+	if (!id || !projectId) return null;
+	const status = typeof row.status === "string" && row.status ? row.status : "unknown";
+	const displayName = typeof row.displayName === "string" ? row.displayName.trim() : "";
+	const activityRow = row.activity as { state?: unknown } | null | undefined;
+	const activity =
+		activityRow && typeof activityRow === "object" && typeof activityRow.state === "string"
+			? activityRow.state
+			: undefined;
+	const branch = typeof row.branch === "string" && row.branch ? row.branch : undefined;
+	const harness = typeof row.harness === "string" && row.harness ? row.harness : undefined;
+	const kind = typeof row.kind === "string" && row.kind ? row.kind : undefined;
+	const updatedAt = typeof row.updatedAt === "string" && row.updatedAt ? row.updatedAt : undefined;
+	return {
+		projectId,
+		session: { id, title: displayName || id, status, activity, branch, harness, kind, updatedAt },
+	};
+}
+
+/**
+ * Shape `GET /api/v1/projects` and `GET /api/v1/sessions` bodies into
+ * PeerProject[], grouping sessions under their project. Unusable rows are
+ * dropped rather than failing the whole list, matching parseMachinesResponse's
+ * one-bad-row-does-not-hide-the-rest rule. A session whose project id is not
+ * in the projects list (the two fetches are not transactional) still gets a
+ * home rather than being dropped.
+ */
+export function buildPeerProjects(projectsBody: unknown, sessionsBody: unknown): PeerProject[] {
+	const projectRows = (projectsBody as { projects?: unknown } | null | undefined)?.projects;
+	const sessionRows = (sessionsBody as { sessions?: unknown } | null | undefined)?.sessions;
+
+	const projects = new Map<string, PeerProject>();
+	if (Array.isArray(projectRows)) {
+		for (const raw of projectRows) {
+			if (!raw || typeof raw !== "object") continue;
+			const row = raw as { id?: unknown; name?: unknown };
+			const id = typeof row.id === "string" ? row.id.trim() : "";
+			if (!id) continue;
+			const name = typeof row.name === "string" && row.name.trim() ? row.name.trim() : id;
+			projects.set(id, { id, name, sessions: [] });
+		}
+	}
+	if (Array.isArray(sessionRows)) {
+		for (const raw of sessionRows) {
+			const parsed = parseSessionRow(raw);
+			if (!parsed) continue;
+			let project = projects.get(parsed.projectId);
+			if (!project) {
+				project = { id: parsed.projectId, name: parsed.projectId, sessions: [] };
+				projects.set(parsed.projectId, project);
+			}
+			project.sessions.push(parsed.session);
+		}
+	}
+	return [...projects.values()];
+}
+
+export function createPeerWorkspacesController(deps: PeerWorkspacesDeps): PeerWorkspacesController {
+	const fetchImpl = deps.fetchImpl ?? fetch;
+	const timeoutMs = deps.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+	const createTokenSource = deps.createTokenSource ?? createMachineTokenSource;
+
+	/** One token source per machine id, independent of createMachineTransport's. */
+	const tokenSources = new Map<string, MachineTokenSource>();
+
+	function tokenSourceFor(machineId: string, credential: AoControlPlaneCredential): MachineTokenSource {
+		let source = tokenSources.get(machineId);
+		if (!source) {
+			source = createTokenSource({
+				controlPlaneUrl: credential.controlPlaneUrl,
+				machineId,
+				controlToken: credential.token,
+				fetchImpl,
+			});
+			tokenSources.set(machineId, source);
+		}
+		return source;
+	}
+
+	async function fetchJson(url: string, headers: Record<string, string>): Promise<unknown> {
+		const controller = new AbortController();
+		const timer = setTimeout(() => controller.abort(), timeoutMs);
+		try {
+			const response = await fetchImpl(url, { headers, signal: controller.signal });
+			if (!response.ok) throw new Error(`peer answered ${response.status}`);
+			return await response.json();
+		} finally {
+			clearTimeout(timer);
+		}
+	}
+
+	async function fetchProjects(baseUrl: string, headers: Record<string, string>): Promise<PeerProject[]> {
+		const [projectsBody, sessionsBody] = await Promise.all([
+			fetchJson(`${baseUrl}/api/v1/projects`, headers),
+			fetchJson(`${baseUrl}/api/v1/sessions`, headers),
+		]);
+		return buildPeerProjects(projectsBody, sessionsBody);
+	}
+
+	async function remotePeer(machine: AoMachine): Promise<PeerWorkspacesResult> {
+		const credential = deps.credential();
+		if (!credential) return unavailable(SIGNED_OUT_REASON);
+
+		let token: string | null;
+		try {
+			token = (await tokenSourceFor(machine.id, credential).get())?.token ?? null;
+		} catch {
+			return unavailable(`Could not sign in to ${machine.name}.`);
+		}
+		if (!token) return unavailable(SIGNED_OUT_REASON);
+
+		try {
+			const projects = await fetchProjects(machine.baseUrl, {
+				Authorization: `Bearer ${token}`,
+				Accept: "application/json",
+			});
+			return { state: "ok", machineId: machine.id, machineName: machine.name, isRemote: true, projects };
+		} catch {
+			return unavailable(`${machine.name} is not reachable.`);
+		}
+	}
+
+	async function localPeer(): Promise<PeerWorkspacesResult> {
+		let contents: string | null;
+		try {
+			contents = await deps.readLocalRunFile();
+		} catch {
+			contents = null;
+		}
+		const info = contents ? parseRunFile(contents) : null;
+		if (!info) return unavailable("This computer's local AO daemon is not running.");
+
+		try {
+			const projects = await fetchProjects(`http://127.0.0.1:${info.port}`, { Accept: "application/json" });
+			return {
+				state: "ok",
+				machineId: LOCAL_MACHINE_ID,
+				machineName: deps.localMachineName,
+				isRemote: false,
+				projects,
+			};
+		} catch {
+			return unavailable("This computer's local AO daemon is not reachable.");
+		}
+	}
+
+	return {
+		async get(): Promise<PeerWorkspacesResult> {
+			const machinesState = deps.getMachinesState();
+			if (machinesState.activeMachineId !== LOCAL_MACHINE_ID) {
+				// A registered machine is active, so the peer is this computer.
+				return localPeer();
+			}
+			const peer = machinesState.machines.find((machine) => !machine.local && machine.reachability === "online");
+			if (!peer) return unavailable("No other machine is online for this account.");
+			return remotePeer(peer);
+		},
+	};
+}

--- a/frontend/src/preload.ts
+++ b/frontend/src/preload.ts
@@ -3,6 +3,7 @@ import { FOCUS_TERMINAL_SHORTCUT_CHANNEL, KEYBOARD_SHORTCUTS_HELP_CHANNEL, NEXT_
 import type { BrowserNavState, BrowserRect } from "./main/browser-view-host";
 import type { AoAccountState } from "./shared/ao-account";
 import type { AoMachinesState } from "./shared/ao-machines";
+import type { PeerWorkspacesResult } from "./shared/peer-workspaces";
 import type { DaemonStatus } from "./shared/daemon-status";
 import type { TelemetryBootstrap } from "./shared/telemetry";
 import type { MigrationState } from "./main/app-state";
@@ -246,6 +247,10 @@ const api = {
 		// It is a fifteen minute token scoped to one machine; the refresh token it
 		// descends from never leaves the main process.
 		gatewayToken: () => ipcRenderer.invoke("aoMachines:gatewayToken") as Promise<string | null>,
+		// Read-only: the peer (non-active) daemon's projects and sessions, for
+		// listing alongside the active machine's. No URL or token here either;
+		// the main process fetches it and shapes the result.
+		peerWorkspaces: () => ipcRenderer.invoke("aoMachines:peerWorkspaces") as Promise<PeerWorkspacesResult>,
 	},
 };
 

--- a/frontend/src/renderer/components/GlobalSettingsForm.tsx
+++ b/frontend/src/renderer/components/GlobalSettingsForm.tsx
@@ -3,6 +3,7 @@ import { useState } from "react";
 import { Mail } from "lucide-react";
 import { ConnectMobileModal } from "./ConnectMobileModal";
 import { AccountSection } from "./settings/AccountSection";
+import { CloudSection } from "./settings/CloudSection";
 import { DeveloperModeSection } from "./settings/DeveloperModeSection";
 import { GeneralSettingsSection } from "./settings/GeneralSettingsSection";
 import { MachinesSection } from "./settings/MachinesSection";
@@ -25,6 +26,7 @@ export function GlobalSettingsForm() {
 					<GeneralSettingsSection onConnectMobile={() => setMobileOpen(true)} />
 					<AccountSection />
 					<MachinesSection />
+					<CloudSection />
 					<UpdatesSection />
 					<DeveloperModeSection />
 					<SettingsSection title="Get help">

--- a/frontend/src/renderer/components/PeerSessionsSection.test.tsx
+++ b/frontend/src/renderer/components/PeerSessionsSection.test.tsx
@@ -1,0 +1,153 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { PeerWorkspacesResult } from "../../shared/peer-workspaces";
+
+const { navigateMock, peerWorkspacesMock, machinesRefreshMock, switchToMachineMock } = vi.hoisted(() => ({
+	navigateMock: vi.fn(),
+	peerWorkspacesMock: vi.fn(),
+	machinesRefreshMock: vi.fn(),
+	switchToMachineMock: vi.fn(),
+}));
+
+vi.mock("@tanstack/react-router", () => ({
+	useNavigate: () => navigateMock,
+}));
+
+vi.mock("../lib/bridge", () => ({
+	aoBridge: {
+		machines: {
+			refresh: (...args: unknown[]) => machinesRefreshMock(...args),
+			peerWorkspaces: (...args: unknown[]) => peerWorkspacesMock(...args),
+		},
+	},
+}));
+
+vi.mock("../lib/peer-session-switch", () => ({
+	switchToMachine: (...args: unknown[]) => switchToMachineMock(...args),
+}));
+
+import { CloudLocalSections } from "./PeerSessionsSection";
+
+function renderSections(activeBoardContent = <div data-testid="active-board">active board</div>) {
+	const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+	return render(
+		<QueryClientProvider client={client}>
+			<CloudLocalSections activeBoardContent={activeBoardContent} />
+		</QueryClientProvider>,
+	);
+}
+
+const okPeer = (overrides: Partial<Extract<PeerWorkspacesResult, { state: "ok" }>> = {}): PeerWorkspacesResult => ({
+	state: "ok",
+	machineId: "mch_1",
+	machineName: "ao-build-01",
+	isRemote: true,
+	projects: [
+		{
+			id: "proj_1",
+			name: "solkit-ui",
+			sessions: [
+				{
+					id: "peer_s1",
+					title: "Fix the header",
+					status: "working",
+					branch: "ao/dev/fix-header",
+					harness: "codex",
+					kind: "worker",
+					updatedAt: "2026-01-01T00:00:00Z",
+				},
+			],
+		},
+	],
+	...overrides,
+});
+
+beforeEach(() => {
+	navigateMock.mockReset();
+	peerWorkspacesMock.mockReset().mockResolvedValue(okPeer());
+	machinesRefreshMock.mockReset().mockResolvedValue({
+		status: "ready",
+		machines: [{ id: "local", name: "This Mac", baseUrl: "", local: true, createdAt: null, lastSeen: null, reachability: "online", harness: "ready", harnessCommand: null }],
+		activeMachineId: "local",
+	});
+	switchToMachineMock.mockReset().mockResolvedValue({ status: "ready" });
+});
+
+describe("CloudLocalSections", () => {
+	it("renders CLOUD first with the peer's sessions, and LOCAL with the active board content", async () => {
+		renderSections();
+
+		const cloud = screen.getByTestId("board-section-cloud");
+		expect(await within(cloud).findByText("solkit-ui")).toBeInTheDocument();
+		expect(within(cloud).getByText("ao-build-01")).toBeInTheDocument();
+		expect(within(cloud).getByText("Fix the header")).toBeInTheDocument();
+
+		const local = screen.getByTestId("board-section-local");
+		expect(within(local).getByTestId("active-board")).toBeInTheDocument();
+
+		// Cloud renders before Local in document order.
+		expect(cloud.compareDocumentPosition(local) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+	});
+
+	it("swaps roles when the peer is local (active machine is the cloud one)", async () => {
+		peerWorkspacesMock.mockResolvedValue(okPeer({ isRemote: false, machineName: "This Mac" }));
+
+		renderSections();
+
+		// Resolve the query before capturing either section. While the peer is
+		// still loading the component defaults to "peer is cloud", and the swap
+		// remounts both sections (one is a component element, the other raw
+		// JSX), so a node captured earlier is detached by the time it settles.
+		expect(await screen.findByText("solkit-ui")).toBeInTheDocument();
+
+		const local = screen.getByTestId("board-section-local");
+		expect(within(local).getByText("solkit-ui")).toBeInTheDocument();
+		const cloud = screen.getByTestId("board-section-cloud");
+		expect(within(cloud).getByTestId("active-board")).toBeInTheDocument();
+	});
+
+	it("shows the peer's reason when unavailable", async () => {
+		peerWorkspacesMock.mockResolvedValue({ state: "unavailable", reason: "No cloud machine registered." });
+
+		renderSections();
+
+		expect(await screen.findByText("No cloud machine registered.")).toBeInTheDocument();
+	});
+
+	it("shows an empty state when the peer has projects but no sessions", async () => {
+		peerWorkspacesMock.mockResolvedValue(okPeer({ projects: [{ id: "p1", name: "empty-proj", sessions: [] }] }));
+
+		renderSections();
+
+		expect(await screen.findByText("No cloud sessions yet.")).toBeInTheDocument();
+	});
+
+	it("switches machines and navigates to the session on click", async () => {
+		renderSections();
+
+		const row = await screen.findByTestId("peer-session-row");
+		await userEvent.click(row);
+
+		expect(switchToMachineMock).toHaveBeenCalledWith("mch_1");
+		expect(navigateMock).toHaveBeenCalledWith({
+			to: "/projects/$projectId/sessions/$sessionId",
+			params: { projectId: "proj_1", sessionId: "peer_s1" },
+		});
+	});
+
+	it("shows an inline error and does not navigate when the switch fails", async () => {
+		switchToMachineMock.mockResolvedValue({ status: "error", message: "Timed out waiting for the machine to become ready." });
+
+		renderSections();
+
+		const row = await screen.findByTestId("peer-session-row");
+		await userEvent.click(row);
+
+		expect(await screen.findByTestId("peer-switch-error")).toHaveTextContent(
+			"Timed out waiting for the machine to become ready.",
+		);
+		expect(navigateMock).not.toHaveBeenCalled();
+	});
+});

--- a/frontend/src/renderer/components/PeerSessionsSection.tsx
+++ b/frontend/src/renderer/components/PeerSessionsSection.tsx
@@ -1,0 +1,297 @@
+import { useState, type ReactNode } from "react";
+import { useNavigate } from "@tanstack/react-router";
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+import { AlertTriangle, GitBranch, Loader2 } from "lucide-react";
+import { usePeerWorkspacesQuery } from "../hooks/usePeerWorkspacesQuery";
+import { switchToMachine } from "../lib/peer-session-switch";
+import { formatTimeCompact } from "../lib/format-time";
+import { getSessionStatusView } from "../lib/session-presentation";
+import { cn } from "../lib/utils";
+import { aoBridge } from "../lib/bridge";
+import { toAgentProvider, toSessionStatus } from "../types/workspace";
+import type { PeerProject, PeerSession, PeerWorkspacesResult } from "../../shared/peer-workspaces";
+import { AgentAvatar } from "./AgentAvatar";
+import { aoMachinesQueryKey } from "./settings/MachinesSection";
+
+type SectionRole = "CLOUD" | "LOCAL";
+
+type RowSwitchState =
+	| { phase: "idle" }
+	| { phase: "switching"; sessionId: string }
+	| { phase: "error"; sessionId: string; message: string };
+
+/**
+ * "Peer" (the daemon that is NOT active) can be either the cloud machine or
+ * this computer, depending on which one is currently active. This resolves
+ * which section the peer plays and which the active board plays, then
+ * renders both in the same card presentation, CLOUD first.
+ */
+export function CloudLocalSections({ activeBoardContent }: { activeBoardContent: ReactNode }) {
+	const peerQuery = usePeerWorkspacesQuery(true);
+	const activeMachineName = useActiveMachineName();
+	const [switchState, setSwitchState] = useState<RowSwitchState>({ phase: "idle" });
+	const navigate = useNavigate();
+	const result = peerQuery.data;
+	// Default to "peer is cloud" (active is local) while unresolved: that is
+	// the common case (this computer is machine zero, always active by
+	// default) and it is what a demo hits before any registered machine
+	// answers a probe.
+	const peerIsRemote = result?.state === "ok" ? result.isRemote : true;
+	const peerRole: SectionRole = peerIsRemote ? "CLOUD" : "LOCAL";
+	const activeRole: SectionRole = peerIsRemote ? "LOCAL" : "CLOUD";
+
+	const openPeerSession = async (session: PeerSession, projectId: string, machineId: string) => {
+		if (switchState.phase === "switching") return;
+		setSwitchState({ phase: "switching", sessionId: session.id });
+		const outcome = await switchToMachine(machineId);
+		if (outcome.status === "error") {
+			setSwitchState({ phase: "error", sessionId: session.id, message: outcome.message });
+			return;
+		}
+		setSwitchState({ phase: "idle" });
+		void navigate({
+			to: "/projects/$projectId/sessions/$sessionId",
+			params: { projectId, sessionId: session.id },
+		});
+	};
+
+	const peerSection = (
+		<PeerSection
+			role={peerRole}
+			query={peerQuery}
+			result={result}
+			switchState={switchState}
+			onOpen={openPeerSession}
+		/>
+	);
+	const activeSection = (
+		<section
+			aria-label={`${activeRole === "CLOUD" ? "Cloud" : "Local"} sessions`}
+			className="flex min-h-0 flex-1 flex-col gap-2"
+			data-testid={activeRole === "CLOUD" ? "board-section-cloud" : "board-section-local"}
+		>
+			<SectionHeading kind={activeRole} machineName={activeMachineName} />
+			<div className="min-h-0 flex-1 overflow-hidden">{activeBoardContent}</div>
+		</section>
+	);
+
+	return (
+		<div className="flex h-full min-h-0 flex-col gap-4 overflow-y-auto">
+			{peerRole === "CLOUD" ? peerSection : activeSection}
+			{peerRole === "CLOUD" ? activeSection : peerSection}
+		</div>
+	);
+}
+
+function useActiveMachineName(): string | undefined {
+	const query = useQuery({ queryKey: aoMachinesQueryKey, queryFn: () => aoBridge.machines.refresh() });
+	const state = query.data;
+	return state?.machines.find((machine) => machine.id === state.activeMachineId)?.name;
+}
+
+function PeerSection({
+	role,
+	query,
+	result,
+	switchState,
+	onOpen,
+}: {
+	role: SectionRole;
+	query: UseQueryResult<PeerWorkspacesResult>;
+	result: PeerWorkspacesResult | undefined;
+	switchState: RowSwitchState;
+	onOpen: (session: PeerSession, projectId: string, machineId: string) => void;
+}) {
+	return (
+		<section
+			aria-label={`${role === "CLOUD" ? "Cloud" : "Local"} sessions`}
+			className="flex min-h-0 flex-col gap-2"
+			data-testid={role === "CLOUD" ? "board-section-cloud" : "board-section-local"}
+		>
+			<SectionHeading kind={role} machineName={result?.state === "ok" ? result.machineName : undefined} />
+			{query.isLoading ? (
+				<PeerStatusMessage icon={Loader2} spin text={`Looking for ${role === "CLOUD" ? "cloud" : "local"} sessions...`} />
+			) : query.isError || !result ? (
+				<PeerStatusMessage icon={AlertTriangle} text={`Could not load ${role === "CLOUD" ? "cloud" : "local"} sessions.`} />
+			) : result.state === "unavailable" ? (
+				<PeerStatusMessage icon={AlertTriangle} text={result.reason} />
+			) : result.projects.every((project) => project.sessions.length === 0) ? (
+				<PeerStatusMessage text={`No ${role === "CLOUD" ? "cloud" : "local"} sessions yet.`} />
+			) : (
+				<div className="board-scrollbar min-h-0 flex-1 overflow-y-auto">
+					<div className="flex flex-col gap-3 pb-2">
+						{result.projects
+							.filter((project) => project.sessions.length > 0)
+							.map((project) => (
+								<PeerProjectGroup
+									key={project.id}
+									machineId={result.machineId}
+									machineName={result.machineName}
+									project={project}
+									onOpen={onOpen}
+									switchState={switchState}
+								/>
+							))}
+					</div>
+				</div>
+			)}
+		</section>
+	);
+}
+
+function SectionHeading({ kind, machineName }: { kind: SectionRole; machineName?: string }) {
+	return (
+		<div className="flex shrink-0 items-baseline gap-2 px-1">
+			<span className="font-mono text-2xs font-medium uppercase tracking-wide-sm text-passive">{kind}</span>
+			{machineName ? <span className="truncate text-caption text-muted-foreground">{machineName}</span> : null}
+		</div>
+	);
+}
+
+function PeerStatusMessage({
+	icon: Icon,
+	text,
+	spin,
+}: {
+	icon?: typeof AlertTriangle;
+	text: string;
+	spin?: boolean;
+}) {
+	return (
+		<div className="flex items-center gap-2 rounded-md border border-border bg-surface px-3 py-2 text-xs text-muted-foreground">
+			{Icon ? <Icon className={cn("size-icon-base shrink-0", spin && "animate-spin")} aria-hidden="true" /> : null}
+			<span>{text}</span>
+		</div>
+	);
+}
+
+function PeerProjectGroup({
+	project,
+	machineId,
+	machineName,
+	onOpen,
+	switchState,
+}: {
+	project: PeerProject;
+	machineId: string;
+	machineName: string;
+	onOpen: (session: PeerSession, projectId: string, machineId: string) => void;
+	switchState: RowSwitchState;
+}) {
+	// Only worker sessions get a card on the board too; the orchestrator is
+	// reached through its own button, not a board row.
+	const sessions = project.sessions.filter((session) => session.kind !== "orchestrator");
+	if (sessions.length === 0) return null;
+
+	return (
+		<div className="flex flex-col gap-1.5" data-testid="peer-project-group">
+			<span className="truncate px-1 text-2xs font-medium text-passive">{project.name}</span>
+			<div className="flex flex-col gap-2">
+				{sessions.map((session) => (
+					<PeerSessionRow
+						key={session.id}
+						session={session}
+						projectId={project.id}
+						machineId={machineId}
+						machineName={machineName}
+						onOpen={onOpen}
+						switchState={switchState}
+					/>
+				))}
+			</div>
+		</div>
+	);
+}
+
+function PeerSessionRow({
+	session,
+	projectId,
+	machineId,
+	machineName,
+	onOpen,
+	switchState,
+}: {
+	session: PeerSession;
+	projectId: string;
+	machineId: string;
+	machineName: string;
+	onOpen: (session: PeerSession, projectId: string, machineId: string) => void;
+	switchState: RowSwitchState;
+}) {
+	const status = toSessionStatus(session.status);
+	const badge = getSessionStatusView(status);
+	const provider = toAgentProvider(session.harness);
+	const isSwitchingThis = switchState.phase === "switching" && switchState.sessionId === session.id;
+	const isBlocked = switchState.phase === "switching" && !isSwitchingThis;
+	const rowError = switchState.phase === "error" && switchState.sessionId === session.id ? switchState.message : undefined;
+
+	return (
+		<div
+			aria-disabled={isBlocked || isSwitchingThis}
+			className={cn(
+				"group relative w-full rounded-lg border text-left transition-[border-color,box-shadow]",
+				badge.cardClassName ?? "border-border bg-surface",
+				!isBlocked && !isSwitchingThis && "cursor-pointer hover:border-border-strong hover:shadow-sm",
+				isBlocked && "opacity-60",
+			)}
+			data-testid="peer-session-row"
+			data-session-id={session.id}
+			onClick={() => {
+				if (isBlocked || isSwitchingThis) return;
+				onOpen(session, projectId, machineId);
+			}}
+			onKeyDown={(event) => {
+				if (event.key !== "Enter" && event.key !== " ") return;
+				if (isBlocked || isSwitchingThis) return;
+				event.preventDefault();
+				onOpen(session, projectId, machineId);
+			}}
+			role="button"
+			tabIndex={isBlocked ? -1 : 0}
+		>
+			<div className="flex items-start gap-2.5 px-3.5 pb-2.5 pt-3">
+				<AgentAvatar className="mt-0.5" provider={provider} />
+				<div className="min-w-0 flex-1">
+					<div
+						className="line-clamp-2 overflow-hidden text-sm-md font-semibold leading-tight tracking-tight text-foreground"
+						title={session.title}
+					>
+						{session.title}
+					</div>
+					{session.branch ? (
+						<div className="mt-1.5 flex min-w-0 items-center gap-1.5 font-mono text-2xs text-passive">
+							<GitBranch aria-hidden="true" className="size-icon-2xs shrink-0" />
+							<span className="truncate">{session.branch}</span>
+						</div>
+					) : null}
+				</div>
+			</div>
+			<div aria-hidden="true" className="mx-3.5 my-px h-px bg-border" />
+			<div className="flex flex-col gap-1.5 px-3.5 py-2">
+				<div className="flex items-center justify-between gap-2">
+					<span className={cn("inline-flex min-w-0 items-center gap-1.5 truncate text-2xs font-medium", badge.className)}>
+						<span className="size-dot-sm shrink-0 rounded-full bg-current" />
+						{badge.label}
+					</span>
+					{session.updatedAt ? (
+						<span className="shrink-0 whitespace-nowrap font-mono text-2xs text-passive" title={`Updated ${session.updatedAt}`}>
+							{formatTimeCompact(session.updatedAt)}
+						</span>
+					) : null}
+				</div>
+				{isSwitchingThis ? (
+					<span className="flex items-center gap-1.5 text-2xs text-muted-foreground" data-testid="peer-switch-progress">
+						<Loader2 className="size-icon-2xs animate-spin" aria-hidden="true" />
+						Switching to {machineName}...
+					</span>
+				) : null}
+				{rowError ? (
+					<span className="flex items-start gap-1.5 text-2xs text-destructive" data-testid="peer-switch-error" role="alert">
+						<AlertTriangle className="mt-0.5 size-icon-2xs shrink-0" aria-hidden="true" />
+						{rowError}
+					</span>
+				) : null}
+			</div>
+		</div>
+	);
+}

--- a/frontend/src/renderer/components/SessionsBoard.test.tsx
+++ b/frontend/src/renderer/components/SessionsBoard.test.tsx
@@ -1,15 +1,27 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { WorkspaceSession, WorkspaceSummary } from "../types/workspace";
+import type { PeerWorkspacesResult } from "../../shared/peer-workspaces";
+import { useUiStore } from "../stores/ui-store";
 
-const { navigateMock, notificationShowMock, postMock, workspaceQueryMock, boardActionsInPanelMock } = vi.hoisted(() => ({
+const {
+	navigateMock,
+	notificationShowMock,
+	postMock,
+	workspaceQueryMock,
+	boardActionsInPanelMock,
+	machinesRefreshMock,
+	peerWorkspacesMock,
+} = vi.hoisted(() => ({
 	navigateMock: vi.fn(),
 	notificationShowMock: vi.fn(),
 	postMock: vi.fn(),
 	workspaceQueryMock: vi.fn(),
 	boardActionsInPanelMock: vi.fn(() => false),
+	machinesRefreshMock: vi.fn(),
+	peerWorkspacesMock: vi.fn(),
 }));
 
 vi.mock("@tanstack/react-router", () => ({
@@ -33,6 +45,10 @@ vi.mock("../lib/bridge", () => ({
 		},
 		notifications: {
 			show: (...args: unknown[]) => notificationShowMock(...args),
+		},
+		machines: {
+			refresh: (...args: unknown[]) => machinesRefreshMock(...args),
+			peerWorkspaces: (...args: unknown[]) => peerWorkspacesMock(...args),
 		},
 	},
 }));
@@ -65,6 +81,8 @@ function renderBoardWithClient(queryClient: QueryClient, projectId?: string) {
 	);
 }
 
+const unavailablePeer: PeerWorkspacesResult = { state: "unavailable", reason: "No cloud machine registered." };
+
 beforeEach(() => {
 	navigateMock.mockReset();
 	notificationShowMock.mockReset().mockResolvedValue(undefined);
@@ -72,6 +90,16 @@ beforeEach(() => {
 	workspaceQueryMock.mockReset().mockReturnValue({ data: [], isError: false });
 	window.localStorage.removeItem("ao.board.archive.layout");
 	boardActionsInPanelMock.mockReset().mockReturnValue(false);
+	machinesRefreshMock.mockReset().mockResolvedValue({
+		status: "ready",
+		machines: [{ id: "local", name: "This Mac", baseUrl: "", local: true, createdAt: null, lastSeen: null, reachability: "online", harness: "ready", harnessCommand: null }],
+		activeMachineId: "local",
+	});
+	peerWorkspacesMock.mockReset().mockResolvedValue(unavailablePeer);
+});
+
+afterEach(() => {
+	useUiStore.getState().setCloudEnabled(false);
 });
 
 describe("SessionsBoard", () => {
@@ -1002,3 +1030,56 @@ function terminatedSession(overrides: Partial<WorkspaceSession> = {}): Workspace
 		...overrides,
 	};
 }
+
+describe("SessionsBoard Cloud toggle", () => {
+	it("issues no peer fetch and shows no Cloud/Local sections while the toggle is off", async () => {
+		renderBoard();
+
+		expect(screen.queryByTestId("board-section-cloud")).not.toBeInTheDocument();
+		expect(screen.queryByTestId("board-section-local")).not.toBeInTheDocument();
+		expect(peerWorkspacesMock).not.toHaveBeenCalled();
+	});
+
+	it("renders both a CLOUD and a LOCAL section once the toggle is on", async () => {
+		peerWorkspacesMock.mockResolvedValue({
+			state: "ok",
+			machineId: "mch_1",
+			machineName: "ao-build-01",
+			isRemote: true,
+			projects: [],
+		} satisfies PeerWorkspacesResult);
+		useUiStore.getState().setCloudEnabled(true);
+
+		renderBoard();
+
+		expect(await screen.findByTestId("board-section-cloud")).toBeInTheDocument();
+		expect(screen.getByTestId("board-section-local")).toBeInTheDocument();
+	});
+
+	it("shows the peer's reason when the peer is unavailable", async () => {
+		peerWorkspacesMock.mockResolvedValue({
+			state: "unavailable",
+			reason: "No cloud machine registered.",
+		} satisfies PeerWorkspacesResult);
+		useUiStore.getState().setCloudEnabled(true);
+
+		renderBoard();
+
+		expect(await screen.findByText("No cloud machine registered.")).toBeInTheDocument();
+	});
+
+	it("shows an empty state when the peer has zero sessions", async () => {
+		peerWorkspacesMock.mockResolvedValue({
+			state: "ok",
+			machineId: "mch_1",
+			machineName: "ao-build-01",
+			isRemote: true,
+			projects: [{ id: "p1", name: "solkit-ui", sessions: [] }],
+		} satisfies PeerWorkspacesResult);
+		useUiStore.getState().setCloudEnabled(true);
+
+		renderBoard();
+
+		expect(await screen.findByText("No cloud sessions yet.")).toBeInTheDocument();
+	});
+});

--- a/frontend/src/renderer/components/SessionsBoard.tsx
+++ b/frontend/src/renderer/components/SessionsBoard.tsx
@@ -36,6 +36,7 @@ import { useRestoreSession } from "../hooks/useRestoreSession";
 import { useTerminateSession } from "../hooks/useTerminateSession";
 import { useWorkspaceQuery, workspaceQueryKey } from "../hooks/useWorkspaceQuery";
 import { NotificationCenter } from "./NotificationCenter";
+import { CloudLocalSections } from "./PeerSessionsSection";
 import { BoardWelcome, ProjectBoardEmpty } from "./BoardEmptyStates";
 import { OrchestratorIcon } from "./icons";
 import { AgentAvatar } from "./AgentAvatar";
@@ -103,6 +104,7 @@ export function SessionsBoard({ projectId }: SessionsBoardProps) {
 	const setOrchestratorReplacementError = useUiStore((state) => state.setOrchestratorReplacementError);
 	const setOrchestratorStartupError = useUiStore((state) => state.setOrchestratorStartupError);
 	const requestNewTask = useUiStore((state) => state.requestNewTask);
+	const cloudEnabled = useUiStore((state) => state.cloudEnabled);
 	const isProjectRestarting = projectId ? restartingProjectIds.has(projectId) : false;
 	const health = workspace ? orchestratorHealth(workspace, isProjectRestarting) : { state: "ok" as const };
 	const visibleSpawnError = spawnError ?? orchestratorStartupError;
@@ -282,12 +284,49 @@ export function SessionsBoard({ projectId }: SessionsBoardProps) {
 		<NotificationCenter />
 	) : undefined;
 
+	// Extracted so the Cloud toggle can wrap it in a LOCAL section without
+	// touching how the active daemon's own board renders.
+	const boardBody = workspaceQuery.isError ? (
+		<p className="py-10 text-center text-xs text-passive">Could not load sessions.</p>
+	) : showWelcome ? (
+		<BoardWelcome />
+	) : showProjectEmpty ? (
+		<ProjectBoardEmpty
+			hasOrchestrator={orchestrator !== undefined}
+			isSpawning={isSpawning}
+			isProjectRestarting={isProjectRestarting}
+			onNewTask={() => projectId && requestNewTask(projectId)}
+			onOpenOrchestrator={() => void openOrchestrator()}
+			spawnError={visibleSpawnError}
+		/>
+	) : (
+		<div className="h-full overflow-hidden">
+			{/* The 4 zone columns share the width and shrink to fit: no
+			    horizontal scroll on a narrow window (each column is min-w-0,
+			    cards truncate/wrap). */}
+			<div className="grid h-full grid-cols-4 gap-2">
+				{COLUMNS.map((col) => (
+					<BoardColumn
+						key={`${projectId ?? "all"}:${col.zone}`}
+						col={col}
+						sessions={byZone.get(col.zone) ?? []}
+						onOpen={openSession}
+						onTerminate={(session) => {
+							terminateSession.reset();
+							setTerminationSession(session);
+						}}
+					/>
+				))}
+			</div>
+		</div>
+	);
+
 	return (
 		<div className="flex h-full min-h-0 flex-col bg-background text-foreground" data-testid="board">
 			{/* macOS: shell topbar is hidden on board routes, so the project/"Board"
 			    crumb + New task / Orchestrator / bell live in this in-panel row.
 			    Win/Linux keep the crumb and actions in the framed ShellTopbar.
-			    Welcome skips the row — a dangling "Board" above the import
+			    Welcome skips the row: a dangling "Board" above the import
 			    chooser was review feedback on #2432. */}
 			{!showWelcome && boardActionsInPanel && (boardLabel || actions) ? (
 				<div className="center-panel-titlebar flex h-toolbar shrink-0 items-center gap-2 pr-4.5" style={dragStyle}>
@@ -314,39 +353,10 @@ export function SessionsBoard({ projectId }: SessionsBoardProps) {
 						) : null}
 					</div>
 				) : null}
-				{workspaceQuery.isError ? (
-					<p className="py-10 text-center text-xs text-passive">Could not load sessions.</p>
-				) : showWelcome ? (
-					<BoardWelcome />
-				) : showProjectEmpty ? (
-					<ProjectBoardEmpty
-						hasOrchestrator={orchestrator !== undefined}
-						isSpawning={isSpawning}
-						isProjectRestarting={isProjectRestarting}
-						onNewTask={() => projectId && requestNewTask(projectId)}
-						onOpenOrchestrator={() => void openOrchestrator()}
-						spawnError={visibleSpawnError}
-					/>
+				{cloudEnabled && !projectId ? (
+					<CloudLocalSections activeBoardContent={boardBody} />
 				) : (
-					<div className="h-full overflow-hidden">
-						{/* The 4 zone columns share the width and shrink to fit — no
-						    horizontal scroll on a narrow window (each column is min-w-0,
-						    cards truncate/wrap). */}
-						<div className="grid h-full grid-cols-4 gap-2">
-							{COLUMNS.map((col) => (
-								<BoardColumn
-									key={`${projectId ?? "all"}:${col.zone}`}
-									col={col}
-									sessions={byZone.get(col.zone) ?? []}
-									onOpen={openSession}
-									onTerminate={(session) => {
-										terminateSession.reset();
-										setTerminationSession(session);
-									}}
-								/>
-							))}
-						</div>
-					</div>
+					boardBody
 				)}
 			</div>
 

--- a/frontend/src/renderer/components/settings/CloudSection.tsx
+++ b/frontend/src/renderer/components/settings/CloudSection.tsx
@@ -1,0 +1,21 @@
+import { Cloud } from "lucide-react";
+import { useUiStore } from "../../stores/ui-store";
+import { Switch } from "../ui/switch";
+import { SettingsRow } from "./SettingsRow";
+import { SettingsSection } from "./SettingsSection";
+
+// Single opt-in toggle that reveals the CLOUD sessions section on the board
+// alongside LOCAL. Persisted via the ui-store, defaults off. Off, the board
+// looks exactly as it does today and no peer daemon fetch happens.
+export function CloudSection() {
+	const cloudEnabled = useUiStore((state) => state.cloudEnabled);
+	const setCloudEnabled = useUiStore((state) => state.setCloudEnabled);
+
+	return (
+		<SettingsSection title="Cloud" sectionId="cloud">
+			<SettingsRow icon={Cloud} label="Turn on Cloud">
+				<Switch aria-label="Turn on Cloud" checked={cloudEnabled} onCheckedChange={setCloudEnabled} />
+			</SettingsRow>
+		</SettingsSection>
+	);
+}

--- a/frontend/src/renderer/hooks/usePeerWorkspacesQuery.ts
+++ b/frontend/src/renderer/hooks/usePeerWorkspacesQuery.ts
@@ -1,0 +1,26 @@
+import { useQuery } from "@tanstack/react-query";
+import { aoBridge } from "../lib/bridge";
+import type { PeerWorkspacesResult } from "../../shared/peer-workspaces";
+
+export const peerWorkspacesQueryKey = ["peer-workspaces"] as const;
+
+async function fetchPeerWorkspaces(): Promise<PeerWorkspacesResult> {
+	return aoBridge.machines.peerWorkspaces();
+}
+
+/**
+ * Mirror of useWorkspaceQuery for the peer (non-active) daemon: "peer" is the
+ * cloud machine when local is active, and local when a cloud machine is
+ * active. Own query key, same polling interval, no SSE (peer sessions are
+ * read-only in this UI). Only enabled while the Cloud toggle is on, so
+ * turning it off issues no peer fetch.
+ */
+export function usePeerWorkspacesQuery(enabled: boolean) {
+	return useQuery({
+		queryKey: peerWorkspacesQueryKey,
+		queryFn: fetchPeerWorkspaces,
+		retry: 1,
+		refetchInterval: 15_000,
+		enabled,
+	});
+}

--- a/frontend/src/renderer/lib/bridge.ts
+++ b/frontend/src/renderer/lib/bridge.ts
@@ -10,6 +10,7 @@ import {
 import { DEFAULT_CONTROL_PLANE_URL } from "../../shared/control-plane";
 import { machineDaemonStatus } from "../../shared/remote-daemon";
 import type { DaemonStatus } from "../../shared/daemon-status";
+import type { PeerProject, PeerWorkspacesResult } from "../../shared/peer-workspaces";
 export type { FeatureBuild } from "../../main/feature-builds";
 
 const BROWSER_PREVIEW_ACCOUNT_STATE: AoAccountState = {
@@ -63,6 +64,59 @@ const browserPreviewMachinesState = (): AoMachinesState => ({
 	machines: BROWSER_PREVIEW_MACHINES,
 	activeMachineId: previewActiveMachineId,
 });
+
+// A couple of demoable sessions for the "Turn on Cloud" preview, whichever
+// side of the toggle plays the peer.
+const BROWSER_PREVIEW_PEER_PROJECTS: PeerProject[] = [
+	{
+		id: "proj_peer",
+		name: "reverbcode",
+		sessions: [
+			{
+				id: "peer_s1",
+				title: "Fix the login redirect loop",
+				status: "working",
+				activity: "active",
+				branch: "ao/dev/fix-login-redirect",
+				harness: "codex",
+				kind: "worker",
+				updatedAt: new Date().toISOString(),
+			},
+			{
+				id: "peer_s2",
+				title: "Add dark mode toggle",
+				status: "pr_open",
+				activity: "idle",
+				branch: "ao/dev/dark-mode-toggle",
+				harness: "claude-code",
+				kind: "worker",
+				updatedAt: new Date(Date.now() - 60 * 60 * 1000).toISOString(),
+			},
+		],
+	},
+];
+
+/** Peer = the daemon that is NOT active, mirroring machines.select's target. */
+const browserPreviewPeerWorkspaces = (): PeerWorkspacesResult => {
+	if (previewActiveMachineId === LOCAL_MACHINE_ID) {
+		const peer = BROWSER_PREVIEW_MACHINES.find((machine) => machine.id === "mch_ready");
+		if (!peer) return { state: "unavailable", reason: "No cloud machine registered." };
+		return {
+			state: "ok",
+			machineId: peer.id,
+			machineName: peer.name,
+			isRemote: true,
+			projects: BROWSER_PREVIEW_PEER_PROJECTS,
+		};
+	}
+	return {
+		state: "ok",
+		machineId: LOCAL_MACHINE_ID,
+		machineName: "This Mac",
+		isRemote: false,
+		projects: BROWSER_PREVIEW_PEER_PROJECTS,
+	};
+};
 
 /**
  * What the app's daemon status would be for the machine picked in preview, from
@@ -241,5 +295,6 @@ export const aoBridge: AoBridge =
 			// Browser preview has no main process, so no machine token either.
 			// Null means "send no Authorization header".
 			gatewayToken: async () => null,
+			peerWorkspaces: async () => browserPreviewPeerWorkspaces(),
 		},
 	} satisfies AoBridge);

--- a/frontend/src/renderer/lib/peer-session-switch.test.ts
+++ b/frontend/src/renderer/lib/peer-session-switch.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { DaemonStatus } from "../../shared/daemon-status";
+
+const { selectMock, getStatusMock, onStatusMock } = vi.hoisted(() => ({
+	selectMock: vi.fn(),
+	getStatusMock: vi.fn(),
+	onStatusMock: vi.fn(),
+}));
+
+vi.mock("./bridge", () => ({
+	aoBridge: {
+		machines: { select: (...args: unknown[]) => selectMock(...args) },
+		daemon: {
+			getStatus: (...args: unknown[]) => getStatusMock(...args),
+			onStatus: (...args: unknown[]) => onStatusMock(...args),
+		},
+	},
+}));
+
+import { switchToMachine } from "./peer-session-switch";
+
+let statusListener: ((status: DaemonStatus) => void) | undefined;
+
+beforeEach(() => {
+	vi.useFakeTimers();
+	selectMock.mockReset().mockResolvedValue(undefined);
+	getStatusMock.mockReset().mockResolvedValue({ state: "starting" } satisfies DaemonStatus);
+	onStatusMock.mockReset().mockImplementation((listener: (status: DaemonStatus) => void) => {
+		statusListener = listener;
+		return () => {
+			statusListener = undefined;
+		};
+	});
+});
+
+afterEach(() => {
+	vi.useRealTimers();
+});
+
+describe("switchToMachine", () => {
+	it("resolves ready once the daemon reports ready", async () => {
+		const promise = switchToMachine("mch_1");
+		await vi.waitFor(() => expect(onStatusMock).toHaveBeenCalled());
+
+		statusListener?.({ state: "ready", port: 4000 });
+
+		await expect(promise).resolves.toEqual({ status: "ready" });
+		expect(selectMock).toHaveBeenCalledWith("mch_1");
+	});
+
+	it("resolves an error if selecting the machine throws", async () => {
+		selectMock.mockRejectedValue(new Error("machine not found"));
+
+		await expect(switchToMachine("mch_missing")).resolves.toEqual({ status: "error", message: "machine not found" });
+		expect(onStatusMock).not.toHaveBeenCalled();
+	});
+
+	it("resolves an error after timing out with no ready status", async () => {
+		const promise = switchToMachine("mch_1");
+		await vi.waitFor(() => expect(onStatusMock).toHaveBeenCalled());
+
+		await vi.advanceTimersByTimeAsync(10_000);
+
+		await expect(promise).resolves.toEqual({
+			status: "error",
+			message: "Timed out waiting for the machine to become ready.",
+		});
+	});
+});

--- a/frontend/src/renderer/lib/peer-session-switch.ts
+++ b/frontend/src/renderer/lib/peer-session-switch.ts
@@ -1,0 +1,50 @@
+import type { DaemonStatus } from "../../shared/daemon-status";
+import { aoBridge } from "./bridge";
+
+// Demo-facing: a hung switch must not spin forever. If the daemon has not
+// reported ready by this point, treat it as a failure and let the user retry.
+const SWITCH_TIMEOUT_MS = 10_000;
+
+export type MachineSwitchResult = { status: "ready" } | { status: "error"; message: string };
+
+/**
+ * Click-to-switch for a peer session row: select the machine (reusing the
+ * same bridge call MachinesSection uses), then wait for the daemon to report
+ * ready before the caller navigates. Never resolves "ready" for a machine
+ * that didn't actually come up.
+ */
+export async function switchToMachine(machineId: string): Promise<MachineSwitchResult> {
+	try {
+		await aoBridge.machines.select(machineId);
+	} catch (err) {
+		return { status: "error", message: err instanceof Error ? err.message : "Could not switch machines." };
+	}
+	return waitForDaemonReady();
+}
+
+function waitForDaemonReady(): Promise<MachineSwitchResult> {
+	return new Promise((resolve) => {
+		let settled = false;
+		let stopListening = () => {};
+		const finish = (result: MachineSwitchResult) => {
+			if (settled) return;
+			settled = true;
+			clearTimeout(timer);
+			stopListening();
+			resolve(result);
+		};
+		const fromStatus = (status: DaemonStatus) => {
+			if (status.state === "ready") finish({ status: "ready" });
+			else if (status.state === "error") {
+				finish({ status: "error", message: status.message ?? "The machine did not become ready." });
+			}
+		};
+		const timer = setTimeout(
+			() => finish({ status: "error", message: "Timed out waiting for the machine to become ready." }),
+			SWITCH_TIMEOUT_MS,
+		);
+		stopListening = aoBridge.daemon.onStatus(fromStatus);
+		// The status may already have settled before onStatus's next event fires.
+		void aoBridge.daemon.getStatus().then(fromStatus);
+	});
+}

--- a/frontend/src/renderer/stores/ui-store.ts
+++ b/frontend/src/renderer/stores/ui-store.ts
@@ -39,6 +39,8 @@ type UiState = {
 	resolvedTheme: Theme;
 	/** When true, developer-only surfaces (e.g. Feature Releases) are revealed. Default off. */
 	developerMode: boolean;
+	/** When true, the board shows CLOUD and LOCAL session sections side by side. Default off. */
+	cloudEnabled: boolean;
 	restartingProjectIds: ReadonlySet<string>;
 	orchestratorReplacementErrors: Record<string, string>;
 	orchestratorStartupErrors: Record<string, string>;
@@ -63,6 +65,7 @@ type UiState = {
 	setWorkbenchTab: (tab: WorkbenchTab) => void;
 	setThemePreference: (theme: ThemePreference) => void;
 	setDeveloperMode: (enabled: boolean) => void;
+	setCloudEnabled: (enabled: boolean) => void;
 	/** Refresh resolvedTheme from OS without writing light/dark to storage. */
 	syncSystemTheme: () => void;
 	toggleSidebar: () => void;
@@ -83,6 +86,7 @@ type UiState = {
 
 const sidebarStorageKey = "ao.sidebar.open";
 const developerModeStorageKey = "ao.developerMode";
+const cloudEnabledStorageKey = "ao.cloudEnabled";
 
 function getLocalStorage() {
 	if (typeof window === "undefined" || !window.localStorage) return null;
@@ -95,6 +99,10 @@ function initialSidebarOpen() {
 
 function initialDeveloperMode() {
 	return getLocalStorage()?.getItem(developerModeStorageKey) === "true";
+}
+
+function initialCloudEnabled() {
+	return getLocalStorage()?.getItem(cloudEnabledStorageKey) === "true";
 }
 
 function inspectorState(sessions: Record<string, InspectorSessionState>, sessionId: string): InspectorSessionState {
@@ -111,6 +119,7 @@ export const useUiStore = create<UiState>((set) => ({
 	themePreference: initialThemePreference,
 	resolvedTheme: resolveTheme(initialThemePreference),
 	developerMode: initialDeveloperMode(),
+	cloudEnabled: initialCloudEnabled(),
 	restartingProjectIds: new Set<string>(),
 	orchestratorReplacementErrors: {},
 	orchestratorStartupErrors: {},
@@ -126,6 +135,10 @@ export const useUiStore = create<UiState>((set) => ({
 	setDeveloperMode: (developerMode) => {
 		getLocalStorage()?.setItem(developerModeStorageKey, String(developerMode));
 		set({ developerMode });
+	},
+	setCloudEnabled: (cloudEnabled) => {
+		getLocalStorage()?.setItem(cloudEnabledStorageKey, String(cloudEnabled));
+		set({ cloudEnabled });
 	},
 	syncSystemTheme: () =>
 		set((state) => {

--- a/frontend/src/renderer/test/setup.ts
+++ b/frontend/src/renderer/test/setup.ts
@@ -2,8 +2,13 @@ import "@testing-library/jest-dom/vitest";
 import type { AoAccountState } from "../../shared/ao-account";
 import { LOCAL_MACHINE_ID, localMachine, type AoMachinesState } from "../../shared/ao-machines";
 import { DEFAULT_CONTROL_PLANE_URL } from "../../shared/control-plane";
+import type { PeerWorkspacesResult } from "../../shared/peer-workspaces";
 
 const signedOutAoAccount: AoAccountState = { status: "signed-out", controlPlaneUrl: DEFAULT_CONTROL_PLANE_URL };
+
+// Default peer result for tests that don't care about the Cloud toggle: no
+// peer machine registered, same as a fresh install.
+const noPeerRegistered: PeerWorkspacesResult = { state: "unavailable", reason: "No cloud machine registered." };
 
 // Signed out is the default everywhere in tests, and this computer is still the
 // active machine: local use never requires an account.
@@ -209,6 +214,7 @@ if (typeof window !== "undefined") {
 			refresh: async () => signedOutAoMachines,
 			select: async () => signedOutAoMachines,
 			gatewayToken: async () => null,
+			peerWorkspaces: async () => noPeerRegistered,
 		},
 	};
 } // end if (typeof window !== "undefined")

--- a/frontend/src/shared/peer-workspaces.ts
+++ b/frontend/src/shared/peer-workspaces.ts
@@ -1,0 +1,36 @@
+/**
+ * The peer daemon's workspaces: a read-only view of the daemon that is NOT the
+ * active one, so the desktop app can list its projects and sessions alongside
+ * the active machine's without re-pointing anything at it.
+ *
+ * "Peer" is defined relative to `activeMachineId` in `./ao-machines`: when this
+ * computer is active, the peer is the account's online registered machine (if
+ * any); when a registered machine is active, the peer is this computer's local
+ * loopback daemon. See `main/peer-workspaces.ts` for the fetch and shaping.
+ *
+ * Pure shapes only, no I/O, matching the split every other shared module here
+ * follows (main owns the fetch, the renderer owns the rendering).
+ */
+
+/** One session on the peer daemon. Read-only: no terminal, no SSE. */
+export type PeerSession = {
+	id: string;
+	title: string;
+	status: string;
+	activity?: string;
+	branch?: string;
+	harness?: string;
+	kind?: string;
+	updatedAt?: string;
+};
+
+/** One project on the peer daemon, with its sessions. */
+export type PeerProject = {
+	id: string;
+	name: string;
+	sessions: PeerSession[];
+};
+
+export type PeerWorkspacesResult =
+	| { state: "unavailable"; reason: string }
+	| { state: "ok"; machineId: string; machineName: string; isRemote: boolean; projects: PeerProject[] };


### PR DESCRIPTION
The app binds to one daemon at a time. The `ready` status carries a base URL that re-points the renderer's REST calls, its SSE stream, and the terminal mux at a single gateway, and there is one `activeMachineId` that is either local or one registered machine. So a remote machine's sessions and this computer's sessions could never be on screen at the same time.

This adds a read-only "peer" path for the daemon that is **not** active, so both can be listed side by side.

## What changed

- **`machines.peerWorkspaces()` IPC.** Resolves the peer (the cloud machine when local is active, the loopback daemon when a machine is active), fetches its projects and sessions **in the main process**, and shapes them to a shared contract in `frontend/src/shared/peer-workspaces.ts`. Doing it in main avoids CORS and keeps the token out of the renderer.
- **Second, independent token source** keyed by machine id for a remote peer. Bearer only, **no cookie**: `ao_gw_token` exists solely for `/mux` and SSE, which a peer never opens. `createMachineTransport` is **not touched**, so the active connection cannot be disturbed by this path.
- **Cloud toggle** in Settings. With it off the board renders exactly as before and no peer fetch is issued.
- **Click a peer session** runs the existing machine switch, shows a transient `Switching to <machine>...` state, then opens the session. A failed switch surfaces inline and does not navigate.
- Every failure returns `{state:"unavailable", reason}`. Reasons never carry a token, covered by a dedicated test.

## Deliberate scope limit

Peer sessions are **not attachable in place**: no SSE and no terminal until the switch completes. Attaching to two daemons at once needs concurrent mux and SSE connections, which is a transport change rather than an additive one. Out of scope here.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run typecheck:e2e` clean (required adding `peerWorkspaces` to the e2e fake bridge)
- [x] `npm test`: 1300 passed, 107 files, 0 failed
- [x] `frontend/src/main/machine-transport.ts` diff is empty, verifying the active transport is untouched
- [ ] Manual: toggle on, confirm both sections populate against a live remote machine