### PR TITLE
fix(desktop): allow machine gateway origins in the renderer CSP

### DIFF
--- a/frontend/vite.renderer.config.ts
+++ b/frontend/vite.renderer.config.ts
@@ -19,17 +19,31 @@ const POSTHOG_ORIGIN = (() => {
 	}
 })();
 
-// CSP for the built renderer. The daemon is loopback-only, so network access is
-// pinned to 127.0.0.1 (REST + SSE over http, terminal mux over ws). Injected at
+// CSP for the built renderer. The local daemon is loopback-only (REST + SSE over
+// http, terminal mux over ws), which is why 127.0.0.1 is pinned. Injected at
 // build time rather than written into index.html because the dev server needs
 // inline scripts (react-refresh preamble) that a static meta tag would block.
+//
+// https: and wss: are here for registered machines. A machine's gateway domain
+// is supplied by the operator at `ao setup-vm` time and only known at runtime,
+// so a build-time policy cannot enumerate the origins the renderer must reach:
+// switching to a machine re-points REST, the SSE stream, and the terminal mux at
+// that gateway. Without these, a packaged build cannot talk to any machine at
+// all and the board fails with a CSP violation, while dev builds appear fine
+// because Vite proxies /api to 127.0.0.1.
+//
+// ponytail: broad https:/wss:. The tight fix is a per-session CSP built in the
+// main process from the registered machine list, narrowing this to exactly the
+// account's gateway origins. Worth doing once machine switching settles.
 const CONTENT_SECURITY_POLICY = [
 	"default-src 'self'",
 	"script-src 'self'",
 	"style-src 'self' 'unsafe-inline'",
 	"img-src 'self' data:",
 	"font-src 'self' data:",
-	["connect-src", "'self'", "http://127.0.0.1:*", "ws://127.0.0.1:*", POSTHOG_ORIGIN].filter(Boolean).join(" "),
+	["connect-src", "'self'", "http://127.0.0.1:*", "ws://127.0.0.1:*", "https:", "wss:", POSTHOG_ORIGIN]
+		.filter(Boolean)
+		.join(" "),
 	"object-src 'none'",
 	"base-uri 'self'",
 	"frame-src 'none'",


### PR DESCRIPTION
The built renderer's CSP pinned `connect-src` to `127.0.0.1`, dating from when the daemon was loopback-only:

```
connect-src 'self' http://127.0.0.1:* ws://127.0.0.1:* https://us.i.posthog.com
```

Registered machines (task 15) broke that assumption. Selecting a machine re-points the renderer's REST calls, its SSE stream, and the terminal mux at that machine's gateway over `https` and `wss`, and the policy blocked all three:

```
Refused to connect to 'https://vm-shared.ao.agentlab.in/api/v1/sessions'
because it violates the document's Content Security Policy.
```

So **a packaged build could not talk to any registered machine at all.** This only ever reproduces in a package: dev builds look fine because Vite proxies `/api` to `127.0.0.1`, which the old policy allowed. Found while running a packaged build against a real machine.

## Why `https:` / `wss:` rather than an explicit origin list

A machine's gateway domain is supplied by the operator at `ao setup-vm` time and is only known at runtime, so a build-time meta tag cannot enumerate them.

This is a deliberate widening and I have marked it. The tight fix is a per-session CSP built in the main process from the registered machine list, narrowing to exactly the account's gateway origins; there is a `ponytail:` note in the config saying so. `script-src` stays `'self'`, so no third-party script can be loaded to exploit the wider `connect-src`.

## Test plan

- [x] Packaged build (`npm run make`) now loads the board against a live machine instead of throwing CSP violations
- [x] Verified the emitted policy in the built `app.asar`
- [ ] Reviewer call on whether to take the broad form now and tighten later, or hold for the per-session CSP