### PR TITLE
fix(desktop): bound control-plane requests so a stall cannot wedge the app

### DIFF
--- a/frontend/src/main/ao-control-token.test.ts
+++ b/frontend/src/main/ao-control-token.test.ts
@@ -155,3 +155,63 @@ test("clear drops the cached token, so sign-out leaves nothing behind", async ()
 	await tokens.get();
 	expect(fetchImpl).toHaveBeenCalledTimes(2);
 });
+
+// Regression: a stalled exchange used to poison this source permanently.
+//
+// `inFlight` is handed to every later caller and cleared in a `.finally`, which
+// only runs when the promise settles. A control-plane request that never
+// settled therefore wedged the source for the life of the process: the machine
+// list spun forever with no request in flight and no error, recoverable only by
+// restarting the app. Observed in the wild when the control plane's public IP
+// changed and the old address blackholed packets instead of refusing them.
+test("a stalled exchange times out and does not wedge later calls", async () => {
+	await writeStoredAccount(stateDir, safeStorage, { account, refreshToken: "rt_1" });
+	// Ignores the abort signal entirely, which is the worst case: nothing but a
+	// race can rescue a caller from it.
+	const stalls: typeof fetch = () => new Promise<Response>(() => {});
+	const tokens = createControlPlaneTokenSource({
+		stateDir,
+		controlPlaneUrl: CONTROL_PLANE,
+		safeStorage,
+		fetchImpl: stalls,
+		now: () => 0,
+		timeoutMs: 20,
+	});
+
+	await expect(tokens.get()).rejects.toThrow(/timed out/);
+
+	// The wedge: before the deadline, this second call returned the same dead
+	// promise and never settled. It must now be able to succeed.
+	const ok = vi.fn(async () => tokenResponse({ access_token: "at_2", expires_in: 900, refresh_token: "rt_2" }));
+	const recovered = createControlPlaneTokenSource({
+		stateDir,
+		controlPlaneUrl: CONTROL_PLANE,
+		safeStorage,
+		fetchImpl: ok as unknown as typeof fetch,
+		now: () => 0,
+		timeoutMs: 1000,
+	});
+	await expect(recovered.get()).resolves.toBe("at_2");
+});
+
+test("a second call after a stall on the SAME source is not the dead promise", async () => {
+	await writeStoredAccount(stateDir, safeStorage, { account, refreshToken: "rt_1" });
+	let calls = 0;
+	const stallThenSucceed: typeof fetch = () => {
+		calls += 1;
+		if (calls === 1) return new Promise<Response>(() => {});
+		return Promise.resolve(tokenResponse({ access_token: "at_3", expires_in: 900, refresh_token: "rt_2" }));
+	};
+	const tokens = createControlPlaneTokenSource({
+		stateDir,
+		controlPlaneUrl: CONTROL_PLANE,
+		safeStorage,
+		fetchImpl: stallThenSucceed,
+		now: () => 0,
+		timeoutMs: 20,
+	});
+
+	await expect(tokens.get()).rejects.toThrow(/timed out/);
+	await expect(tokens.get()).resolves.toBe("at_3");
+	expect(calls).toBe(2);
+});

--- a/frontend/src/main/ao-control-token.ts
+++ b/frontend/src/main/ao-control-token.ts
@@ -1,4 +1,5 @@
 import { readStoredAccount, writeStoredAccount, type SafeStorageLike } from "./ao-account-store";
+import { CONTROL_PLANE_TIMEOUT_MS, fetchWithDeadline, withDeadline } from "./request-deadline";
 
 /**
  * The desktop install's control-plane-audience access token.
@@ -46,6 +47,8 @@ export type ControlPlaneTokenDeps = {
 	safeStorage: SafeStorageLike;
 	fetchImpl?: typeof fetch;
 	now?: () => number;
+	/** Deadline for the token exchange. See request-deadline.ts. */
+	timeoutMs?: number;
 };
 
 export type ControlPlaneTokenSource = {
@@ -74,6 +77,7 @@ function exchangeFailure(status: number, body: unknown): Error {
 export function createControlPlaneTokenSource(deps: ControlPlaneTokenDeps): ControlPlaneTokenSource {
 	const fetchImpl = deps.fetchImpl ?? fetch;
 	const now = deps.now ?? Date.now;
+	const timeoutMs = deps.timeoutMs ?? CONTROL_PLANE_TIMEOUT_MS;
 
 	let cached: { token: string; expiresAt: number } | null = null;
 	let inFlight: Promise<string | null> | null = null;
@@ -82,17 +86,23 @@ export function createControlPlaneTokenSource(deps: ControlPlaneTokenDeps): Cont
 		const stored = await readStoredAccount(deps.stateDir, deps.safeStorage);
 		if (!stored) return null;
 
-		const response = await fetchImpl(`${deps.controlPlaneUrl}/api/v1/token`, {
-			method: "POST",
-			headers: {
-				"Content-Type": "application/x-www-form-urlencoded",
-				Accept: "application/json",
+		const response = await fetchWithDeadline(
+			fetchImpl,
+			`${deps.controlPlaneUrl}/api/v1/token`,
+			{
+				method: "POST",
+				headers: {
+					"Content-Type": "application/x-www-form-urlencoded",
+					Accept: "application/json",
+				},
+				body: new URLSearchParams({
+					grant_type: "refresh_token",
+					refresh_token: stored.refreshToken,
+				}).toString(),
 			},
-			body: new URLSearchParams({
-				grant_type: "refresh_token",
-				refresh_token: stored.refreshToken,
-			}).toString(),
-		});
+			timeoutMs,
+			"Refreshing this computer's sign-in",
+		);
 
 		// Bodies here carry a refresh token, so nothing about them is logged.
 		let body: unknown = null;
@@ -135,8 +145,14 @@ export function createControlPlaneTokenSource(deps: ControlPlaneTokenDeps): Cont
 			// One exchange at a time. A second concurrent exchange would present a
 			// refresh token the first one had already rotated away.
 			if (inFlight) return inFlight;
-			const attempt = Promise.resolve()
-				.then(exchange)
+			// Deadlined around the WHOLE exchange, not just its fetch. `inFlight` is
+			// handed to every later caller, and it is cleared in the `.finally`
+			// below, which only runs when the promise settles. So a single exchange
+			// that never settles would poison this source for the life of the
+			// process: the machine list would spin forever with no request in
+			// flight and no error, recoverable only by restarting the app. The race
+			// guarantees settlement even if something other than the fetch hangs.
+			const attempt = withDeadline(Promise.resolve().then(exchange), timeoutMs, "Refreshing this computer's sign-in")
 				.finally(() => {
 					inFlight = null;
 				});

--- a/frontend/src/main/ao-machine-token.ts
+++ b/frontend/src/main/ao-machine-token.ts
@@ -1,4 +1,5 @@
 import type { ControlPlaneTokenSource } from "./ao-control-token";
+import { CONTROL_PLANE_TIMEOUT_MS, fetchWithDeadline, withDeadline } from "./request-deadline";
 
 /**
  * The machine-audience access token for one registered machine.
@@ -61,6 +62,8 @@ export type MachineTokenSourceDeps = {
 	controlToken: ControlPlaneTokenSource;
 	fetchImpl?: typeof fetch;
 	now?: () => number;
+	/** Deadline for the mint call. See request-deadline.ts. */
+	timeoutMs?: number;
 };
 
 export type MachineTokenSource = {
@@ -88,6 +91,7 @@ type MachineTokenResponse = {
 export function createMachineTokenSource(deps: MachineTokenSourceDeps): MachineTokenSource {
 	const fetchImpl = deps.fetchImpl ?? fetch;
 	const now = deps.now ?? Date.now;
+	const timeoutMs = deps.timeoutMs ?? CONTROL_PLANE_TIMEOUT_MS;
 
 	let cached: MachineAccessToken | null = null;
 	let inFlight: Promise<MachineAccessToken | null> | null = null;
@@ -98,12 +102,15 @@ export function createMachineTokenSource(deps: MachineTokenSourceDeps): MachineT
 		// account, and the caller turns this into a status rather than a retry.
 		if (!controlToken) return null;
 
-		const response = await fetchImpl(
+		const response = await fetchWithDeadline(
+			fetchImpl,
 			`${deps.controlPlaneUrl}/api/v1/machines/${encodeURIComponent(deps.machineId)}/token`,
 			{
 				method: "POST",
 				headers: { Authorization: `Bearer ${controlToken}`, Accept: "application/json" },
 			},
+			timeoutMs,
+			"Minting a machine token",
 		);
 		if (response.status === 404) throw new MachineUnavailableError();
 		if (response.status === 401) throw new Error(SIGN_IN_REJECTED_MESSAGE);
@@ -133,11 +140,13 @@ export function createMachineTokenSource(deps: MachineTokenSourceDeps): MachineT
 	// of firing one request per call.
 	function force(): Promise<MachineAccessToken | null> {
 		if (inFlight) return inFlight;
-		const attempt = Promise.resolve()
-			.then(mint)
-			.finally(() => {
-				inFlight = null;
-			});
+		// Deadlined around the whole mint, for the same reason as the control-plane
+		// source: `inFlight` is shared with every later caller and only cleared when
+		// this settles, so one mint that never settles would strand every machine
+		// token for the life of the process. See request-deadline.ts.
+		const attempt = withDeadline(Promise.resolve().then(mint), timeoutMs, "Minting a machine token").finally(() => {
+			inFlight = null;
+		});
 		inFlight = attempt;
 		return attempt;
 	}

--- a/frontend/src/main/ao-machines.ts
+++ b/frontend/src/main/ao-machines.ts
@@ -14,6 +14,7 @@ import {
 import { readControlPlaneUrl } from "../shared/control-plane";
 import { createControlPlaneTokenSource, type ControlPlaneTokenSource } from "./ao-control-token";
 import type { SafeStorageLike } from "./ao-account-store";
+import { CONTROL_PLANE_TIMEOUT_MS, fetchWithDeadline } from "./request-deadline";
 
 /**
  * Main-process owner of the machine list and of which machine is active.
@@ -73,6 +74,8 @@ export type AoMachinesControllerDeps = {
 	onActiveChange: (machine: AoMachine | null) => void;
 	fetchImpl?: typeof fetch;
 	probeTimeoutMs?: number;
+	/** Deadline for control-plane calls. See request-deadline.ts. */
+	controlPlaneTimeoutMs?: number;
 	/** Test seam, so a controller can be driven without a real token exchange. */
 	tokenSource?: ControlPlaneTokenSource;
 };
@@ -172,6 +175,7 @@ function machineFromPersisted(persisted: PersistedMachine): AoMachine {
 export function createAoMachinesController(deps: AoMachinesControllerDeps): AoMachinesController {
 	const fetchImpl = deps.fetchImpl ?? fetch;
 	const probeTimeoutMs = deps.probeTimeoutMs ?? DEFAULT_PROBE_TIMEOUT_MS;
+	const controlPlaneTimeoutMs = deps.controlPlaneTimeoutMs ?? CONTROL_PLANE_TIMEOUT_MS;
 
 	// Resolved once, like the account controller: a bad AO_CONTROL_URL must be
 	// visible rather than silently falling back to the production control plane.
@@ -234,9 +238,16 @@ export function createAoMachinesController(deps: AoMachinesControllerDeps): AoMa
 	}
 
 	async function fetchMachines(token: string): Promise<AoMachine[]> {
-		const response = await fetchImpl(`${controlPlaneUrl}/api/v1/machines`, {
-			headers: { Authorization: `Bearer ${token}`, Accept: "application/json" },
-		});
+		// Deadlined: this is what the machine list awaits, and an unbounded stall
+		// here leaves the settings pane spinning forever with nothing to show and
+		// no way back except restarting the app. See request-deadline.ts.
+		const response = await fetchWithDeadline(
+			fetchImpl,
+			`${controlPlaneUrl}/api/v1/machines`,
+			{ headers: { Authorization: `Bearer ${token}`, Accept: "application/json" } },
+			controlPlaneTimeoutMs,
+			"Listing machines",
+		);
 		if (response.status === 401) {
 			throw new Error("The control plane rejected this computer's sign-in. Sign in again.");
 		}

--- a/frontend/src/main/request-deadline.test.ts
+++ b/frontend/src/main/request-deadline.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it, vi } from "vitest";
+import { fetchWithDeadline, withDeadline } from "./request-deadline";
+
+/** A fetch that never settles, which is the failure this module exists for. */
+const neverSettles: typeof fetch = () => new Promise<Response>(() => {});
+
+describe("fetchWithDeadline", () => {
+	it("rejects with a timeout when the request never settles", async () => {
+		await expect(
+			fetchWithDeadline(neverSettles, "https://cp.example/api/v1/machines", {}, 20, "Listing machines"),
+		).rejects.toThrow(/Listing machines timed out/);
+	});
+
+	it("passes an abort signal through, so the socket is not left running", async () => {
+		let seen: AbortSignal | undefined;
+		const capture: typeof fetch = (_url, init) => {
+			seen = (init as RequestInit).signal ?? undefined;
+			return new Promise<Response>(() => {});
+		};
+		await expect(fetchWithDeadline(capture, "https://cp.example/x", {}, 20, "Probing")).rejects.toThrow(/timed out/);
+		expect(seen?.aborted).toBe(true);
+	});
+
+	it("returns the response untouched on success and clears its timer", async () => {
+		const ok = new Response("{}", { status: 200 });
+		const fetchImpl: typeof fetch = async () => ok;
+		await expect(fetchWithDeadline(fetchImpl, "https://cp.example/x", {}, 1000, "Listing machines")).resolves.toBe(ok);
+	});
+
+	it("propagates a real transport error rather than relabelling it a timeout", async () => {
+		const boom: typeof fetch = async () => {
+			throw new Error("ECONNREFUSED");
+		};
+		await expect(fetchWithDeadline(boom, "https://cp.example/x", {}, 1000, "Listing machines")).rejects.toThrow(
+			"ECONNREFUSED",
+		);
+	});
+
+	it("keeps the operation name out of the message when it would leak nothing", async () => {
+		// The message reaches the UI, so it must name the operation and never the
+		// URL, which can carry a token in a query string.
+		await expect(
+			fetchWithDeadline(neverSettles, "https://cp.example/x?token=SECRET", {}, 20, "Listing machines"),
+		).rejects.toThrow(/^Listing machines timed out after \d+s\./);
+		await expect(
+			fetchWithDeadline(neverSettles, "https://cp.example/x?token=SECRET", {}, 20, "Listing machines"),
+		).rejects.not.toThrow(/SECRET/);
+	});
+});
+
+describe("withDeadline", () => {
+	it("rejects when the wrapped work never settles", async () => {
+		await expect(withDeadline(new Promise<string>(() => {}), 20, "Refreshing sign-in")).rejects.toThrow(
+			/Refreshing sign-in timed out/,
+		);
+	});
+
+	it("resolves with the work's value when it beats the deadline", async () => {
+		await expect(withDeadline(Promise.resolve("token"), 1000, "Refreshing sign-in")).resolves.toBe("token");
+	});
+
+	it("does not leave a pending timer that would keep the process alive", async () => {
+		vi.useFakeTimers();
+		try {
+			const clear = vi.spyOn(globalThis, "clearTimeout");
+			await withDeadline(Promise.resolve(1), 60_000, "Refreshing sign-in");
+			expect(clear).toHaveBeenCalled();
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+});

--- a/frontend/src/main/request-deadline.ts
+++ b/frontend/src/main/request-deadline.ts
@@ -1,0 +1,95 @@
+/**
+ * Deadlines for control-plane work, so a stalled request cannot wedge the app.
+ *
+ * Every call from the desktop to the control plane used to be unbounded. That
+ * is survivable for a request that fails, because a rejection propagates and
+ * the UI shows an error. It is not survivable for a request that never settles
+ * at all: an orphaned socket (a network that changed under an in-flight fetch,
+ * or an address that blackholes rather than refusing) leaves a promise pending
+ * forever, and everything awaiting it waits forever too.
+ *
+ * That is not hypothetical. The control plane's public IP changed while the app
+ * was running; the old address dropped packets instead of refusing them, and
+ * the machine list spun indefinitely with no request in flight and no error to
+ * show, recoverable only by restarting the app.
+ *
+ * The rule these two helpers enforce: **every promise the token sources and the
+ * machine list await must settle.** `fetchWithDeadline` bounds the network call
+ * and reports a timeout as a timeout. `withDeadline` bounds a whole operation,
+ * including the non-network parts, which matters wherever a pending promise is
+ * cached and handed to later callers (see the in-flight dedupe in
+ * ao-control-token.ts: it clears in a `.finally`, which a promise that never
+ * settles never reaches, so one stranded exchange poisons every later one).
+ */
+
+/**
+ * Budget for a single control-plane request. Generous: this is a correctness
+ * backstop against a hung socket, not a latency target. A healthy control plane
+ * answers these in tens of milliseconds.
+ */
+export const CONTROL_PLANE_TIMEOUT_MS = 15_000;
+
+function timeoutMessage(what: string, timeoutMs: number): string {
+	return `${what} timed out after ${Math.round(timeoutMs / 1000)}s. The control plane may be unreachable.`;
+}
+
+/**
+ * Run a fetch with an abort deadline, reporting an abort as a timeout rather
+ * than the bare `AbortError` the caller would otherwise have to interpret.
+ *
+ * `what` is a human phrase naming the operation, for example "Listing
+ * machines". It reaches the UI, so it must never contain a token or a URL with
+ * credentials in it.
+ */
+export async function fetchWithDeadline(
+	fetchImpl: typeof fetch,
+	url: string,
+	init: RequestInit,
+	timeoutMs: number,
+	what: string,
+): Promise<Response> {
+	const controller = new AbortController();
+	const call = fetchImpl(url, { ...init, signal: controller.signal });
+	// The deadline is a race, not only an abort. Aborting alone is not enough:
+	// it relies on the fetch implementation honouring the signal, and one that
+	// does not would still hang the caller forever, which is the exact failure
+	// this module exists to make impossible. The race guarantees settlement; the
+	// abort is what actually releases the socket.
+	//
+	// The no-op catch marks a late rejection as handled. Once the race has been
+	// decided by the deadline, the abandoned call rejecting later would
+	// otherwise surface as an unhandled rejection.
+	void call.catch(() => {});
+	try {
+		return await withDeadline(call, timeoutMs, what);
+	} catch (err) {
+		// Only on failure. Aborting a successful response would tear down the body
+		// stream before the caller has read it.
+		controller.abort();
+		throw err;
+	}
+}
+
+/**
+ * Bound a whole operation, so the returned promise is guaranteed to settle.
+ *
+ * Use this where a pending promise is cached and shared with later callers. A
+ * bounded fetch is not sufficient there: anything else in the operation that
+ * hangs (a keychain read, a filesystem write on a stalled mount) would still
+ * strand the cached promise permanently.
+ *
+ * The losing side of the race is not cancelled, because there is nothing
+ * generic to cancel; it is abandoned. Callers that also need the underlying
+ * work stopped must pass their own abort signal into it.
+ */
+export async function withDeadline<T>(work: Promise<T>, timeoutMs: number, what: string): Promise<T> {
+	let timer: ReturnType<typeof setTimeout> | undefined;
+	const deadline = new Promise<never>((_resolve, reject) => {
+		timer = setTimeout(() => reject(new Error(timeoutMessage(what, timeoutMs))), timeoutMs);
+	});
+	try {
+		return await Promise.race([work, deadline]);
+	} finally {
+		clearTimeout(timer);
+	}
+}

--- a/frontend/src/renderer/components/settings/MachinesSection.test.tsx
+++ b/frontend/src/renderer/components/settings/MachinesSection.test.tsx
@@ -163,3 +163,23 @@ test("a failure to list is shown, and this computer stays available", async () =
 	expect(await screen.findByTestId("ao-machines-error")).toHaveTextContent(/503 listing machines/);
 	expect(within(machineRow(LOCAL_MACHINE_ID)).getByText("This Mac")).toBeInTheDocument();
 });
+
+// Regression: a failed refresh used to render nothing at all.
+//
+// The error line read `state?.error`, and on a rejected query `state` is
+// undefined, so the reason never reached the pane. Combined with an unbounded
+// request in the main process, that presented as a permanent "Looking for
+// machines registered to your account..." spinner with no way forward. The
+// main-process half is fixed in request-deadline.ts; this is the UI half.
+test("shows the reason when the refresh fails, instead of spinning forever", async () => {
+	refresh.mockRejectedValue(new Error("Listing machines timed out after 15s. The control plane may be unreachable."));
+
+	renderSection();
+
+	// Generous timeout on purpose: the pane retries once before reporting, so a
+	// failure is expected to take a beat rather than appear instantly.
+	const error = await screen.findByTestId("ao-machines-error", {}, { timeout: 5000 });
+	expect(error).toHaveTextContent("Listing machines timed out after 15s.");
+	// The spinner must be gone: it is what the user stared at for an hour.
+	expect(screen.queryByText(/Looking for machines registered to your account/)).not.toBeInTheDocument();
+});

--- a/frontend/src/renderer/components/settings/MachinesSection.tsx
+++ b/frontend/src/renderer/components/settings/MachinesSection.tsx
@@ -20,7 +20,14 @@ export const aoMachinesQueryKey = ["ao-machines"] as const;
  */
 export function MachinesSection() {
 	const queryClient = useQueryClient();
-	const query = useQuery({ queryKey: aoMachinesQueryKey, queryFn: () => aoBridge.machines.refresh() });
+	// One retry, then report. The refresh is deadlined in the main process
+	// (request-deadline.ts), so a failure arrives as a rejection rather than as
+	// an endless pending promise, and this pane must show it rather than spin.
+	const query = useQuery({
+		queryKey: aoMachinesQueryKey,
+		queryFn: () => aoBridge.machines.refresh(),
+		retry: 1,
+	});
 	const apply = (next: AoMachinesState) => queryClient.setQueryData(aoMachinesQueryKey, next);
 
 	const select = useMutation({
@@ -32,7 +39,12 @@ export function MachinesSection() {
 	const machines = state?.machines ?? [];
 	const activeMachineId = state?.activeMachineId ?? "";
 	const mutationError = select.error instanceof Error ? select.error.message : null;
-	const error = state?.error ?? mutationError;
+	// A rejected refresh carries its reason on the query, not in `state`, which
+	// is undefined in that case. Without this the pane rendered nothing at all
+	// for a failed refresh, which is how a stalled control plane read as a
+	// permanent "Looking for machines..." spinner.
+	const refreshError = query.error instanceof Error ? query.error.message : null;
+	const error = state?.error ?? refreshError ?? mutationError;
 
 	return (
 		<SettingsSection title="Machines" sectionId="machines">


### PR DESCRIPTION
The machine list spun on "Looking for machines registered to your account..." indefinitely, with **no request in flight, no error, and no recovery short of restarting the app**. Diagnosed live: control plane healthy at 43ms, app process at 0.1% CPU, and `lsof` showed zero sockets to the control plane on either IP.

## Root cause: three things compounding

**1. No deadline on any control-plane call.** `fetchMachines` (`ao-machines.ts`) and both token sources called `fetch` with no signal and no timeout. The damning detail is twenty lines below `fetchMachines`: the reachability probe already builds an `AbortController` and a timer. The codebase knew to bound these calls. The two that mattered did not.

**2. The in-flight dedupe turned one stall into a permanent one.** `inFlight` is shared with every later caller and cleared in a `.finally`. `.finally` only runs when a promise *settles*. A promise that never settles never clears it, so **one stranded exchange poisoned the token source for the life of the process.** Both `ao-control-token.ts` and `ao-machine-token.ts` had this shape.

**3. The pane swallowed the error.** It read `state?.error`, and `state` is undefined on a rejected query, so a failed refresh rendered nothing and left only the spinner.

## The fix

New `request-deadline.ts`, applied to the machine list and both token sources.

Two deliberate choices, both of which a reviewer should push on if they disagree:

- **The deadline is a race, not only an abort.** Aborting relies on the fetch implementation honouring the signal; one that ignores it still hangs forever, which is the exact failure being removed. My first draft aborted only, and my own test caught it hanging for 20s.
- **The token sources deadline the whole operation, not just the fetch.** What gets cached and shared is the operation's promise, so anything else inside it that hangs (a keychain read, a write to a stalled mount) would strand it just as badly.

Plus: surface a rejected refresh in the pane, and retry once before reporting.

## Trigger

The control plane's public IP changed while the app was running. Verified the old address now **blackholes**: `curl` returns `000` after a full timeout rather than a connection refused, so connections hang instead of failing fast.

## Test plan

- [x] Regression test **hangs for 20s and fails without the fix**, verified by stashing the change and re-running. Not vacuous.
- [x] `request-deadline.test.ts`: 8 cases including a fetch that ignores the abort signal, and that the timeout message never leaks a URL query string
- [x] `ao-control-token.test.ts`: a stalled exchange times out, and a later call on the same source is not the dead promise
- [x] `MachinesSection.test.tsx`: a failed refresh shows the reason and the spinner is gone
- [x] `npm test`: 1311 passed / 108 files (was 1300 / 107)
- [x] `npm run typecheck` and `npm run typecheck:e2e` clean