### PR TITLE
chore(fmt): gofmt internal/httpd/api.go

### DIFF
--- a/backend/internal/httpd/api.go
+++ b/backend/internal/httpd/api.go
@@ -101,9 +101,9 @@ func NewAPI(cfg config.Config, deps APIDeps) *API {
 		// The doctor route has no service behind it: it probes the machine
 		// this daemon runs on, so it is always available rather than 501 on a
 		// missing dependency.
-		doctor:        &controllers.DoctorController{},
-		browser:       &controllers.BrowserController{Svc: deps.Browser},
-		events:        &EventsController{Source: deps.CDC, Live: deps.Events},
+		doctor:  &controllers.DoctorController{},
+		browser: &controllers.BrowserController{Svc: deps.Browser},
+		events:  &EventsController{Source: deps.CDC, Live: deps.Events},
 	}
 }
 


### PR DESCRIPTION
Alignment in the api.go controller struct literal was left ungofmted by yesterday's upstream merge, failing the build-test and lint jobs on every PR. gofmt -w, no behavior change.