### PR TITLE
fix(remote): stop bare gateway requests and lost daemon-status pushes

### DIFF
--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -272,18 +272,27 @@ function focusMainWindow(): void {
 	mainWindow.focus();
 }
 
+// The last status actually DELIVERED to a renderer, distinct from daemonStatus
+// (the current status). Deduping against daemonStatus conflated the two: a push
+// that found no window to receive it still counted as sent, so the next
+// identical status was suppressed and the renderer never learned of the
+// transition (issue #82).
+let lastSentDaemonStatus: string | undefined;
+
 function setDaemonStatus(nextStatus: DaemonStatus): void {
 	// Push only on actual change. A remote machine's status is rebuilt (same
 	// content, new object) on every read, and the renderer invalidates queries
 	// on every push, so an unconditional send here closes a feedback loop:
 	// status read -> push -> invalidate -> refetch -> status read, saturating
 	// IPC and hammering the machine's gateway with hundreds of requests/s.
-	const changed = JSON.stringify(nextStatus) !== JSON.stringify(daemonStatus);
 	daemonStatus = nextStatus;
-	if (changed) {
-		mainWindow?.webContents.send("daemon:status", daemonStatus);
-	}
-	if (changed && nextStatus.state === "ready" && browserViewHost) {
+	const encoded = JSON.stringify(nextStatus);
+	if (encoded === lastSentDaemonStatus) return;
+	const contents = mainWindow?.webContents;
+	if (!contents || contents.isDestroyed()) return;
+	contents.send("daemon:status", daemonStatus);
+	lastSentDaemonStatus = encoded;
+	if (nextStatus.state === "ready" && browserViewHost) {
 		establishBrowserRuntimeLink();
 	}
 }

--- a/frontend/src/renderer/lib/api-client.test.ts
+++ b/frontend/src/renderer/lib/api-client.test.ts
@@ -58,6 +58,7 @@ describe("apiClient runtime base URL", () => {
 	});
 
 	it("rebases remote API calls with credentials included for the gateway cookie", async () => {
+		gatewayTokenMock.mockResolvedValue("machine.audience.jwt");
 		const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
 			new Response(JSON.stringify({ projects: [] }), {
 				status: 200,
@@ -91,16 +92,19 @@ describe("apiClient runtime base URL", () => {
 		expect(init).toMatchObject({ credentials: "include" });
 	});
 
-	it("sends no Authorization header when there is no machine token", async () => {
+	it("never sends a bare request to a remote gateway when there is no machine token", async () => {
+		// Regression: a null token used to go out as a request with no Authorization
+		// header at all, which the gateway 401s without logging; the renderer then
+		// retried forever with nothing anywhere saying why (issue #82).
 		gatewayTokenMock.mockResolvedValue(null);
-		const fetchSpy = vi
-			.spyOn(globalThis, "fetch")
-			.mockResolvedValue(new Response(JSON.stringify({ projects: [] }), { status: 200 }));
+		const fetchSpy = vi.spyOn(globalThis, "fetch");
 
 		setApiBaseUrl("https://vm.example.com");
-		await apiClient.GET("/api/v1/projects");
+		const { response, error } = await apiClient.GET("/api/v1/projects");
 
-		expect(new Headers(fetchSpy.mock.calls[0]?.[1]?.headers).has("authorization")).toBe(false);
+		expect(fetchSpy).not.toHaveBeenCalled();
+		expect(response?.status).toBe(503);
+		expect(error).toMatchObject({ code: "machine_token_unavailable" });
 	});
 
 	it("does not ask for a machine token for a loopback daemon", async () => {

--- a/frontend/src/renderer/lib/api-client.ts
+++ b/frontend/src/renderer/lib/api-client.ts
@@ -167,7 +167,12 @@ export function normalizeApiOperation(method: string, pathname: string): string 
 	return `${method.toUpperCase()} ${best?.normalized ?? fallbackNormalize(pathname)}`;
 }
 
-type ApiErrorCategory = "daemon_unavailable" | "network_error" | "http_4xx" | "http_5xx";
+type ApiErrorCategory =
+	| "daemon_unavailable"
+	| "machine_token_unavailable"
+	| "network_error"
+	| "http_4xx"
+	| "http_5xx";
 
 // One event per (operation, category, status) per window: a daemon outage
 // makes every polling query fail at once and on every retry — the failure
@@ -199,6 +204,28 @@ async function runtimeFetch(input: Request): Promise<Response> {
 		});
 	}
 
+	// Bearer is the only credential the machine gateway accepts on a REST route:
+	// its cookie is confined to /mux and the SSE stream, so nothing
+	// state-changing rides an ambient credential (controlplane/TOKEN_CONTRACT.md).
+	// Asked for per request because the main process owns expiry and the silent
+	// refresh. Null when no machine is selected (local daemon) or in browser preview.
+	const remote = baseUrl ? isRemoteDaemonBaseUrl(baseUrl) : false;
+	const gatewayToken = remote ? await aoBridge.machines.gatewayToken() : null;
+	if (remote && !gatewayToken) {
+		// No usable machine credential right now (the silent refresh is failing, or
+		// the main process no longer has this machine). A request sent anyway would
+		// reach the gateway bare and become a silent 401 the gateway does not even
+		// log; answer locally instead so the failure is visible and retryable.
+		reportApiError(operation, "machine_token_unavailable", 503);
+		return new Response(
+			JSON.stringify({
+				message: "This machine's sign-in is not available right now. Reconnecting.",
+				code: "machine_token_unavailable",
+			}),
+			{ status: 503, headers: { "Content-Type": "application/json" } },
+		);
+	}
+
 	const send = async (): Promise<Response> => {
 		if (!baseUrl) {
 			return fetch(input);
@@ -206,14 +233,7 @@ async function runtimeFetch(input: Request): Promise<Response> {
 
 		const url = new URL(input.url);
 		const target = new URL(url.pathname + url.search + url.hash, baseUrl);
-		const remote = isRemoteDaemonBaseUrl(baseUrl);
 		const credentials = remote ? "include" : input.credentials;
-		// Bearer is the only credential the machine gateway accepts on a REST route:
-		// its cookie is confined to /mux and the SSE stream, so nothing
-		// state-changing rides an ambient credential (controlplane/TOKEN_CONTRACT.md).
-		// Asked for per request because the main process owns expiry and the silent
-		// refresh. Null when no machine is selected (local daemon) or in browser preview.
-		const gatewayToken = remote ? await aoBridge.machines.gatewayToken() : null;
 		if (target.href === input.url && credentials === input.credentials && !gatewayToken) {
 			return fetch(input);
 		}


### PR DESCRIPTION
Fixes the user-facing half of #82, informed by a second live occurrence captured today with full console logging.

## What the capture showed

The 13:46 incident lined up exactly with machine-token expiry: GitHub API timeouts in the same log prove the network was flaky, the control-plane refresh chain shows a successful rotation at 13:40 (so the account credential was fine), and the gateway journal has zero token-rejected lines (so every 401 was a request with no bearer at all). When the silent machine-token refresh fails at expiry, `machine-transport.token()` starts returning null, and the renderer sent requests anyway.

## The two fixes

1. **Renderer (`api-client.ts`)**: a remote REST call with a null machine token no longer goes out bare. It short-circuits with a local 503 envelope (`machine_token_unavailable`) plus telemetry, mirroring the existing no-daemon branch. Queries stay retryable and heal as soon as a mint succeeds; the gateway never sees the storm.
2. **Main (`main.ts`)**: `setDaemonStatus` deduped against the current status instead of the last delivered one, so a push that found no window still counted as sent, and the next identical status was suppressed. That is how the renderer could keep a stale remote base URL after main had moved off the machine. Dedupe now tracks actual delivery.

The trigger for the `ao-machine.json` deletion (the other thread in #82) is still open; these two changes make the failure visible and self-healing regardless.

## Verification

- New regression test: null machine token on a remote base performs no fetch and yields the 503 envelope (replaces the test that codified the old bare-send behavior).
- Full frontend suite 2254/2254, typecheck clean.