### PR TITLE
feat(vmgateway): add pair mode configuration and self-signed certificate

### DIFF
--- a/backend/internal/vmgateway/config.go
+++ b/backend/internal/vmgateway/config.go
@@ -1,10 +1,17 @@
 // Package vmgateway implements `ao vm serve`: a public TLS reverse-proxy
-// gateway, run as its own process in front of the loopback daemon, on a
-// user-owned hosted VM. It obtains a Let's Encrypt certificate for the
+// gateway, run as its own process in front of the loopback daemon. It has two
+// mutually exclusive configurations, selected by Config.Mode. ModeHosted runs
+// on a user-owned hosted VM: it obtains a Let's Encrypt certificate for the
 // configured domain, verifies the AO access token on every request against a
 // cached JWKS, and proxies authenticated requests to the daemon. See
 // docs/adr/0002-hosted-public-gateway.md and TOKEN_CONTRACT.md in agentlab-in/ao-controlplane,
-// which this package must stay in sync with.
+// which this package must stay in sync with. ModePair runs on a box the user
+// owns on a network they trust, reached by bare IP: it presents a long-lived
+// self-signed certificate instead of one from a CA, so there is no domain and
+// no control plane involved. See docs/adr/0003-pair-mode-gateway.md. Pair
+// mode's credential check (a passcode, replacing the JWT) is a separate,
+// later change; this package only carries the certificate and configuration
+// halves of pair mode so far.
 package vmgateway
 
 import (
@@ -36,30 +43,66 @@ const (
 	DefaultDaemonAddr = "127.0.0.1:3001"
 )
 
+// Mode selects which of the two mutually exclusive gateway configurations
+// Resolve built. NewServer and Server.Run branch on it to decide whether to
+// run autocert and bind the ACME challenge listener at all.
+type Mode string
+
+const (
+	// ModeHosted is the default: ACME via autocert.Manager scoped to Domain,
+	// and (outside this package) machine-audience JWT verification against
+	// the control plane's JWKS. See docs/adr/0002-hosted-public-gateway.md.
+	ModeHosted Mode = "hosted"
+	// ModePair is a box on a network the user trusts, reached by bare IP: a
+	// long-lived self-signed certificate persisted under the state root
+	// (LoadOrCreatePairCertificate) instead of one from a CA, and no contact
+	// with the control plane at all. Passcode auth, replacing the JWT check,
+	// is added in a later change. See docs/adr/0003-pair-mode-gateway.md.
+	ModePair Mode = "pair"
+)
+
 // Config is the fully-resolved gateway configuration. It is immutable once
 // built by Resolve.
 type Config struct {
+	// Mode selects hosted vs pair configuration; see the Mode type doc.
+	// Fields documented as hosted-only are always zero-valued when Mode is
+	// ModePair, and Resolve rejects any attempt to set them alongside pair
+	// mode rather than silently ignoring them.
+	Mode Mode
 	// Domain is the single hostname this gateway serves and the only one
 	// autocert will ever request a certificate for. Always a bare hostname:
 	// machine.json's publicUrl is a full origin and Resolve reduces it, see
-	// normalizeDomain.
+	// normalizeDomain. Hosted-only: always empty in pair mode.
 	Domain string
-	// MachineID is this machine's id, checked against the token's `aud`.
+	// MachineID is this machine's id. In hosted mode it is checked against
+	// the token's `aud`. Set in both modes when available; pair mode does not
+	// require it.
 	MachineID string
 	// AccountID is the single account allowlisted for this machine, checked
-	// against the token's `sub`.
+	// against the token's `sub`. Hosted-only: always empty in pair mode,
+	// which has no account at all.
 	AccountID string
-	// Issuer is the expected token `iss`.
+	// Issuer is the expected token `iss`. Hosted-only: always empty in pair
+	// mode, which never verifies a JWT.
 	Issuer string
 	// JWKSURL is where the control plane publishes its signing keys.
+	// Hosted-only: always empty in pair mode, which never contacts a control
+	// plane.
 	JWKSURL string
 	// DaemonAddr is the loopback daemon's host:port, the reverse-proxy target.
+	// Used by both modes.
 	DaemonAddr string
-	// CertDir is where the ACME certificate cache is stored, under ~/.ao/hosted.
+	// CertDir is where certificate material is stored: the ACME cache
+	// directory in hosted mode (autocert.DirCache), or the persisted
+	// self-signed certificate and key in pair mode
+	// (LoadOrCreatePairCertificate). The default location differs by mode;
+	// see Resolve.
 	CertDir string
 	// HTTPAddr is the ACME HTTP-01 challenge / redirect listener address.
+	// Hosted-only: always empty in pair mode, which binds only HTTPSAddr —
+	// there is no ACME challenge to answer.
 	HTTPAddr string
-	// HTTPSAddr is the public TLS listener address.
+	// HTTPSAddr is the public TLS listener address. Used by both modes.
 	HTTPSAddr string
 }
 
@@ -77,27 +120,43 @@ type Options struct {
 	CertDir     string
 	HTTPAddr    string
 	HTTPSAddr   string
+	// Pair requests ModePair instead of ModeHosted. See AO_VM_PAIR.
+	Pair bool
 }
 
 // Resolve builds a Config from opts, environment variables, and (for
 // Domain/MachineID/AccountID, when still unset) ~/.ao/hosted/machine.json.
 // Precedence: explicit flag > environment variable > machine.json > built-in
 // default. dataDir is the resolved AO data directory (config.Config.DataDir)
-// used for the certificate cache when --cert-dir/AO_VM_CERT_DIR is not set.
+// used for the hosted-mode ACME certificate cache when --cert-dir/AO_VM_CERT_DIR
+// is not set; pair mode ignores it (see the AO_VM_CERT_DIR entry below).
+//
+// opts.Pair (or AO_VM_PAIR) selects ModePair instead of ModeHosted. The two
+// modes are mutually exclusive: Resolve rejects, at this call rather than at
+// first request, any hosted-only field (domain, account id, issuer, JWKS URL,
+// the ACME listener address) explicitly configured alongside pair mode.
 //
 // Recognised variables:
 //
-//	AO_VM_DOMAIN        public domain               (falls back to machine.json)
+//	AO_VM_PAIR          request pair mode instead of hosted (off|on, default off)
+//	AO_VM_DOMAIN        public domain               (falls back to machine.json; hosted only)
 //	AO_VM_MACHINE_ID    this machine's id           (falls back to machine.json)
-//	AO_VM_ACCOUNT_ID    the allowlisted account id  (falls back to machine.json)
-//	AO_VM_ISSUER        expected token issuer       (default DefaultIssuer)
-//	AO_VM_JWKS_URL      control-plane JWKS URL      (default <issuer>/.well-known/jwks.json)
+//	AO_VM_ACCOUNT_ID    the allowlisted account id  (falls back to machine.json; hosted only)
+//	AO_VM_ISSUER        expected token issuer       (default DefaultIssuer; hosted only)
+//	AO_VM_JWKS_URL      control-plane JWKS URL      (default <issuer>/.well-known/jwks.json; hosted only)
 //	AO_VM_DAEMON_ADDR   loopback daemon host:port   (default DefaultDaemonAddr)
 //	AO_MACHINE_FILE     machine.json path           (default ~/.ao/hosted/machine.json)
-//	AO_VM_CERT_DIR      ACME cert cache dir         (default <dataDir>/vm-gateway/certs)
-//	AO_VM_HTTP_ADDR     ACME challenge listener     (default DefaultHTTPAddr)
+//	AO_VM_CERT_DIR      certificate storage dir     (default <dataDir>/vm-gateway/certs in
+//	                                                 hosted mode, <state root>/vm-gateway/pair-cert
+//	                                                 in pair mode)
+//	AO_VM_HTTP_ADDR     ACME challenge listener     (default DefaultHTTPAddr; hosted only)
 //	AO_VM_HTTPS_ADDR    public TLS listener         (default DefaultHTTPSAddr)
 func Resolve(opts Options, dataDir string) (Config, error) {
+	pairMode, err := resolvePairMode(opts)
+	if err != nil {
+		return Config{}, err
+	}
+
 	machineFilePath := firstNonEmpty(opts.MachineFile, os.Getenv("AO_MACHINE_FILE"))
 	if machineFilePath == "" {
 		p, err := DefaultMachineFilePath()
@@ -112,14 +171,28 @@ func Resolve(opts Options, dataDir string) (Config, error) {
 	}
 
 	cfg := Config{
-		Issuer:     firstNonEmpty(opts.Issuer, os.Getenv("AO_VM_ISSUER"), DefaultIssuer),
+		Mode:       ModeHosted,
 		DaemonAddr: firstNonEmpty(opts.DaemonAddr, os.Getenv("AO_VM_DAEMON_ADDR"), DefaultDaemonAddr),
-		HTTPAddr:   firstNonEmpty(opts.HTTPAddr, os.Getenv("AO_VM_HTTP_ADDR"), DefaultHTTPAddr),
 		HTTPSAddr:  firstNonEmpty(opts.HTTPSAddr, os.Getenv("AO_VM_HTTPS_ADDR"), DefaultHTTPSAddr),
 	}
-
-	cfg.Domain = firstNonEmpty(opts.Domain, os.Getenv("AO_VM_DOMAIN"))
 	cfg.MachineID = firstNonEmpty(opts.MachineID, os.Getenv("AO_VM_MACHINE_ID"))
+	if mf != nil {
+		cfg.MachineID = firstNonEmpty(cfg.MachineID, mf.MachineID)
+	}
+	if err := validateHostPort("daemon address", cfg.DaemonAddr); err != nil {
+		return Config{}, err
+	}
+	if err := validateHostPort("https listener address", cfg.HTTPSAddr); err != nil {
+		return Config{}, err
+	}
+
+	if pairMode {
+		return resolvePair(cfg, opts)
+	}
+
+	cfg.Issuer = firstNonEmpty(opts.Issuer, os.Getenv("AO_VM_ISSUER"), DefaultIssuer)
+	cfg.HTTPAddr = firstNonEmpty(opts.HTTPAddr, os.Getenv("AO_VM_HTTP_ADDR"), DefaultHTTPAddr)
+	cfg.Domain = firstNonEmpty(opts.Domain, os.Getenv("AO_VM_DOMAIN"))
 	cfg.AccountID = firstNonEmpty(opts.AccountID, os.Getenv("AO_VM_ACCOUNT_ID"))
 	// domainSource names where Domain came from so a rejected value points at
 	// the file or the flag the operator actually has to fix.
@@ -129,7 +202,6 @@ func Resolve(opts Options, dataDir string) (Config, error) {
 	}
 	if mf != nil {
 		cfg.Domain = firstNonEmpty(cfg.Domain, mf.PublicURL)
-		cfg.MachineID = firstNonEmpty(cfg.MachineID, mf.MachineID)
 		cfg.AccountID = firstNonEmpty(cfg.AccountID, mf.AccountID)
 	}
 
@@ -167,20 +239,91 @@ func Resolve(opts Options, dataDir string) (Config, error) {
 	}
 	cfg.Domain = domain
 
-	if err := validateHostPort("daemon address", cfg.DaemonAddr); err != nil {
-		return Config{}, err
-	}
-	// HTTPAddr/HTTPSAddr get the same check as DaemonAddr for the same reason:
-	// net.Listen on a colon-less value like "443" (the AO_VM_HTTPS_ADDR=443
-	// mistake, missing the leading colon) passes straight through Resolve and
-	// only fails later, deep inside http.Server.ListenAndServeTLS, with a raw
+	// HTTPAddr gets the same check DaemonAddr/HTTPSAddr already had above (for
+	// the same reason: net.Listen on a colon-less value like "80", the
+	// AO_VM_HTTP_ADDR=80 mistake, passes straight through Resolve and only
+	// fails later, deep inside http.Server.ListenAndServe, with a raw
 	// "missing port in address" net error and no indication which flag or
-	// variable caused it.
+	// variable caused it). It only applies here because pair mode never sets
+	// HTTPAddr at all.
 	if err := validateHostPort("http listener address", cfg.HTTPAddr); err != nil {
 		return Config{}, err
 	}
-	if err := validateHostPort("https listener address", cfg.HTTPSAddr); err != nil {
-		return Config{}, err
+
+	return cfg, nil
+}
+
+// resolvePairMode reports whether pair mode was requested, by flag or by
+// AO_VM_PAIR. Unlike the other AO_VM_* variables this one is a strict on/off
+// toggle (mirroring config.Load's AO_TELEMETRY_* toggles): an unrecognised
+// value fails loudly rather than silently being treated as "not pair mode",
+// because guessing wrong here means the gateway silently starts in the wrong
+// mode with the wrong trust model.
+func resolvePairMode(opts Options) (bool, error) {
+	if opts.Pair {
+		return true, nil
+	}
+	raw, ok := os.LookupEnv("AO_VM_PAIR")
+	if !ok || strings.TrimSpace(raw) == "" {
+		return false, nil
+	}
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "1", "true", "on", "yes":
+		return true, nil
+	case "0", "false", "off", "no":
+		return false, nil
+	default:
+		return false, fmt.Errorf("invalid AO_VM_PAIR %q: must be off|on", raw)
+	}
+}
+
+// resolvePair finishes building a ModePair Config from the mode-agnostic
+// fields Resolve has already filled in on cfg. Pair mode has no domain, no
+// control-plane URL, and no JWKS (see docs/adr/0003-pair-mode-gateway.md), so
+// any hosted-only field explicitly configured here is rejected loudly rather
+// than silently ignored: it means either the wrong flags were copied onto
+// this box, or --pair itself was a mistake, and either way the operator needs
+// to see it now, not discover it as a confusing runtime failure later.
+func resolvePair(cfg Config, opts Options) (Config, error) {
+	cfg.Mode = ModePair
+
+	var mixed []string
+	if firstNonEmpty(opts.Domain, os.Getenv("AO_VM_DOMAIN")) != "" {
+		mixed = append(mixed, "--domain/AO_VM_DOMAIN")
+	}
+	if firstNonEmpty(opts.AccountID, os.Getenv("AO_VM_ACCOUNT_ID")) != "" {
+		mixed = append(mixed, "--account-id/AO_VM_ACCOUNT_ID")
+	}
+	if firstNonEmpty(opts.Issuer, os.Getenv("AO_VM_ISSUER")) != "" {
+		mixed = append(mixed, "--issuer/AO_VM_ISSUER")
+	}
+	if firstNonEmpty(opts.JWKSURL, os.Getenv("AO_VM_JWKS_URL")) != "" {
+		mixed = append(mixed, "--jwks-url/AO_VM_JWKS_URL")
+	}
+	if firstNonEmpty(opts.HTTPAddr, os.Getenv("AO_VM_HTTP_ADDR")) != "" {
+		mixed = append(mixed, "--http-addr/AO_VM_HTTP_ADDR")
+	}
+	if len(mixed) > 0 {
+		return Config{}, fmt.Errorf(
+			"ao vm serve --pair: %s not allowed in pair mode (pair mode has no domain, no control-plane URL, no JWKS, and no ACME challenge listener; hosted mode and pair mode are mutually exclusive)",
+			strings.Join(mixed, ", "))
+	}
+
+	cfg.CertDir = firstNonEmpty(opts.CertDir, os.Getenv("AO_VM_CERT_DIR"))
+	if cfg.CertDir == "" {
+		stateDir, err := config.DefaultStateDir()
+		if err != nil {
+			return Config{}, fmt.Errorf("resolve pair cert dir: %w", err)
+		}
+		// Unlike the hosted ACME cache (under dataDir, see Resolve above), the
+		// pair-mode certificate is identity, not disposable cache: losing it
+		// forces every paired client to re-pair (see
+		// docs/adr/0003-pair-mode-gateway.md), so it must survive an
+		// AO_DATA_DIR change the same way machine.json does. It therefore
+		// defaults under the state root rather than the data dir, mirroring
+		// the asymmetry DefaultMachineFilePath's comment explains for the same
+		// reason.
+		cfg.CertDir = filepath.Join(stateDir, "vm-gateway", "pair-cert")
 	}
 
 	return cfg, nil

--- a/backend/internal/vmgateway/config_test.go
+++ b/backend/internal/vmgateway/config_test.go
@@ -340,6 +340,192 @@ func TestDefaultMachineFilePath_IsHomeNotDataDir(t *testing.T) {
 	}
 }
 
+func TestResolve_DefaultsToHostedMode(t *testing.T) {
+	cfg, err := Resolve(Options{
+		Domain: "vm.example.com", MachineID: "machine-1", AccountID: "account-1",
+		MachineFile: filepath.Join(t.TempDir(), "missing.json"),
+	}, t.TempDir())
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if cfg.Mode != ModeHosted {
+		t.Errorf("Mode = %q, want %q", cfg.Mode, ModeHosted)
+	}
+}
+
+func TestResolve_PairMode_Basic(t *testing.T) {
+	cfg, err := Resolve(Options{
+		Pair:        true,
+		MachineFile: filepath.Join(t.TempDir(), "missing.json"),
+	}, t.TempDir())
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if cfg.Mode != ModePair {
+		t.Fatalf("Mode = %q, want %q", cfg.Mode, ModePair)
+	}
+	// Pair mode has no domain, no control-plane URL, and no JWKS, and skips
+	// the ACME challenge listener entirely.
+	if cfg.Domain != "" {
+		t.Errorf("Domain = %q, want empty in pair mode", cfg.Domain)
+	}
+	if cfg.AccountID != "" {
+		t.Errorf("AccountID = %q, want empty in pair mode", cfg.AccountID)
+	}
+	if cfg.Issuer != "" {
+		t.Errorf("Issuer = %q, want empty in pair mode", cfg.Issuer)
+	}
+	if cfg.JWKSURL != "" {
+		t.Errorf("JWKSURL = %q, want empty in pair mode", cfg.JWKSURL)
+	}
+	if cfg.HTTPAddr != "" {
+		t.Errorf("HTTPAddr = %q, want empty in pair mode (no :80 bind)", cfg.HTTPAddr)
+	}
+	if cfg.HTTPSAddr != DefaultHTTPSAddr {
+		t.Errorf("HTTPSAddr = %q, want default %q", cfg.HTTPSAddr, DefaultHTTPSAddr)
+	}
+	if cfg.DaemonAddr != DefaultDaemonAddr {
+		t.Errorf("DaemonAddr = %q, want default %q", cfg.DaemonAddr, DefaultDaemonAddr)
+	}
+	if cfg.CertDir == "" {
+		t.Error("CertDir should default to somewhere under the state root")
+	}
+}
+
+func TestResolve_PairMode_ViaEnvVar(t *testing.T) {
+	t.Setenv("AO_VM_PAIR", "on")
+	cfg, err := Resolve(Options{MachineFile: filepath.Join(t.TempDir(), "missing.json")}, t.TempDir())
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if cfg.Mode != ModePair {
+		t.Fatalf("Mode = %q, want %q (AO_VM_PAIR=on)", cfg.Mode, ModePair)
+	}
+}
+
+func TestResolve_PairMode_InvalidEnvValueIsRejected(t *testing.T) {
+	t.Setenv("AO_VM_PAIR", "sure-why-not")
+	_, err := Resolve(Options{MachineFile: filepath.Join(t.TempDir(), "missing.json")}, t.TempDir())
+	if err == nil {
+		t.Fatal("expected an error for an unrecognised AO_VM_PAIR value, not a silent fallback to hosted mode")
+	}
+}
+
+// TestResolve_PairMode_RejectsHostedFlags is the mode-mixing validation the
+// task requires: pair mode has no domain, no control-plane URL, and no JWKS,
+// so any flag that configures one of those alongside --pair is operator
+// error and must be rejected loudly at Resolve, not silently ignored.
+func TestResolve_PairMode_RejectsHostedFlags(t *testing.T) {
+	base := Options{Pair: true, MachineFile: filepath.Join(t.TempDir(), "missing.json")}
+	cases := []struct {
+		name       string
+		mutate     func(*Options)
+		wantSubstr string
+	}{
+		{"domain", func(o *Options) { o.Domain = "vm.example.com" }, "--domain"},
+		{"accountID", func(o *Options) { o.AccountID = "account-1" }, "--account-id"},
+		{"issuer", func(o *Options) { o.Issuer = "https://issuer.example.com" }, "--issuer"},
+		{"jwksURL", func(o *Options) { o.JWKSURL = "https://issuer.example.com/jwks.json" }, "--jwks-url"},
+		{"httpAddr", func(o *Options) { o.HTTPAddr = ":8080" }, "--http-addr"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			opts := base
+			tc.mutate(&opts)
+			_, err := Resolve(opts, t.TempDir())
+			if err == nil {
+				t.Fatal("expected an error mixing pair mode with a hosted-only field")
+			}
+			if !strings.Contains(err.Error(), tc.wantSubstr) {
+				t.Errorf("error %q should name the offending flag %q", err, tc.wantSubstr)
+			}
+		})
+	}
+}
+
+func TestResolve_PairMode_RejectsHostedEnvVar(t *testing.T) {
+	t.Setenv("AO_VM_DOMAIN", "env.example.com")
+	_, err := Resolve(Options{Pair: true, MachineFile: filepath.Join(t.TempDir(), "missing.json")}, t.TempDir())
+	if err == nil || !strings.Contains(err.Error(), "AO_VM_DOMAIN") {
+		t.Fatalf("expected an error naming AO_VM_DOMAIN, got %v", err)
+	}
+}
+
+func TestResolve_PairMode_MachineIDStillResolvesFromMachineFile(t *testing.T) {
+	path := writeMachineFile(t, MachineFile{MachineID: "paired-box-1"})
+	cfg, err := Resolve(Options{Pair: true, MachineFile: path}, t.TempDir())
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if cfg.MachineID != "paired-box-1" {
+		t.Errorf("MachineID = %q, want %q (pair mode does not require it, but should still read it)", cfg.MachineID, "paired-box-1")
+	}
+}
+
+func TestResolve_PairMode_InvalidDaemonAddr(t *testing.T) {
+	_, err := Resolve(Options{
+		Pair:        true,
+		DaemonAddr:  "not-a-host-port",
+		MachineFile: filepath.Join(t.TempDir(), "missing.json"),
+	}, t.TempDir())
+	if err == nil {
+		t.Fatal("expected an error for an invalid daemon address in pair mode")
+	}
+}
+
+func TestResolve_PairMode_InvalidHTTPSAddr(t *testing.T) {
+	_, err := Resolve(Options{
+		Pair:        true,
+		HTTPSAddr:   "443",
+		MachineFile: filepath.Join(t.TempDir(), "missing.json"),
+	}, t.TempDir())
+	if err == nil {
+		t.Fatal("expected an error for an https listener address missing its port separator, in pair mode too")
+	}
+}
+
+// TestResolve_PairMode_CertDirDefaultsUnderStateRoot is the pair-mode
+// analogue of TestResolve_CertDirDefaultsUnderDataDir above, and the
+// asymmetry between them is deliberate, not a bug: the pair-mode certificate
+// is identity (losing it forces every paired client to re-pair), so it has
+// to survive an AO_DATA_DIR change the same way machine.json does, and
+// therefore defaults under the state root rather than the data dir.
+func TestResolve_PairMode_CertDirDefaultsUnderStateRoot(t *testing.T) {
+	home := t.TempDir()
+	setHomeEnv(t, home)
+	dataDir := t.TempDir()
+
+	cfg, err := Resolve(Options{
+		Pair:        true,
+		MachineFile: filepath.Join(t.TempDir(), "missing.json"),
+	}, dataDir)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	want := filepath.Join(home, ".ao", "hosted", "vm-gateway", "pair-cert")
+	if cfg.CertDir != want {
+		t.Errorf("CertDir = %q, want %q", cfg.CertDir, want)
+	}
+	if strings.HasPrefix(cfg.CertDir, dataDir) {
+		t.Errorf("CertDir %q must not be under dataDir %q in pair mode", cfg.CertDir, dataDir)
+	}
+}
+
+func TestResolve_PairMode_CertDirOverrideWins(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "custom-pair-certs")
+	cfg, err := Resolve(Options{
+		Pair:        true,
+		CertDir:     dir,
+		MachineFile: filepath.Join(t.TempDir(), "missing.json"),
+	}, t.TempDir())
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if cfg.CertDir != dir {
+		t.Errorf("CertDir = %q, want override %q", cfg.CertDir, dir)
+	}
+}
+
 func setHomeEnv(t *testing.T, home string) {
 	t.Helper()
 	if runtime.GOOS == "windows" {

--- a/backend/internal/vmgateway/paircert.go
+++ b/backend/internal/vmgateway/paircert.go
@@ -1,0 +1,168 @@
+package vmgateway
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"math/big"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const (
+	// pairCertFileName and pairKeyFileName are the two files
+	// LoadOrCreatePairCertificate persists under a pair-mode Config.CertDir.
+	pairCertFileName = "cert.pem"
+	pairKeyFileName  = "key.pem"
+
+	// pairCertValidity is how long a freshly generated pair-mode certificate
+	// is valid for. Long by design: this is the certificate a client pins by
+	// fingerprint (see docs/adr/0003-pair-mode-gateway.md), so its expiry is
+	// the one thing that WOULD force every paired client to re-pair on a
+	// schedule, the exact failure LoadOrCreatePairCertificate otherwise
+	// exists to prevent. Ten years comfortably outlives any realistic
+	// upgrade cadence for a box that is not otherwise being renewed by
+	// anything; a deliberate rotation (a fresh state root, or a future
+	// rotate command) is how this is ever meant to change.
+	pairCertValidity = 10 * 365 * 24 * time.Hour
+
+	// pairCertCommonName labels the certificate; it carries no security
+	// meaning because pair-mode clients pin the certificate's fingerprint
+	// (see PairFingerprint), never a name in it.
+	pairCertCommonName = "ao-pair-gateway"
+)
+
+// LoadOrCreatePairCertificate returns the pair-mode gateway's TLS
+// certificate, persisted under dir as cert.pem and key.pem. The first call
+// (neither file exists) generates a new self-signed key pair and certificate
+// and persists them. Every subsequent call, including across process
+// restarts and binary upgrades, loads and returns the exact same certificate
+// rather than generating a new one.
+//
+// That reuse is the whole point: a client that has pinned this certificate's
+// fingerprint (trust-on-first-use, see docs/adr/0003-pair-mode-gateway.md)
+// must never see it change under a running box, because a routine restart
+// producing a new certificate would be indistinguishable, from the client's
+// side, from an attacker presenting a different one. If exactly one of the
+// two files is present, or the pair fails to parse, that is treated as
+// corruption, not "first run": returning a fresh certificate in that
+// situation would be exactly the silent rotation this function exists to
+// prevent, so it fails loudly instead and leaves recovery (deleting both
+// files, which does force a re-pair) to a deliberate operator action.
+func LoadOrCreatePairCertificate(dir string) (tls.Certificate, error) {
+	certPath := filepath.Join(dir, pairCertFileName)
+	keyPath := filepath.Join(dir, pairKeyFileName)
+	certExists := fileExists(certPath)
+	keyExists := fileExists(keyPath)
+
+	switch {
+	case certExists && keyExists:
+		cert, err := tls.LoadX509KeyPair(certPath, keyPath)
+		if err != nil {
+			return tls.Certificate{}, fmt.Errorf(
+				"load existing pair certificate from %s: %w (deleting %s and %s regenerates it, which forces every paired client to re-pair)",
+				dir, err, pairCertFileName, pairKeyFileName)
+		}
+		return cert, nil
+	case certExists || keyExists:
+		return tls.Certificate{}, fmt.Errorf(
+			"pair certificate directory %s has only one of %s/%s, which looks like an interrupted write: remove both files to regenerate (this forces every paired client to re-pair)",
+			dir, pairCertFileName, pairKeyFileName)
+	}
+
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return tls.Certificate{}, fmt.Errorf("create pair cert dir: %w", err)
+	}
+	certDER, keyDER, err := generatePairCertificate()
+	if err != nil {
+		return tls.Certificate{}, fmt.Errorf("generate pair certificate: %w", err)
+	}
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+
+	// Key first, then certificate: if a crash lands between the two writes,
+	// the mismatched-pair branch above catches it on the next start rather
+	// than silently generating a new certificate.
+	if err := os.WriteFile(keyPath, keyPEM, 0o600); err != nil {
+		return tls.Certificate{}, fmt.Errorf("write pair certificate key: %w", err)
+	}
+	if err := os.WriteFile(certPath, certPEM, 0o600); err != nil {
+		return tls.Certificate{}, fmt.Errorf("write pair certificate: %w", err)
+	}
+
+	return tls.X509KeyPair(certPEM, keyPEM)
+}
+
+// generatePairCertificate creates a new ECDSA P-256 key and a self-signed
+// certificate over it, returning both DER-encoded.
+func generatePairCertificate() (certDER, keyDER []byte, err error) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, nil, fmt.Errorf("generate private key: %w", err)
+	}
+	serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		return nil, nil, fmt.Errorf("generate serial number: %w", err)
+	}
+	now := time.Now()
+	template := &x509.Certificate{
+		SerialNumber: serial,
+		Subject:      pkix.Name{CommonName: pairCertCommonName},
+		// Backdated an hour to tolerate a box whose clock has not synced yet
+		// at first boot; NotBefore in the future would make the certificate
+		// invalid until the clock catches up.
+		NotBefore:             now.Add(-time.Hour),
+		NotAfter:              now.Add(pairCertValidity),
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		DNSNames:              []string{pairCertCommonName},
+	}
+	certDER, err = x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	if err != nil {
+		return nil, nil, fmt.Errorf("create certificate: %w", err)
+	}
+	keyDER, err = x509.MarshalECPrivateKey(key)
+	if err != nil {
+		return nil, nil, fmt.Errorf("marshal private key: %w", err)
+	}
+	return certDER, keyDER, nil
+}
+
+// PairFingerprint renders the SHA-256 fingerprint of a pair-mode
+// certificate's leaf (its DER bytes, cert.Certificate[0]) as uppercase hex
+// octets separated by colons, e.g. "07:CA:9F:3E:B2:11:...".
+//
+// This exact rendering is the pairing contract and three components must
+// keep producing byte-identical output for the same certificate: the box
+// prints it during setup (batch 3, `ao setup-vm --pair`), the CLI can print
+// it again later, and the desktop app (batch 2) renders the fingerprint it
+// receives over TLS in this same format so a person can compare the two
+// strings by eye during trust-on-first-use pairing (see
+// docs/adr/0003-pair-mode-gateway.md). Do not change the case, the grouping,
+// the separator, or the hash algorithm without updating all three.
+func PairFingerprint(cert tls.Certificate) (string, error) {
+	if len(cert.Certificate) == 0 {
+		return "", errors.New("pair certificate fingerprint: certificate has no DER bytes")
+	}
+	sum := sha256.Sum256(cert.Certificate[0])
+	octets := make([]string, len(sum))
+	for i, b := range sum {
+		octets[i] = fmt.Sprintf("%02X", b)
+	}
+	return strings.Join(octets, ":"), nil
+}
+
+func fileExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}

--- a/backend/internal/vmgateway/paircert_test.go
+++ b/backend/internal/vmgateway/paircert_test.go
@@ -1,0 +1,183 @@
+package vmgateway
+
+import (
+	"bytes"
+	"crypto/tls"
+	"crypto/x509"
+	"os"
+	"path/filepath"
+	"regexp"
+	"testing"
+	"time"
+)
+
+// TestLoadOrCreatePairCertificate_ReusesOnSecondStart is the single most
+// important test in this file. A pair-mode client pins the certificate's
+// fingerprint on first connection (trust-on-first-use); if a routine restart
+// or upgrade generated a new certificate, the fingerprint would change and
+// every paired client would either be locked out or, worse, would have no way
+// to tell a routine restart apart from an attacker presenting a different
+// certificate. See docs/adr/0003-pair-mode-gateway.md.
+func TestLoadOrCreatePairCertificate_ReusesOnSecondStart(t *testing.T) {
+	dir := t.TempDir()
+
+	first, err := LoadOrCreatePairCertificate(dir)
+	if err != nil {
+		t.Fatalf("first start: LoadOrCreatePairCertificate: %v", err)
+	}
+	firstFP, err := PairFingerprint(first)
+	if err != nil {
+		t.Fatalf("PairFingerprint(first): %v", err)
+	}
+
+	// A second call models a process restart: the same dir, a fresh call,
+	// nothing in memory carried over.
+	second, err := LoadOrCreatePairCertificate(dir)
+	if err != nil {
+		t.Fatalf("second start: LoadOrCreatePairCertificate: %v", err)
+	}
+	secondFP, err := PairFingerprint(second)
+	if err != nil {
+		t.Fatalf("PairFingerprint(second): %v", err)
+	}
+
+	if !bytes.Equal(first.Certificate[0], second.Certificate[0]) {
+		t.Fatal("second start generated a different certificate than the first: this is exactly the spurious rotation that is indistinguishable from an attack to a client that has pinned the old fingerprint")
+	}
+	if firstFP != secondFP {
+		t.Fatalf("fingerprint changed across restarts: first %s, second %s", firstFP, secondFP)
+	}
+
+	// A third call, modelling a binary upgrade (new process, same state
+	// root), must still agree.
+	third, err := LoadOrCreatePairCertificate(dir)
+	if err != nil {
+		t.Fatalf("third start: LoadOrCreatePairCertificate: %v", err)
+	}
+	thirdFP, err := PairFingerprint(third)
+	if err != nil {
+		t.Fatalf("PairFingerprint(third): %v", err)
+	}
+	if thirdFP != firstFP {
+		t.Fatalf("fingerprint drifted on a third start: %s, want %s", thirdFP, firstFP)
+	}
+}
+
+func TestLoadOrCreatePairCertificate_GeneratesOnFirstStart(t *testing.T) {
+	dir := t.TempDir()
+
+	cert, err := LoadOrCreatePairCertificate(dir)
+	if err != nil {
+		t.Fatalf("LoadOrCreatePairCertificate: %v", err)
+	}
+	if len(cert.Certificate) == 0 {
+		t.Fatal("expected a non-empty certificate chain")
+	}
+
+	certPath := filepath.Join(dir, pairCertFileName)
+	keyPath := filepath.Join(dir, pairKeyFileName)
+	if _, err := os.Stat(certPath); err != nil {
+		t.Errorf("expected %s to be persisted: %v", certPath, err)
+	}
+	if info, err := os.Stat(keyPath); err != nil {
+		t.Errorf("expected %s to be persisted: %v", keyPath, err)
+	} else if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Errorf("key file permissions = %o, want 0600 (it is a private key)", perm)
+	}
+
+	leaf, err := x509.ParseCertificate(cert.Certificate[0])
+	if err != nil {
+		t.Fatalf("parse generated certificate: %v", err)
+	}
+	if leaf.IsCA {
+		t.Error("pair-mode certificate must be a leaf certificate, not a CA")
+	}
+	validFor := leaf.NotAfter.Sub(leaf.NotBefore)
+	if validFor < 9*365*24*time.Hour {
+		t.Errorf("certificate validity = %s, want a long-lived certificate (see pairCertValidity)", validFor)
+	}
+	found := false
+	for _, use := range leaf.ExtKeyUsage {
+		if use == x509.ExtKeyUsageServerAuth {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("certificate must be usable for TLS server auth")
+	}
+}
+
+func TestLoadOrCreatePairCertificate_MismatchedFilesIsError(t *testing.T) {
+	dir := t.TempDir()
+	// Simulate an interrupted write: only one of the two files present.
+	if err := os.WriteFile(filepath.Join(dir, pairCertFileName), []byte("not a real cert"), 0o644); err != nil {
+		t.Fatalf("write partial cert file: %v", err)
+	}
+
+	if _, err := LoadOrCreatePairCertificate(dir); err == nil {
+		t.Fatal("expected an error when only cert.pem is present, not a silent regeneration")
+	}
+}
+
+func TestLoadOrCreatePairCertificate_CorruptFilesIsError(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, pairCertFileName), []byte("not a real cert"), 0o644); err != nil {
+		t.Fatalf("write corrupt cert file: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, pairKeyFileName), []byte("not a real key"), 0o600); err != nil {
+		t.Fatalf("write corrupt key file: %v", err)
+	}
+
+	if _, err := LoadOrCreatePairCertificate(dir); err == nil {
+		t.Fatal("expected an error for an unparseable existing certificate pair, not a silent regeneration")
+	}
+}
+
+// TestPairFingerprint_Format pins the exact rendering documented on
+// PairFingerprint: 32 uppercase hex octets (a SHA-256 digest) separated by
+// colons. Two later tasks (the desktop pinning UI and the CLI/setup printer)
+// depend on this exact string shape matching byte for byte.
+func TestPairFingerprint_Format(t *testing.T) {
+	dir := t.TempDir()
+	cert, err := LoadOrCreatePairCertificate(dir)
+	if err != nil {
+		t.Fatalf("LoadOrCreatePairCertificate: %v", err)
+	}
+	fp, err := PairFingerprint(cert)
+	if err != nil {
+		t.Fatalf("PairFingerprint: %v", err)
+	}
+
+	pattern := regexp.MustCompile(`^[0-9A-F]{2}(:[0-9A-F]{2}){31}$`)
+	if !pattern.MatchString(fp) {
+		t.Fatalf("fingerprint %q does not match the documented format (32 uppercase hex octets separated by colons)", fp)
+	}
+}
+
+func TestPairFingerprint_EmptyCertificateErrors(t *testing.T) {
+	if _, err := PairFingerprint(tls.Certificate{}); err == nil {
+		t.Fatal("expected an error for a certificate with no DER bytes")
+	}
+}
+
+func TestPairFingerprint_DifferentDirsProduceDifferentFingerprints(t *testing.T) {
+	certA, err := LoadOrCreatePairCertificate(t.TempDir())
+	if err != nil {
+		t.Fatalf("LoadOrCreatePairCertificate (a): %v", err)
+	}
+	certB, err := LoadOrCreatePairCertificate(t.TempDir())
+	if err != nil {
+		t.Fatalf("LoadOrCreatePairCertificate (b): %v", err)
+	}
+	fpA, err := PairFingerprint(certA)
+	if err != nil {
+		t.Fatalf("PairFingerprint(a): %v", err)
+	}
+	fpB, err := PairFingerprint(certB)
+	if err != nil {
+		t.Fatalf("PairFingerprint(b): %v", err)
+	}
+	if fpA == fpB {
+		t.Fatal("two independently generated certificates produced the same fingerprint; the generator is not actually randomizing the key/serial")
+	}
+}

--- a/backend/internal/vmgateway/server.go
+++ b/backend/internal/vmgateway/server.go
@@ -2,6 +2,7 @@ package vmgateway
 
 import (
 	"context"
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -12,27 +13,66 @@ import (
 	"golang.org/x/crypto/acme/autocert"
 )
 
-// Server owns the gateway's two listeners: HTTPAddr for the ACME HTTP-01
-// challenge (and a redirect to https for everything else), and HTTPSAddr for
-// TLS, serving the handler passed to NewServer. Both share one
+// Server owns the gateway's listeners, serving the handler passed to
+// NewServer. In hosted mode (Config.Mode == ModeHosted) that is two
+// listeners: HTTPAddr for the ACME HTTP-01 challenge (and a redirect to https
+// for everything else), and HTTPSAddr for TLS. Both share one
 // autocert.Manager scoped to exactly the configured domain, so ao vm serve
 // can never be tricked into requesting a certificate for an arbitrary Host
-// header sent to this machine's IP.
+// header sent to this machine's IP. In pair mode (ModePair) there is no ACME
+// HTTP-01 challenge to answer, so httpSrv is never built: Server binds only
+// the TLS listener, presenting the long-lived self-signed certificate from
+// LoadOrCreatePairCertificate.
 type Server struct {
 	cfg *Config
 	log *slog.Logger
 
-	httpSrv  *http.Server
+	httpSrv  *http.Server // nil in pair mode
 	httpsSrv *http.Server
 }
 
 // NewServer builds a Server. It does not bind any socket yet; call Run.
 func NewServer(cfg Config, handler http.Handler, log *slog.Logger) (*Server, error) {
+	if cfg.CertDir == "" {
+		return nil, errors.New("vm gateway: a certificate directory is required")
+	}
+	log = loggerOrDefault(log)
+	// net/http writes its own internal errors (failed TLS handshakes,
+	// autocert/ACME failures such as a blocked :80, a rate-limited Let's
+	// Encrypt account, or an unroutable DNS record) to ErrorLog, which
+	// defaults to log.Default() on raw stderr rather than this process's
+	// structured logger. Without this, certificate breakage on a
+	// systemd-managed, internet-facing gateway is invisible to anyone reading
+	// slog output. Warn (not Error) because most of what lands here is
+	// ordinary internet noise (a client resetting a handshake mid-flight) that
+	// happens to be routed through the same hook as a real ACME failure; the
+	// gateway has no way to tell them apart from the message alone. Applies in
+	// both modes: a pair-mode gateway is just as internet-reachable as a
+	// hosted one, TLS noise and all.
+	errLog := slog.NewLogLogger(log.Handler(), slog.LevelWarn)
+	s := &Server{cfg: &cfg, log: log}
+
+	if cfg.Mode == ModePair {
+		cert, err := LoadOrCreatePairCertificate(cfg.CertDir)
+		if err != nil {
+			return nil, fmt.Errorf("pair mode certificate: %w", err)
+		}
+		s.httpsSrv = &http.Server{
+			Addr:              cfg.HTTPSAddr,
+			Handler:           handler,
+			TLSConfig:         &tls.Config{Certificates: []tls.Certificate{cert}},
+			ReadHeaderTimeout: 10 * time.Second,
+			// See the IdleTimeout/ErrorLog comments on the hosted-mode
+			// httpsSrv below; the same slowloris and log-visibility reasoning
+			// applies unchanged to the pair-mode TLS listener.
+			IdleTimeout: 2 * time.Minute,
+			ErrorLog:    errLog,
+		}
+		return s, nil
+	}
+
 	if cfg.Domain == "" {
 		return nil, errors.New("vm gateway: a domain is required")
-	}
-	if cfg.CertDir == "" {
-		return nil, errors.New("vm gateway: a certificate cache directory is required")
 	}
 	// Fail fast, before ever binding a port, if the cache directory cannot be
 	// created (e.g. an unwritable AO_DATA_DIR override).
@@ -46,19 +86,6 @@ func NewServer(cfg Config, handler http.Handler, log *slog.Logger) (*Server, err
 		HostPolicy: autocert.HostWhitelist(cfg.Domain),
 	}
 
-	log = loggerOrDefault(log)
-	// net/http writes its own internal errors (failed TLS handshakes,
-	// autocert/ACME failures such as a blocked :80, a rate-limited Let's
-	// Encrypt account, or an unroutable DNS record) to ErrorLog, which
-	// defaults to log.Default() on raw stderr rather than this process's
-	// structured logger. Without this, certificate breakage on a
-	// systemd-managed, internet-facing gateway is invisible to anyone reading
-	// slog output. Warn (not Error) because most of what lands here is
-	// ordinary internet noise (a client resetting a handshake mid-flight) that
-	// happens to be routed through the same hook as a real ACME failure; the
-	// gateway has no way to tell them apart from the message alone.
-	errLog := slog.NewLogLogger(log.Handler(), slog.LevelWarn)
-	s := &Server{cfg: &cfg, log: log}
 	s.httpSrv = &http.Server{
 		Addr: cfg.HTTPAddr,
 		// nil fallback: every non-challenge request on :80 is redirected to
@@ -93,22 +120,32 @@ func NewServer(cfg Config, handler http.Handler, log *slog.Logger) (*Server, err
 	return s, nil
 }
 
-// Run serves both listeners until ctx is cancelled (SIGINT/SIGTERM, via
-// signal.NotifyContext in the caller), then performs a graceful shutdown of
-// both bounded by shutdownTimeout. It blocks until both have stopped. If
-// either listener fails on its own (for example the configured port is
-// already in use), Run shuts down the other and returns that error.
+// Run serves the gateway's listener(s) until ctx is cancelled (SIGINT/SIGTERM,
+// via signal.NotifyContext in the caller), then performs a graceful shutdown
+// bounded by shutdownTimeout. It blocks until every listener has stopped. In
+// hosted mode that is two listeners (ACME challenge and TLS); in pair mode,
+// where httpSrv is nil because there is no ACME challenge to answer, it is
+// the TLS listener alone. If a listener fails on its own (for example the
+// configured port is already in use), Run shuts down the other, if any, and
+// returns that error.
 func (s *Server) Run(ctx context.Context, shutdownTimeout time.Duration) error {
-	serveErr := make(chan error, 2)
+	listeners := 1
+	if s.httpSrv != nil {
+		listeners = 2
+	}
+	serveErr := make(chan error, listeners)
 
+	if s.httpSrv != nil {
+		go func() {
+			s.log.Info("vm gateway: ACME challenge listener starting", "addr", s.cfg.HTTPAddr)
+			serveErr <- serveOrNil(s.httpSrv.ListenAndServe())
+		}()
+	}
 	go func() {
-		s.log.Info("vm gateway: ACME challenge listener starting", "addr", s.cfg.HTTPAddr)
-		serveErr <- serveOrNil(s.httpSrv.ListenAndServe())
-	}()
-	go func() {
-		s.log.Info("vm gateway: TLS listener starting", "addr", s.cfg.HTTPSAddr, "domain", s.cfg.Domain)
-		// TLSConfig on the server already carries the autocert manager's
-		// GetCertificate, so no cert/key files are passed here.
+		s.log.Info("vm gateway: TLS listener starting", "addr", s.cfg.HTTPSAddr, "mode", s.cfg.Mode, "domain", s.cfg.Domain)
+		// TLSConfig on the server already carries either the autocert
+		// manager's GetCertificate (hosted mode) or the fixed pair-mode
+		// certificate (pair mode), so no cert/key files are passed here.
 		serveErr <- serveOrNil(s.httpsSrv.ListenAndServeTLS("", ""))
 	}()
 
@@ -124,17 +161,19 @@ func (s *Server) Run(ctx context.Context, shutdownTimeout time.Duration) error {
 
 	shutdownCtx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
 	defer cancel()
-	if err := s.httpSrv.Shutdown(shutdownCtx); err != nil && runErr == nil {
-		runErr = fmt.Errorf("shut down http listener: %w", err)
+	if s.httpSrv != nil {
+		if err := s.httpSrv.Shutdown(shutdownCtx); err != nil && runErr == nil {
+			runErr = fmt.Errorf("shut down http listener: %w", err)
+		}
 	}
 	if err := s.httpsSrv.Shutdown(shutdownCtx); err != nil && runErr == nil {
 		runErr = fmt.Errorf("shut down https listener: %w", err)
 	}
 
-	// Both goroutines are guaranteed to unblock and send exactly once, each,
+	// Every goroutine is guaranteed to unblock and send exactly once, each,
 	// once Shutdown has been called on their server; drain whichever ones
-	// this call hasn't already consumed so neither goroutine leaks.
-	for ; consumed < 2; consumed++ {
+	// this call hasn't already consumed so none of them leak.
+	for ; consumed < listeners; consumed++ {
 		if err := <-serveErr; err != nil && runErr == nil {
 			runErr = err
 		}

--- a/backend/internal/vmgateway/server_test.go
+++ b/backend/internal/vmgateway/server_test.go
@@ -91,6 +91,148 @@ func TestNewServer_ErrorLogWritesToSlog(t *testing.T) {
 	}
 }
 
+// TestNewServer_HostedMode_BindsHTTPAndUsesAutocert pins the hosted half of
+// "hosted mode still binds :80 and uses autocert, and pair mode does
+// neither": httpSrv must be built, and the TLS listener's certificate must
+// come from autocert's GetCertificate hook rather than a fixed certificate.
+func TestNewServer_HostedMode_BindsHTTPAndUsesAutocert(t *testing.T) {
+	cfg := Config{
+		Mode:      ModeHosted,
+		Domain:    "vm.example.com",
+		CertDir:   t.TempDir(),
+		HTTPAddr:  "127.0.0.1:0",
+		HTTPSAddr: "127.0.0.1:0",
+	}
+	srv, err := NewServer(cfg, http.NotFoundHandler(), discardLogger())
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	if srv.httpSrv == nil {
+		t.Fatal("hosted mode must bind the :80 ACME challenge listener")
+	}
+	if srv.httpsSrv.TLSConfig == nil || srv.httpsSrv.TLSConfig.GetCertificate == nil {
+		t.Error("hosted mode must serve certificates via autocert.Manager.GetCertificate")
+	}
+	if len(srv.httpsSrv.TLSConfig.Certificates) != 0 {
+		t.Error("hosted mode must not set a fixed certificate list; that is the pair-mode shape")
+	}
+}
+
+// TestNewServer_PairMode_SkipsHTTPListenerAndAutocert pins the pair half of
+// the same contract: no httpSrv at all (no :80 bind, no ACME challenge to
+// answer), and the TLS listener presents a fixed, persisted certificate
+// rather than going through autocert.
+func TestNewServer_PairMode_SkipsHTTPListenerAndAutocert(t *testing.T) {
+	cfg := Config{
+		Mode:      ModePair,
+		CertDir:   t.TempDir(),
+		HTTPSAddr: "127.0.0.1:0",
+	}
+	srv, err := NewServer(cfg, http.NotFoundHandler(), discardLogger())
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	if srv.httpSrv != nil {
+		t.Error("pair mode must not build an HTTP (:80 ACME challenge) listener")
+	}
+	if srv.httpsSrv == nil {
+		t.Fatal("pair mode must still build the TLS listener")
+	}
+	if srv.httpsSrv.TLSConfig == nil || len(srv.httpsSrv.TLSConfig.Certificates) != 1 {
+		t.Fatal("pair mode must present the persisted self-signed certificate directly")
+	}
+	if srv.httpsSrv.TLSConfig.GetCertificate != nil {
+		t.Error("pair mode must not use autocert's GetCertificate hook")
+	}
+}
+
+// TestNewServer_PairMode_DoesNotRequireDomain proves pair mode's
+// certificate/config half does not need a Domain at all, unlike hosted mode
+// (TestNewServer_RequiresDomain above).
+func TestNewServer_PairMode_DoesNotRequireDomain(t *testing.T) {
+	cfg := Config{Mode: ModePair, CertDir: t.TempDir(), HTTPSAddr: "127.0.0.1:0"}
+	if _, err := NewServer(cfg, http.NotFoundHandler(), discardLogger()); err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+}
+
+func TestNewServer_PairMode_PersistsCertificateUnderCertDir(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "nested", "pair-cert")
+	cfg := Config{Mode: ModePair, CertDir: dir, HTTPSAddr: "127.0.0.1:0"}
+	if _, err := NewServer(cfg, http.NotFoundHandler(), discardLogger()); err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	for _, name := range []string{"cert.pem", "key.pem"} {
+		if _, err := os.Stat(filepath.Join(dir, name)); err != nil {
+			t.Errorf("expected %s to be persisted under CertDir: %v", name, err)
+		}
+	}
+}
+
+// TestNewServer_PairMode_SetsIdleTimeoutAndErrorLog mirrors
+// TestNewServer_SetsIdleTimeoutNotReadOrWriteTimeout and
+// TestNewServer_ErrorLogWritesToSlog above for the pair-mode TLS listener: a
+// pair-mode gateway is just as internet-reachable as a hosted one, so it
+// needs the same slowloris and log-visibility hardening.
+func TestNewServer_PairMode_SetsIdleTimeoutAndErrorLog(t *testing.T) {
+	var buf bytes.Buffer
+	log := slog.New(slog.NewTextHandler(&buf, nil))
+	cfg := Config{Mode: ModePair, CertDir: t.TempDir(), HTTPSAddr: "127.0.0.1:0"}
+	srv, err := NewServer(cfg, http.NotFoundHandler(), log)
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	if srv.httpsSrv.IdleTimeout <= 0 {
+		t.Errorf("IdleTimeout = %v, want a positive bound", srv.httpsSrv.IdleTimeout)
+	}
+	if srv.httpsSrv.ReadTimeout != 0 || srv.httpsSrv.WriteTimeout != 0 {
+		t.Error("ReadTimeout/WriteTimeout must stay unset: they would also bound the hijacked /mux tunnel and long SSE responses")
+	}
+	if srv.httpsSrv.ErrorLog == nil {
+		t.Fatal("pair mode must set ErrorLog")
+	}
+	srv.httpsSrv.ErrorLog.Print("simulated TLS handshake failure")
+	if got := buf.String(); !strings.Contains(got, "simulated TLS handshake failure") {
+		t.Errorf("slog output = %q, want the net/http ErrorLog line forwarded into it", got)
+	}
+}
+
+// TestServer_Run_PairMode_SkipsPort80AndShutsDownCleanly is the pair-mode
+// analogue of TestServer_RunShutsDownOnContextCancel below: it proves Run
+// starts and cleanly stops a single (TLS-only) listener, with no :80
+// goroutine to leak or fail to shut down.
+func TestServer_Run_PairMode_SkipsPort80AndShutsDownCleanly(t *testing.T) {
+	cfg := Config{
+		Mode:      ModePair,
+		CertDir:   t.TempDir(),
+		HTTPSAddr: "127.0.0.1:0",
+	}
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) })
+	srv, err := NewServer(cfg, handler, discardLogger())
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	if srv.cfg.HTTPAddr != "" {
+		t.Fatalf("HTTPAddr = %q, want empty in pair mode", srv.cfg.HTTPAddr)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- srv.Run(ctx, time.Second) }()
+
+	time.Sleep(50 * time.Millisecond) // give the TLS listener time to bind
+	cancel()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Run returned an error on graceful shutdown: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Run did not return after context cancellation; the TLS listener goroutine leaked")
+	}
+}
+
 // TestServer_RunShutsDownOnContextCancel exercises Run's graceful-shutdown
 // path without ever completing a TLS handshake or touching the network:
 // autocert only calls out to Let's Encrypt when a client actually connects


### PR DESCRIPTION
## Summary

Task 3 of the pair-by-IP batch (Refs #86): the certificate and configuration
halves of pair mode for the VM gateway. Authentication (the passcode
replacing the JWT) is a separate, later task and is not touched here.

- `config.go`: `Config` now carries a `Mode` (`ModeHosted` or `ModePair`).
  `Resolve` takes `opts.Pair` or `AO_VM_PAIR` and, in pair mode, leaves the
  domain/account/issuer/JWKS fields empty rather than defaulted. The two
  modes are mutually exclusive and validated loudly at `Resolve`: any
  hosted-only flag or env var supplied alongside `--pair` is rejected with
  the offending flag named. Pair mode's certificate directory defaults under
  the state root (`config.DefaultStateDir`), not the data dir the hosted ACME
  cache uses, mirroring the same asymmetry `DefaultMachineFilePath` already
  documents for `machine.json`: the certificate is identity, not disposable
  cache, and must survive an `AO_DATA_DIR` change.
- `paircert.go` (new): `LoadOrCreatePairCertificate` generates a long-lived
  (10 year) self-signed ECDSA P-256 certificate on first start and persists
  it as `cert.pem`/`key.pem`. Every later start loads and returns the same
  certificate rather than generating a new one — the reuse is the point,
  since a routine restart producing a different certificate would be
  indistinguishable, to a client that has pinned the old fingerprint, from an
  attacker presenting a different one. A partial or corrupt existing pair
  fails loudly instead of silently regenerating. `PairFingerprint` renders
  the certificate's SHA-256 as uppercase hex octets separated by colons
  (`07:CA:9F:...`); this exact rendering is the pairing contract two later
  tasks (the CLI printer, the desktop pinning UI) depend on.
- `server.go`: `NewServer`/`Run` branch on `Config.Mode`. Pair mode builds
  only the TLS listener, presenting the persisted certificate directly
  instead of going through `autocert.Manager`, and never builds the `:80`
  ACME challenge listener (no HTTP-01 challenge to answer). Hosted mode is
  unchanged.

Hard constraints honored: the daemon (`internal/daemon`, `internal/httpd`) is
untouched, the proxy allowlist in `proxy.go` is untouched, `token.go` is
untouched, and the state root is derived from `config.StateRootSegments()`/
`config.DefaultStateDir()` rather than re-spelled.

## Test plan

- [x] `cd backend && go build ./...`
- [x] `cd backend && go vet ./...`
- [x] `cd backend && go test ./...`
- [x] `cd backend && go test -race ./internal/vmgateway/...`
- [x] `golangci-lint run` (repo-wide and vmgateway-scoped): 0 issues
- [x] New tests: mode-mixing validation, pair cert dir default under the
      state root, certificate generation and **reuse across restarts**
      (`TestLoadOrCreatePairCertificate_ReusesOnSecondStart`, the load-bearing
      one), corrupted/partial certificate detection, fingerprint format and
      stability, hosted mode still binding `:80`/using autocert while pair
      mode does neither