### PR TITLE
docs: branch from develop, not main

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,7 +132,7 @@ Commit `openapi.yaml` and `frontend/src/api/schema.ts` together with the Go chan
 
 ## PR hygiene
 
-- Branch from `main` unless explicitly continuing an existing PR.
+- Branch from `develop`, and open PRs against `develop`, unless explicitly continuing an existing PR. `develop` is this repository's default branch and every PR merges there. `main` is a stale snapshot, not the integration branch, so branching from it produces PRs against the wrong base and a diff full of changes that are already shipped.
 - Keep one issue per PR. If asked for separate work, create a separate branch and PR.
 - Use conventional commit messages (`feat:`, `fix:`, `docs:`, `test:`, `chore:`).
 - Explain intentional omissions in the PR body, especially when the TypeScript original had more behavior than the Go rewrite domain currently supports.


### PR DESCRIPTION
`AGENTS.md` told agents to branch from `main`. That is wrong and has been for a
while.

Evidence:

- GitHub's default branch for this repository is `develop`.
- `develop` is **10 commits ahead** of `main`; `main` is **0 ahead** of `develop`.
- Every recent PR (#77, #78, #79, #80, #83, #84, and the four just merged for the
  pair-by-IP feature) merged into `develop`.

An agent following the old rule branches from a stale snapshot, opens the PR
against the wrong base, and carries a diff full of work that already shipped.

Found while dispatching workers for the pair-by-IP feature: the rule had to be
overridden by hand in every single worker brief, which is a reliable sign the
doc is lying rather than that the workers were wrong.

If `main` is meant to become a release branch later, that is worth writing down
explicitly, because right now nothing distinguishes it from an abandoned copy.