### PR TITLE
feat(desktop): persist paired machines and enforce TLS pinning at the session level

### DIFF
--- a/frontend/e2e/support/fake-bridge.ts
+++ b/frontend/e2e/support/fake-bridge.ts
@@ -217,6 +217,18 @@ export async function installFakeBridge(page: Page, opts: FakeBridgeOptions = {}
 					// rest of this harness: no main process, so no second daemon.
 					peerWorkspaces: async () => ({ state: "unavailable" as const, reason: "This computer is signed out of AO." }),
 				},
+				// No main process under the browser harness, so nothing is paired and
+				// there is no certificate to present. `add` throws rather than returning
+				// a stub machine: pinning a fingerprint is a real trust decision and a
+				// fake that silently succeeds would hide a regression in that path.
+				pairedMachines: {
+					list: async () => [],
+					probeFingerprint: async () => ({ error: "No main process under the browser harness." }),
+					add: async () => {
+						throw new Error("Pairing is unavailable under the browser harness.");
+					},
+					remove: async () => {},
+				},
 			} satisfies AoBridge;
 			(window as unknown as { ao: unknown }).ao = ao;
 		},
@@ -656,6 +668,18 @@ export async function installFakeAgent(page: Page, opts: FakeAgentOptions = {}):
 					// Signed out, so there is no peer daemon to list. Matches the
 					// rest of this harness: no main process, so no second daemon.
 					peerWorkspaces: async () => ({ state: "unavailable" as const, reason: "This computer is signed out of AO." }),
+				},
+				// No main process under the browser harness, so nothing is paired and
+				// there is no certificate to present. `add` throws rather than returning
+				// a stub machine: pinning a fingerprint is a real trust decision and a
+				// fake that silently succeeds would hide a regression in that path.
+				pairedMachines: {
+					list: async () => [],
+					probeFingerprint: async () => ({ error: "No main process under the browser harness." }),
+					add: async () => {
+						throw new Error("Pairing is unavailable under the browser harness.");
+					},
+					remove: async () => {},
 				},
 			} satisfies AoBridge;
 			(window as unknown as { ao: unknown }).ao = ao;

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -75,6 +75,7 @@ import { readMigrationState, updateMigration, writeAppStateMarker, type Migratio
 import { createAoAccountController } from "./main/ao-account";
 import { createAoMachinesController } from "./main/ao-machines";
 import { createPeerWorkspacesController } from "./main/peer-workspaces";
+import { createPairedMachinesController } from "./main/paired-machines";
 import type { AoMachine } from "./shared/ao-machines";
 import { isAllowedAppExternalURL, openAllowedAppExternalURL } from "./main/external-open";
 import { shouldSignalAttention, shouldToast } from "./main/notification-signals";
@@ -1578,6 +1579,27 @@ function aoMachines(): ReturnType<typeof createAoMachinesController> {
 	return aoMachinesController;
 }
 
+// Paired boxes (docs/adr/0003-pair-mode-gateway.md): the registry of machines
+// reached by address, port, and passcode instead of the control plane, and the
+// pinned certificate fingerprint each one trusts. Never touches the control
+// plane. session.defaultSession's certificate-verify proc, installed in
+// app.whenReady below, is what actually enforces the pin; this controller only
+// holds the data it reads from.
+let pairedMachinesController: ReturnType<typeof createPairedMachinesController> | null = null;
+function pairedMachines(): ReturnType<typeof createPairedMachinesController> {
+	if (pairedMachinesController) return pairedMachinesController;
+	const runFile = runFilePath();
+	pairedMachinesController = createPairedMachinesController({
+		stateDir: runFile ? path.dirname(runFile) : null,
+		safeStorage,
+		// net.fetch, not the global fetch: it runs through the session's network
+		// stack, which is what verifyCertificate below actually sees. A plain
+		// fetch would bypass the session (and the pin) entirely.
+		netFetch: (input, init) => net.fetch(String(input), init),
+	});
+	return pairedMachinesController;
+}
+
 // Read-only view of the daemon that is NOT the app's active one (the
 // "peer"), so the UI can list its projects and sessions alongside the active
 // one's. Fully independent of machineTransport(): a peer never opens /mux or
@@ -1669,6 +1691,22 @@ ipcMain.handle("aoMachines:gatewayToken", (_event, forceRefresh?: boolean) =>
 	machineTransportInstance?.token(forceRefresh) ?? null,
 );
 ipcMain.handle("aoMachines:peerWorkspaces", () => peerWorkspaces().get());
+
+// Paired boxes: the data half of pair mode (docs/adr/0003-pair-mode-gateway.md).
+// Address, port, and passcode entry, and the fingerprint comparison screen, are
+// task 8; this is only what that UI reads and writes through.
+ipcMain.handle("pairedMachines:list", () => pairedMachines().list());
+ipcMain.handle("pairedMachines:probeFingerprint", (_event, address: string, port: number) =>
+	pairedMachines().probeFingerprint(address, port),
+);
+ipcMain.handle(
+	"pairedMachines:add",
+	(
+		_event,
+		input: { id: string; name: string; address: string; port: number; passcode: string; fingerprint: string },
+	) => pairedMachines().add(input),
+);
+ipcMain.handle("pairedMachines:remove", (_event, id: string) => pairedMachines().remove(id));
 
 ipcMain.handle("updates:getStatus", (): UpdateStatus => getUpdateStatus());
 ipcMain.handle("updates:check", async (_event, options?: UpdateCheckOptions) => {
@@ -1899,6 +1937,18 @@ app.whenReady().then(async () => {
 	} catch (err) {
 		console.error("failed to restore the active machine:", err);
 	}
+
+	// The paired-machine pin cache must be populated, and the verify proc
+	// installed, before the window opens and the renderer can make its first
+	// request: any request that lands first would race the pin (see
+	// paired-machine-cert.ts for why this has to be a session-level proc
+	// rather than a per-fetch check).
+	try {
+		await pairedMachines().load();
+	} catch (err) {
+		console.error("failed to load paired machines:", err);
+	}
+	session.defaultSession.setCertificateVerifyProc(pairedMachines().verifyCertificate);
 
 	if (isTrayEnabled(process.platform, app.isPackaged, app.getVersion())) {
 		const initialUiSettings = keybindingRunFile ? await readUiSettings(path.dirname(keybindingRunFile)) : { locale: "en" as const };

--- a/frontend/src/main/paired-machine-cert.test.ts
+++ b/frontend/src/main/paired-machine-cert.test.ts
@@ -1,0 +1,127 @@
+// @vitest-environment node
+import { expect, test, vi } from "vitest";
+import {
+	CERT_VERIFY_ACCEPT,
+	CERT_VERIFY_REJECT,
+	CERT_VERIFY_USE_DEFAULT,
+	computePairFingerprint,
+	createPairCertificateVerifyProc,
+	type PairCertificateRequest,
+} from "./paired-machine-cert";
+
+/**
+ * A real self-signed EC certificate (generated once with `openssl req -x509
+ * -newkey ec ...`, CN=test), used as a fixture rather than generated at test
+ * time so the expected fingerprint below is a fixed, independently
+ * verifiable value, not something the test computes and then checks against
+ * itself.
+ */
+const CERT_PEM = `-----BEGIN CERTIFICATE-----
+MIIBdDCCARmgAwIBAgIUUvaO5qV4lYJUJvB86I5+gJtYg8UwCgYIKoZIzj0EAwIw
+DzENMAsGA1UEAwwEdGVzdDAeFw0yNjA4MTcwOTE2NTZaFw0yNjA4MTgwOTE2NTZa
+MA8xDTALBgNVBAMMBHRlc3QwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAARlsPrG
+o5uD+vjNG2xauAee0+9QvTvujnrf0+jC6fsmopqPMvkotQ2IiiJloA94aQHO3gB5
+ZmRdPTOaOy2Jry4Xo1MwUTAdBgNVHQ4EFgQUIeE+Q4oqUd9Kut/ztrqizj8omBMw
+HwYDVR0jBBgwFoAUIeE+Q4oqUd9Kut/ztrqizj8omBMwDwYDVR0TAQH/BAUwAwEB
+/zAKBggqhkjOPQQDAgNJADBGAiEAn9NMvNxBzBZSI/67DaytKRMz5LACGlwoketR
+rJZoaUICIQCkpVhVKVw/W7rEW+nTMAha8AzRrC4gh02oEc6gudhp/w==
+-----END CERTIFICATE-----`;
+
+/**
+ * The SHA-256 fingerprint of CERT_PEM's DER bytes, uppercase hex octets
+ * joined by colons. Independently verified with:
+ *   openssl x509 -in cert.pem -noout -fingerprint -sha256
+ * and hand-computed with sha256(DER) + `%02X` joined by `:`, matching Go's
+ * PairFingerprint exactly (backend/internal/vmgateway/paircert.go) byte for
+ * byte -- this is the same rendering, not a coincidentally similar one.
+ */
+const CERT_FINGERPRINT = "DF:9A:6C:0D:63:16:53:39:2F:43:4F:02:D8:5F:61:51:63:21:70:BE:21:45:E1:9E:B1:25:D2:44:6F:D4:AB:E5";
+
+/** A second, unrelated certificate, standing in for a swapped/attacker cert. */
+const OTHER_CERT_PEM = `-----BEGIN CERTIFICATE-----
+MIIBdDCCARugAwIBAgIUMzz/EDkOedEV76i5gCgRFg60xv0wCgYIKoZIzj0EAwIw
+EDEOMAwGA1UEAwwFdGVzdDIwHhcNMjYwODE3MDkyMjE3WhcNMjYwODE4MDkyMjE3
+WjAQMQ4wDAYDVQQDDAV0ZXN0MjBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABE2K
+jZbJkEjs1Q2uNJfuYpG9at/geTaamvrcza7xJo2YS0Gpiov3t1uLddItplpb6DeE
+0HKq9PnUQO6ZXZNMsQOjUzBRMB0GA1UdDgQWBBQGPekCiEsYWCbL93gvmUEgeacp
+9TAfBgNVHSMEGDAWgBQGPekCiEsYWCbL93gvmUEgeacp9TAPBgNVHRMBAf8EBTAD
+AQH/MAoGCCqGSM49BAMCA0cAMEQCIBrjUHRvpztw9S63YzDQrXHjUiow5PQePgOc
+kaum9sXnAiBWQyafyurASxXHB+UORQpWHpfyWCm9gr1/x2+SjPBeQQ==
+-----END CERTIFICATE-----`;
+
+function request(hostname: string, pem: string): PairCertificateRequest {
+	return { hostname, certificate: { data: pem } };
+}
+
+test("computePairFingerprint matches PairFingerprint's exact rendering: uppercase hex octets joined by colons", () => {
+	const fingerprint = computePairFingerprint(CERT_PEM);
+	expect(fingerprint).toBe(CERT_FINGERPRINT);
+	expect(fingerprint).toMatch(/^([0-9A-F]{2}:){31}[0-9A-F]{2}$/);
+});
+
+test("a host that is not a paired machine gets default Chromium verification, untouched", () => {
+	const isPairHost = vi.fn(() => false);
+	const getPinnedFingerprint = vi.fn(() => null);
+	const onPresented = vi.fn();
+	const proc = createPairCertificateVerifyProc({ isPairHost, getPinnedFingerprint, onPresented });
+
+	const callback = vi.fn();
+	proc(request("ao.agentlab.in", CERT_PEM), callback);
+
+	expect(callback).toHaveBeenCalledExactlyOnceWith(CERT_VERIFY_USE_DEFAULT);
+	// Nothing about the cert of an unrelated host is inspected at all.
+	expect(getPinnedFingerprint).not.toHaveBeenCalled();
+	expect(onPresented).not.toHaveBeenCalled();
+});
+
+test("a pinned machine whose presented certificate matches the pin is accepted", () => {
+	const proc = createPairCertificateVerifyProc({
+		isPairHost: () => true,
+		getPinnedFingerprint: () => CERT_FINGERPRINT,
+		onPresented: () => undefined,
+	});
+
+	const callback = vi.fn();
+	proc(request("192.168.1.5", CERT_PEM), callback);
+
+	expect(callback).toHaveBeenCalledExactlyOnceWith(CERT_VERIFY_ACCEPT);
+});
+
+test("a pinned machine whose presented certificate does not match the pin is refused, with no fallback", () => {
+	const proc = createPairCertificateVerifyProc({
+		isPairHost: () => true,
+		getPinnedFingerprint: () => CERT_FINGERPRINT,
+		onPresented: () => undefined,
+	});
+
+	const callback = vi.fn();
+	// OTHER_CERT_PEM stands in for a swapped or attacker certificate: the
+	// hostname is recognised as a paired machine, but what is presented does
+	// not match what was pinned.
+	proc(request("192.168.1.5", OTHER_CERT_PEM), callback);
+
+	expect(callback).toHaveBeenCalledExactlyOnceWith(CERT_VERIFY_REJECT);
+	// No other verification result was ever offered: not the default result,
+	// and not an accept. A hard refusal has exactly one outcome.
+	expect(callback).not.toHaveBeenCalledWith(CERT_VERIFY_ACCEPT);
+	expect(callback).not.toHaveBeenCalledWith(CERT_VERIFY_USE_DEFAULT);
+});
+
+test("first connect: an unpinned pairing candidate is refused, but the presented fingerprint is still captured", () => {
+	const onPresented = vi.fn();
+	const proc = createPairCertificateVerifyProc({
+		isPairHost: () => true,
+		getPinnedFingerprint: () => null,
+		onPresented,
+	});
+
+	const callback = vi.fn();
+	proc(request("192.168.1.5", CERT_PEM), callback);
+
+	// Trust-on-first-use never auto-accepts: there is nothing pinned yet, so
+	// the connection itself is refused...
+	expect(callback).toHaveBeenCalledExactlyOnceWith(CERT_VERIFY_REJECT);
+	// ...but the pairing flow still learns what was presented, so it can be
+	// shown to the user for comparison against what the box printed.
+	expect(onPresented).toHaveBeenCalledExactlyOnceWith("192.168.1.5", CERT_FINGERPRINT);
+});

--- a/frontend/src/main/paired-machine-cert.ts
+++ b/frontend/src/main/paired-machine-cert.ts
@@ -1,0 +1,108 @@
+import { X509Certificate } from "node:crypto";
+
+/**
+ * Certificate-pin enforcement for paired boxes, at the Electron session level.
+ *
+ * A paired machine (docs/adr/0003-pair-mode-gateway.md) has no certificate
+ * authority behind it: the box mints a long-lived self-signed certificate and
+ * the desktop pins its fingerprint on first connect (trust-on-first-use). That
+ * pin has to be enforced everywhere the session talks to the box, not only on
+ * REST calls, because the terminal mux WebSocket and the SSE event stream ride
+ * the same TLS connection. `session.setCertificateVerifyProc` is the one seam
+ * that sees every connection a session makes regardless of which API opened
+ * it, which is why the verifier here is wired directly into
+ * `session.defaultSession` in main.ts rather than into a fetch wrapper.
+ *
+ * The corollary is the hard constraint this module exists to satisfy: it must
+ * touch nothing about how any other host is verified. `isPairHost` is the
+ * gate, and a request for a hostname it does not recognise is handed back to
+ * Chromium's own verification untouched (CERT_VERIFY_USE_DEFAULT).
+ */
+
+/** callback(0): accept the certificate for this connection. */
+export const CERT_VERIFY_ACCEPT = 0;
+/** callback(-2): reject outright. No click-through exists above this module. */
+export const CERT_VERIFY_REJECT = -2;
+/** callback(-3): defer to Chromium's own verification result, unmodified. */
+export const CERT_VERIFY_USE_DEFAULT = -3;
+
+/**
+ * The subset of Electron's `Request` (see `session.setCertificateVerifyProc`)
+ * this module reads. Kept minimal and structural, rather than importing
+ * `Electron.Request`, so this file has no runtime dependency on the `electron`
+ * module and unit tests can construct one with a plain object.
+ */
+export type PairCertificateRequest = {
+	/** Host being connected to. Electron does not report the port here, so a
+	 * pin is scoped to a hostname, not a hostname:port pair. */
+	hostname: string;
+	certificate: { data: string };
+};
+
+export type PairCertificateVerifyProc = (
+	request: PairCertificateRequest,
+	callback: (verificationResult: number) => void,
+) => void;
+
+/** What the verifier needs from the paired-machine registry, kept in memory so
+ * every call is synchronous: Electron calls this proc from the network
+ * service and does not await it. */
+export type PairPinLookup = {
+	/** True for a registered paired machine, or a host currently being probed
+	 * for first-time pairing. False for every other host, including the
+	 * control plane and any hosted machine with a real certificate. */
+	isPairHost: (hostname: string) => boolean;
+	/** The pinned fingerprint for a registered paired machine, or null when
+	 * the host is only a pairing candidate with nothing pinned yet. */
+	getPinnedFingerprint: (hostname: string) => string | null;
+	/** Called with the fingerprint of whatever certificate was actually
+	 * presented, for every pair-host connection, whether accepted or
+	 * rejected. This is the first-connect capture: the pairing flow reads it
+	 * back to show the user what to compare against the box's printout. */
+	onPresented: (hostname: string, fingerprint: string) => void;
+};
+
+/**
+ * Render a certificate's SHA-256 fingerprint the same way
+ * `backend/internal/vmgateway/paircert.go`'s `PairFingerprint` does: uppercase
+ * hex octets joined by colons, over the leaf certificate's DER bytes.
+ *
+ * `X509Certificate.fingerprint256` computes exactly that (SHA-256 over the
+ * certificate's DER encoding, rendered as upper-case colon-separated hex) for
+ * both PEM and DER input, so this is the whole implementation; hand-rolling a
+ * PEM parse and hasher would only be a slower way to arrive at the same
+ * bytes. `pem` is `Certificate.data` from Electron's verify-proc request,
+ * which is PEM encoded.
+ */
+export function computePairFingerprint(pem: string): string {
+	return new X509Certificate(pem).fingerprint256;
+}
+
+/**
+ * Build the proc to hand to `session.setCertificateVerifyProc`.
+ *
+ * Decision table, in order:
+ * 1. Not a pair host at all -> CERT_VERIFY_USE_DEFAULT. Every other host,
+ *    including the control plane and hosted machines, is untouched.
+ * 2. A pair host with a pinned fingerprint that matches what was presented ->
+ *    CERT_VERIFY_ACCEPT.
+ * 3. Anything else for a pair host -- a mismatch, or no pin yet -> REJECT.
+ *    There is no accept path for an unpinned host: the presented fingerprint
+ *    is still captured via `onPresented` so the pairing flow can show it, but
+ *    the connection itself is refused rather than silently trusted. This is
+ *    what makes trust-on-first-use a *user* accepting a fingerprint (task 8's
+ *    UI, by calling the registry's add/pin step) rather than the transport
+ *    accepting it on the user's behalf.
+ */
+export function createPairCertificateVerifyProc(lookup: PairPinLookup): PairCertificateVerifyProc {
+	return (request, callback) => {
+		if (!lookup.isPairHost(request.hostname)) {
+			callback(CERT_VERIFY_USE_DEFAULT);
+			return;
+		}
+		const presented = computePairFingerprint(request.certificate.data);
+		lookup.onPresented(request.hostname, presented);
+		const pinned = lookup.getPinnedFingerprint(request.hostname);
+		callback(pinned && pinned === presented ? CERT_VERIFY_ACCEPT : CERT_VERIFY_REJECT);
+	};
+}

--- a/frontend/src/main/paired-machines.test.ts
+++ b/frontend/src/main/paired-machines.test.ts
@@ -1,0 +1,239 @@
+// @vitest-environment node
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+import type { SafeStorageLike } from "./ao-account-store";
+import type { PairCertificateVerifyProc } from "./paired-machine-cert";
+import { AO_PAIRED_MACHINES_FILE_NAME, createPairedMachinesController } from "./paired-machines";
+
+// Same fixture certificate and fingerprint as paired-machine-cert.test.ts.
+const CERT_PEM = `-----BEGIN CERTIFICATE-----
+MIIBdDCCARmgAwIBAgIUUvaO5qV4lYJUJvB86I5+gJtYg8UwCgYIKoZIzj0EAwIw
+DzENMAsGA1UEAwwEdGVzdDAeFw0yNjA4MTcwOTE2NTZaFw0yNjA4MTgwOTE2NTZa
+MA8xDTALBgNVBAMMBHRlc3QwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAARlsPrG
+o5uD+vjNG2xauAee0+9QvTvujnrf0+jC6fsmopqPMvkotQ2IiiJloA94aQHO3gB5
+ZmRdPTOaOy2Jry4Xo1MwUTAdBgNVHQ4EFgQUIeE+Q4oqUd9Kut/ztrqizj8omBMw
+HwYDVR0jBBgwFoAUIeE+Q4oqUd9Kut/ztrqizj8omBMwDwYDVR0TAQH/BAUwAwEB
+/zAKBggqhkjOPQQDAgNJADBGAiEAn9NMvNxBzBZSI/67DaytKRMz5LACGlwoketR
+rJZoaUICIQCkpVhVKVw/W7rEW+nTMAha8AzRrC4gh02oEc6gudhp/w==
+-----END CERTIFICATE-----`;
+const CERT_FINGERPRINT = "DF:9A:6C:0D:63:16:53:39:2F:43:4F:02:D8:5F:61:51:63:21:70:BE:21:45:E1:9E:B1:25:D2:44:6F:D4:AB:E5";
+
+const OTHER_CERT_PEM = `-----BEGIN CERTIFICATE-----
+MIIBdDCCARugAwIBAgIUMzz/EDkOedEV76i5gCgRFg60xv0wCgYIKoZIzj0EAwIw
+EDEOMAwGA1UEAwwFdGVzdDIwHhcNMjYwODE3MDkyMjE3WhcNMjYwODE4MDkyMjE3
+WjAQMQ4wDAYDVQQDDAV0ZXN0MjBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABE2K
+jZbJkEjs1Q2uNJfuYpG9at/geTaamvrcza7xJo2YS0Gpiov3t1uLddItplpb6DeE
+0HKq9PnUQO6ZXZNMsQOjUzBRMB0GA1UdDgQWBBQGPekCiEsYWCbL93gvmUEgeacp
+9TAfBgNVHSMEGDAWgBQGPekCiEsYWCbL93gvmUEgeacp9TAPBgNVHRMBAf8EBTAD
+AQH/MAoGCCqGSM49BAMCA0cAMEQCIBrjUHRvpztw9S63YzDQrXHjUiow5PQePgOc
+kaum9sXnAiBWQyafyurASxXHB+UORQpWHpfyWCm9gr1/x2+SjPBeQQ==
+-----END CERTIFICATE-----`;
+
+const safeStorage: SafeStorageLike = {
+	isEncryptionAvailable: () => true,
+	encryptString: (plain) => Buffer.from(`enc:${plain}`, "utf8"),
+	decryptString: (cipher) => cipher.toString("utf8").replace(/^enc:/, ""),
+};
+
+/**
+ * Stands in for Electron's net.fetch: runs the same certificate through the
+ * controller's own verifyCertificate, exactly as Chromium's network service
+ * would during a real TLS handshake, then resolves or rejects the way a real
+ * fetch would given that verdict. This is what lets probeFingerprint and the
+ * pin-enforcement paths be exercised without a real network stack.
+ */
+function netFetchPresenting(pem: string, verify: PairCertificateVerifyProc): typeof fetch {
+	return (async (input: string | URL | Request) => {
+		const url = new URL(String(input));
+		let verdict: number | undefined;
+		verify({ hostname: url.hostname, certificate: { data: pem } }, (result) => {
+			verdict = result;
+		});
+		if (verdict === 0) return new Response("ok", { status: 200 });
+		throw new Error("certificate verification failed");
+	}) as unknown as typeof fetch;
+}
+
+/** A box that never answers at all: no TLS handshake, nothing presented. */
+const unreachableFetch: typeof fetch = (async () => {
+	throw new Error("connect ECONNREFUSED");
+}) as unknown as typeof fetch;
+
+let stateDir = "";
+
+beforeEach(async () => {
+	stateDir = await mkdtemp(path.join(os.tmpdir(), "ao-paired-machines-"));
+});
+afterEach(async () => {
+	await rm(stateDir, { recursive: true, force: true });
+});
+
+function controller(netFetch: typeof fetch = unreachableFetch) {
+	return createPairedMachinesController({ stateDir, safeStorage, netFetch, probeTimeoutMs: 200 });
+}
+
+test("starts empty", async () => {
+	const machines = controller();
+	await machines.load();
+	expect(machines.list()).toEqual([]);
+});
+
+test("probing a box with no pin yet captures the presented fingerprint without pairing it", async () => {
+	// netFetch must run the SAME controller's verifyCertificate that
+	// probeFingerprint marks the host pending on, exactly as Electron's
+	// network service and session.setCertificateVerifyProc share one session
+	// in the real app. The indirection here only exists because the
+	// controller and its netFetch dependency would otherwise be a
+	// construction cycle.
+	let verify: PairCertificateVerifyProc | undefined;
+	const netFetch = netFetchPresenting(CERT_PEM, (request, callback) => verify?.(request, callback));
+	const machines = createPairedMachinesController({ stateDir, safeStorage, netFetch, probeTimeoutMs: 200 });
+	verify = machines.verifyCertificate;
+	await machines.load();
+
+	const result = await machines.probeFingerprint("192.168.1.5", 8443);
+	expect(result).toEqual({ fingerprint: CERT_FINGERPRINT });
+	// Nothing was pinned by the probe alone.
+	expect(machines.list()).toEqual([]);
+});
+
+test("probing an unreachable address reports an error, not a fingerprint", async () => {
+	const machines = controller(unreachableFetch);
+	await machines.load();
+	const result = await machines.probeFingerprint("192.168.1.9", 8443);
+	expect(result).toEqual({ error: expect.stringContaining("No certificate could be retrieved") });
+});
+
+test("add persists the pairing and round-trips through disk", async () => {
+	const machines = controller();
+	await machines.load();
+
+	const added = await machines.add({
+		id: "box_1",
+		name: "Pi in the closet",
+		address: "192.168.1.5",
+		port: 8443,
+		passcode: "abc123XY",
+		fingerprint: CERT_FINGERPRINT,
+	});
+	expect(added).toMatchObject({
+		id: "box_1",
+		name: "Pi in the closet",
+		baseUrl: "https://192.168.1.5:8443",
+		local: false,
+		reachability: "unknown",
+	});
+
+	// Reload as a fresh controller, the way a relaunch would.
+	const reloaded = createPairedMachinesController({ stateDir, safeStorage });
+	await reloaded.load();
+	expect(reloaded.list()).toEqual([added]);
+});
+
+test("the passcode is never written to disk in plaintext, and round-trips through safeStorage", async () => {
+	const machines = controller();
+	await machines.load();
+	await machines.add({
+		id: "box_1",
+		name: "Pi",
+		address: "192.168.1.5",
+		port: 8443,
+		passcode: "super-secret-passcode",
+		fingerprint: CERT_FINGERPRINT,
+	});
+
+	const onDisk = await readFile(path.join(stateDir, AO_PAIRED_MACHINES_FILE_NAME), "utf8");
+	expect(onDisk).not.toContain("super-secret-passcode");
+
+	expect(await machines.getPasscode("box_1")).toBe("super-secret-passcode");
+	expect(await machines.getPasscode("no_such_machine")).toBeNull();
+});
+
+test("remove drops the machine and persists the removal", async () => {
+	const machines = controller();
+	await machines.load();
+	await machines.add({
+		id: "box_1",
+		name: "Pi",
+		address: "192.168.1.5",
+		port: 8443,
+		passcode: "abc123XY",
+		fingerprint: CERT_FINGERPRINT,
+	});
+	await machines.remove("box_1");
+	expect(machines.list()).toEqual([]);
+
+	const reloaded = createPairedMachinesController({ stateDir, safeStorage });
+	await reloaded.load();
+	expect(reloaded.list()).toEqual([]);
+});
+
+test("after pairing, the pin is enforced: the same certificate is accepted", async () => {
+	const machines = controller();
+	await machines.load();
+	await machines.add({
+		id: "box_1",
+		name: "Pi",
+		address: "192.168.1.5",
+		port: 8443,
+		passcode: "abc123XY",
+		fingerprint: CERT_FINGERPRINT,
+	});
+
+	const callback = vi.fn();
+	machines.verifyCertificate({ hostname: "192.168.1.5", certificate: { data: CERT_PEM } }, callback);
+	expect(callback).toHaveBeenCalledExactlyOnceWith(0);
+});
+
+test("after pairing, a swapped certificate on the same host is refused, with no fallback", async () => {
+	const machines = controller();
+	await machines.load();
+	await machines.add({
+		id: "box_1",
+		name: "Pi",
+		address: "192.168.1.5",
+		port: 8443,
+		passcode: "abc123XY",
+		fingerprint: CERT_FINGERPRINT,
+	});
+
+	const callback = vi.fn();
+	machines.verifyCertificate({ hostname: "192.168.1.5", certificate: { data: OTHER_CERT_PEM } }, callback);
+	expect(callback).toHaveBeenCalledExactlyOnceWith(-2);
+});
+
+test("a host that was never paired or probed gets default certificate verification", async () => {
+	const machines = controller();
+	await machines.load();
+	await machines.add({
+		id: "box_1",
+		name: "Pi",
+		address: "192.168.1.5",
+		port: 8443,
+		passcode: "abc123XY",
+		fingerprint: CERT_FINGERPRINT,
+	});
+
+	// ao.agentlab.in (the control plane) and any other unrelated host must be
+	// completely unaffected by a pin that exists for a different machine.
+	const callback = vi.fn();
+	machines.verifyCertificate({ hostname: "ao.agentlab.in", certificate: { data: CERT_PEM } }, callback);
+	expect(callback).toHaveBeenCalledExactlyOnceWith(-3);
+});
+
+test("add refuses the reserved local machine id, an out-of-range port, and an unusable address", async () => {
+	const machines = controller();
+	await machines.load();
+
+	await expect(
+		machines.add({ id: "local", name: "x", address: "192.168.1.5", port: 8443, passcode: "p", fingerprint: CERT_FINGERPRINT }),
+	).rejects.toThrow(/machine id/);
+	await expect(
+		machines.add({ id: "box_1", name: "x", address: "192.168.1.5", port: 99999, passcode: "p", fingerprint: CERT_FINGERPRINT }),
+	).rejects.toThrow(/valid port/);
+	await expect(
+		machines.add({ id: "box_1", name: "x", address: "not a host!", port: 8443, passcode: "p", fingerprint: CERT_FINGERPRINT }),
+	).rejects.toThrow(/usable address/);
+});

--- a/frontend/src/main/paired-machines.ts
+++ b/frontend/src/main/paired-machines.ts
@@ -1,0 +1,347 @@
+import { randomBytes } from "node:crypto";
+import { mkdir, open, readFile, rename, rm } from "node:fs/promises";
+import path from "node:path";
+import { LOCAL_MACHINE_ID, parseMachineOrigin, type AoMachine } from "../shared/ao-machines";
+import type { SafeStorageLike } from "./ao-account-store";
+import { createPairCertificateVerifyProc, type PairCertificateVerifyProc } from "./paired-machine-cert";
+import { fetchWithDeadline } from "./request-deadline";
+
+/**
+ * The registry of paired boxes (docs/adr/0003-pair-mode-gateway.md) and their
+ * pinned certificate fingerprints: the third machine origin, alongside local
+ * and hosted, reusing `AoMachine` rather than a parallel shape.
+ *
+ * Everything here lives under the state root and never reaches the control
+ * plane: pair mode's whole point is a box that needs no domain and no
+ * account, so nothing about it is sent anywhere but this file on disk. The
+ * passcode is encrypted with the same `safeStorage` mechanism
+ * ao-account-store.ts already uses for the account refresh token.
+ *
+ * This module owns the data and the transport-level pin enforcement
+ * (`verifyCertificate`, wired into `session.defaultSession` in main.ts). The
+ * add-machine screen, the passcode entry form, and the fingerprint comparison
+ * screen are a different task (batch 3, task 8); this module only exposes
+ * what that UI needs through the preload bridge.
+ */
+
+/** File under the ~/.ao state dir, beside ao-account.json and ao-machine.json. */
+export const AO_PAIRED_MACHINES_FILE_NAME = "ao-paired-machines.json";
+
+const SCHEMA_VERSION = 1;
+
+/** A probe attempt is denied by design (see paired-machine-cert.ts); this just
+ * bounds how long the app waits for the TLS handshake that captures the
+ * presented fingerprint before giving up. */
+const DEFAULT_PROBE_TIMEOUT_MS = 8000;
+
+export type PairedMachineRecord = {
+	id: string;
+	name: string;
+	address: string;
+	port: number;
+	/** Null until the user has compared and accepted a fingerprint. */
+	pinnedFingerprint: string | null;
+	lastSeen: string | null;
+};
+
+type PersistedPairedMachine = PairedMachineRecord & {
+	/** base64 of safeStorage.encryptString(passcode). */
+	passcode: string;
+};
+
+type PairedMachinesFile = {
+	version: number;
+	machines: PersistedPairedMachine[];
+};
+
+export type PairFingerprintResult = { fingerprint: string } | { error: string };
+
+export type PairedMachinesControllerDeps = {
+	/** The ~/.ao state dir, or null when the home dir is unresolvable. */
+	stateDir: string | null;
+	safeStorage: SafeStorageLike;
+	/** Electron's `net.fetch`, which runs through the session's network stack
+	 * and therefore through `verifyCertificate` below. A plain global `fetch`
+	 * would not: it bypasses the session entirely, which is exactly the gap
+	 * this whole module exists to close. */
+	netFetch?: typeof fetch;
+	probeTimeoutMs?: number;
+};
+
+export type PairedMachinesController = {
+	/** Load the registry off disk. Must resolve before `verifyCertificate` can
+	 * see any pin: it runs synchronously off the in-memory cache this builds,
+	 * because Electron calls it from the network service without awaiting it. */
+	load: () => Promise<void>;
+	list: () => AoMachine[];
+	/**
+	 * Add a newly paired machine, or update an existing one (matched by id) --
+	 * a re-pair after a fingerprint mismatch is the same call with a fresh
+	 * fingerprint and passcode. `fingerprint` must already be the value the
+	 * user compared and accepted; this module never pins one on its own.
+	 */
+	add: (input: {
+		id: string;
+		name: string;
+		address: string;
+		port: number;
+		passcode: string;
+		fingerprint: string;
+	}) => Promise<AoMachine>;
+	remove: (id: string) => Promise<void>;
+	/** Decrypted passcode for a paired machine, or null if it is not registered. */
+	getPasscode: (id: string) => Promise<string | null>;
+	touchLastSeen: (id: string) => Promise<void>;
+	/**
+	 * Attempt a connection to an address:port that is not (yet) a registered
+	 * paired machine, so the pairing flow can show the presented fingerprint
+	 * for comparison against what the box printed. The connection is always
+	 * denied at the TLS layer (see paired-machine-cert.ts): this only ever
+	 * captures what was presented, it never trusts it.
+	 */
+	probeFingerprint: (address: string, port: number) => Promise<PairFingerprintResult>;
+	/** Wire directly into `session.defaultSession.setCertificateVerifyProc`. */
+	verifyCertificate: PairCertificateVerifyProc;
+};
+
+function filePath(stateDir: string): string {
+	return path.join(stateDir, AO_PAIRED_MACHINES_FILE_NAME);
+}
+
+function validatePort(port: number): boolean {
+	return Number.isInteger(port) && port > 0 && port <= 65535;
+}
+
+/** `AoMachine.baseUrl` for a paired machine, and the validation gate for its
+ * address: reuses parseMachineOrigin rather than re-deriving the same rules
+ * about scheme, path, and credentials. */
+function baseUrlFor(address: string, port: number): string | null {
+	return parseMachineOrigin(`https://${address}:${port}`);
+}
+
+async function readAll(stateDir: string): Promise<PersistedPairedMachine[]> {
+	let raw: string;
+	try {
+		raw = await readFile(filePath(stateDir), "utf8");
+	} catch (err) {
+		const code = (err as NodeJS.ErrnoException).code;
+		if (code === "ENOENT" || code === "ENOTDIR") return [];
+		throw err;
+	}
+	let parsed: Partial<PairedMachinesFile>;
+	try {
+		parsed = JSON.parse(raw) as Partial<PairedMachinesFile>;
+	} catch {
+		return [];
+	}
+	if (parsed.version !== SCHEMA_VERSION || !Array.isArray(parsed.machines)) return [];
+	return parsed.machines.filter((machine): machine is PersistedPairedMachine => {
+		return (
+			!!machine &&
+			typeof machine.id === "string" &&
+			!!machine.id &&
+			typeof machine.address === "string" &&
+			!!machine.address &&
+			validatePort(machine.port) &&
+			typeof machine.passcode === "string"
+		);
+	});
+}
+
+/** Atomic write, mirroring ao-account.json and ao-machine.json: a random-named
+ * temp file in the same dir, fsync, then rename, so a reader never observes a
+ * half-written registry and a crashed write cannot leave a stale temp with
+ * predictable permissions. */
+async function writeAll(stateDir: string, machines: PersistedPairedMachine[]): Promise<void> {
+	const file: PairedMachinesFile = { version: SCHEMA_VERSION, machines };
+	await mkdir(stateDir, { recursive: true, mode: 0o750 });
+	const tmp = path.join(stateDir, `.ao-paired-machines-${randomBytes(8).toString("hex")}.json`);
+	try {
+		const handle = await open(tmp, "wx", 0o600);
+		try {
+			await handle.writeFile(`${JSON.stringify(file, null, 2)}\n`);
+			await handle.sync();
+		} finally {
+			await handle.close();
+		}
+		await rename(tmp, filePath(stateDir));
+	} catch (err) {
+		await rm(tmp, { force: true });
+		throw err;
+	}
+}
+
+function toAoMachine(record: PairedMachineRecord): AoMachine | null {
+	const baseUrl = baseUrlFor(record.address, record.port);
+	if (!baseUrl) return null;
+	return {
+		id: record.id,
+		name: record.name || record.address,
+		baseUrl,
+		local: false,
+		createdAt: null,
+		lastSeen: record.lastSeen,
+		reachability: "unknown",
+		harness: "unknown",
+		harnessCommand: null,
+	};
+}
+
+export function createPairedMachinesController(deps: PairedMachinesControllerDeps): PairedMachinesController {
+	const netFetch = deps.netFetch ?? fetch;
+	const probeTimeoutMs = deps.probeTimeoutMs ?? DEFAULT_PROBE_TIMEOUT_MS;
+
+	/** In-memory mirror of disk, keyed by id. verifyCertificate reads only the
+	 * derived maps below, never this directly, and never touches disk: it must
+	 * stay synchronous. */
+	let records = new Map<string, PersistedPairedMachine>();
+	/** hostname -> pinned fingerprint, for every record that has one. Rebuilt
+	 * whenever `records` changes. */
+	let pinnedByHost = new Map<string, string>();
+	/** Hosts currently mid-probe for first-time pairing: not yet in `records`,
+	 * but connections to them must still be intercepted so the presented
+	 * fingerprint can be captured instead of falling through to default
+	 * verification (which would fail anyway, and would capture nothing). */
+	const pendingHosts = new Set<string>();
+	/** Latest fingerprint actually presented per hostname, for any host
+	 * `isPairHost` recognises. What `probeFingerprint` reads back. */
+	const presented = new Map<string, string>();
+
+	function rebuildPinnedByHost(): void {
+		pinnedByHost = new Map(
+			[...records.values()]
+				.filter((record) => record.pinnedFingerprint)
+				.map((record) => [record.address, record.pinnedFingerprint as string]),
+		);
+	}
+
+	async function persist(): Promise<void> {
+		if (!deps.stateDir) throw new Error("Could not resolve the ~/.ao state directory, so pairing cannot be saved.");
+		await writeAll(deps.stateDir, [...records.values()]);
+	}
+
+	const verifyCertificate = createPairCertificateVerifyProc({
+		isPairHost: (hostname) => pendingHosts.has(hostname) || pinnedByHost.has(hostname),
+		getPinnedFingerprint: (hostname) => pinnedByHost.get(hostname) ?? null,
+		onPresented: (hostname, fingerprint) => presented.set(hostname, fingerprint),
+	});
+
+	return {
+		async load(): Promise<void> {
+			if (!deps.stateDir) return;
+			const rows = await readAll(deps.stateDir);
+			records = new Map(rows.map((row) => [row.id, row]));
+			rebuildPinnedByHost();
+		},
+
+		list(): AoMachine[] {
+			return [...records.values()]
+				.map((record) => toAoMachine(record))
+				.filter((machine): machine is AoMachine => machine !== null);
+		},
+
+		async add(input): Promise<AoMachine> {
+			if (!input.id || input.id === LOCAL_MACHINE_ID) throw new Error(`Not a usable machine id: ${input.id}`);
+			if (!validatePort(input.port)) throw new Error(`Not a valid port: ${input.port}`);
+			const baseUrl = baseUrlFor(input.address, input.port);
+			if (!baseUrl) throw new Error(`Not a usable address: ${input.address}`);
+			if (!input.fingerprint) throw new Error("Refusing to pair a machine with no accepted fingerprint.");
+			if (!input.passcode) throw new Error("Refusing to store an empty passcode.");
+			if (!deps.safeStorage.isEncryptionAvailable()) {
+				throw new Error(
+					"This system has no OS credential store available, so the paired machine's passcode cannot be " +
+						"encrypted. The app will not write it to disk in plaintext.",
+				);
+			}
+			const record: PersistedPairedMachine = {
+				id: input.id,
+				name: input.name || input.address,
+				address: input.address,
+				port: input.port,
+				pinnedFingerprint: input.fingerprint,
+				lastSeen: records.get(input.id)?.lastSeen ?? null,
+				passcode: deps.safeStorage.encryptString(input.passcode).toString("base64"),
+			};
+			const previous = records;
+			records = new Map(previous).set(record.id, record);
+			rebuildPinnedByHost();
+			try {
+				await persist();
+			} catch (err) {
+				records = previous;
+				rebuildPinnedByHost();
+				throw err;
+			}
+			const machine = toAoMachine(record);
+			if (!machine) throw new Error(`Not a usable address: ${input.address}`);
+			return machine;
+		},
+
+		async remove(id: string): Promise<void> {
+			if (!records.has(id)) return;
+			const previous = records;
+			records = new Map(previous);
+			records.delete(id);
+			rebuildPinnedByHost();
+			try {
+				await persist();
+			} catch (err) {
+				records = previous;
+				rebuildPinnedByHost();
+				throw err;
+			}
+		},
+
+		async getPasscode(id: string): Promise<string | null> {
+			const record = records.get(id);
+			if (!record) return null;
+			if (!deps.safeStorage.isEncryptionAvailable()) {
+				throw new Error("This system has no OS credential store available, so the paired machine's passcode cannot be read.");
+			}
+			try {
+				return deps.safeStorage.decryptString(Buffer.from(record.passcode, "base64"));
+			} catch {
+				throw new Error("This paired machine's stored passcode could not be decrypted on this machine. Re-pair it.");
+			}
+		},
+
+		async touchLastSeen(id: string): Promise<void> {
+			const record = records.get(id);
+			if (!record) return;
+			const previous = records;
+			records = new Map(previous).set(id, { ...record, lastSeen: new Date().toISOString() });
+			try {
+				await persist();
+			} catch (err) {
+				records = previous;
+				throw err;
+			}
+		},
+
+		async probeFingerprint(address: string, port: number): Promise<PairFingerprintResult> {
+			if (!validatePort(port)) return { error: `Not a valid port: ${port}` };
+			const baseUrl = baseUrlFor(address, port);
+			if (!baseUrl) return { error: `Not a usable address: ${address}` };
+
+			presented.delete(address);
+			pendingHosts.add(address);
+			try {
+				await fetchWithDeadline(netFetch, `${baseUrl}/`, { method: "GET", redirect: "manual" }, probeTimeoutMs, "Pairing probe");
+			} catch {
+				// Expected: an unpinned host is always denied at the TLS layer (see
+				// paired-machine-cert.ts), and a box that is simply unreachable denies
+				// nothing to capture at all. Either way, the fingerprint map below is
+				// the source of truth for whether anything was actually presented.
+			} finally {
+				pendingHosts.delete(address);
+			}
+
+			const fingerprint = presented.get(address);
+			return fingerprint
+				? { fingerprint }
+				: { error: "No certificate could be retrieved from that address. Check the address, port, and that the box is reachable." };
+		},
+
+		verifyCertificate,
+	};
+}

--- a/frontend/src/preload.ts
+++ b/frontend/src/preload.ts
@@ -14,8 +14,9 @@ import {
 	type TrayOpenSessionTarget,
 } from "./shared/tray";
 import type { AoAccountState } from "./shared/ao-account";
-import type { AoMachinesState } from "./shared/ao-machines";
+import type { AoMachine, AoMachinesState } from "./shared/ao-machines";
 import type { PeerWorkspacesResult } from "./shared/peer-workspaces";
+import type { PairFingerprintResult } from "./main/paired-machines";
 import type { DaemonStatus } from "./shared/daemon-status";
 import type { TelemetryBootstrap } from "./shared/telemetry";
 import type { MigrationState } from "./main/app-state";
@@ -348,6 +349,23 @@ const api = {
 		// listing alongside the active machine's. No URL or token here either;
 		// the main process fetches it and shapes the result.
 		peerWorkspaces: () => ipcRenderer.invoke("aoMachines:peerWorkspaces") as Promise<PeerWorkspacesResult>,
+	},
+	// Paired boxes (docs/adr/0003-pair-mode-gateway.md): the data and pin-store
+	// half. The add-machine form, the passcode entry, and the fingerprint
+	// comparison screen are a different task; this is what that UI calls into.
+	pairedMachines: {
+		list: () => ipcRenderer.invoke("pairedMachines:list") as Promise<AoMachine[]>,
+		// Attempts a connection so the caller can show the presented fingerprint
+		// for comparison against what the box printed. The connection itself is
+		// always denied (trust-on-first-use never auto-accepts); this only ever
+		// reports what was seen, or an error when nothing was.
+		probeFingerprint: (address: string, port: number) =>
+			ipcRenderer.invoke("pairedMachines:probeFingerprint", address, port) as Promise<PairFingerprintResult>,
+		// Persists the pairing. `fingerprint` must be the value the user compared
+		// and accepted; nothing here pins one on the caller's behalf.
+		add: (input: { id: string; name: string; address: string; port: number; passcode: string; fingerprint: string }) =>
+			ipcRenderer.invoke("pairedMachines:add", input) as Promise<AoMachine>,
+		remove: (id: string) => ipcRenderer.invoke("pairedMachines:remove", id) as Promise<void>,
 	},
 };
 

--- a/frontend/src/renderer/lib/bridge.ts
+++ b/frontend/src/renderer/lib/bridge.ts
@@ -325,4 +325,16 @@ export const aoBridge: AoBridge =
 			gatewayToken: async () => null,
 			peerWorkspaces: async () => browserPreviewPeerWorkspaces(),
 		},
+		// Browser preview has no main process, so no pin store and nothing to
+		// probe or pair.
+		pairedMachines: {
+			list: async () => [],
+			probeFingerprint: async () => ({
+				error: "Pairing needs the desktop app; it is not available in browser preview.",
+			}),
+			add: async () => {
+				throw new Error("Pairing needs the desktop app; it is not available in browser preview.");
+			},
+			remove: async () => undefined,
+		},
 	} satisfies AoBridge);

--- a/frontend/src/renderer/test/setup.ts
+++ b/frontend/src/renderer/test/setup.ts
@@ -246,5 +246,13 @@ if (typeof window !== "undefined") {
 			gatewayToken: async () => null,
 			peerWorkspaces: async () => noPeerRegistered,
 		},
+		pairedMachines: {
+			list: async () => [],
+			probeFingerprint: async () => ({ error: "not available in tests" }),
+			add: async () => {
+				throw new Error("not available in tests");
+			},
+			remove: async () => undefined,
+		},
 	};
 } // end if (typeof window !== "undefined")


### PR DESCRIPTION
## Summary

Desktop-side data and transport layer for pair mode (Refs #86, task 6). Implements:

- **Paired-machine registry** (`frontend/src/main/paired-machines.ts`) under the state root, keyed the same way `ao-account.json`/`ao-machine.json` are: atomic write, one JSON file. Stores address, port, machine id, display name, pinned fingerprint, and last-seen. Reuses `AoMachine` (via `frontend/src/shared/ao-machines.ts`) rather than a parallel shape; never contacts the control plane.
- **Passcode storage** encrypted with `safeStorage`, the same mechanism `ao-account-store.ts` uses for the account refresh token. Never written to disk in plaintext.
- **Pin enforcement at the Electron session level**, via `session.defaultSession.setCertificateVerifyProc` (`frontend/src/main/paired-machine-cert.ts`), wired up in `main.ts` before the window opens. This is the load-bearing part of the task: enforcing at the session covers the terminal mux WebSocket and the SSE stream, not only REST, because all three ride the same session's TLS connections. A host that is not a paired machine gets Chromium's default verification, completely untouched.
- **Hard refusal on mismatch.** A pinned machine whose presented certificate does not match is refused with `CERT_VERIFY_REJECT` and no fallback path exists in the code (no click-through, no "connect anyway").
- **First-connect capture.** `probeFingerprint(address, port)` attempts a connection to an unpaired candidate; the connection is always denied (trust-on-first-use never auto-accepts), but the presented fingerprint is captured and returned so a future pairing UI can show it for comparison.

Fingerprints are computed with `node:crypto`'s `X509Certificate.fingerprint256`, which renders SHA-256 over the leaf certificate's DER bytes as uppercase hex octets joined by colons; this is byte-for-byte the same rendering as backend `PairFingerprint` (`backend/internal/vmgateway/paircert.go`), verified against a real certificate fixture in the tests.

## Scope

Main-process data and transport layer only. The add-machine screen, passcode entry form, and fingerprint comparison screen are a separate task (batch 3, task 8); this exposes `list`, `probeFingerprint`, `add`, and `remove` through the existing preload/bridge pattern (`ao.pairedMachines.*`) for that UI to call into.

## Test plan

- [x] `cd frontend && npm run typecheck` passes
- [x] `npx vitest run src/main/paired-machine-cert.test.ts src/main/paired-machines.test.ts` (20 tests): fingerprint format match, pin accept/mismatch/no-fallback, non-pair-host default verification, first-connect capture without auto-accept, registry round-trip through disk, passcode never on disk in plaintext
- [x] `npx vitest run src/main/ao-machines.test.ts` still green, including the signed-out no-network-call regression at `frontend/src/main/ao-machines.test.ts:107`
- [x] Full `npx vitest run`: 2274/2279 passing; the 5 failures are pre-existing and unrelated (`src/landing/scripts/generate-markdown-twins.test.mjs`, missing `cheerio` dependency in the landing workspace)