### PR TITLE
feat(vmgateway): add pair-mode passcode authentication

### DIFF
--- a/backend/internal/cli/vm.go
+++ b/backend/internal/cli/vm.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"fmt"
 	"log/slog"
+	"net/http"
 	"os"
 	"os/signal"
 	"strings"
@@ -57,6 +58,7 @@ func newVMServeCommand(ctx *commandContext) *cobra.Command {
 	flags.StringVar(&opts.CertDir, "cert-dir", "", "ACME certificate cache directory (default under the AO data dir)")
 	flags.StringVar(&opts.HTTPAddr, "http-addr", "", fmt.Sprintf("ACME HTTP-01 challenge / redirect listener address (default %s)", vmgateway.DefaultHTTPAddr))
 	flags.StringVar(&opts.HTTPSAddr, "https-addr", "", fmt.Sprintf("Public TLS listener address (default %s)", vmgateway.DefaultHTTPSAddr))
+	flags.StringVar(&opts.PasscodeDir, "passcode-dir", "", "Pair-mode passcode hash storage directory (default under the state root; pair mode only)")
 	return cmd
 }
 
@@ -89,26 +91,42 @@ func (c *commandContext) runVMServe(cmd *cobra.Command, opts vmgateway.Options) 
 
 	log := slog.New(slog.NewTextHandler(cmd.ErrOrStderr(), nil))
 
-	verify := vmgateway.VerifyOptions{
-		Issuer:   gwCfg.Issuer,
-		Audience: gwCfg.MachineID,
-		Subject:  gwCfg.AccountID,
-		Skew:     vmgateway.DefaultSkew,
-	}
-	jwks := vmgateway.NewJWKSCache(gwCfg.JWKSURL, nil)
-
 	// resolveDaemonAddr lets the gateway recover on its own if the daemon was
 	// not up yet at gateway boot (discoverDaemonAddr returned nothing, so
 	// gwCfg.DaemonAddr is DefaultDaemonAddr) or later restarts onto a
-	// different port: NewHandler's proxy re-reads running.json after a
-	// connection failure instead of proxying to a dead port until this
-	// process is restarted. nil when the address was pinned, so a re-resolve
-	// never overrides it.
+	// different port: the proxy re-reads running.json after a connection
+	// failure instead of proxying to a dead port until this process is
+	// restarted. nil when the address was pinned, so a re-resolve never
+	// overrides it.
 	var resolveDaemonAddr func() (string, bool)
 	if !pinnedDaemonAddr {
 		resolveDaemonAddr = func() (string, bool) { return discoverDaemonAddr(cfg.RunFilePath) }
 	}
-	handler, err := vmgateway.NewHandler(gwCfg.DaemonAddr, resolveDaemonAddr, jwks, verify, cfg.AllowedOrigins, log)
+
+	// The credential check is mode-specific and mutually exclusive, mirroring
+	// gwCfg.Mode itself: hosted mode verifies a machine-audience JWT against
+	// the control plane's JWKS, exactly as before pair mode existed; pair
+	// mode loads the persisted passcode store instead and never touches JWKS
+	// at all. A missing or corrupt passcode store is fatal here, before any
+	// socket is bound, per docs/adr/0003-pair-mode-gateway.md.
+	var handler http.Handler
+	switch gwCfg.Mode {
+	case vmgateway.ModePair:
+		passcodes, loadErr := vmgateway.LoadPasscodeStore(gwCfg.PasscodeDir)
+		if loadErr != nil {
+			return loadErr
+		}
+		handler, err = vmgateway.NewPairHandler(gwCfg.DaemonAddr, resolveDaemonAddr, passcodes, cfg.AllowedOrigins, log)
+	default:
+		verify := vmgateway.VerifyOptions{
+			Issuer:   gwCfg.Issuer,
+			Audience: gwCfg.MachineID,
+			Subject:  gwCfg.AccountID,
+			Skew:     vmgateway.DefaultSkew,
+		}
+		jwks := vmgateway.NewJWKSCache(gwCfg.JWKSURL, nil)
+		handler, err = vmgateway.NewHandler(gwCfg.DaemonAddr, resolveDaemonAddr, jwks, verify, cfg.AllowedOrigins, log)
+	}
 	if err != nil {
 		return fmt.Errorf("build gateway handler: %w", err)
 	}

--- a/backend/internal/vmgateway/config.go
+++ b/backend/internal/vmgateway/config.go
@@ -104,6 +104,11 @@ type Config struct {
 	HTTPAddr string
 	// HTTPSAddr is the public TLS listener address. Used by both modes.
 	HTTPSAddr string
+	// PasscodeDir is where the pair-mode passcode's hash is persisted
+	// (passcode.hash; see LoadPasscodeStore and GeneratePasscode in
+	// passcode.go). Pair-only: always empty in hosted mode, which has no
+	// passcode and no notion of this directory at all.
+	PasscodeDir string
 }
 
 // Options carries the raw flag values from the `ao vm serve` command, before
@@ -120,6 +125,9 @@ type Options struct {
 	CertDir     string
 	HTTPAddr    string
 	HTTPSAddr   string
+	// PasscodeDir overrides where the pair-mode passcode hash is stored; see
+	// Config.PasscodeDir. Pair mode only.
+	PasscodeDir string
 	// Pair requests ModePair instead of ModeHosted. See AO_VM_PAIR.
 	Pair bool
 }
@@ -151,6 +159,8 @@ type Options struct {
 //	                                                 in pair mode)
 //	AO_VM_HTTP_ADDR     ACME challenge listener     (default DefaultHTTPAddr; hosted only)
 //	AO_VM_HTTPS_ADDR    public TLS listener         (default DefaultHTTPSAddr)
+//	AO_VM_PASSCODE_DIR  pair-mode passcode hash dir (default <state root>/vm-gateway/pair-passcode;
+//	                                                 pair only)
 func Resolve(opts Options, dataDir string) (Config, error) {
 	pairMode, err := resolvePairMode(opts)
 	if err != nil {
@@ -326,6 +336,15 @@ func resolvePair(cfg Config, opts Options) (Config, error) {
 		cfg.CertDir = filepath.Join(stateDir, "vm-gateway", "pair-cert")
 	}
 
+	cfg.PasscodeDir = firstNonEmpty(opts.PasscodeDir, os.Getenv("AO_VM_PASSCODE_DIR"))
+	if cfg.PasscodeDir == "" {
+		dir, err := DefaultPasscodeDir()
+		if err != nil {
+			return Config{}, err
+		}
+		cfg.PasscodeDir = dir
+	}
+
 	return cfg, nil
 }
 
@@ -395,6 +414,21 @@ func DefaultMachineFilePath() (string, error) {
 		return "", fmt.Errorf("resolve machine file path: %w", err)
 	}
 	return filepath.Join(stateDir, "machine.json"), nil
+}
+
+// DefaultPasscodeDir is where the pair-mode passcode's hash is persisted
+// when --passcode-dir/AO_VM_PASSCODE_DIR is unset:
+// <state root>/vm-gateway/pair-passcode, a sibling of the pair
+// certificate's own default directory (<state root>/vm-gateway/pair-cert;
+// see resolvePair). Exported so provisioning (ao setup-vm --pair, batch 3)
+// calls GeneratePasscode against the exact directory this package's own
+// default resolves to, without duplicating the path.
+func DefaultPasscodeDir() (string, error) {
+	stateDir, err := config.DefaultStateDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve pair passcode dir: %w", err)
+	}
+	return filepath.Join(stateDir, "vm-gateway", "pair-passcode"), nil
 }
 
 // firstNonEmpty returns the first non-empty (after trimming) candidate, or ""

--- a/backend/internal/vmgateway/passcode.go
+++ b/backend/internal/vmgateway/passcode.go
@@ -1,0 +1,311 @@
+package vmgateway
+
+import (
+	"encoding/hex"
+	"fmt"
+	"log/slog"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/httpd/envelope"
+	"github.com/aoagents/agent-orchestrator/backend/internal/mobilebridge"
+)
+
+// passcodeFileName is the single file LoadPasscodeStore/GeneratePasscode
+// persist under a pair-mode Config.PasscodeDir. Only the hash is ever
+// written to disk; the plaintext passcode exists only in memory, for the
+// instant between generation and being handed to the caller (a provisioning
+// command that prints it once, or Rotate's return value), and this package
+// never persists it anywhere.
+const passcodeFileName = "passcode.hash"
+
+// passcodeHashHexLen is the length of mobilebridge.HashPassword's
+// hex-encoded SHA-256 output. readPasscodeHash uses it to recognise a
+// corrupt file (anything else found on disk) instead of silently treating
+// garbage as a hash no real passcode will ever match.
+const passcodeHashHexLen = 64
+
+// PasscodeStore holds a pair-mode gateway's current passcode hash in memory,
+// loaded from and persisted to a single file (passcode.hash) under a
+// pair-mode Config.PasscodeDir. It never holds the plaintext passcode.
+//
+// LoadPasscodeStore requires the file to already exist and be well-formed.
+// Per docs/adr/0003-pair-mode-gateway.md, a gateway that starts with no
+// usable passcode would be an open door, so a missing or corrupt store fails
+// loudly at startup rather than falling back to "generate one now" (which
+// would silently start authenticating every request against a passcode
+// nobody has ever seen) or "accept everything" (the actual open door).
+// Provisioning (ao setup-vm --pair, batch 3) creates the file with
+// GeneratePasscode before the gateway process that loads it is ever started.
+type PasscodeStore struct {
+	dir  string
+	hash atomic.Pointer[string]
+}
+
+// LoadPasscodeStore reads the persisted passcode hash from dir and returns a
+// store ready to verify requests against it. See the PasscodeStore doc for
+// why a missing or corrupt file is a fatal error here rather than a fallback.
+func LoadPasscodeStore(dir string) (*PasscodeStore, error) {
+	hash, err := readPasscodeHash(dir)
+	if err != nil {
+		return nil, err
+	}
+	s := &PasscodeStore{dir: dir}
+	s.hash.Store(&hash)
+	return s, nil
+}
+
+// currentHash returns the passcode hash currently in effect. Safe for
+// concurrent use with Rotate: the pointer swap in Rotate is atomic, so a
+// request in flight sees either the old or the new hash in full, never a
+// torn value.
+func (s *PasscodeStore) currentHash() string {
+	if p := s.hash.Load(); p != nil {
+		return *p
+	}
+	return ""
+}
+
+// Rotate generates a fresh passcode, persists its hash to disk, and swaps
+// the store's in-memory hash so the very next request checked against it,
+// from any client including ones already connected, is verified against the
+// new value and fails if it still presents the old one. It returns the new
+// plaintext passcode exactly once; printing it is the caller's job (a
+// rotate command, not built in this change), matching Connect Mobile's own
+// rotate semantics: dropping every connected client.
+func (s *PasscodeStore) Rotate() (string, error) {
+	plaintext, hash, err := newPasscodeHash()
+	if err != nil {
+		return "", err
+	}
+	if err := writePasscodeHash(s.dir, hash); err != nil {
+		return "", err
+	}
+	s.hash.Store(&hash)
+	return plaintext, nil
+}
+
+// GeneratePasscode creates a brand-new passcode and persists its hash under
+// dir, for first-run provisioning where no store has been loaded yet (ao
+// setup-vm --pair, batch 3): LoadPasscodeStore fails loudly against an empty
+// directory by design, so provisioning calls this instead, before the
+// gateway process that will later call LoadPasscodeStore ever starts. It
+// returns the plaintext passcode exactly once; the caller prints it, this
+// package does not.
+func GeneratePasscode(dir string) (string, error) {
+	plaintext, hash, err := newPasscodeHash()
+	if err != nil {
+		return "", err
+	}
+	if err := writePasscodeHash(dir, hash); err != nil {
+		return "", err
+	}
+	return plaintext, nil
+}
+
+// newPasscodeHash generates a fresh plaintext passcode and its hash, without
+// touching disk. It reuses mobilebridge.GeneratePassword rather than a
+// second alphanumeric generator: the spec for both is identical (8
+// characters, alphanumeric, drawn from a cryptographically secure source),
+// and mobilebridge is already a dependency of this package for
+// HashPassword/PasswordMatches.
+func newPasscodeHash() (plaintext, hash string, err error) {
+	plaintext, err = mobilebridge.GeneratePassword()
+	if err != nil {
+		return "", "", fmt.Errorf("generate passcode: %w", err)
+	}
+	return plaintext, mobilebridge.HashPassword(plaintext), nil
+}
+
+func passcodeHashPath(dir string) string {
+	return filepath.Join(dir, passcodeFileName)
+}
+
+// readPasscodeHash reads and validates the persisted hash at dir, failing
+// loudly, rather than falling back to any default, on either a missing file
+// or one that cannot be a real mobilebridge.HashPassword output.
+func readPasscodeHash(dir string) (string, error) {
+	path := passcodeHashPath(dir)
+	b, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", fmt.Errorf(
+				"pair mode: no passcode found at %s: provision this box first (ao setup-vm --pair), which generates one and prints it once",
+				path)
+		}
+		return "", fmt.Errorf("read passcode store %s: %w", path, err)
+	}
+	hash := strings.TrimSpace(string(b))
+	if !isPasscodeHash(hash) {
+		return "", fmt.Errorf(
+			"pair mode: passcode store %s is corrupt (not a %d-character hex sha-256 hash): delete it and re-provision with ao setup-vm --pair to regenerate",
+			path, passcodeHashHexLen)
+	}
+	return hash, nil
+}
+
+func isPasscodeHash(s string) bool {
+	if len(s) != passcodeHashHexLen {
+		return false
+	}
+	_, err := hex.DecodeString(s)
+	return err == nil
+}
+
+// writePasscodeHash persists hash to dir atomically (temp file + rename),
+// mirroring mobilebridge.Save's own persistence shape for the same reason: a
+// crash mid-write must never leave a torn, "corrupt" file behind, only ever
+// the old hash or the new one.
+func writePasscodeHash(dir, hash string) error {
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("create passcode dir: %w", err)
+	}
+	tmp, err := os.CreateTemp(dir, ".passcode-*.tmp")
+	if err != nil {
+		return fmt.Errorf("create passcode temp file: %w", err)
+	}
+	tmpName := tmp.Name()
+	defer func() { _ = os.Remove(tmpName) }()
+	if err := tmp.Chmod(0o600); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("chmod passcode temp file: %w", err)
+	}
+	if _, err := tmp.WriteString(hash); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("write passcode temp file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close passcode temp file: %w", err)
+	}
+	if err := os.Rename(tmpName, passcodeHashPath(dir)); err != nil {
+		return fmt.Errorf("persist passcode store: %w", err)
+	}
+	return nil
+}
+
+// passcodeLockoutLimit and passcodeLockoutCooldown mirror the numbers
+// internal/httpd/lan_listener.go uses to construct the daemon's own LAN
+// listener lockout (newLockout(5, time.Minute, time.Now)): the same wire
+// shape (a bearer passcode) and the same threat model (a hostile device on
+// the network guessing) get the same throttle. Vars rather than consts only
+// so a test can shrink the cooldown instead of sleeping out a full minute,
+// mirroring bareRequestLogWindow in proxy.go.
+var (
+	passcodeLockoutLimit    = 5
+	passcodeLockoutCooldown = time.Minute
+)
+
+// passcodeLockout throttles pair-mode passcode guessing per source address.
+// It is modelled on, but is a separate implementation from, the lockout in
+// internal/httpd/auth.go: that file belongs to the daemon, which this
+// task's hard constraints forbid modifying or reaching into the unexported
+// helpers of, so the same per-source throttle shape is reimplemented here
+// rather than shared.
+type passcodeLockout struct {
+	mu       sync.Mutex
+	limit    int
+	cooldown time.Duration
+	now      func() time.Time
+	fails    map[string]int
+	until    map[string]time.Time
+}
+
+func newPasscodeLockout(limit int, cooldown time.Duration, now func() time.Time) *passcodeLockout {
+	if now == nil {
+		now = time.Now
+	}
+	return &passcodeLockout{
+		limit: limit, cooldown: cooldown, now: now,
+		fails: map[string]int{}, until: map[string]time.Time{},
+	}
+}
+
+func (l *passcodeLockout) blocked(src string) bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	t, ok := l.until[src]
+	if !ok {
+		return false
+	}
+	if l.now().Before(t) {
+		return true
+	}
+	// Cooldown elapsed: clear it and the fail counter so this source starts a
+	// fresh window, mirroring internal/httpd/auth.go's lockout.blocked (see
+	// its comment for why: otherwise the very next failure would re-lock for
+	// another full cooldown, and a source that keeps retrying would never
+	// recover).
+	delete(l.until, src)
+	delete(l.fails, src)
+	return false
+}
+
+func (l *passcodeLockout) fail(src string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.fails[src]++
+	if l.fails[src] >= l.limit {
+		l.until[src] = l.now().Add(l.cooldown)
+	}
+}
+
+func (l *passcodeLockout) reset(src string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	delete(l.fails, src)
+	delete(l.until, src)
+}
+
+// passcodeSourceKey identifies the caller for lockout purposes: the
+// request's remote IP, stripped of its port. Mirrors sourceKey in
+// internal/httpd/auth.go for the same reason that function exists (a
+// per-source, not global, lockout), reimplemented rather than imported
+// because that function is unexported in a package this task must not
+// modify or reach into.
+func passcodeSourceKey(r *http.Request) string {
+	if host, _, err := net.SplitHostPort(r.RemoteAddr); err == nil {
+		return host
+	}
+	return r.RemoteAddr
+}
+
+// requirePasscode is pair mode's credential check, the branch NewHandler
+// takes instead of requireToken when Config.Mode is ModePair. It rejects any
+// request whose token, read by extractToken (the same helper requireToken
+// uses, so /mux and the SSE routes' gateway-cookie transport keep working
+// unchanged in pair mode too), does not match the store's current passcode
+// hash, comparing constant-time via mobilebridge.PasswordMatches per
+// docs/adr/0003-pair-mode-gateway.md. A per-source lockout throttles
+// repeated failures without penalizing any other source, and a successful
+// auth resets that source's failure count.
+func requirePasscode(store *PasscodeStore, lock *passcodeLockout, log *slog.Logger) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			src := passcodeSourceKey(r)
+			if lock.blocked(src) {
+				tooManyRequests(w, r)
+				return
+			}
+			token, _ := extractToken(r)
+			if !mobilebridge.PasswordMatches(store.currentHash(), token) {
+				log.Warn("vm gateway: passcode rejected", "path", r.URL.Path, "source", src)
+				lock.fail(src)
+				unauthorized(w, r)
+				return
+			}
+			lock.reset(src)
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+func tooManyRequests(w http.ResponseWriter, r *http.Request) {
+	envelope.WriteAPIError(w, r, http.StatusTooManyRequests, "too_many_requests", "LOCKED_OUT",
+		"too many failed attempts; try again shortly", nil)
+}

--- a/backend/internal/vmgateway/passcode_test.go
+++ b/backend/internal/vmgateway/passcode_test.go
@@ -1,0 +1,354 @@
+package vmgateway
+
+import (
+	"crypto/ed25519"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/mobilebridge"
+)
+
+// --- passcode store: generation, persistence, corruption ---
+
+func TestGeneratePasscode_ReturnsPlaintextAndPersistsOnlyHash(t *testing.T) {
+	dir := t.TempDir()
+	plaintext, err := GeneratePasscode(dir)
+	if err != nil {
+		t.Fatalf("GeneratePasscode: %v", err)
+	}
+	if len(plaintext) != 8 {
+		t.Fatalf("plaintext passcode %q has length %d, want 8", plaintext, len(plaintext))
+	}
+
+	raw, err := os.ReadFile(filepath.Join(dir, passcodeFileName))
+	if err != nil {
+		t.Fatalf("read persisted passcode file: %v", err)
+	}
+	persisted := strings.TrimSpace(string(raw))
+	if persisted == plaintext {
+		t.Fatalf("passcode file contains the plaintext passcode, want only the hash")
+	}
+	if persisted != mobilebridge.HashPassword(plaintext) {
+		t.Fatalf("persisted hash = %q, want mobilebridge.HashPassword(%q) = %q", persisted, plaintext, mobilebridge.HashPassword(plaintext))
+	}
+}
+
+func TestGeneratePasscode_TwoCallsProduceDifferentPasscodes(t *testing.T) {
+	a, err := GeneratePasscode(t.TempDir())
+	if err != nil {
+		t.Fatalf("GeneratePasscode: %v", err)
+	}
+	b, err := GeneratePasscode(t.TempDir())
+	if err != nil {
+		t.Fatalf("GeneratePasscode: %v", err)
+	}
+	if a == b {
+		t.Fatalf("two independent GeneratePasscode calls both returned %q; want a cryptographically random passcode each time", a)
+	}
+}
+
+func TestLoadPasscodeStore_MissingStoreFailsLoudly(t *testing.T) {
+	_, err := LoadPasscodeStore(t.TempDir())
+	if err == nil {
+		t.Fatal("LoadPasscodeStore on an empty directory: want an error, got nil (a gateway that starts with no usable passcode would be an open door)")
+	}
+}
+
+func TestLoadPasscodeStore_CorruptStoreFailsLoudly(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, passcodeFileName), []byte("not-a-real-hash"), 0o600); err != nil {
+		t.Fatalf("seed corrupt store: %v", err)
+	}
+	_, err := LoadPasscodeStore(dir)
+	if err == nil {
+		t.Fatal("LoadPasscodeStore on a corrupt file: want an error, got nil")
+	}
+}
+
+func TestLoadPasscodeStore_RoundTripsWithGeneratePasscode(t *testing.T) {
+	dir := t.TempDir()
+	plaintext, err := GeneratePasscode(dir)
+	if err != nil {
+		t.Fatalf("GeneratePasscode: %v", err)
+	}
+	store, err := LoadPasscodeStore(dir)
+	if err != nil {
+		t.Fatalf("LoadPasscodeStore after GeneratePasscode: %v", err)
+	}
+	if !mobilebridge.PasswordMatches(store.currentHash(), plaintext) {
+		t.Fatal("loaded store does not match the passcode GeneratePasscode just persisted")
+	}
+}
+
+func TestPasscodeStore_Rotate_ChangesHashAndOldPasscodeStopsMatching(t *testing.T) {
+	dir := t.TempDir()
+	oldPlaintext, err := GeneratePasscode(dir)
+	if err != nil {
+		t.Fatalf("GeneratePasscode: %v", err)
+	}
+	store, err := LoadPasscodeStore(dir)
+	if err != nil {
+		t.Fatalf("LoadPasscodeStore: %v", err)
+	}
+
+	newPlaintext, err := store.Rotate()
+	if err != nil {
+		t.Fatalf("Rotate: %v", err)
+	}
+	if newPlaintext == oldPlaintext {
+		t.Fatal("Rotate returned the same plaintext passcode as before")
+	}
+	if mobilebridge.PasswordMatches(store.currentHash(), oldPlaintext) {
+		t.Fatal("store still matches the pre-rotation passcode; rotation must drop it")
+	}
+	if !mobilebridge.PasswordMatches(store.currentHash(), newPlaintext) {
+		t.Fatal("store does not match the freshly rotated passcode")
+	}
+
+	// The rotation must also be durable: a fresh load from disk sees the new
+	// hash, not the one GeneratePasscode originally wrote.
+	reloaded, err := LoadPasscodeStore(dir)
+	if err != nil {
+		t.Fatalf("LoadPasscodeStore after Rotate: %v", err)
+	}
+	if !mobilebridge.PasswordMatches(reloaded.currentHash(), newPlaintext) {
+		t.Fatal("reloaded store from disk does not match the rotated passcode")
+	}
+}
+
+// --- pair-mode request verification, via NewHandler(ModePair, ...) ---
+
+// newTestPairGateway wires a fake daemon behind a pair-mode gateway handler,
+// mirroring newTestGateway in proxy_test.go but for ModePair: passcode
+// verification instead of JWT.
+type testPairGateway struct {
+	daemonCalls []*http.Request
+	daemon      *httptest.Server
+	handler     http.Handler
+	passcode    string
+}
+
+func newTestPairGateway(t *testing.T) *testPairGateway {
+	t.Helper()
+	tg := &testPairGateway{}
+
+	tg.daemon = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		clone := r.Clone(r.Context())
+		tg.daemonCalls = append(tg.daemonCalls, clone)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	t.Cleanup(tg.daemon.Close)
+
+	daemonURL, err := url.Parse(tg.daemon.URL)
+	if err != nil {
+		t.Fatalf("parse daemon url: %v", err)
+	}
+
+	dir := t.TempDir()
+	plaintext, err := GeneratePasscode(dir)
+	if err != nil {
+		t.Fatalf("GeneratePasscode: %v", err)
+	}
+	tg.passcode = plaintext
+	store, err := LoadPasscodeStore(dir)
+	if err != nil {
+		t.Fatalf("LoadPasscodeStore: %v", err)
+	}
+
+	h, err := NewPairHandler(daemonURL.Host, nil, store, []string{testOrigin}, discardLogger())
+	if err != nil {
+		t.Fatalf("NewPairHandler: %v", err)
+	}
+	tg.handler = h
+	return tg
+}
+
+func (tg *testPairGateway) request(method, path, bearer, remoteAddr string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(method, path, nil)
+	if bearer != "" {
+		req.Header.Set("Authorization", "Bearer "+bearer)
+	}
+	if remoteAddr != "" {
+		req.RemoteAddr = remoteAddr
+	}
+	rec := httptest.NewRecorder()
+	tg.handler.ServeHTTP(rec, req)
+	return rec
+}
+
+func TestPairGateway_CorrectPasscode_Authenticates(t *testing.T) {
+	tg := newTestPairGateway(t)
+	rec := tg.request(http.MethodGet, "/api/v1/projects", tg.passcode, "203.0.113.1:1")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200, body: %s", rec.Code, rec.Body.String())
+	}
+	if len(tg.daemonCalls) != 1 {
+		t.Fatalf("daemon calls = %d, want 1", len(tg.daemonCalls))
+	}
+}
+
+func TestPairGateway_WrongPasscode_Gets401WithAPIErrorEnvelope(t *testing.T) {
+	tg := newTestPairGateway(t)
+	rec := tg.request(http.MethodGet, "/api/v1/projects", "totally-wrong", "203.0.113.1:1")
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401, body: %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "\"code\"") || !strings.Contains(rec.Body.String(), "UNAUTHORIZED") {
+		t.Errorf("body = %q, want the gateway's existing API error envelope with an UNAUTHORIZED code", rec.Body.String())
+	}
+	if len(tg.daemonCalls) != 0 {
+		t.Errorf("daemon calls = %d, want 0: an unauthenticated request must never reach the daemon", len(tg.daemonCalls))
+	}
+}
+
+// TestPairGateway_Lockout_IsPerSource is the security property that matters
+// most here: repeated failures from one source must never lock out another.
+func TestPairGateway_Lockout_IsPerSource(t *testing.T) {
+	original := passcodeLockoutLimit
+	passcodeLockoutLimit = 3
+	t.Cleanup(func() { passcodeLockoutLimit = original })
+
+	tg := newTestPairGateway(t)
+	const sourceA = "198.51.100.1:5555"
+	const sourceB = "198.51.100.2:6666"
+
+	// Drive source A past the lockout limit with wrong passcodes.
+	for i := 0; i < passcodeLockoutLimit; i++ {
+		rec := tg.request(http.MethodGet, "/api/v1/projects", "wrong-passcode", sourceA)
+		if rec.Code != http.StatusUnauthorized {
+			t.Fatalf("source A attempt %d: status = %d, want 401", i, rec.Code)
+		}
+	}
+	// Source A is now locked out, even with the CORRECT passcode.
+	recA := tg.request(http.MethodGet, "/api/v1/projects", tg.passcode, sourceA)
+	if recA.Code != http.StatusTooManyRequests {
+		t.Fatalf("source A after %d failures, status = %d, want 429 (locked out)", passcodeLockoutLimit, recA.Code)
+	}
+
+	// Source B, presenting the correct passcode, must be entirely unaffected
+	// by source A's lockout.
+	recB := tg.request(http.MethodGet, "/api/v1/projects", tg.passcode, sourceB)
+	if recB.Code != http.StatusOK {
+		t.Fatalf("source B status = %d, want 200: source A's lockout must not affect source B, body: %s", recB.Code, recB.Body.String())
+	}
+}
+
+func TestPairGateway_Lockout_ResetsAfterSuccessfulAuth(t *testing.T) {
+	original := passcodeLockoutLimit
+	passcodeLockoutLimit = 3
+	t.Cleanup(func() { passcodeLockoutLimit = original })
+
+	tg := newTestPairGateway(t)
+	const source = "198.51.100.9:7777"
+
+	// One fewer failure than the limit, then a success: the counter must
+	// reset rather than carrying the near-miss forward.
+	for i := 0; i < passcodeLockoutLimit-1; i++ {
+		rec := tg.request(http.MethodGet, "/api/v1/projects", "wrong-passcode", source)
+		if rec.Code != http.StatusUnauthorized {
+			t.Fatalf("attempt %d: status = %d, want 401", i, rec.Code)
+		}
+	}
+	if rec := tg.request(http.MethodGet, "/api/v1/projects", tg.passcode, source); rec.Code != http.StatusOK {
+		t.Fatalf("successful auth status = %d, want 200", rec.Code)
+	}
+
+	// Repeat the same near-miss pattern immediately after: if the reset did
+	// not happen, this second round would tip the source over the limit.
+	for i := 0; i < passcodeLockoutLimit-1; i++ {
+		rec := tg.request(http.MethodGet, "/api/v1/projects", "wrong-passcode", source)
+		if rec.Code != http.StatusUnauthorized {
+			t.Fatalf("post-reset attempt %d: status = %d, want 401", i, rec.Code)
+		}
+	}
+	if rec := tg.request(http.MethodGet, "/api/v1/projects", tg.passcode, source); rec.Code != http.StatusOK {
+		t.Fatalf("post-reset successful auth status = %d, want 200 (lockout must have reset after the earlier success)", rec.Code)
+	}
+}
+
+func TestPairGateway_ControlRoutesStayBlocked_EvenWithValidPasscode(t *testing.T) {
+	tg := newTestPairGateway(t)
+	for _, path := range []string{"/shutdown", "/api/v1/mobile/status", "/api/v1/dev/reset"} {
+		t.Run(path, func(t *testing.T) {
+			rec := tg.request(http.MethodGet, path, tg.passcode, "203.0.113.5:1")
+			if rec.Code != http.StatusNotFound {
+				t.Fatalf("status = %d, want 404 (blocked before proxying, regardless of a valid passcode)", rec.Code)
+			}
+			if len(tg.daemonCalls) != 0 {
+				t.Errorf("daemon calls = %d, want 0: a control route must never reach the daemon", len(tg.daemonCalls))
+			}
+		})
+	}
+}
+
+func TestPairGateway_RejectsAValidJWT_ThereIsNoJWKSToVerifyAgainst(t *testing.T) {
+	tg := newTestPairGateway(t)
+	_, priv, _ := ed25519.GenerateKey(nil)
+	now := time.Now()
+	jwt := signToken(t, priv, map[string]any{"alg": "EdDSA", "kid": testKid}, validClaims(now))
+
+	rec := tg.request(http.MethodGet, "/api/v1/projects", jwt, "203.0.113.9:1")
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401: pair mode has no JWKS and must not accept a JWT", rec.Code)
+	}
+	if len(tg.daemonCalls) != 0 {
+		t.Errorf("daemon calls = %d, want 0", len(tg.daemonCalls))
+	}
+}
+
+func TestPairGateway_CORSPreflight_NoCredentialRequired(t *testing.T) {
+	tg := newTestPairGateway(t)
+	req := httptest.NewRequest(http.MethodOptions, "/api/v1/projects", nil)
+	req.Header.Set("Origin", testOrigin)
+	req.Header.Set("Access-Control-Request-Method", "POST")
+	rec := httptest.NewRecorder()
+
+	tg.handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("preflight status = %d, want 204", rec.Code)
+	}
+	if len(tg.daemonCalls) != 0 {
+		t.Errorf("preflight must never reach the daemon, got %d calls", len(tg.daemonCalls))
+	}
+}
+
+// --- hosted mode is unaffected by pair mode's existence ---
+
+func TestHostedGateway_StillRejectsAPasscodeAndAcceptsAValidJWT(t *testing.T) {
+	tg := newTestGateway(t)
+
+	// A plausible 8-char alphanumeric passcode is not JWT-shaped, so it is
+	// rejected as a malformed token, same as before pair mode existed.
+	rec := tg.request(http.MethodGet, "/api/v1/projects", "aB3xK9mQ")
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("hosted mode with a passcode-shaped bearer token: status = %d, want 401", rec.Code)
+	}
+
+	recValid := tg.request(http.MethodGet, "/api/v1/projects", tg.validToken(t))
+	if recValid.Code != http.StatusOK {
+		t.Fatalf("hosted mode with a valid JWT: status = %d, want 200, body: %s", recValid.Code, recValid.Body.String())
+	}
+}
+
+// request is a small helper added alongside the pair-mode tests above; it
+// mirrors the inline httptest.NewRequest + Authorization header pattern the
+// existing hosted-mode tests in this file (proxy_test.go) already use
+// individually, factored out only because the hosted/pair comparison test
+// above needs it twice.
+func (tg *testGateway) request(method, path, bearer string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(method, path, nil)
+	if bearer != "" {
+		req.Header.Set("Authorization", "Bearer "+bearer)
+	}
+	rec := httptest.NewRecorder()
+	tg.handler.ServeHTTP(rec, req)
+	return rec
+}

--- a/backend/internal/vmgateway/proxy.go
+++ b/backend/internal/vmgateway/proxy.go
@@ -88,22 +88,29 @@ var maxRequestBodyBytes int64 = 25<<20*4/3 + (2 << 20) // ~37,049,685 bytes, ~35
 // answered; see newReverseProxy.
 const upstreamResponseHeaderTimeout = 6 * time.Minute
 
-// NewHandler assembles the gateway's HTTP handler: panic recovery, CORS
-// preflight, a deny-by-default path allowlist, AO token verification, a
-// request body size cap, then a reverse proxy onto the loopback daemon,
-// initially at daemonAddr. Middleware order (outermost first): panic recovery
-// guards every layer below it so a panic anywhere in the chain logs and
-// returns a clean 500 instead of dropping the connection with nothing in
-// slog; CORS answers preflights and gates disallowed origins before anything
-// else runs — this also is the only Origin check a WebSocket upgrade to /mux
-// ever gets, since browsers do not enforce same-origin on WebSocket
-// connections themselves and /mux's cookie is ambient (browser-attached)
-// credential; deny-by-default rejects any path outside the proxyable set with
-// 404, so an unrecognised or loopback-only route never reaches the daemon
-// regardless of auth; token verification rejects an unauthenticated or
-// invalid request with 401 before the daemon ever sees it; the body size cap
-// applies only once a request is authenticated, so an anonymous flood cannot
-// use it to force allocation.
+// NewHandler assembles the gateway's HTTP handler for hosted mode: panic
+// recovery, CORS preflight, a deny-by-default path allowlist, AO token
+// verification, a request body size cap, then a reverse proxy onto the
+// loopback daemon, initially at daemonAddr. Middleware order (outermost
+// first): panic recovery guards every layer below it so a panic anywhere in
+// the chain logs and returns a clean 500 instead of dropping the connection
+// with nothing in slog; CORS answers preflights and gates disallowed origins
+// before anything else runs — this also is the only Origin check a WebSocket
+// upgrade to /mux ever gets, since browsers do not enforce same-origin on
+// WebSocket connections themselves and /mux's cookie is ambient
+// (browser-attached) credential; deny-by-default rejects any path outside the
+// proxyable set with 404, so an unrecognised or loopback-only route never
+// reaches the daemon regardless of auth; token verification rejects an
+// unauthenticated or invalid request with 401 before the daemon ever sees it;
+// the body size cap applies only once a request is authenticated, so an
+// anonymous flood cannot use it to force allocation.
+//
+// See NewPairHandler for pair mode's equivalent, which shares this exact
+// middleware chain via newHandler and swaps only the credential check
+// (requirePasscode instead of requireToken), per
+// docs/adr/0003-pair-mode-gateway.md's "Add a branch, do not rewrite the
+// existing path" framing: this function and its signature are unchanged by
+// pair mode's existence.
 //
 // resolveDaemonAddr, when non-nil, is consulted by the reverse proxy's
 // ErrorHandler after a failed round trip to re-read the daemon's current
@@ -113,13 +120,37 @@ const upstreamResponseHeaderTimeout = 6 * time.Minute
 // explicitly (a flag or environment variable), so a re-resolve never
 // silently overrides an operator's explicit choice.
 func NewHandler(daemonAddr string, resolveDaemonAddr func() (string, bool), jwks *JWKSCache, verify VerifyOptions, allowedOrigins []string, log *slog.Logger) (http.Handler, error) {
+	return newHandler(requireToken(jwks, verify, log), daemonAddr, resolveDaemonAddr, allowedOrigins, log)
+}
+
+// NewPairHandler assembles the gateway's HTTP handler for pair mode: the
+// same middleware chain NewHandler builds for hosted mode (panic recovery,
+// CORS preflight, the deny-by-default path allowlist, a request body size
+// cap, and the reverse proxy), with requirePasscode against passcodes as the
+// credential check instead of requireToken against a JWKS. See
+// docs/adr/0003-pair-mode-gateway.md. passcodes must be a store already
+// loaded by LoadPasscodeStore; a nil store is refused here rather than
+// starting a gateway with no usable passcode.
+func NewPairHandler(daemonAddr string, resolveDaemonAddr func() (string, bool), passcodes *PasscodeStore, allowedOrigins []string, log *slog.Logger) (http.Handler, error) {
+	if passcodes == nil {
+		return nil, errors.New("vm gateway: pair mode requires a loaded passcode store")
+	}
+	lock := newPasscodeLockout(passcodeLockoutLimit, passcodeLockoutCooldown, time.Now)
+	return newHandler(requirePasscode(passcodes, lock, log), daemonAddr, resolveDaemonAddr, allowedOrigins, log)
+}
+
+// newHandler builds the middleware chain NewHandler and NewPairHandler both
+// use, parameterized only by which credential check (authMW) sits in the
+// requireToken/requirePasscode slot; every other layer, and their order, is
+// identical between hosted and pair mode.
+func newHandler(authMW func(http.Handler) http.Handler, daemonAddr string, resolveDaemonAddr func() (string, bool), allowedOrigins []string, log *slog.Logger) (http.Handler, error) {
 	if _, err := url.Parse("http://" + daemonAddr); err != nil {
 		return nil, err
 	}
 
 	h := http.Handler(newReverseProxy(daemonAddr, resolveDaemonAddr, log))
 	h = limitBody(h)
-	h = requireToken(jwks, verify, log)(h)
+	h = authMW(h)
 	h = denyByDefault(h)
 	h = corsGate(allowedOrigins)(h)
 	h = recoverAndLog(log)(h)


### PR DESCRIPTION
## Summary

Adds passcode verification as the pair-mode credential path, per docs/adr/0003-pair-mode-gateway.md and the task 5 breakdown in docs/plans/2026-08-16-pair-by-ip-headless-boxes.md.

- **Passcode store** (`backend/internal/vmgateway/passcode.go`): persists only the SHA-256 hash under a directory derived from `config.StateRootSegments()` (`<state root>/vm-gateway/pair-passcode/passcode.hash`, sibling to the pair certificate's own directory). `LoadPasscodeStore` fails loudly on a missing or corrupt file at startup rather than falling back to any default, so the gateway never starts with an unknown or absent passcode.
- **Generation**: `GeneratePasscode(dir)` produces the plaintext once and persists only the hash, reusing `mobilebridge.GeneratePassword` (identical spec: 8-character alphanumeric, crypto/rand) rather than a second generator. Intended for provisioning (task 7) to call and print the plaintext; no CLI printing is wired up here.
- **Verification**: `requirePasscode` compares constant-time via `mobilebridge.PasswordMatches`, reusing the gateway's existing `extractToken` so `/mux` and the SSE routes' cookie transport work unchanged in pair mode too.
- **Per-source lockout**: `passcodeLockout`, modelled on (not shared with) `internal/httpd/auth.go`'s lockout — same limit/cooldown (5 failures / 1 minute) — keyed by remote IP so one hostile source can never lock out another. Resets on successful auth.
- **Rotate primitive**: `(*PasscodeStore).Rotate()` regenerates, persists, and atomically swaps the in-memory hash so the next request from any client (including already-connected ones) is checked against the new value. Returns the plaintext once; no CLI wiring here either.

Hosted mode is untouched by design: `NewHandler`'s signature and JWT verification path are unchanged, and a new `NewPairHandler` shares the exact same middleware chain (panic recovery, CORS preflight, deny-by-default path allowlist, body cap, reverse proxy) through a private `newHandler` helper, swapping in `requirePasscode` instead of `requireToken`. This kept the change out of `internal/httpd` entirely (a cross-package test there calls the unchanged `vmgateway.NewHandler`, so its signature had to stay stable) and avoided touching the proxy path allowlist.

`ao vm serve` (`backend/internal/cli/vm.go`) now branches on `gwCfg.Mode`: hosted mode builds `VerifyOptions`/`JWKSCache` exactly as before; pair mode loads the passcode store (`LoadPasscodeStore(gwCfg.PasscodeDir)`, fatal on failure) and calls `NewPairHandler`. Added `--passcode-dir`/`AO_VM_PASSCODE_DIR` alongside the existing `--cert-dir` for symmetry; no `--pair` flag exists yet (pre-existing gap, only `AO_VM_PAIR` currently selects pair mode), so this is unchanged.

## Test plan

- [x] `cd backend && go build ./... && go vet ./...`
- [x] `go test ./...` (full suite; one unrelated tmux integration test flaked once and passed clean on rerun, confirmed no diff touches that package)
- [x] `go test -race ./internal/vmgateway/...`
- [x] New tests in `backend/internal/vmgateway/passcode_test.go`: passcode generation/persistence/corruption, store round-trip, rotate, correct/wrong passcode, per-source lockout (the property that matters most here), lockout reset after success, control routes blocked in pair mode with a valid passcode, pair mode rejecting a JWT, hosted mode still rejecting a passcode and accepting a JWT, CORS preflight without a credential in pair mode
- [x] Confirmed `internal/vmgateway/token_test.go` and everything under `internal/httpd/` are byte-identical to `origin/develop` (untouched)

Refs #86