### PR TITLE
feat(cli): add pair-mode provisioning to ao setup-vm

### DIFF
--- a/backend/internal/cli/setupvm.go
+++ b/backend/internal/cli/setupvm.go
@@ -988,17 +988,28 @@ func chownSetupTree(dir string, owner *user.User) error {
 	if err != nil {
 		// A non-numeric id is a Windows user, and this path only ever runs on
 		// the Debian-family box the platform gate already checked for.
-		return nil
+		return nil //nolint:nilerr // deliberate: a non-numeric id means there is nothing to chown here, not a failure to report
 	}
 	gid, err := strconv.Atoi(owner.Gid)
 	if err != nil {
-		return nil
+		return nil //nolint:nilerr // same as above
 	}
-	return filepath.WalkDir(dir, func(path string, _ fs.DirEntry, walkErr error) error {
+	// Root-scoped traversal, and Lchown rather than Chown, because this runs as
+	// root against a directory inside an unprivileged user's home. That user can
+	// plant a symlink there before invoking sudo. A plain filepath.WalkDir plus
+	// os.Chown would follow it and hand them ownership of whatever it points at.
+	// os.Root confines every path to dir, and Lchown acts on the link itself, so
+	// a planted symlink can only ever retarget the chown onto itself.
+	root, err := os.OpenRoot(dir)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = root.Close() }()
+	return fs.WalkDir(root.FS(), ".", func(path string, _ fs.DirEntry, walkErr error) error {
 		if walkErr != nil {
 			return walkErr
 		}
-		return os.Chown(path, uid, gid)
+		return root.Lchown(path, uid, gid)
 	})
 }
 

--- a/backend/internal/cli/setupvm.go
+++ b/backend/internal/cli/setupvm.go
@@ -10,9 +10,11 @@ import (
 	"bytes"
 	"context"
 	"crypto/sha256"
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"net"
 	"net/http"
 	"net/url"
@@ -21,6 +23,7 @@ import (
 	"path"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -61,22 +64,31 @@ type setupVMOptions struct {
 	ProbeURL        string
 	ControlPlaneURL string
 	DryRun          bool
+	// Pair requests pair mode: no domain, no AO account, self-signed TLS with
+	// a passcode instead. See docs/adr/0003-pair-mode-gateway.md.
+	Pair bool
 }
 
 func newSetupVMCommand(ctx *commandContext) *cobra.Command {
 	var opts setupVMOptions
 	cmd := &cobra.Command{
 		Use:   "setup-vm",
-		Short: "Preflight and install AO on a hosted Ubuntu VM",
-		Long: "ao setup-vm prepares a hosted Ubuntu LTS VM to run remote agents. It gates\n" +
-			"on the platform, preflights DNS, the public ports, and sudo before it touches\n" +
-			"anything, then installs the ao binary, tmux, git, and gh, and writes two\n" +
-			"systemd units: one for the loopback daemon and one for the public TLS gateway\n" +
-			"(see docs/adr/0002-hosted-public-gateway.md).\n\n" +
+		Short: "Preflight and install AO on a hosted VM, or pair a Debian-family box by IP",
+		Long: "ao setup-vm prepares a Debian-family Linux machine (Ubuntu, Debian, Raspberry Pi OS)\n" +
+			"to run remote agents. It gates on the platform, preflights sudo and (in the default,\n" +
+			"hosted mode) DNS and the public ports before it touches anything, then installs the\n" +
+			"ao binary, tmux, git, and gh, and writes two systemd units: one for the loopback\n" +
+			"daemon and one for the public TLS gateway (see docs/adr/0002-hosted-public-gateway.md).\n\n" +
 			"It then binds this machine to an AO account over an RFC 8628 device code: it\n" +
 			"prints a short code and a URL, waits for you to approve the machine in a browser\n" +
 			"on any device, writes ~/.ao/hosted/machine.json, and restarts the gateway so it reads\n" +
 			"the new binding.\n\n" +
+			"With --pair, it provisions a box for the desktop app to reach by IP instead: no\n" +
+			"domain, no AO account, and no contact with the control plane at all. It generates a\n" +
+			"self-signed certificate and a passcode on first run, prints both once alongside this\n" +
+			"machine's address, and the desktop app pins the certificate's fingerprint on first\n" +
+			"connection (see docs/adr/0003-pair-mode-gateway.md). Re-running never rotates either;\n" +
+			"use `ao vm rotate-passcode` to roll the passcode on purpose.\n\n" +
 			"A failed preflight changes nothing at all: it prints exactly what to fix and\n" +
 			"exits. A successful run is idempotent, so running it again is safe; an\n" +
 			"already-bound machine has its current binding printed and is then bound again.\n" +
@@ -89,15 +101,23 @@ func newSetupVMCommand(ctx *commandContext) *cobra.Command {
 		},
 	}
 	flags := cmd.Flags()
-	flags.StringVar(&opts.Domain, "domain", "", "Public hostname you own, with a DNS record pointing at this machine (required)")
-	flags.StringVar(&opts.PublicIP, "public-ip", "", "This machine's public IP, for when it cannot be discovered automatically")
-	flags.StringVar(&opts.ProbeURL, "reachability-probe-url", defaultSetupVMProbeURL, "Off-box prober used to confirm 80 and 443 are reachable from the internet")
-	flags.StringVar(&opts.ControlPlaneURL, "control-plane-url", vmgateway.DefaultIssuer, "AO control plane this machine is bound against")
+	flags.StringVar(&opts.Domain, "domain", "", "Public hostname you own, with a DNS record pointing at this machine (required unless --pair)")
+	flags.StringVar(&opts.PublicIP, "public-ip", "", "This machine's public IP, for when it cannot be discovered automatically (hosted mode only)")
+	flags.StringVar(&opts.ProbeURL, "reachability-probe-url", defaultSetupVMProbeURL, "Off-box prober used to confirm 80 and 443 are reachable from the internet (hosted mode only)")
+	flags.StringVar(&opts.ControlPlaneURL, "control-plane-url", vmgateway.DefaultIssuer, "AO control plane this machine is bound against (hosted mode only)")
 	flags.BoolVar(&opts.DryRun, "dry-run", false, "Gate, preflight, print the plan and both unit files, and change nothing")
+	flags.BoolVar(&opts.Pair, "pair", false, "Pair mode: no domain and no AO account, self-signed TLS with a passcode instead (see docs/adr/0003-pair-mode-gateway.md)")
 	return cmd
 }
 
 func (c *commandContext) runSetupVM(cmd *cobra.Command, opts setupVMOptions) error {
+	if opts.Pair {
+		if strings.TrimSpace(opts.Domain) != "" {
+			return usageError{errors.New("--pair does not take --domain: pair mode has no domain (see docs/adr/0003-pair-mode-gateway.md)")}
+		}
+		return c.runSetupVMPair(cmd, opts)
+	}
+
 	ctx := cmd.Context()
 	out := cmd.OutOrStdout()
 
@@ -119,7 +139,7 @@ func (c *commandContext) runSetupVM(cmd *cobra.Command, opts setupVMOptions) err
 		return err
 	}
 
-	preflight := c.probeSetupPreflight(ctx, domain, opts)
+	preflight := c.probeSetupPreflight(ctx, domain, opts, false)
 	problems, preflightWarnings := evaluatePreflight(preflight)
 	warnings = append(warnings, preflightWarnings...)
 	if len(problems) > 0 {
@@ -186,8 +206,13 @@ func (c *commandContext) probeSetupPlatform() setupPlatform {
 	return platform
 }
 
-func (c *commandContext) probeSetupPreflight(ctx context.Context, domain string, opts setupVMOptions) setupPreflight {
-	preflight := setupPreflight{Domain: domain, UID: os.Getuid()}
+// probeSetupPreflight probes the box for both modes. pair skips every check
+// that only makes sense with a domain and a public internet presence
+// (discovering this machine's public IP, resolving domain, and the off-box
+// reachability probe), and checks only the HTTPS port instead of :80 and
+// :443. See docs/adr/0003-pair-mode-gateway.md.
+func (c *commandContext) probeSetupPreflight(ctx context.Context, domain string, opts setupVMOptions, pair bool) setupPreflight {
+	preflight := setupPreflight{Domain: domain, UID: os.Getuid(), Pair: pair}
 
 	// Who the units would run as is a preflight fact, not an install-time one: a
 	// root target has to be refused before anything on this box is touched. A
@@ -209,20 +234,26 @@ func (c *commandContext) probeSetupPreflight(ctx context.Context, domain string,
 		preflight.Cloud = setupCloudFromVendor(string(vendor))
 	}
 
-	preflight.PublicIP = strings.TrimSpace(opts.PublicIP)
-	switch {
-	case preflight.PublicIP == "":
-		preflight.PublicIP, preflight.PublicIPErr = c.discoverPublicIP(ctx)
-	case net.ParseIP(preflight.PublicIP) == nil:
-		preflight.PublicIPErr = fmt.Errorf("--public-ip %q is not an IP address", preflight.PublicIP)
+	ports := setupVMPorts
+	if pair {
+		ports = setupVMPortsPair
+	} else {
+		preflight.PublicIP = strings.TrimSpace(opts.PublicIP)
+		switch {
+		case preflight.PublicIP == "":
+			preflight.PublicIP, preflight.PublicIPErr = c.discoverPublicIP(ctx)
+		case net.ParseIP(preflight.PublicIP) == nil:
+			preflight.PublicIPErr = fmt.Errorf("--public-ip %q is not an IP address", preflight.PublicIP)
+		}
+		preflight.ResolvedIPs, preflight.ResolveErr = net.DefaultResolver.LookupHost(ctx, domain)
 	}
-
-	preflight.ResolvedIPs, preflight.ResolveErr = net.DefaultResolver.LookupHost(ctx, domain)
 
 	gatewayActive := c.setupUnitActive(ctx, setupVMGatewayUnit)
 	preflight.GatewayActive = gatewayActive
-	preflight.Ports = probeSetupPorts(setupVMPorts, gatewayActive)
-	preflight.Reach = c.probeSetupReachability(ctx, opts.ProbeURL, domain, gatewayActive)
+	preflight.Ports = probeSetupPorts(ports, gatewayActive)
+	if !pair {
+		preflight.Reach = c.probeSetupReachability(ctx, opts.ProbeURL, domain, gatewayActive)
+	}
 	return preflight
 }
 
@@ -433,6 +464,26 @@ func (c *commandContext) buildSetupVMPlan(domain string) (setupPlan, error) {
 	return plan, nil
 }
 
+// buildSetupVMPlanPair is buildSetupVMPlan's pair-mode counterpart: no
+// domain, and Bound stays false, since pair mode has no account to bind.
+func (c *commandContext) buildSetupVMPlanPair() (setupPlan, error) {
+	target, err := setupTargetUser()
+	if err != nil {
+		return setupPlan{}, err
+	}
+	in := setupPlanInput{
+		Pair:    true,
+		User:    target.Username,
+		Home:    target.HomeDir,
+		DataDir: os.Getenv("AO_DATA_DIR"),
+		RunFile: os.Getenv("AO_RUN_FILE"),
+	}
+	if group, err := user.LookupGroupId(target.Gid); err == nil {
+		in.Group = group.Name
+	}
+	return buildSetupPlan(in)
+}
+
 // setupTargetUser is the unprivileged owner of the machine: SUDO_USER when the
 // command was run through sudo, otherwise whoever is running it.
 func setupTargetUser() (*user.User, error) {
@@ -522,9 +573,12 @@ func (c *commandContext) installSetupVM(ctx context.Context, out io.Writer, plan
 		notes = append(notes, setupVersionSkewNote(oldBinaryVersion))
 	}
 
-	if !plan.Bound {
+	if !plan.Pair && !plan.Bound {
 		// `ao vm serve` reads machine.json once at startup and cannot serve
-		// without it, so starting it now would only produce a restart loop.
+		// without it, so starting it now would only produce a restart loop. Pair
+		// mode has no account to bind at all, so it never hits this: by the time
+		// installSetupVM runs, the caller has already generated the passcode and
+		// certificate the gateway needs to start.
 		return units, notes, step("%s enabled but not started: this machine is not bound yet", setupVMGatewayUnit)
 	}
 	// The gateway holds no session state, so a new binary or unit is safe to
@@ -790,4 +844,185 @@ func setupFileSum(filePath string) (string, error) {
 func writeSetupText(out io.Writer, text string) error {
 	_, err := io.WriteString(out, text)
 	return err
+}
+
+// ---------------------------------------------------------------------------
+// pair mode
+// ---------------------------------------------------------------------------
+//
+// runSetupVMPair provisions a box for `ao setup-vm --pair`: the same
+// preflight, package, binary, and systemd machinery runSetupVM uses, minus
+// ACME and the device-flow bind, which never run here at all. Pair mode never
+// contacts the control plane. See docs/adr/0003-pair-mode-gateway.md.
+
+func (c *commandContext) runSetupVMPair(cmd *cobra.Command, opts setupVMOptions) error {
+	ctx := cmd.Context()
+	out := cmd.OutOrStdout()
+
+	platform := c.probeSetupPlatform()
+	warnings, err := checkSetupPlatform(platform)
+	if err != nil {
+		if writeErr := writeSetupText(out, renderManualPathPair(platform)); writeErr != nil {
+			return writeErr
+		}
+		return err
+	}
+
+	preflight := c.probeSetupPreflight(ctx, "", opts, true)
+	problems, preflightWarnings := evaluatePreflight(preflight)
+	warnings = append(warnings, preflightWarnings...)
+	if len(problems) > 0 {
+		if writeErr := writeSetupText(out, renderPreflightFailure(problems)); writeErr != nil {
+			return writeErr
+		}
+		return errors.New("ao setup-vm --pair preflight failed, so nothing on this machine was changed")
+	}
+
+	plan, err := c.buildSetupVMPlanPair()
+	if err != nil {
+		return err
+	}
+
+	if opts.DryRun {
+		return writeSetupText(out, renderSetupDryRunPair(plan, warnings))
+	}
+
+	owner, err := setupTargetUser()
+	if err != nil {
+		return err
+	}
+
+	// Generated before installSetupVM runs: pair mode has no account to bind
+	// and no "not bound yet" gate, so installSetupVM starts the gateway
+	// immediately, and it needs the passcode and certificate to already be on
+	// disk when it does.
+	passcode, generated, err := c.ensureSetupPasscode(plan.PasscodeDir, owner)
+	if err != nil {
+		return err
+	}
+	if generated {
+		if err := writeSetupText(out, "==> generated a new pair-mode passcode (printed once, at the end of this run)\n"); err != nil {
+			return err
+		}
+	} else {
+		if err := writeSetupText(out, "==> pair-mode passcode already set from an earlier run; unchanged\n"); err != nil {
+			return err
+		}
+	}
+
+	cert, err := c.ensureSetupPairCert(plan.PairCertDir, owner)
+	if err != nil {
+		return err
+	}
+	fingerprint, err := vmgateway.PairFingerprint(cert)
+	if err != nil {
+		return err
+	}
+	if err := writeSetupText(out, "==> pair-mode certificate ready (fingerprint printed at the end of this run)\n"); err != nil {
+		return err
+	}
+
+	units, notes, err := c.installSetupVM(ctx, out, plan)
+	if err != nil {
+		return err
+	}
+	warnings = append(warnings, notes...)
+
+	addrs := discoverPairListenAddresses()
+	return writeSetupText(out, renderSetupSummaryPair(plan, units, warnings, passcode, generated, fingerprint, addrs))
+}
+
+// ensureSetupPasscode returns this box's pair-mode passcode, generating and
+// persisting a fresh one only when dir holds none yet (first run) or an
+// unreadable one (recovery from corruption). Re-running against a directory
+// that already holds a good passcode changes nothing and returns
+// generated=false with no plaintext at all. That is the one guarantee pair
+// mode cannot compromise on: a silent rotation would drop every paired
+// client with no signal beyond a suddenly-wrong passcode, and a changed
+// fingerprint is indistinguishable from an attack to a client that pinned
+// the old one. See docs/adr/0003-pair-mode-gateway.md.
+func (c *commandContext) ensureSetupPasscode(dir string, owner *user.User) (plaintext string, generated bool, err error) {
+	if _, loadErr := vmgateway.LoadPasscodeStore(dir); loadErr == nil {
+		return "", false, nil
+	}
+	plaintext, err = vmgateway.GeneratePasscode(dir)
+	if err != nil {
+		return "", false, err
+	}
+	if err := chownSetupTree(dir, owner); err != nil {
+		return "", false, err
+	}
+	return plaintext, true, nil
+}
+
+// ensureSetupPairCert loads or creates the pair-mode certificate under dir.
+// vmgateway.LoadOrCreatePairCertificate is already idempotent (it loads the
+// existing certificate rather than generating a new one whenever both files
+// are already present), so re-running this never rotates it either.
+func (c *commandContext) ensureSetupPairCert(dir string, owner *user.User) (tls.Certificate, error) {
+	cert, err := vmgateway.LoadOrCreatePairCertificate(dir)
+	if err != nil {
+		return tls.Certificate{}, err
+	}
+	if err := chownSetupTree(dir, owner); err != nil {
+		return tls.Certificate{}, err
+	}
+	return cert, nil
+}
+
+// chownSetupTree hands every file under dir to owner, recursively. It is a
+// no-op when this process is not root: an unprivileged invocation already
+// writes as the right user, and only a root (sudo) invocation can produce a
+// file the gateway's own unprivileged systemd unit cannot read.
+// vmgateway.GeneratePasscode, PasscodeStore.Rotate, and
+// LoadOrCreatePairCertificate all write directly with this process's own
+// euid, with no idea who the target unit's user is, so this is what stops a
+// root-owned passcode.hash or cert.pem from leaving the gateway unable to
+// start on a machine that was just provisioned or rotated successfully.
+// Mirrors chownMachineFile's reasoning in setupvm_bind.go.
+func chownSetupTree(dir string, owner *user.User) error {
+	if owner == nil || os.Getuid() != 0 {
+		return nil
+	}
+	uid, err := strconv.Atoi(owner.Uid)
+	if err != nil {
+		// A non-numeric id is a Windows user, and this path only ever runs on
+		// the Debian-family box the platform gate already checked for.
+		return nil
+	}
+	gid, err := strconv.Atoi(owner.Gid)
+	if err != nil {
+		return nil
+	}
+	return filepath.WalkDir(dir, func(path string, _ fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		return os.Chown(path, uid, gid)
+	})
+}
+
+// discoverPairListenAddresses lists this box's own non-loopback IPv4
+// addresses: the ones a Mac on the same network can actually type into the
+// desktop app. Best effort and never fatal: an empty result just falls back
+// to telling the operator to find the address themselves.
+func discoverPairListenAddresses() []string {
+	addrs, err := net.InterfaceAddrs()
+	if err != nil {
+		return nil
+	}
+	var out []string
+	for _, addr := range addrs {
+		ipNet, ok := addr.(*net.IPNet)
+		if !ok || ipNet.IP.IsLoopback() {
+			continue
+		}
+		ip4 := ipNet.IP.To4()
+		if ip4 == nil {
+			continue
+		}
+		out = append(out, ip4.String())
+	}
+	sort.Strings(out)
+	return out
 }

--- a/backend/internal/cli/setupvm_plan.go
+++ b/backend/internal/cli/setupvm_plan.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/config"
+	"github.com/aoagents/agent-orchestrator/backend/internal/vmgateway"
 )
 
 const (
@@ -119,8 +120,14 @@ var setupVMPackages = []string{"tmux", "git", "gh"}
 
 // setupVMPorts are the ports the gateway must be able to bind and be reached
 // on: 80 for the ACME HTTP-01 challenge and the https redirect, 443 for the
-// public TLS listener.
+// public TLS listener. Hosted mode only.
 var setupVMPorts = []int{80, 443}
+
+// setupVMPortsPair is pair mode's port list: the public TLS listener only.
+// Pair mode never binds :80, because there is no ACME HTTP-01 challenge to
+// answer (docs/adr/0003-pair-mode-gateway.md), so preflight must not demand
+// it be free either.
+var setupVMPortsPair = []int{443}
 
 // ---------------------------------------------------------------------------
 // Platform gate
@@ -134,13 +141,13 @@ type setupPlatform struct {
 	HasAptGet    bool
 }
 
-// errUnsupportedPlatform reports that this box is not an Ubuntu box with
-// systemd and apt. The command prints the manual path and exits without
+// errUnsupportedPlatform reports that this box is not a Debian-family box
+// with systemd and apt. The command prints the manual path and exits without
 // touching anything.
 type errUnsupportedPlatform struct{ reason string }
 
 func (e errUnsupportedPlatform) Error() string {
-	return "ao setup-vm supports Ubuntu LTS with systemd and apt only: " + e.reason
+	return "ao setup-vm supports Debian-family Linux (Ubuntu, Debian, Raspberry Pi OS) with systemd and apt only: " + e.reason
 }
 
 // parseOSRelease parses the shell-assignment format of /etc/os-release. Values
@@ -182,15 +189,21 @@ func (p setupPlatform) platformName() string {
 }
 
 // checkSetupPlatform is the platform gate. It returns an
-// errUnsupportedPlatform for anything that is not Ubuntu with systemd and apt,
-// so the caller can print the manual path instead of half-installing. A
-// non-LTS Ubuntu is a warning rather than a refusal: apt and systemd are
-// there, so every step still works, the release just goes end-of-life sooner.
+// errUnsupportedPlatform for anything that is not a Debian-family distro with
+// systemd and apt, so the caller can print the manual path instead of
+// half-installing. Ubuntu, Debian itself, and Raspberry Pi OS (which reports
+// either ID=debian directly or ID=raspbian with ID_LIKE=debian, depending on
+// the release) all pass; anything else is refused. A non-LTS Ubuntu is a
+// warning rather than a refusal: apt and systemd are there, so every step
+// still works, the release just goes end-of-life sooner. The LTS warning is
+// Ubuntu-specific wording and does not apply to the rest of the Debian
+// family, which does not use that term.
 func checkSetupPlatform(p setupPlatform) (warnings []string, err error) {
 	if p.GOOS != "linux" {
 		return nil, errUnsupportedPlatform{reason: "this is " + p.GOOS + ", not Linux"}
 	}
-	if id := strings.ToLower(p.OSRelease["ID"]); id != "ubuntu" {
+	id := strings.ToLower(p.OSRelease["ID"])
+	if !isDebianFamilyID(id, p.OSRelease["ID_LIKE"]) {
 		return nil, errUnsupportedPlatform{reason: "this box reports " + p.platformName()}
 	}
 	if !p.HasSystemctl {
@@ -199,7 +212,7 @@ func checkSetupPlatform(p setupPlatform) (warnings []string, err error) {
 	if !p.HasAptGet {
 		return nil, errUnsupportedPlatform{reason: "apt-get was not found on PATH, so packages cannot be installed"}
 	}
-	if !strings.Contains(strings.ToUpper(p.OSRelease["VERSION"]), "LTS") {
+	if id == "ubuntu" && !strings.Contains(strings.ToUpper(p.OSRelease["VERSION"]), "LTS") {
 		warnings = append(warnings, fmt.Sprintf(
 			"%s is not an LTS release. Setup will work, but the release goes end-of-life sooner than an LTS one.",
 			p.platformName()))
@@ -207,12 +220,30 @@ func checkSetupPlatform(p setupPlatform) (warnings []string, err error) {
 	return warnings, nil
 }
 
+// isDebianFamilyID reports whether id, or (when id itself is not "debian")
+// its ID_LIKE, marks a Debian-family distribution. Ubuntu and Debian itself
+// are always accepted by id; everything else is accepted only through
+// ID_LIKE, which is how a derivative such as Raspberry Pi OS's older
+// "raspbian" id names its ancestry.
+func isDebianFamilyID(id, idLike string) bool {
+	id = strings.ToLower(strings.TrimSpace(id))
+	if id == "ubuntu" || id == "debian" {
+		return true
+	}
+	for _, like := range strings.Fields(strings.ToLower(idLike)) {
+		if like == "debian" {
+			return true
+		}
+	}
+	return false
+}
+
 // renderManualPath is what an unsupported box gets instead of a half-install:
 // the same work, spelled out, for a machine ao setup-vm will not touch.
 func renderManualPath(p setupPlatform, domain string) string {
 	var b strings.Builder
-	b.WriteString("ao setup-vm automates Ubuntu LTS only, because it installs apt packages and\n")
-	fmt.Fprintf(&b, "systemd units. This machine reports %s, so nothing was changed.\n", p.platformName())
+	b.WriteString("ao setup-vm automates Debian-family Linux only, because it installs apt packages\n")
+	fmt.Fprintf(&b, "and systemd units. This machine reports %s, so nothing was changed.\n", p.platformName())
 	b.WriteString("\nSet the machine up by hand instead:\n")
 	b.WriteString("\n  1. Install tmux, git, and the GitHub CLI (gh) with this system's package manager.\n")
 	fmt.Fprintf(&b, "  2. Put the ao binary on PATH at an absolute location, for example %s.\n", setupVMBinaryPath)
@@ -281,6 +312,11 @@ type setupReachability struct {
 // computed by evaluatePreflight, which is pure.
 type setupPreflight struct {
 	Domain string
+	// Pair is whether this preflight is for `ao setup-vm --pair`, which skips
+	// every check that only makes sense with a domain and a public internet
+	// presence (DNS, public IP discovery, off-box reachability) and checks
+	// only the HTTPS port, never :80. See docs/adr/0003-pair-mode-gateway.md.
+	Pair bool
 
 	// UID is this process's user id, 0 when it is already root.
 	UID int
@@ -318,12 +354,22 @@ func evaluatePreflight(pf setupPreflight) (problems []setupProblem, warnings []s
 	if p := checkSetupPrivilege(pf); p != nil {
 		problems = append(problems, *p)
 	}
-	if p := checkSetupDNS(pf); p != nil {
-		problems = append(problems, *p)
+	// DNS, public IP discovery, and off-box reachability all exist to prove a
+	// domain resolves to this machine before ACME can issue for it. Pair mode
+	// has no domain and never contacts the control plane at all
+	// (docs/adr/0003-pair-mode-gateway.md), so none of it applies.
+	if !pf.Pair {
+		if p := checkSetupDNS(pf); p != nil {
+			problems = append(problems, *p)
+		}
 	}
 	portProblems, portWarnings := checkSetupPorts(pf)
 	problems = append(problems, portProblems...)
 	warnings = append(warnings, portWarnings...)
+
+	if pf.Pair {
+		return problems, warnings
+	}
 
 	blocked := blockedSetupPorts(pf.Reach)
 	switch {
@@ -369,20 +415,25 @@ func checkSetupPrivilege(pf setupPreflight) *setupProblem {
 	// "nothing on this machine was changed" guarantee. buildSetupPlan rejects it
 	// again for anything that reaches it another way.
 	if isRootSetupIdentity(pf.TargetUser) {
-		problem := rootSetupUserProblem(pf.Domain)
+		problem := rootSetupUserProblem(pf.Domain, pf.Pair)
 		return &problem
 	}
 	if pf.UID == 0 {
 		return nil
 	}
 	rerun := fmt.Sprintf("sudo ao setup-vm --domain %s", pf.Domain)
+	manualRerun := "ao setup-vm --domain " + pf.Domain
+	if pf.Pair {
+		rerun = "sudo ao setup-vm --pair"
+		manualRerun = "ao setup-vm --pair"
+	}
 	if pf.SudoPath == "" {
 		return &setupProblem{
 			Check:  "sudo",
 			Detail: "sudo is not installed and this command is not running as root",
 			Remediation: []string{
 				"Installing packages and systemd units needs root. Either log in as root and run:",
-				"  ao setup-vm --domain " + pf.Domain,
+				"  " + manualRerun,
 				"or install sudo first:",
 				"  apt-get install -y sudo",
 			},
@@ -411,9 +462,12 @@ func isRootSetupIdentity(name string) bool {
 // rootSetupUserProblem is the single wording for a root target user, shared by
 // the preflight check and buildSetupPlan so the two can never disagree about
 // why it is refused or how to fix it.
-func rootSetupUserProblem(domain string) setupProblem {
+func rootSetupUserProblem(domain string, pair bool) setupProblem {
 	rerun := "ao setup-vm --domain " + domain
-	if strings.TrimSpace(domain) == "" {
+	switch {
+	case pair:
+		rerun = "ao setup-vm --pair"
+	case strings.TrimSpace(domain) == "":
 		rerun = "ao setup-vm --domain <your domain>"
 	}
 	return setupProblem{
@@ -529,7 +583,7 @@ func checkSetupPorts(pf setupPreflight) (problems []setupProblem, warnings []str
 		problems = append(problems, setupProblem{
 			Check:       fmt.Sprintf("port %d", probe.Port),
 			Detail:      fmt.Sprintf("cannot bind :%d on this machine: %s", probe.Port, probe.Err.Error()),
-			Remediation: portRemediation(probe),
+			Remediation: portRemediation(probe, pf.Pair),
 		})
 	}
 	return problems, warnings
@@ -538,13 +592,17 @@ func checkSetupPorts(pf setupPreflight) (problems []setupProblem, warnings []str
 // portRemediation classifies a bind failure by its message rather than by
 // errno, because this function has to compile and be testable on every OS the
 // CLI E2E matrix runs.
-func portRemediation(probe setupPortProbe) []string {
+func portRemediation(probe setupPortProbe, pair bool) []string {
 	msg := strings.ToLower(probe.Err.Error())
+	rerun := "sudo ao setup-vm --domain <your domain>"
+	if pair {
+		rerun = "sudo ao setup-vm --pair"
+	}
 	switch {
 	case strings.Contains(msg, "permission denied"), strings.Contains(msg, "access"):
 		return []string{
 			"Ports below 1024 need privilege. Run the whole command through sudo:",
-			"  sudo ao setup-vm --domain <your domain>",
+			"  " + rerun,
 			"The gateway unit itself does not run as root: it gets CAP_NET_BIND_SERVICE instead.",
 		}
 	case strings.Contains(msg, "in use"), strings.Contains(msg, "address already"):
@@ -727,6 +785,10 @@ func parseSetupReachability(body []byte, ports []int) (map[int]bool, error) {
 // disagree about where state lives.
 type setupPlan struct {
 	Domain string
+	// Pair is whether this plan is for `ao setup-vm --pair`: no domain, no
+	// account, no control-plane contact, a self-signed certificate and a
+	// passcode instead. See docs/adr/0003-pair-mode-gateway.md.
+	Pair bool
 	// User and Group own every path below and are who both units run as. The
 	// daemon runs agent sessions, git, and gh, so it must not be root.
 	User  string
@@ -741,12 +803,25 @@ type setupPlan struct {
 	DataDir     string
 	RunFile     string
 	MachineFile string
-	CertDir     string
+	// CertDir is the hosted-mode ACME cache directory. Pair-only plans still
+	// carry it (harmless, unused) rather than special-casing it away.
+	CertDir string
+	// PairCertDir and PasscodeDir are pair-only: the persisted self-signed
+	// certificate and the passcode hash, both under the state root rather
+	// than DataDir, mirroring vmgateway.resolvePair's own defaults, because
+	// they are identity, not disposable cache (losing either forces every
+	// paired client to re-pair). Always computed, even for a hosted plan,
+	// since they are pure path arithmetic with no side effect; setupDirs only
+	// creates them when Pair is true.
+	PairCertDir string
+	PasscodeDir string
 	BinaryPath  string
 	Packages    []string
 	// Bound is whether machine.json already exists. `ao vm serve` reads it
 	// once at startup, so an unbound machine gets an enabled-but-stopped
 	// gateway and a summary line telling the user to restart it after binding.
+	// Pair-only: always false, since pair mode has no account to bind and the
+	// gateway starts as soon as its passcode and certificate exist.
 	Bound bool
 }
 
@@ -754,6 +829,7 @@ type setupPlan struct {
 // whatever AO_* overrides the environment carries.
 type setupPlanInput struct {
 	Domain      string
+	Pair        bool
 	User        string
 	Group       string
 	Home        string
@@ -777,8 +853,8 @@ func buildSetupPlan(in setupPlanInput) (setupPlan, error) {
 	if isRootSetupIdentity(in.User) || isRootSetupIdentity(in.Group) {
 		return setupPlan{}, fmt.Errorf(
 			"refusing to install units that run as root: %s\n%s",
-			rootSetupUserProblem(in.Domain).Detail,
-			strings.Join(prefixLines(rootSetupUserProblem(in.Domain).Remediation, "  "), "\n"))
+			rootSetupUserProblem(in.Domain, in.Pair).Detail,
+			strings.Join(prefixLines(rootSetupUserProblem(in.Domain, in.Pair).Remediation, "  "), "\n"))
 	}
 	if !isLinuxAbs(in.Home) {
 		return setupPlan{}, fmt.Errorf("home directory %q for user %s is not an absolute path", in.Home, in.User)
@@ -793,6 +869,7 @@ func buildSetupPlan(in setupPlanInput) (setupPlan, error) {
 	aoDir := slashPath(append([]string{in.Home}, config.StateRootSegments()...)...)
 	plan := setupPlan{
 		Domain:      in.Domain,
+		Pair:        in.Pair,
 		User:        in.User,
 		Group:       group,
 		Home:        in.Home,
@@ -800,6 +877,14 @@ func buildSetupPlan(in setupPlanInput) (setupPlan, error) {
 		DataDir:     slashPath(aoDir, "data"),
 		RunFile:     slashPath(aoDir, "running.json"),
 		MachineFile: slashPath(aoDir, "machine.json"),
+		// Mirrors vmgateway.resolvePair's own defaults exactly
+		// (<state root>/vm-gateway/pair-cert and .../pair-passcode), computed
+		// here rather than by calling vmgateway.DefaultPasscodeDir() because
+		// that function resolves against this process's own home directory,
+		// which under sudo is root's, not the target user's; aoDir above is
+		// already resolved against the right one.
+		PairCertDir: slashPath(aoDir, "vm-gateway", "pair-cert"),
+		PasscodeDir: slashPath(aoDir, "vm-gateway", "pair-passcode"),
 		BinaryPath:  setupVMBinaryPath,
 		Packages:    setupVMPackages,
 		Bound:       in.Bound,
@@ -870,7 +955,13 @@ func isLinuxAbs(p string) bool {
 // the target user and none of them outside ~/.ao/hosted.
 func (p setupPlan) setupDirs() []string {
 	dirs := []string{p.AODir}
-	for _, dir := range []string{p.DataDir, p.CertDir, path.Dir(p.RunFile)} {
+	extra := []string{p.DataDir, path.Dir(p.RunFile)}
+	if p.Pair {
+		extra = append(extra, p.PairCertDir, p.PasscodeDir)
+	} else {
+		extra = append(extra, p.CertDir)
+	}
+	for _, dir := range extra {
 		if !slices.Contains(dirs, dir) {
 			dirs = append(dirs, dir)
 		}
@@ -1049,6 +1140,9 @@ func renderDaemonUnit(p setupPlan) string {
 // absolute and set here rather than derived from the process working
 // directory, which is how ACME keys and state silently relocate under systemd.
 func renderGatewayUnit(p setupPlan) string {
+	if p.Pair {
+		return renderPairGatewayUnit(p)
+	}
 	env := append(p.unitEnvironment(),
 		[2]string{"AO_MACHINE_FILE", p.MachineFile},
 		[2]string{"AO_VM_DOMAIN", p.Domain},
@@ -1079,6 +1173,44 @@ func renderGatewayUnit(p setupPlan) string {
 		MemoryMax: setupVMGatewayMemoryMax,
 		CPUQuota:  setupVMGatewayCPUQuota,
 		TasksMax:  setupVMGatewayTasksMax,
+	})
+}
+
+// renderPairGatewayUnit is renderGatewayUnit's pair-mode branch. It never sets
+// AO_VM_DOMAIN, AO_MACHINE_FILE, or any other hosted-only variable:
+// vmgateway.Resolve rejects hosted-only fields alongside AO_VM_PAIR outright
+// (see resolvePair in internal/vmgateway/config.go), so setting one here would
+// make the unit it renders fail to start. AO_VM_PAIR=on is what selects pair
+// mode; AO_VM_CERT_DIR and AO_VM_PASSCODE_DIR point at the certificate and
+// passcode ao setup-vm --pair generated. See
+// docs/adr/0003-pair-mode-gateway.md.
+func renderPairGatewayUnit(p setupPlan) string {
+	env := append(p.unitEnvironment(),
+		[2]string{"AO_VM_PAIR", "on"},
+		[2]string{"AO_VM_CERT_DIR", p.PairCertDir},
+		[2]string{"AO_VM_PASSCODE_DIR", p.PasscodeDir},
+	)
+	return renderSystemdUnit(systemdUnit{
+		Comment: []string{
+			"The AO VM gateway in pair mode: binds only the HTTPS port with a",
+			"persisted self-signed certificate, verifies a passcode instead of an AO",
+			"access token, and never contacts the control plane. No :80, no ACME,",
+			"no domain, no account. It is a separate process from the daemon and",
+			"must stay one (ADR 0002); see docs/adr/0003-pair-mode-gateway.md.",
+		},
+		Description: "Agent Orchestrator VM gateway (pair mode, HTTPS only)",
+		Wants:       []string{"network-online.target"},
+		After:       []string{"network-online.target", setupVMDaemonUnit},
+		User:        p.User,
+		Group:       p.Group,
+		WorkingDir:  p.DataDir,
+		Env:         env,
+		ExecStart:   p.BinaryPath + " vm serve",
+		AmbientCaps: []string{"CAP_NET_BIND_SERVICE"},
+		Restart:     "always",
+		MemoryMax:   setupVMGatewayMemoryMax,
+		CPUQuota:    setupVMGatewayCPUQuota,
+		TasksMax:    setupVMGatewayTasksMax,
 	})
 }
 
@@ -1218,6 +1350,171 @@ func renderSetupDryRun(p setupPlan, warnings []string) string {
 	b.WriteString("needs a browser and a human to approve it, and then writes the machine file\n")
 	b.WriteString("above and restarts the gateway so it reads it.\n")
 	b.WriteString("\nRun the same command without --dry-run to apply this.\n")
+	return b.String()
+}
+
+// ---------------------------------------------------------------------------
+// pair mode: the closing summary, the dry run, and the unsupported-platform
+// manual path. Pair mode never touches a domain or an AO account, so these
+// deliberately do not share renderSetupSummary/renderSetupDryRun/
+// renderManualPath, whose whole shape is built around one.
+// ---------------------------------------------------------------------------
+
+// renderManualPathPair is renderManualPath's pair-mode counterpart: the same
+// "nothing was changed, here is how by hand" guarantee, but describing
+// AO_VM_PAIR instead of a domain and ACME.
+func renderManualPathPair(p setupPlatform) string {
+	var b strings.Builder
+	b.WriteString("ao setup-vm --pair automates Debian-family Linux only, because it installs apt\n")
+	fmt.Fprintf(&b, "packages and systemd units. This machine reports %s, so nothing was changed.\n", p.platformName())
+	b.WriteString("\nSet the machine up by hand instead:\n")
+	b.WriteString("\n  1. Install tmux, git, and the GitHub CLI (gh) with this system's package manager.\n")
+	fmt.Fprintf(&b, "  2. Put the ao binary on PATH at an absolute location, for example %s.\n", setupVMBinaryPath)
+	b.WriteString("  3. Run the daemon as your own (non-root) user, with the state directory set\n")
+	b.WriteString("     explicitly to an absolute path:\n")
+	b.WriteString("       AO_DATA_DIR=\"$HOME/.ao/hosted/data\" ao daemon\n")
+	b.WriteString("     It listens on 127.0.0.1 only and has no authentication, which is why it must\n")
+	b.WriteString("     never be exposed directly.\n")
+	b.WriteString("  4. Run the gateway as a second, separate process, never the same one:\n")
+	b.WriteString("       AO_DATA_DIR=\"$HOME/.ao/hosted/data\" AO_VM_PAIR=on ao vm serve\n")
+	b.WriteString("     It binds only the HTTPS port, presenting a self-signed certificate; no domain,\n")
+	b.WriteString("     no ACME, no control plane.\n")
+	b.WriteString("  5. Supervise both processes with whatever this system uses, restarting them on\n")
+	b.WriteString("     failure and on boot.\n")
+	b.WriteString("\nThen finish the same way ao setup-vm --pair would:\n")
+	b.WriteString("  ao vm setup-harness claude   (log in to an agent harness in the foreground)\n")
+	b.WriteString("  gh auth login                (git credentials for private repositories)\n")
+	return b.String()
+}
+
+// renderPairCredentials is the pairing block ao setup-vm --pair prints once,
+// at the end of a successful run: the passcode (only when this run generated
+// one; re-running never rotates it), the certificate fingerprint (never a
+// secret, so it is always printed, on every run, for a client that needs to
+// re-pair or wants to double-check it), and where to point the desktop app.
+// Read this off the SSH session it was printed on and compare the fingerprint
+// against what the desktop app shows on first connect, by eye: they must
+// match exactly, and any mismatch means refuse and re-pair, never continue.
+func renderPairCredentials(passcode string, generated bool, fingerprint string, addrs []string, httpsAddr string) string {
+	var b strings.Builder
+	b.WriteString("\nPairing this box to the AO desktop app:\n")
+	if generated {
+		b.WriteString("\n  Passcode (shown once here, never stored anywhere in plaintext):\n")
+		fmt.Fprintf(&b, "\n      %s\n", passcode)
+	} else {
+		b.WriteString("\n  Passcode: already set from an earlier run, so it is not shown again.\n")
+		b.WriteString("  Roll a new one, which drops every connected client, with:\n")
+		b.WriteString("    ao vm rotate-passcode\n")
+	}
+	b.WriteString("\n  Certificate fingerprint (compare this, by eye, against what the desktop app\n")
+	b.WriteString("  shows on first connect; a mismatch means refuse and re-pair, never continue):\n")
+	fmt.Fprintf(&b, "\n      %s\n", fingerprint)
+	b.WriteString("\n  Address to enter in the desktop app:\n")
+	port := strings.TrimPrefix(httpsAddr, ":")
+	if len(addrs) == 0 {
+		fmt.Fprintf(&b, "\n      <this machine's LAN IP>:%s  (no address was found automatically; find it with `ip addr`)\n", port)
+	} else {
+		for _, addr := range addrs {
+			fmt.Fprintf(&b, "\n      %s:%s\n", addr, port)
+		}
+	}
+	return b.String()
+}
+
+// renderSetupSummaryPair is renderSetupSummary's pair-mode counterpart.
+func renderSetupSummaryPair(p setupPlan, units setupUnitStates, warnings []string, passcode string, passcodeGenerated bool, fingerprint string, addrs []string) string {
+	var b strings.Builder
+	b.WriteString("\nao setup-vm --pair finished. No domain, no AO account, no control-plane contact.\n")
+
+	b.WriteString("\nInstalled:\n")
+	fmt.Fprintf(&b, "  ao binary        %s\n", p.BinaryPath)
+	fmt.Fprintf(&b, "  packages         %s\n", strings.Join(p.Packages, ", "))
+	fmt.Fprintf(&b, "  state directory  %s (owned by %s)\n", p.AODir, p.User)
+	daemonState := "enabled, running, loopback only"
+	if !units.DaemonRunning {
+		daemonState = "enabled, but not running: see the warnings below"
+	}
+	fmt.Fprintf(&b, "  daemon unit      %s (%s)\n", slashPath(setupVMUnitDir, setupVMDaemonUnit), daemonState)
+	gatewayState := "enabled, running (HTTPS only, no :80)"
+	if !units.GatewayRunning {
+		gatewayState = "enabled, but not running: see the warnings below"
+	}
+	fmt.Fprintf(&b, "  gateway unit     %s (%s)\n", slashPath(setupVMUnitDir, setupVMGatewayUnit), gatewayState)
+
+	if len(warnings) > 0 {
+		b.WriteString("\nWarnings from this run:\n")
+		for _, warning := range warnings {
+			fmt.Fprintf(&b, "  %s\n", warning)
+		}
+	}
+
+	b.WriteString(renderPairCredentials(passcode, passcodeGenerated, fingerprint, addrs, vmgateway.DefaultHTTPSAddr))
+
+	b.WriteString("\nStill missing. Nothing below is done for you:\n")
+	b.WriteString("\n  1. No agent harness is configured. Run it in the foreground and finish the\n")
+	b.WriteString("     harness's own login:\n")
+	b.WriteString("       ao vm setup-harness claude\n")
+	b.WriteString("\n  2. No git credentials on this machine, so private repositories cannot be cloned.\n")
+	b.WriteString("     gh is installed; authenticate it once:\n")
+	b.WriteString("       gh auth login\n")
+
+	b.WriteString("\nCheck this machine at any time:\n")
+	b.WriteString("  ao doctor\n")
+	fmt.Fprintf(&b, "  systemctl status %s %s\n", setupVMDaemonUnit, setupVMGatewayUnit)
+	fmt.Fprintf(&b, "  journalctl -u %s -f\n", setupVMGatewayUnit)
+	return b.String()
+}
+
+// renderSetupDryRunPair is renderSetupDryRun's pair-mode counterpart: the
+// whole plan and both unit files, without touching the machine or generating
+// a passcode or a certificate.
+func renderSetupDryRunPair(p setupPlan, warnings []string) string {
+	var b strings.Builder
+	b.WriteString("Dry run. Nothing on this machine was changed.\n")
+	if len(warnings) > 0 {
+		b.WriteString("\nWarnings:\n")
+		for _, warning := range warnings {
+			fmt.Fprintf(&b, "  %s\n", warning)
+		}
+	}
+	b.WriteString("\nPlan (pair mode: no domain, no AO account, no control-plane contact):\n")
+	fmt.Fprintf(&b, "  run as           %s:%s\n", p.User, p.Group)
+	fmt.Fprintf(&b, "  state directory  %s\n", p.AODir)
+	fmt.Fprintf(&b, "  data dir         %s\n", p.DataDir)
+	fmt.Fprintf(&b, "  run file         %s\n", p.RunFile)
+	fmt.Fprintf(&b, "  pair cert dir    %s\n", p.PairCertDir)
+	fmt.Fprintf(&b, "  passcode dir     %s\n", p.PasscodeDir)
+	fmt.Fprintf(&b, "  ao binary        %s\n", p.BinaryPath)
+	fmt.Fprintf(&b, "  apt packages     %s\n", strings.Join(p.Packages, ", "))
+
+	for _, unit := range []struct {
+		name    string
+		content string
+	}{
+		{setupVMDaemonUnit, renderDaemonUnit(p)},
+		{setupVMGatewayUnit, renderGatewayUnit(p)},
+	} {
+		fmt.Fprintf(&b, "\n--- %s ---\n", slashPath(setupVMUnitDir, unit.name))
+		b.WriteString(unit.content)
+	}
+	b.WriteString("\nA real run also generates, on first run only, a passcode and a self-signed\n")
+	b.WriteString("certificate, then prints both once alongside this machine's listening address.\n")
+	b.WriteString("Re-running never rotates either; use `ao vm rotate-passcode` to roll the passcode\n")
+	b.WriteString("on purpose.\n")
+	b.WriteString("\nRun the same command without --dry-run to apply this.\n")
+	return b.String()
+}
+
+// renderPasscodeRotated is the whole output of `ao vm rotate-passcode`: the
+// new passcode, printed once, framed differently from ao setup-vm --pair's
+// first-run output so the two are never mistaken for each other.
+func renderPasscodeRotated(passcode string) string {
+	var b strings.Builder
+	b.WriteString("\nPasscode rotated. Every device connected with the old passcode has been dropped\n")
+	b.WriteString("and must enter this new one. The pinned certificate is unchanged, so there is no\n")
+	b.WriteString("fingerprint to re-check.\n")
+	b.WriteString("\n  New passcode (shown once here, never stored anywhere in plaintext):\n")
+	fmt.Fprintf(&b, "\n      %s\n", passcode)
 	return b.String()
 }
 

--- a/backend/internal/cli/setupvm_plan_test.go
+++ b/backend/internal/cli/setupvm_plan_test.go
@@ -67,16 +67,42 @@ func TestCheckSetupPlatform(t *testing.T) {
 			},
 			wantWarning: "not an LTS release",
 		},
+		// The distro gate widened to the whole Debian family
+		// (docs/plans/2026-08-16-pair-by-ip-headless-boxes.md, task 7), so
+		// Raspberry Pi OS can pass it: Debian itself and Raspberry Pi OS both
+		// now pass, and neither gets the Ubuntu-specific "not an LTS release"
+		// warning, since neither uses that term.
 		{
-			name: "debian is refused",
+			name: "debian passes and gets no LTS warning",
 			platform: setupPlatform{
 				GOOS: "linux", HasSystemctl: true, HasAptGet: true,
-				OSRelease: parseOSRelease("ID=debian\nPRETTY_NAME=\"Debian GNU/Linux 12 (bookworm)\"\n"),
+				OSRelease: parseOSRelease("ID=debian\nVERSION=\"12 (bookworm)\"\nPRETTY_NAME=\"Debian GNU/Linux 12 (bookworm)\"\n"),
 			},
-			wantErr: true,
+		},
+		{
+			name: "raspberry pi os (id=debian) passes",
+			platform: setupPlatform{
+				GOOS: "linux", HasSystemctl: true, HasAptGet: true,
+				OSRelease: parseOSRelease("ID=debian\nVERSION=\"12 (bookworm)\"\nPRETTY_NAME=\"Raspberry Pi OS (64-bit)\"\n"),
+			},
+		},
+		{
+			name: "raspberry pi os (older id=raspbian, id_like=debian) passes",
+			platform: setupPlatform{
+				GOOS: "linux", HasSystemctl: true, HasAptGet: true,
+				OSRelease: parseOSRelease("ID=raspbian\nID_LIKE=debian\nVERSION=\"11 (bullseye)\"\nPRETTY_NAME=\"Raspbian GNU/Linux 11 (bullseye)\"\n"),
+			},
 		},
 		{name: "macOS is refused", platform: setupPlatform{GOOS: "darwin"}, wantErr: true},
 		{name: "windows is refused", platform: setupPlatform{GOOS: "windows"}, wantErr: true},
+		{
+			name: "a genuinely unsupported distro is still refused",
+			platform: setupPlatform{
+				GOOS: "linux", HasSystemctl: true, HasAptGet: true,
+				OSRelease: parseOSRelease("ID=fedora\nPRETTY_NAME=\"Fedora Linux 40\"\n"),
+			},
+			wantErr: true,
+		},
 		{
 			name: "ubuntu without systemd is refused",
 			platform: setupPlatform{
@@ -88,6 +114,22 @@ func TestCheckSetupPlatform(t *testing.T) {
 			name: "ubuntu without apt is refused",
 			platform: setupPlatform{
 				GOOS: "linux", HasSystemctl: true, OSRelease: parseOSRelease(ubuntuNobleOSRelease),
+			},
+			wantErr: true,
+		},
+		{
+			name: "debian without systemd is still refused: the widened gate does not drop the real requirements",
+			platform: setupPlatform{
+				GOOS: "linux", HasAptGet: true,
+				OSRelease: parseOSRelease("ID=debian\nPRETTY_NAME=\"Debian GNU/Linux 12 (bookworm)\"\n"),
+			},
+			wantErr: true,
+		},
+		{
+			name: "debian without apt-get is still refused",
+			platform: setupPlatform{
+				GOOS: "linux", HasSystemctl: true,
+				OSRelease: parseOSRelease("ID=debian\nPRETTY_NAME=\"Debian GNU/Linux 12 (bookworm)\"\n"),
 			},
 			wantErr: true,
 		},
@@ -352,6 +394,71 @@ func TestEvaluatePreflight_PortProblems(t *testing.T) {
 			t.Fatalf("warnings = %v, want one naming the gateway", warnings)
 		}
 	})
+}
+
+// TestEvaluatePreflight_PairDoesNotDemandPort80 is the pair-mode port
+// requirement directly: pair mode binds only the HTTPS port, never :80 (no
+// ACME challenge to answer), so preflight must never probe or complain about
+// :80 in pair mode, and setupVMPortsPair itself must be HTTPS only.
+func TestEvaluatePreflight_PairDoesNotDemandPort80(t *testing.T) {
+	if len(setupVMPortsPair) != 1 || setupVMPortsPair[0] != 443 {
+		t.Fatalf("setupVMPortsPair = %v, want only 443: pair mode never binds :80", setupVMPortsPair)
+	}
+	pf := setupPreflight{
+		Pair:       true,
+		TargetUser: "ubuntu",
+		Ports:      []setupPortProbe{{Port: 443}},
+	}
+	problems, warnings := evaluatePreflight(pf)
+	if len(problems) != 0 {
+		t.Fatalf("problems = %+v, want none", problems)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("warnings = %v, want none: pair mode has no domain and no off-box reachability check", warnings)
+	}
+}
+
+// TestEvaluatePreflight_PairSkipsDNSAndReachability confirms pair mode never
+// reports a DNS or reachability problem, even when the (unused) fields that
+// would normally cause one are populated: a pair preflight simply never
+// looks at them, because pair mode has no domain and never contacts the
+// control plane (docs/adr/0003-pair-mode-gateway.md).
+func TestEvaluatePreflight_PairSkipsDNSAndReachability(t *testing.T) {
+	pf := setupPreflight{
+		Pair:        true,
+		TargetUser:  "ubuntu",
+		Domain:      "",
+		ResolveErr:  errors.New("no such host"),
+		PublicIPErr: errors.New("dial tcp: i/o timeout"),
+		Reach:       setupReachability{Ran: true, Open: map[int]bool{80: false, 443: false}},
+		Ports:       []setupPortProbe{{Port: 443}},
+	}
+	problems, warnings := evaluatePreflight(pf)
+	if len(problems) != 0 {
+		t.Fatalf("problems = %+v, want none: pair mode must not evaluate DNS or reachability at all", problems)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("warnings = %v, want none", warnings)
+	}
+}
+
+// TestEvaluatePreflight_PairPortFailureUsesPairRerun pins the pair-specific
+// remediation wording: a low-port bind failure in pair mode must point at
+// `ao setup-vm --pair`, never at the hosted `--domain` form, which pair mode
+// does not take at all.
+func TestEvaluatePreflight_PairPortFailureUsesPairRerun(t *testing.T) {
+	pf := setupPreflight{
+		Pair:       true,
+		TargetUser: "ubuntu",
+		Ports: []setupPortProbe{
+			{Port: 443, Err: errors.New("listen tcp 127.0.0.1:443: bind: permission denied")},
+		},
+	}
+	problems, _ := evaluatePreflight(pf)
+	problem := assertProblem(t, problems, "port 443", "sudo ao setup-vm --pair")
+	if strings.Contains(strings.Join(problem.Remediation, "\n"), "--domain") {
+		t.Errorf("pair-mode remediation must not mention --domain: %v", problem.Remediation)
+	}
 }
 
 func TestEvaluatePreflight_BlockedFirewallIsDetectedAndNamed(t *testing.T) {
@@ -633,6 +740,61 @@ func TestSetupDirsAreDeduplicated(t *testing.T) {
 	}
 }
 
+// testPairSetupPlan mirrors testSetupPlan for a pair-mode plan: no domain.
+func testPairSetupPlan(t *testing.T) setupPlan {
+	t.Helper()
+	plan, err := buildSetupPlan(setupPlanInput{
+		Pair:  true,
+		User:  "ubuntu",
+		Group: "ubuntu",
+		Home:  "/home/ubuntu",
+	})
+	if err != nil {
+		t.Fatalf("buildSetupPlan err = %v", err)
+	}
+	return plan
+}
+
+func TestBuildSetupPlan_PairDefaultsUnderAODir(t *testing.T) {
+	plan := testPairSetupPlan(t)
+	if !plan.Pair {
+		t.Fatal("Pair must be true")
+	}
+	if plan.Domain != "" {
+		t.Errorf("Domain = %q, want empty: pair mode has no domain", plan.Domain)
+	}
+	if plan.PairCertDir != "/home/ubuntu/.ao/hosted/vm-gateway/pair-cert" {
+		t.Errorf("PairCertDir = %q, want it under the state root, matching vmgateway.resolvePair's own default", plan.PairCertDir)
+	}
+	if plan.PasscodeDir != "/home/ubuntu/.ao/hosted/vm-gateway/pair-passcode" {
+		t.Errorf("PasscodeDir = %q, want it under the state root, matching vmgateway.resolvePair's own default", plan.PasscodeDir)
+	}
+	if plan.Bound {
+		t.Error("a pair plan must never claim Bound: pair mode has no account to bind")
+	}
+}
+
+// TestSetupDirsPairModeCreatesPairDirsNotTheACMEOne is the pair-mode half of
+// TestSetupDirsAreDeduplicated: a pair plan must create its own certificate
+// and passcode directories, and must not create the hosted ACME cache
+// directory it will never use.
+func TestSetupDirsPairModeCreatesPairDirsNotTheACMEOne(t *testing.T) {
+	plan := testPairSetupPlan(t)
+	dirs := plan.setupDirs()
+	seen := map[string]bool{}
+	for _, dir := range dirs {
+		seen[dir] = true
+	}
+	for _, want := range []string{plan.AODir, plan.DataDir, plan.PairCertDir, plan.PasscodeDir} {
+		if !seen[want] {
+			t.Errorf("setupDirs is missing %q: %v", want, dirs)
+		}
+	}
+	if seen[plan.CertDir] {
+		t.Errorf("setupDirs must not create the unused hosted ACME cert dir %q in pair mode: %v", plan.CertDir, dirs)
+	}
+}
+
 func TestRenderDaemonUnit(t *testing.T) {
 	unit := renderDaemonUnit(testSetupPlan(t))
 	for _, want := range []string{
@@ -723,6 +885,35 @@ func TestRenderGatewayUnit(t *testing.T) {
 	}
 	if !strings.Contains(unit, "needs a restart") {
 		t.Error("the gateway unit should record that machine.json is read once at startup")
+	}
+	assertNoDashes(t, unit)
+}
+
+// TestRenderGatewayUnit_Pair pins pair mode's gateway unit env: AO_VM_PAIR=on
+// selects pair mode, AO_VM_CERT_DIR and AO_VM_PASSCODE_DIR point at the pair
+// certificate and passcode directories, and none of the hosted-only
+// variables are set. vmgateway.Resolve's resolvePair rejects any of them
+// alongside AO_VM_PAIR (internal/vmgateway/config.go), so setting one here
+// would make the rendered unit fail to start.
+func TestRenderGatewayUnit_Pair(t *testing.T) {
+	plan := testPairSetupPlan(t)
+	unit := renderGatewayUnit(plan)
+	for _, want := range []string{
+		`Environment="AO_VM_PAIR=on"`,
+		`Environment="AO_VM_CERT_DIR=/home/ubuntu/.ao/hosted/vm-gateway/pair-cert"`,
+		`Environment="AO_VM_PASSCODE_DIR=/home/ubuntu/.ao/hosted/vm-gateway/pair-passcode"`,
+		"ExecStart=/usr/local/bin/ao vm serve",
+		"AmbientCapabilities=CAP_NET_BIND_SERVICE",
+		"Restart=always",
+	} {
+		if !strings.Contains(unit, want) {
+			t.Errorf("pair gateway unit is missing %q:\n%s", want, unit)
+		}
+	}
+	for _, unwanted := range []string{"AO_VM_DOMAIN", "AO_MACHINE_FILE", "AO_VM_ISSUER", "AO_VM_ACCOUNT_ID", "AO_VM_JWKS_URL", "AO_VM_HTTP_ADDR"} {
+		if strings.Contains(unit, unwanted) {
+			t.Errorf("pair gateway unit must not set %q: vmgateway.resolvePair rejects hosted-only fields alongside AO_VM_PAIR:\n%s", unwanted, unit)
+		}
 	}
 	assertNoDashes(t, unit)
 }
@@ -976,6 +1167,136 @@ func TestRenderSetupDryRunShowsBothUnitsAndChangesNothing(t *testing.T) {
 			t.Errorf("dry run output is missing %q:\n%s", want, text)
 		}
 	}
+}
+
+func TestRenderSetupDryRunPairShowsBothUnitsAndChangesNothing(t *testing.T) {
+	plan := testPairSetupPlan(t)
+	text := renderSetupDryRunPair(plan, nil)
+	if !strings.HasPrefix(text, "Dry run. Nothing on this machine was changed.") {
+		t.Fatalf("dry run must lead with the no-mutation guarantee:\n%s", text)
+	}
+	for _, want := range []string{
+		"no domain, no AO account, no control-plane contact",
+		"/etc/systemd/system/ao-daemon.service",
+		"/etc/systemd/system/ao-gateway.service",
+		"ExecStart=/usr/local/bin/ao daemon",
+		"ExecStart=/usr/local/bin/ao vm serve",
+		"AO_VM_PAIR=on",
+		"pair cert dir",
+		"passcode dir",
+		"Re-running never rotates either",
+		"ao vm rotate-passcode",
+		"without --dry-run",
+	} {
+		if !strings.Contains(text, want) {
+			t.Errorf("pair dry run output is missing %q:\n%s", want, text)
+		}
+	}
+	if strings.Contains(text, "AO_VM_DOMAIN") || strings.Contains(text, "device code") {
+		t.Errorf("pair dry run must not mention the hosted domain/device-flow path:\n%s", text)
+	}
+	assertNoDashes(t, text)
+}
+
+// TestRenderSetupSummaryPair_FirstRunShowsThePasscodeOnce is the printed-output
+// half of the single most important pair-mode contract: the passcode and
+// fingerprint appear together, once, on the run that generated them.
+func TestRenderSetupSummaryPair_FirstRunShowsThePasscodeOnce(t *testing.T) {
+	plan := testPairSetupPlan(t)
+	summary := renderSetupSummaryPair(plan, setupUnitStates{DaemonRunning: true, GatewayRunning: true}, nil,
+		"AB12CD34", true, "07:CA:9F:3E:B2:11:00:11:22:33:44:55:66:77:88:99:AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99", nil)
+	for _, want := range []string{
+		"No domain, no AO account, no control-plane contact",
+		"AB12CD34",
+		"07:CA:9F:3E:B2:11",
+		"HTTPS only, no :80",
+		"ao vm setup-harness claude",
+		"gh auth login",
+		"ao doctor",
+		"mismatch means refuse and re-pair",
+	} {
+		if !strings.Contains(summary, want) {
+			t.Errorf("pair summary is missing %q:\n%s", want, summary)
+		}
+	}
+	if strings.Contains(summary, "AO account") == false {
+		t.Errorf("pair summary must state no AO account is involved:\n%s", summary)
+	}
+	assertNoDashes(t, summary)
+}
+
+// TestRenderSetupSummaryPair_ReRunNeverShowsThePasscodeAgain is the printed
+// side of the non-rotation guarantee: a run that did not generate a fresh
+// passcode must never print one, plaintext or otherwise, and must point at
+// the deliberate rotate command instead.
+func TestRenderSetupSummaryPair_ReRunNeverShowsThePasscodeAgain(t *testing.T) {
+	plan := testPairSetupPlan(t)
+	summary := renderSetupSummaryPair(plan, setupUnitStates{DaemonRunning: true, GatewayRunning: true}, nil,
+		"", false, "07:CA:9F:3E:B2:11:00:11:22:33:44:55:66:77:88:99:AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99", nil)
+	if strings.Contains(summary, "AB12CD34") {
+		t.Error("a re-run must never print a passcode")
+	}
+	if !strings.Contains(summary, "already set from an earlier run") {
+		t.Errorf("a re-run must say the passcode is unchanged:\n%s", summary)
+	}
+	if !strings.Contains(summary, "ao vm rotate-passcode") {
+		t.Errorf("a re-run must point at the deliberate rotate command:\n%s", summary)
+	}
+	// The fingerprint is not a secret and must still be printed every run.
+	if !strings.Contains(summary, "07:CA:9F:3E:B2:11") {
+		t.Errorf("the fingerprint must still be printed on a re-run:\n%s", summary)
+	}
+	assertNoDashes(t, summary)
+}
+
+func TestRenderPairCredentials_FallsBackWhenNoAddressWasFound(t *testing.T) {
+	text := renderPairCredentials("AB12CD34", true, "07:CA", nil, ":443")
+	if !strings.Contains(text, "443") {
+		t.Errorf("must still print the port when no address was found: %q", text)
+	}
+	if !strings.Contains(text, "LAN IP") {
+		t.Errorf("must fall back to telling the operator to find their own address: %q", text)
+	}
+}
+
+func TestRenderPairCredentials_ListsEveryDiscoveredAddress(t *testing.T) {
+	text := renderPairCredentials("AB12CD34", true, "07:CA", []string{"192.168.1.20", "10.0.0.5"}, ":443")
+	for _, want := range []string{"192.168.1.20:443", "10.0.0.5:443"} {
+		if !strings.Contains(text, want) {
+			t.Errorf("credentials block is missing %q:\n%s", want, text)
+		}
+	}
+}
+
+func TestRenderManualPathPair_NamesEveryStep(t *testing.T) {
+	text := renderManualPathPair(setupPlatform{GOOS: "darwin"})
+	for _, want := range []string{
+		"nothing was changed",
+		"ao daemon",
+		"AO_VM_PAIR=on",
+		"ao vm serve",
+		"ao vm setup-harness claude",
+		"gh auth login",
+		"AO_DATA_DIR",
+	} {
+		if !strings.Contains(text, want) {
+			t.Errorf("pair manual path is missing %q:\n%s", want, text)
+		}
+	}
+	if strings.Contains(text, "--domain") {
+		t.Errorf("pair manual path must not mention --domain:\n%s", text)
+	}
+	assertNoDashes(t, text)
+}
+
+func TestRenderPasscodeRotated(t *testing.T) {
+	text := renderPasscodeRotated("XY98ZW76")
+	for _, want := range []string{"XY98ZW76", "Every device connected with the old passcode has been dropped", "fingerprint to re-check"} {
+		if !strings.Contains(text, want) {
+			t.Errorf("rotation output is missing %q:\n%s", want, text)
+		}
+	}
+	assertNoDashes(t, text)
 }
 
 func TestSetupPackagesExcludeHarnesses(t *testing.T) {

--- a/backend/internal/cli/setupvm_test.go
+++ b/backend/internal/cli/setupvm_test.go
@@ -7,6 +7,7 @@ package cli
 // setupvm_plan_test.go.
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -14,11 +15,15 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"os/user"
 	"path/filepath"
 	"runtime"
 	"strings"
 	"sync"
 	"testing"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/mobilebridge"
+	"github.com/aoagents/agent-orchestrator/backend/internal/vmgateway"
 )
 
 // errRoundTripper fails every HTTP request, so a test can never depend on the
@@ -376,6 +381,199 @@ func TestSetupVersionSkewNote(t *testing.T) {
 			t.Errorf("identical versions are not skew:\n%s", note)
 		}
 	})
+}
+
+// TestSetupVM_PairRejectsDomain pins the mutual exclusivity between --pair
+// and --domain at the CLI boundary: pair mode has no domain at all, so
+// combining the two is refused as misuse before anything runs, mirroring
+// vmgateway.Resolve's own resolvePair rejection of hosted-only fields.
+func TestSetupVM_PairRejectsDomain(t *testing.T) {
+	deps, calls := recordingDeps(t)
+	_, _, err := executeCLI(t, deps, "setup-vm", "--pair", "--domain", "vm.example.com")
+	if err == nil {
+		t.Fatal("expected an error when --pair and --domain are combined")
+	}
+	if got := ExitCode(err); got != 2 {
+		t.Errorf("ExitCode = %d, want 2 (misuse)", got)
+	}
+	assertNoSetupMutation(t, calls())
+}
+
+// TestSetupVM_PairRefusesNonDebianWithTheManualPath is --pair's platform-gate
+// refusal path, mirroring TestSetupVM_RefusesNonUbuntuWithTheManualPath: a
+// failed gate must change nothing and must print the pair-specific manual
+// path, not the hosted one (no --domain, no ACME, no device flow).
+func TestSetupVM_PairRefusesNonDebianWithTheManualPath(t *testing.T) {
+	if runtime.GOOS == "linux" {
+		t.Skip("the gate only refuses non-Linux hosts here; Linux is covered by checkSetupPlatform's table test")
+	}
+	deps, calls := recordingDeps(t)
+	out, _, err := executeCLI(t, deps, "setup-vm", "--pair")
+	if err == nil {
+		t.Fatal("expected ao setup-vm --pair to refuse to run on " + runtime.GOOS)
+	}
+	if got := ExitCode(err); got != 1 {
+		t.Errorf("ExitCode = %d, want 1: an unsupported platform is a runtime refusal, not misuse", got)
+	}
+	var unsupported errUnsupportedPlatform
+	if !errors.As(err, &unsupported) {
+		t.Errorf("err = %v, want errUnsupportedPlatform", err)
+	}
+	for _, want := range []string{"nothing was changed", "AO_VM_PAIR=on", "gh auth login"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("pair refusal output is missing %q:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "--domain") {
+		t.Errorf("pair refusal output must not mention --domain:\n%s", out)
+	}
+	assertNoSetupMutation(t, calls())
+}
+
+// TestEnsureSetupPasscode_ReRunDoesNotRotate is the single most important
+// test in this file: re-running ao setup-vm --pair must never rotate the
+// passcode a client has already pinned. The first call generates one; every
+// call after that, against the same directory, must return generated=false
+// with no plaintext and must leave the persisted hash byte-for-byte
+// identical. See docs/adr/0003-pair-mode-gateway.md.
+func TestEnsureSetupPasscode_ReRunDoesNotRotate(t *testing.T) {
+	c := &commandContext{deps: DefaultDeps()}
+	dir := t.TempDir()
+
+	first, generated, err := c.ensureSetupPasscode(dir, nil)
+	if err != nil {
+		t.Fatalf("first ensureSetupPasscode: %v", err)
+	}
+	if !generated {
+		t.Fatal("the first call against an empty directory must generate a passcode")
+	}
+	if first == "" {
+		t.Fatal("the first call must return the plaintext passcode")
+	}
+	firstHash := readSoleFile(t, dir)
+
+	for i := 0; i < 3; i++ {
+		again, generatedAgain, err := c.ensureSetupPasscode(dir, nil)
+		if err != nil {
+			t.Fatalf("re-run %d: %v", i, err)
+		}
+		if generatedAgain {
+			t.Fatalf("re-run %d: generated = true, want false: re-running must not rotate the passcode", i)
+		}
+		if again != "" {
+			t.Fatalf("re-run %d: plaintext = %q, want empty: an unchanged passcode must never be printed again", i, again)
+		}
+		if got := readSoleFile(t, dir); !bytes.Equal(got, firstHash) {
+			t.Fatalf("re-run %d: the persisted passcode hash changed:\nbefore: %s\nafter:  %s", i, firstHash, got)
+		}
+	}
+
+	// The originally generated passcode must still be the one that verifies,
+	// proving the store was never silently rotated underneath the caller.
+	if hash := mobilebridge.HashPassword(first); string(firstHash) != hash {
+		t.Fatalf("the persisted hash does not match the originally generated passcode: stored %s, want hash of %q (%s)", firstHash, first, hash)
+	}
+}
+
+// TestEnsureSetupPairCert_ReRunDoesNotRotate is the certificate half of the
+// same guarantee: a changed fingerprint is indistinguishable from an attack
+// to a client that pinned the old one, so re-running must load the exact
+// same certificate rather than generating a new one.
+func TestEnsureSetupPairCert_ReRunDoesNotRotate(t *testing.T) {
+	c := &commandContext{deps: DefaultDeps()}
+	dir := t.TempDir()
+
+	first, err := c.ensureSetupPairCert(dir, nil)
+	if err != nil {
+		t.Fatalf("first ensureSetupPairCert: %v", err)
+	}
+	firstFingerprint, err := vmgateway.PairFingerprint(first)
+	if err != nil {
+		t.Fatalf("PairFingerprint: %v", err)
+	}
+	before := readAllFiles(t, dir)
+
+	for i := 0; i < 3; i++ {
+		again, err := c.ensureSetupPairCert(dir, nil)
+		if err != nil {
+			t.Fatalf("re-run %d: %v", i, err)
+		}
+		fingerprint, err := vmgateway.PairFingerprint(again)
+		if err != nil {
+			t.Fatalf("re-run %d: PairFingerprint: %v", i, err)
+		}
+		if fingerprint != firstFingerprint {
+			t.Fatalf("re-run %d: fingerprint changed from %s to %s: re-running must load the same certificate", i, firstFingerprint, fingerprint)
+		}
+		after := readAllFiles(t, dir)
+		for name, want := range before {
+			if got := after[name]; !bytes.Equal(got, want) {
+				t.Fatalf("re-run %d: %s changed on disk, want byte-identical", i, name)
+			}
+		}
+	}
+}
+
+func TestChownSetupTree_NoOpWhenNotRoot(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("this test asserts the not-root no-op path; it cannot run as root")
+	}
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "f"), []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	owner := &user.User{Uid: "1", Gid: "1", Username: "someone-else"}
+	if err := chownSetupTree(dir, owner); err != nil {
+		t.Fatalf("chownSetupTree must be a no-op (and never fail) when not root: %v", err)
+	}
+}
+
+func TestDiscoverPairListenAddresses_ExcludesLoopback(t *testing.T) {
+	addrs := discoverPairListenAddresses()
+	for _, addr := range addrs {
+		if addr == "127.0.0.1" {
+			t.Errorf("discoverPairListenAddresses() = %v, must not include loopback", addrs)
+		}
+	}
+}
+
+// readSoleFile reads the single file expected to exist directly under dir,
+// without needing to know vmgateway's internal file name for it.
+func readSoleFile(t *testing.T, dir string) []byte {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("ReadDir(%s): %v", dir, err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("ReadDir(%s) = %d entries, want exactly 1: %v", dir, len(entries), entries)
+	}
+	b, err := os.ReadFile(filepath.Join(dir, entries[0].Name()))
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	return b
+}
+
+// readAllFiles reads every regular file directly under dir, keyed by name.
+func readAllFiles(t *testing.T, dir string) map[string][]byte {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("ReadDir(%s): %v", dir, err)
+	}
+	out := map[string][]byte{}
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		b, err := os.ReadFile(filepath.Join(dir, e.Name()))
+		if err != nil {
+			t.Fatalf("ReadFile(%s): %v", e.Name(), err)
+		}
+		out[e.Name()] = b
+	}
+	return out
 }
 
 // assertNoSetupMutation fails if the command ran anything that could have

--- a/backend/internal/cli/vm.go
+++ b/backend/internal/cli/vm.go
@@ -25,6 +25,7 @@ func newVMCommand(ctx *commandContext) *cobra.Command {
 	}
 	cmd.AddCommand(newVMServeCommand(ctx))
 	cmd.AddCommand(newVMSetupHarnessCommand(ctx))
+	cmd.AddCommand(newVMRotatePasscodeCommand(ctx))
 	return cmd
 }
 
@@ -141,6 +142,68 @@ func (c *commandContext) runVMServe(cmd *cobra.Command, opts vmgateway.Options) 
 	log.Info("ao vm serve starting",
 		"domain", gwCfg.Domain, "machineId", gwCfg.MachineID, "daemonAddr", gwCfg.DaemonAddr)
 	return srv.Run(ctxSig, cfg.ShutdownTimeout)
+}
+
+// newVMRotatePasscodeCommand deliberately rolls a pair-mode box's passcode,
+// the counterpart to the accidental non-rotation ao setup-vm --pair
+// guarantees on every re-run. Named for symmetry with the other `ao vm`
+// subcommands (serve, setup-harness): a verb naming what it does to this
+// machine, run on the box itself.
+func newVMRotatePasscodeCommand(ctx *commandContext) *cobra.Command {
+	var passcodeDir string
+	cmd := &cobra.Command{
+		Use:   "rotate-passcode",
+		Short: "Roll this pair-mode box's passcode and drop every connected client",
+		Long: "ao vm rotate-passcode generates a fresh pair-mode passcode, replacing the one\n" +
+			"ao setup-vm --pair printed (or the last rotation), and restarts\n" +
+			"ao-gateway.service so the change takes effect immediately. Every client still\n" +
+			"connected with the old passcode is dropped and has to enter the new one; the\n" +
+			"pinned certificate is unaffected, so there is no fingerprint to re-check.\n\n" +
+			"The new passcode is printed exactly once, here, and is never written to disk\n" +
+			"in plaintext. Run this on the box itself, the same place ao setup-vm --pair ran.\n\n" +
+			"This is the deliberate counterpart to ao setup-vm --pair's own guarantee: running\n" +
+			"setup again never rotates the passcode on its own (see\n" +
+			"docs/adr/0003-pair-mode-gateway.md). Use this command when you actually want to.",
+		Args: noArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return ctx.runVMRotatePasscode(cmd, passcodeDir)
+		},
+	}
+	cmd.Flags().StringVar(&passcodeDir, "passcode-dir", "", "Pair-mode passcode hash storage directory (default under the state root)")
+	return cmd
+}
+
+func (c *commandContext) runVMRotatePasscode(cmd *cobra.Command, passcodeDirFlag string) error {
+	dir := strings.TrimSpace(passcodeDirFlag)
+	if dir == "" {
+		dir = strings.TrimSpace(os.Getenv("AO_VM_PASSCODE_DIR"))
+	}
+	if dir == "" {
+		plan, err := c.buildSetupVMPlanPair()
+		if err != nil {
+			return err
+		}
+		dir = plan.PasscodeDir
+	}
+
+	store, err := vmgateway.LoadPasscodeStore(dir)
+	if err != nil {
+		return fmt.Errorf("no pair-mode passcode to rotate at %s: %w", dir, err)
+	}
+	newPasscode, err := store.Rotate()
+	if err != nil {
+		return fmt.Errorf("rotate the passcode: %w", err)
+	}
+	if owner, ownerErr := setupTargetUser(); ownerErr == nil {
+		if err := chownSetupTree(dir, owner); err != nil {
+			return fmt.Errorf("rotated the passcode but could not hand %s to %s: %w", dir, owner.Username, err)
+		}
+	}
+
+	if err := c.runSetupPrivileged(cmd.Context(), "systemctl", "restart", setupVMGatewayUnit); err != nil {
+		return fmt.Errorf("rotated the passcode but could not restart %s so it takes effect: %w", setupVMGatewayUnit, err)
+	}
+	return writeSetupText(cmd.OutOrStdout(), renderPasscodeRotated(newPasscode))
 }
 
 // The claude harness is the only one ao vm setup-harness supports in v1. Its

--- a/backend/internal/cli/vm_test.go
+++ b/backend/internal/cli/vm_test.go
@@ -7,10 +7,13 @@ import (
 	"fmt"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/aoagents/agent-orchestrator/backend/internal/mobilebridge"
 	"github.com/aoagents/agent-orchestrator/backend/internal/runfile"
+	"github.com/aoagents/agent-orchestrator/backend/internal/vmgateway"
 )
 
 func TestDiscoverDaemonAddr_FromRunFile(t *testing.T) {
@@ -188,6 +191,69 @@ func TestVMSetupHarnessErrorsWhenClaudeMissing(t *testing.T) {
 	}
 	if len(calls) != 0 {
 		t.Errorf("interactive calls = %v, want none when claude is missing", calls)
+	}
+}
+
+// TestVMRotatePasscode_RotatesRestartsAndInvalidatesTheOldOne is the rotate
+// command's core contract: it changes the persisted passcode, restarts the
+// gateway unit so the change actually takes effect (the running gateway only
+// ever loads the hash once, at startup), and the old passcode's hash no
+// longer matches what ends up on disk.
+func TestVMRotatePasscode_RotatesRestartsAndInvalidatesTheOldOne(t *testing.T) {
+	setConfigEnv(t)
+	dir := t.TempDir()
+	oldPasscode, err := vmgateway.GeneratePasscode(dir)
+	if err != nil {
+		t.Fatalf("GeneratePasscode: %v", err)
+	}
+	oldHash := readSoleFile(t, dir)
+
+	var calls []string
+	var mu sync.Mutex
+	deps := Deps{
+		CommandOutput: func(_ context.Context, name string, args ...string) ([]byte, error) {
+			mu.Lock()
+			calls = append(calls, strings.TrimSpace(name+" "+strings.Join(args, " ")))
+			mu.Unlock()
+			return nil, nil
+		},
+	}
+	stdout, _, err := executeCLI(t, deps, "vm", "rotate-passcode", "--passcode-dir", dir)
+	if err != nil {
+		t.Fatalf("ao vm rotate-passcode: %v", err)
+	}
+	if !strings.Contains(stdout, "Passcode rotated") {
+		t.Errorf("stdout = %q, want the rotation confirmation", stdout)
+	}
+
+	newHash := readSoleFile(t, dir)
+	if bytes.Equal(newHash, oldHash) {
+		t.Fatal("rotate-passcode must change the persisted hash")
+	}
+	if mobilebridge.PasswordMatches(string(newHash), oldPasscode) {
+		t.Fatal("the old passcode must no longer verify against the rotated hash")
+	}
+
+	mu.Lock()
+	got := strings.Join(calls, "\n")
+	mu.Unlock()
+	if !strings.Contains(got, "systemctl restart "+setupVMGatewayUnit) {
+		t.Errorf("rotate-passcode must restart the gateway so the new passcode takes effect (the running gateway only loads it once, at startup): calls = %v", calls)
+	}
+}
+
+// TestVMRotatePasscode_NoExistingPasscodeFails confirms the command refuses
+// cleanly, rather than silently provisioning a first passcode, when no box
+// has ever been paired at this directory: only ao setup-vm --pair generates
+// the first one.
+func TestVMRotatePasscode_NoExistingPasscodeFails(t *testing.T) {
+	setConfigEnv(t)
+	_, _, err := executeCLI(t, Deps{}, "vm", "rotate-passcode", "--passcode-dir", t.TempDir())
+	if err == nil {
+		t.Fatal("expected an error when no passcode has ever been provisioned")
+	}
+	if got := ExitCode(err); got != 1 {
+		t.Errorf("ExitCode = %d, want 1 (a runtime precondition, not CLI misuse)", got)
 	}
 }
 

--- a/backend/internal/telemetrymeta/cli.go
+++ b/backend/internal/telemetrymeta/cli.go
@@ -139,10 +139,11 @@ var legacyActorlessUserCLICommands = map[string]struct{}{
 	"ao version":                {},
 
 	// Hosted: a human bootstrapping or inspecting a hosted machine.
-	"ao setup-vm":         {},
-	"ao vm":               {},
-	"ao vm setup-harness": {},
-	"ao whoami":           {},
+	"ao setup-vm":           {},
+	"ao vm":                 {},
+	"ao vm setup-harness":   {},
+	"ao vm rotate-passcode": {},
+	"ao whoami":             {},
 
 	// Legacy commands observed in PostHog's current billing-period data.
 	"ao handoff":                   {},


### PR DESCRIPTION
## Summary

- Adds `ao setup-vm --pair`: provisions a Debian-family box (Ubuntu, Debian, Raspberry Pi OS) with no domain and no AO account, reusing the existing preflight, apt/package, binary, and systemd machinery, and skipping ACME configuration and the device-flow account bind entirely. Pair mode never contacts the control plane.
- The gateway unit renders with `AO_VM_PAIR=on`, `AO_VM_CERT_DIR`, `AO_VM_PASSCODE_DIR` and never sets any hosted-only variable (vmgateway's `resolvePair` rejects those alongside pair mode). It binds only the HTTPS port.
- Preflight checks the ports the provisioning mode actually needs: hosted mode still checks 80 and 443; pair mode checks only 443 and skips DNS/public-IP discovery/off-box reachability entirely (no domain to check).
- The distro gate widens from Ubuntu-only to the whole Debian family (Ubuntu, Debian, Raspberry Pi OS) while still requiring `systemctl` and `apt-get`.
- The passcode and certificate fingerprint are generated and printed exactly once, at the end of the run that creates them. Re-running `ao setup-vm --pair` never rotates either — verified directly with a test that re-runs the underlying generation path and asserts the on-disk hash/certificate are byte-identical.
- Adds `ao vm rotate-passcode`: the deliberate counterpart that rolls the passcode, restarts `ao-gateway.service` so the change takes effect (the gateway only loads the passcode hash once, at startup), and prints the new passcode once.

## Test plan

- [x] `cd backend && go build ./... && go vet ./... && go test ./...` (one pre-existing, environment-flaky failure in `internal/service/project`'s `TestManager_AddCloneAuthFailureRemediation` reproduced identically on a clean `origin/develop` checkout with none of this PR's changes — unrelated)
- [x] `go test -race ./internal/cli/... ./internal/vmgateway/...`
- [x] New test explicitly proves re-running does not rotate the passcode or certificate (`TestEnsureSetupPasscode_ReRunDoesNotRotate`, `TestEnsureSetupPairCert_ReRunDoesNotRotate`)
- [x] New test proves rotation does change the passcode and the old one stops verifying (`TestVMRotatePasscode_RotatesRestartsAndInvalidatesTheOldOne`)
- [x] Pre-existing hosted-mode tests in `setupvm_test.go`, `setupvm_plan_test.go`, `setupvm_bind_test.go` pass unchanged (one sub-case in `TestCheckSetupPlatform` was updated per the task's own Tests section, since "Debian is refused" is exactly the behavior being deliberately widened)

Refs #86