### PR TITLE
feat(desktop): connect to paired machines over a passcode transport

### DIFF
--- a/frontend/e2e/support/fake-bridge.ts
+++ b/frontend/e2e/support/fake-bridge.ts
@@ -223,6 +223,7 @@ export async function installFakeBridge(page: Page, opts: FakeBridgeOptions = {}
 				// fake that silently succeeds would hide a regression in that path.
 				pairedMachines: {
 					list: async () => [],
+					refresh: async () => [],
 					probeFingerprint: async () => ({ error: "No main process under the browser harness." }),
 					getPinnedFingerprint: async () => null,
 					add: async () => {
@@ -676,6 +677,7 @@ export async function installFakeAgent(page: Page, opts: FakeAgentOptions = {}):
 				// fake that silently succeeds would hide a regression in that path.
 				pairedMachines: {
 					list: async () => [],
+					refresh: async () => [],
 					probeFingerprint: async () => ({ error: "No main process under the browser harness." }),
 					getPinnedFingerprint: async () => null,
 					add: async () => {

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -82,6 +82,8 @@ import { shouldSignalAttention, shouldToast } from "./main/notification-signals"
 import { buildWindowsAppMenuTemplate } from "./main/menu";
 import { createRemoteDaemonLifecycle } from "./main/remote-daemon";
 import { createMachineTransport, type MachineTransport } from "./main/machine-transport";
+import { createPairedMachineTransport, type PairedMachineTransport } from "./main/paired-machine-transport";
+import { createMachineSelection, type MachineSelection } from "./main/machine-selection";
 import { ancestorRepositorySetupWarning, scanImportFolder } from "./main/import-folder-scan";
 
 // Globals injected at compile time by @electron-forge/plugin-vite.
@@ -1600,6 +1602,49 @@ function pairedMachines(): ReturnType<typeof createPairedMachinesController> {
 	return pairedMachinesController;
 }
 
+// The passcode-credentialed sibling of machineTransport() below, for a paired
+// box (docs/adr/0003-pair-mode-gateway.md). Unlike the hosted transport this
+// one always exists: pair mode needs no control-plane credential to build, so
+// there is no null case to guard on construction.
+let pairedMachineTransportInstance: PairedMachineTransport | null = null;
+function pairedMachineTransport(): PairedMachineTransport {
+	if (pairedMachineTransportInstance) return pairedMachineTransportInstance;
+	pairedMachineTransportInstance = createPairedMachineTransport({
+		cookies: session.defaultSession.cookies,
+		onStatus: (status) => {
+			// Dropped while local/hosted owns activeMachineStatus (see
+			// machineSelection's isPairedActive and its module doc comment): this
+			// only fires as a direct result of a setMachine call this file makes,
+			// never a background timer, so the guard only ever suppresses a
+			// teardown call's own status push, never a legitimate update.
+			if (!machineSelection().isPairedActive()) return;
+			activeMachineStatus = status;
+			void startDaemon();
+		},
+	});
+	return pairedMachineTransportInstance;
+}
+
+// The one entry point for making a machine active -- local, hosted, or
+// paired -- and the arbiter of which of the two remote transports may write
+// activeMachineStatus at any moment. See machine-selection.ts's module doc
+// comment for why parking a transport during a switch cannot be allowed to
+// publish its own status.
+let machineSelectionInstance: MachineSelection | null = null;
+function machineSelection(): MachineSelection {
+	if (machineSelectionInstance) return machineSelectionInstance;
+	machineSelectionInstance = createMachineSelection({
+		aoMachines: aoMachines(),
+		pairedMachines: pairedMachines(),
+		pairedTransport: pairedMachineTransport(),
+		// Read the singleton directly rather than calling machineTransport():
+		// parking it must never force a hosted transport into existence (and
+		// with it, a control-plane token attempt) just to immediately null it out.
+		getHostedTransport: () => machineTransportInstance,
+	});
+	return machineSelectionInstance;
+}
+
 // Read-only view of the daemon that is NOT the app's active one (the
 // "peer"), so the UI can list its projects and sessions alongside the active
 // one's. Fully independent of machineTransport(): a peer never opens /mux or
@@ -1641,6 +1686,12 @@ function machineTransport(): MachineTransport | null {
 		controlPlaneUrl: credential.controlPlaneUrl,
 		controlToken: credential.token,
 		onStatus: (status) => {
+			// A paired machine currently owns activeMachineStatus (see
+			// machineSelection().isPairedActive() and pairedMachineTransport()'s own
+			// onStatus above): this transport is parked, and its background token
+			// refresh or a reachability flip on the machine it used to point at must
+			// not clobber the paired machine's status.
+			if (machineSelection().isPairedActive()) return;
 			activeMachineStatus = status;
 			void startDaemon();
 		},
@@ -1680,15 +1731,19 @@ function applyActiveMachine(machine: AoMachine | null): void {
 	void startDaemon();
 }
 
-ipcMain.handle("aoMachines:getState", () => aoMachines().getState());
-ipcMain.handle("aoMachines:refresh", () => aoMachines().refresh());
-ipcMain.handle("aoMachines:select", (_event, machineId: string) => aoMachines().select(machineId));
-// Read from the already-built transport rather than machineTransport(), so a
-// local-only install never constructs one just to be told there is no token.
+// Routed through machineSelection() rather than aoMachines() directly, so a
+// paired machine id is resolved and the picker's active id reflects it too
+// (docs/plans/2026-08-16-pair-by-ip-headless-boxes.md task 9). Local and
+// hosted selection still land in ao-machines.ts exactly as before; see
+// machine-selection.ts.
+ipcMain.handle("aoMachines:getState", () => machineSelection().getState());
+ipcMain.handle("aoMachines:refresh", () => machineSelection().refresh());
+ipcMain.handle("aoMachines:select", (_event, machineId: string) => machineSelection().select(machineId));
 // forceRefresh: the renderer's runtimeFetch sends this after the gateway
-// itself 401/403s a request, so a revoked/rotated token is not repeated verbatim.
+// itself 401/403s a request, so a revoked/rotated token is not repeated
+// verbatim. Ignored on the paired path: there is nothing to refresh.
 ipcMain.handle("aoMachines:gatewayToken", (_event, forceRefresh?: boolean) =>
-	machineTransportInstance?.token(forceRefresh) ?? null,
+	machineSelection().gatewayToken(forceRefresh),
 );
 ipcMain.handle("aoMachines:peerWorkspaces", () => peerWorkspaces().get());
 
@@ -1696,6 +1751,7 @@ ipcMain.handle("aoMachines:peerWorkspaces", () => peerWorkspaces().get());
 // Address, port, and passcode entry, and the fingerprint comparison screen, are
 // task 8; this is only what that UI reads and writes through.
 ipcMain.handle("pairedMachines:list", () => pairedMachines().list());
+ipcMain.handle("pairedMachines:refresh", () => pairedMachines().refresh());
 ipcMain.handle("pairedMachines:probeFingerprint", (_event, address: string, port: number) =>
 	pairedMachines().probeFingerprint(address, port),
 );

--- a/frontend/src/main/machine-selection.test.ts
+++ b/frontend/src/main/machine-selection.test.ts
@@ -1,0 +1,208 @@
+import { expect, test, vi } from "vitest";
+import { LOCAL_MACHINE_ID, type AoMachine, type AoMachinesState } from "../shared/ao-machines";
+import { createMachineSelection, type MachineSelectionDeps } from "./machine-selection";
+
+const PASSCODE = "sup3rSecr3t";
+
+const hostedMachine: AoMachine = {
+	id: "mch_1",
+	name: "ao-build-01",
+	baseUrl: "https://vm.example.com",
+	local: false,
+	createdAt: null,
+	lastSeen: null,
+	reachability: "online",
+	harness: "unknown",
+	harnessCommand: null,
+};
+
+const pairedMachine: AoMachine = {
+	id: "box_1",
+	name: "Pi in the closet",
+	baseUrl: "https://192.168.1.5:8443",
+	local: false,
+	createdAt: null,
+	lastSeen: null,
+	reachability: "online",
+	harness: "unknown",
+	harnessCommand: null,
+};
+
+function baseState(activeMachineId = LOCAL_MACHINE_ID): AoMachinesState {
+	return {
+		status: "ready",
+		machines: [{ ...hostedMachine, id: LOCAL_MACHINE_ID, local: true, baseUrl: "" }, hostedMachine],
+		activeMachineId,
+	};
+}
+
+function harness(
+	overrides: Partial<{ pinned: string | null; passcode: string | null; passcodeError: string }> = {},
+) {
+	const calls: string[] = [];
+	let activeId = LOCAL_MACHINE_ID;
+
+	const aoMachines: MachineSelectionDeps["aoMachines"] = {
+		getState: vi.fn(() => baseState(activeId)),
+		refresh: vi.fn(async () => {
+			calls.push("aoMachines.refresh");
+			return baseState(activeId);
+		}),
+		select: vi.fn(async (machineId: string) => {
+			calls.push(`aoMachines.select:${machineId}`);
+			activeId = machineId;
+			return baseState(activeId);
+		}),
+	};
+
+	const pairedMachines: MachineSelectionDeps["pairedMachines"] = {
+		list: vi.fn(() => [pairedMachine]),
+		getPinnedFingerprint: vi.fn(() => (overrides.pinned === undefined ? "AA:BB" : overrides.pinned)),
+		getPasscode: vi.fn(async () => {
+			if (overrides.passcodeError) throw new Error(overrides.passcodeError);
+			return overrides.passcode === undefined ? PASSCODE : overrides.passcode;
+		}),
+	};
+
+	const pairedTransport: MachineSelectionDeps["pairedTransport"] = {
+		setMachine: vi.fn((machine) => {
+			calls.push(`paired.setMachine:${machine?.id ?? "null"}`);
+		}),
+		token: vi.fn(() => PASSCODE),
+	};
+
+	const hostedTransport = {
+		setMachine: vi.fn((machine: AoMachine | null) => {
+			calls.push(`hosted.setMachine:${machine?.id ?? "null"}`);
+		}),
+		token: vi.fn(async (forceRefresh?: boolean) => `jwt${forceRefresh ? "-fresh" : ""}`),
+	};
+
+	const selection = createMachineSelection({
+		aoMachines,
+		pairedMachines,
+		pairedTransport,
+		getHostedTransport: () => hostedTransport,
+	});
+
+	return { selection, aoMachines, pairedMachines, pairedTransport, hostedTransport, calls };
+}
+
+test("selecting a paired machine points the renderer at its base URL", async () => {
+	const { selection } = harness();
+	const state = await selection.select("box_1");
+
+	expect(state.activeMachineId).toBe("box_1");
+	expect(state.machines.find((m) => m.id === "box_1")).toBeUndefined(); // not in the CP list; overlay is id-only, matching the picker's own paired query
+	expect(selection.getState().activeMachineId).toBe("box_1");
+});
+
+test("the paired path sends the passcode as a bearer credential, and touches no control-plane call", async () => {
+	const { selection, pairedTransport, aoMachines } = harness();
+	await selection.select("box_1");
+
+	expect(pairedTransport.setMachine).toHaveBeenCalledExactlyOnceWith(pairedMachine, PASSCODE);
+	expect(await selection.gatewayToken()).toBe(PASSCODE);
+	// getState() is documented no-network on ao-machines.ts and may be read for
+	// the overlay; select/refresh are the network-touching methods and must
+	// never fire for a purely paired selection.
+	expect(aoMachines.select).not.toHaveBeenCalled();
+	expect(aoMachines.refresh).not.toHaveBeenCalled();
+});
+
+test("selecting a hosted machine still uses the JWT credential path, unchanged", async () => {
+	const { selection, aoMachines, hostedTransport } = harness();
+	const state = await selection.select("mch_1");
+
+	expect(aoMachines.select).toHaveBeenCalledExactlyOnceWith("mch_1");
+	expect(state.activeMachineId).toBe("mch_1");
+	expect(selection.isPairedActive()).toBe(false);
+	expect(await selection.gatewayToken(true)).toBe("jwt-fresh");
+	expect(hostedTransport.token).toHaveBeenCalledExactlyOnceWith(true);
+});
+
+test("selecting local still works and clears the active machine", async () => {
+	const { selection, aoMachines } = harness();
+	await selection.select("box_1");
+	expect(selection.isPairedActive()).toBe(true);
+
+	const state = await selection.select(LOCAL_MACHINE_ID);
+
+	expect(aoMachines.select).toHaveBeenCalledExactlyOnceWith(LOCAL_MACHINE_ID);
+	expect(state.activeMachineId).toBe(LOCAL_MACHINE_ID);
+	expect(selection.isPairedActive()).toBe(false);
+});
+
+test("switching from paired to hosted parks the paired transport and hands off cleanly", async () => {
+	const { selection, calls } = harness();
+	await selection.select("box_1");
+	calls.length = 0;
+	await selection.select("mch_1");
+
+	// Paired is torn down before the hosted select is allowed to publish.
+	expect(calls).toEqual(["paired.setMachine:null", "aoMachines.select:mch_1"]);
+});
+
+test("switching from hosted to paired parks the hosted transport before activating paired", async () => {
+	const { selection, calls } = harness();
+	await selection.select("mch_1");
+	calls.length = 0;
+	await selection.select("box_1");
+
+	expect(calls).toEqual(["hosted.setMachine:null", "paired.setMachine:box_1"]);
+});
+
+test("selecting paired works when no hosted transport exists yet (no control-plane credential in this install)", async () => {
+	const { aoMachines, pairedMachines, pairedTransport } = harness();
+	const selection = createMachineSelection({
+		aoMachines,
+		pairedMachines,
+		pairedTransport,
+		getHostedTransport: () => null,
+	});
+
+	const state = await selection.select("box_1");
+	expect(pairedTransport.setMachine).toHaveBeenCalledExactlyOnceWith(pairedMachine, PASSCODE);
+	expect(state.activeMachineId).toBe("box_1");
+});
+
+test("a paired machine with no pinned fingerprint cannot be selected into a working connection", async () => {
+	const { selection, pairedTransport } = harness({ pinned: null });
+	const state = await selection.select("box_1");
+
+	expect(pairedTransport.setMachine).not.toHaveBeenCalled();
+	expect(selection.isPairedActive()).toBe(false);
+	expect(state.error).toMatch(/no accepted fingerprint/);
+	expect(state.activeMachineId).toBe(LOCAL_MACHINE_ID);
+});
+
+test("a paired machine with no stored passcode cannot be selected into a working connection", async () => {
+	const { selection, pairedTransport } = harness({ passcode: null });
+	const state = await selection.select("box_1");
+
+	expect(pairedTransport.setMachine).not.toHaveBeenCalled();
+	expect(selection.isPairedActive()).toBe(false);
+	expect(state.error).toMatch(/no stored passcode/);
+});
+
+test("a passcode decrypt failure is reported without ever including the passcode", async () => {
+	const { selection } = harness({
+		passcodeError: "This paired machine's stored passcode could not be decrypted on this machine. Re-pair it.",
+	});
+	const state = await selection.select("box_1");
+
+	expect(state.error).toBeDefined();
+	expect(state.error).not.toContain(PASSCODE);
+	expect(JSON.stringify(state)).not.toContain(PASSCODE);
+});
+
+test("gatewayToken() routes to whichever transport is active", async () => {
+	const { selection, hostedTransport, pairedTransport } = harness();
+	await selection.select("mch_1");
+	expect(await selection.gatewayToken()).toBe("jwt");
+	expect(hostedTransport.token).toHaveBeenCalled();
+
+	await selection.select("box_1");
+	expect(await selection.gatewayToken()).toBe(PASSCODE);
+	expect(pairedTransport.token).toHaveBeenCalled();
+});

--- a/frontend/src/main/machine-selection.ts
+++ b/frontend/src/main/machine-selection.ts
@@ -1,0 +1,143 @@
+import type { AoMachine, AoMachinesState } from "../shared/ao-machines";
+import type { MachineTransport } from "./machine-transport";
+import type { PairedMachineTransport } from "./paired-machine-transport";
+
+/**
+ * The one entry point for making a machine active: local, hosted, or paired
+ * (docs/plans/2026-08-16-pair-by-ip-headless-boxes.md, task 9).
+ *
+ * `ao-machines.ts`'s own `select()` only ever searches the control-plane-listed
+ * `remote` array, so a paired machine id would be rejected as "no longer in
+ * this account's list". This module resolves a paired id first and drives the
+ * passcode-credentialed transport instead, without touching `ao-machines.ts`
+ * at all: local and hosted selection keep calling straight through to it,
+ * unchanged.
+ *
+ * Two transports, two credential models, but only one can be allowed to write
+ * the app's daemon status at a time. `isPairedActive()` is that arbiter: it is
+ * true from the moment a paired `select()` succeeds until the next local or
+ * hosted `select()`, and main.ts's own onStatus callbacks for the two
+ * transports each check it (with opposite polarity) before writing
+ * `activeMachineStatus`. That guard is what lets `select()` below park the
+ * transport being left, by calling its own `setMachine(null, ...)`, without
+ * that teardown call's status push racing the one just activated: whichever
+ * transport the flag says is NOT current has its write dropped, so flipping
+ * the flag before touching either transport makes the switch atomic from the
+ * status sink's point of view. See main.ts's two `onStatus` wirings.
+ */
+
+/** The slice of `ao-machines.ts`'s controller this module drives. */
+export type MachineSelectionAoMachines = {
+	getState: () => AoMachinesState;
+	refresh: () => Promise<AoMachinesState>;
+	select: (machineId: string) => Promise<AoMachinesState>;
+};
+
+/** The slice of `paired-machines.ts`'s controller this module reads. */
+export type MachineSelectionPairedMachines = {
+	list: () => AoMachine[];
+	getPinnedFingerprint: (id: string) => string | null;
+	getPasscode: (id: string) => Promise<string | null>;
+};
+
+export type MachineSelectionDeps = {
+	aoMachines: MachineSelectionAoMachines;
+	pairedMachines: MachineSelectionPairedMachines;
+	pairedTransport: PairedMachineTransport;
+	/**
+	 * The hosted transport, or null when no control-plane credential can exist
+	 * (main.ts's `machineTransport()` already reports that as its own state).
+	 * Read lazily via a getter, exactly like main.ts's own
+	 * `machineTransportInstance` access, so parking one never forces a hosted
+	 * transport into existence just to immediately null it out.
+	 */
+	getHostedTransport: () => MachineTransport | null;
+};
+
+export type MachineSelection = {
+	/** Current known state, paired-overlaid. No network: same contract as ao-machines.ts's own getState(). */
+	getState: () => AoMachinesState;
+	/** Re-list and re-probe the control-plane machines, paired-overlaid. */
+	refresh: () => Promise<AoMachinesState>;
+	/** Make one machine (local, hosted, or paired) active. */
+	select: (machineId: string) => Promise<AoMachinesState>;
+	/** The gateway bearer for a REST call to whichever transport is active. */
+	gatewayToken: (forceRefresh?: boolean) => Promise<string | null>;
+	/** Whether a paired machine currently owns the app's daemon status. */
+	isPairedActive: () => boolean;
+};
+
+const errorMessage = (err: unknown): string => (err instanceof Error ? err.message : String(err));
+
+export function createMachineSelection(deps: MachineSelectionDeps): MachineSelection {
+	let activePairedMachine: AoMachine | null = null;
+
+	function overlay(state: AoMachinesState): AoMachinesState {
+		return activePairedMachine ? { ...state, activeMachineId: activePairedMachine.id } : state;
+	}
+
+	async function selectPaired(paired: AoMachine): Promise<AoMachinesState> {
+		// A machine whose fingerprint is not pinned is not connectable: selection
+		// must not be a way around the comparison step. `add()` never stores a
+		// record without an accepted fingerprint, and the certificate pin would
+		// refuse the TLS handshake anyway (paired-machine-cert.ts), but this must
+		// fail closed on its own rather than rely only on that second layer.
+		const pinned = deps.pairedMachines.getPinnedFingerprint(paired.id);
+		if (!pinned) {
+			return overlay({
+				...deps.aoMachines.getState(),
+				error: `${paired.name} has no accepted fingerprint. Re-pair it before connecting.`,
+			});
+		}
+
+		let passcode: string | null;
+		try {
+			passcode = await deps.pairedMachines.getPasscode(paired.id);
+		} catch (err) {
+			// The passcode itself is never in this message; getPasscode's own
+			// failure text (a decrypt error, no OS credential store) already avoids it.
+			return overlay({ ...deps.aoMachines.getState(), error: errorMessage(err) });
+		}
+		if (!passcode) {
+			return overlay({ ...deps.aoMachines.getState(), error: `${paired.name} has no stored passcode. Re-pair it.` });
+		}
+
+		// Flip the flag before touching either transport (see the module doc
+		// comment): this is what makes the hosted transport's own onStatus guard
+		// drop the write from parking it next, instead of that write racing the
+		// paired status about to be published.
+		activePairedMachine = paired;
+		deps.getHostedTransport()?.setMachine(null);
+		deps.pairedTransport.setMachine(paired, passcode);
+
+		return overlay(deps.aoMachines.getState());
+	}
+
+	async function select(machineId: string): Promise<AoMachinesState> {
+		const paired = deps.pairedMachines.list().find((machine) => machine.id === machineId);
+		if (paired) return selectPaired(paired);
+
+		// Local or a hosted machine. Clear the flag first: the paired transport's
+		// own onStatus is guarded on it, so this teardown call's null status push
+		// is dropped rather than landing after the hosted/local select below
+		// publishes the real one.
+		activePairedMachine = null;
+		deps.pairedTransport.setMachine(null, null);
+
+		// Never touched for a paired id (selectPaired above returns before this
+		// point is reached), so a hosted machine keeps using its JWT credential
+		// path exactly as ao-machines.ts already implements it.
+		return overlay(await deps.aoMachines.select(machineId));
+	}
+
+	return {
+		getState: () => overlay(deps.aoMachines.getState()),
+		refresh: async () => overlay(await deps.aoMachines.refresh()),
+		select,
+		gatewayToken: async (forceRefresh) => {
+			if (activePairedMachine) return deps.pairedTransport.token();
+			return (await deps.getHostedTransport()?.token(forceRefresh)) ?? null;
+		},
+		isPairedActive: () => activePairedMachine !== null,
+	};
+}

--- a/frontend/src/main/paired-machine-transport.test.ts
+++ b/frontend/src/main/paired-machine-transport.test.ts
@@ -1,0 +1,155 @@
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+import type { AoMachine } from "../shared/ao-machines";
+import type { DaemonStatus } from "../shared/daemon-status";
+import { GATEWAY_COOKIE_NAME } from "../shared/remote-daemon";
+import { createPairedMachineTransport } from "./paired-machine-transport";
+
+const PASSCODE = "sup3rSecr3t";
+
+const machine = (extra: Partial<AoMachine> = {}): AoMachine => ({
+	id: "box_1",
+	name: "Pi in the closet",
+	baseUrl: "https://192.168.1.5:8443",
+	local: false,
+	createdAt: null,
+	lastSeen: null,
+	reachability: "online",
+	harness: "unknown",
+	harnessCommand: null,
+	...extra,
+});
+
+function harness() {
+	const set = vi.fn().mockResolvedValue(undefined);
+	const remove = vi.fn().mockResolvedValue(undefined);
+	const onStatus = vi.fn<(status: DaemonStatus | null) => void>();
+	const transport = createPairedMachineTransport({ cookies: { set, remove }, onStatus });
+	return { set, remove, onStatus, transport };
+}
+
+beforeEach(() => {
+	vi.useFakeTimers();
+});
+afterEach(() => {
+	vi.useRealTimers();
+});
+
+const settle = async (): Promise<void> => {
+	await vi.advanceTimersByTimeAsync(0);
+};
+
+test("sends the passcode as a bearer credential via token(), never a control-plane call", async () => {
+	const { transport, onStatus } = harness();
+	transport.setMachine(machine(), PASSCODE);
+	await settle();
+
+	expect(await transport.token()).toBe(PASSCODE);
+	// Ready only after the cookie carrying the same passcode is installed.
+	expect(onStatus).toHaveBeenLastCalledWith(
+		expect.objectContaining({ state: "ready", baseUrl: "https://192.168.1.5:8443" }),
+	);
+});
+
+test("installs the gateway cookie with the passcode, the same shape /mux and SSE read", async () => {
+	const { transport, set } = harness();
+	transport.setMachine(machine(), PASSCODE);
+	await settle();
+
+	expect(set).toHaveBeenCalledExactlyOnceWith(
+		expect.objectContaining({
+			url: "https://192.168.1.5:8443",
+			name: GATEWAY_COOKIE_NAME,
+			value: PASSCODE,
+			secure: true,
+			httpOnly: true,
+			sameSite: "no_restriction",
+		}),
+	);
+});
+
+test("publishes connecting, then ready, in that order", async () => {
+	const { transport, onStatus } = harness();
+	transport.setMachine(machine(), PASSCODE);
+	// Before the cookie install (a microtask) resolves, only "connecting" is out.
+	expect(onStatus).toHaveBeenCalledExactlyOnceWith(expect.objectContaining({ state: "starting" }));
+
+	await settle();
+	expect(onStatus).toHaveBeenLastCalledWith(expect.objectContaining({ state: "ready" }));
+});
+
+test("this transport has no control-plane dependency of any kind to call", () => {
+	// Structural guarantee, not just a runtime assertion: createPairedMachineTransport's
+	// deps type carries no fetch implementation, no control-plane URL, and no
+	// token source -- there is nothing here capable of reaching the control plane.
+	const deps = harness();
+	expect(Object.keys(deps.transport)).toEqual(["setMachine", "token"]);
+});
+
+test("no reachability check means no acquisition: reachability !== online never installs a cookie", async () => {
+	const { transport, set, onStatus } = harness();
+	transport.setMachine(machine({ reachability: "offline" }), PASSCODE);
+	await settle();
+
+	expect(set).not.toHaveBeenCalled();
+	expect(onStatus).toHaveBeenLastCalledWith(expect.objectContaining({ state: "error", code: "daemon_unreachable" }));
+});
+
+test("no passcode: an auth-failed status, and no cookie install attempted", async () => {
+	const { transport, set, onStatus } = harness();
+	transport.setMachine(machine(), null);
+	await settle();
+
+	expect(set).not.toHaveBeenCalled();
+	expect(onStatus).toHaveBeenCalledExactlyOnceWith(
+		expect.objectContaining({ state: "error", code: "machine_auth_failed" }),
+	);
+	expect(await transport.token()).toBeNull();
+});
+
+test("setMachine(null) clears the token, drops the cookie, and publishes null", async () => {
+	const { transport, set, remove, onStatus } = harness();
+	transport.setMachine(machine(), PASSCODE);
+	await settle();
+
+	transport.setMachine(null, null);
+	await settle();
+
+	expect(await transport.token()).toBeNull();
+	expect(remove).toHaveBeenCalledExactlyOnceWith("https://192.168.1.5:8443", GATEWAY_COOKIE_NAME);
+	expect(onStatus).toHaveBeenLastCalledWith(null);
+	expect(set).toHaveBeenCalledTimes(1); // only the earlier connect, never re-installed
+});
+
+test("switching to a different machine's baseUrl drops the old cookie", async () => {
+	const { transport, remove } = harness();
+	transport.setMachine(machine(), PASSCODE);
+	await settle();
+
+	transport.setMachine(machine({ id: "box_2", baseUrl: "https://192.168.1.9:8443" }), "other-code");
+	await settle();
+
+	expect(remove).toHaveBeenCalledExactlyOnceWith("https://192.168.1.5:8443", GATEWAY_COOKIE_NAME);
+});
+
+test("a superseded connect never publishes its status: the newest setMachine wins", async () => {
+	const { transport, onStatus, set } = harness();
+	// Make the first cookie install hang so the second setMachine can race it.
+	set.mockReturnValueOnce(new Promise(() => undefined));
+	transport.setMachine(machine(), PASSCODE);
+	transport.setMachine(null, null);
+	await settle();
+
+	// The stale "ready" from the first call must never land after the null.
+	expect(onStatus).toHaveBeenLastCalledWith(null);
+});
+
+test("the passcode never appears in any status the transport publishes", async () => {
+	const { transport, onStatus } = harness();
+	transport.setMachine(machine(), PASSCODE);
+	transport.setMachine(machine(), null); // auth-failed path
+	await settle();
+
+	for (const call of onStatus.mock.calls) {
+		expect(JSON.stringify(call[0])).not.toContain(PASSCODE);
+	}
+});

--- a/frontend/src/main/paired-machine-transport.ts
+++ b/frontend/src/main/paired-machine-transport.ts
@@ -1,0 +1,157 @@
+import type { AoMachine } from "../shared/ao-machines";
+import type { DaemonStatus } from "../shared/daemon-status";
+import {
+	GATEWAY_COOKIE_NAME,
+	machineAuthFailedStatus,
+	machineConnectingStatus,
+	machineDaemonStatus,
+} from "../shared/remote-daemon";
+import type { GatewayCookieStore } from "./machine-transport";
+
+/**
+ * The desktop's transport to a paired machine's gateway
+ * (docs/adr/0003-pair-mode-gateway.md, docs/plans/2026-08-16-pair-by-ip-headless-boxes.md task 9).
+ *
+ * Sibling to machine-transport.ts, not a variant of it. Pair mode's whole
+ * point is no control plane, so unlike the hosted transport there is no token
+ * to mint, no expiry, and no silent refresh here: the credential is the
+ * passcode the user entered once, decrypted by paired-machines.ts and handed
+ * in by the caller. It travels exactly the way the gateway's `requirePasscode`
+ * expects (backend/internal/vmgateway/passcode.go), because `requirePasscode`
+ * reads it with the same `extractToken` `requireToken` uses for hosted mode:
+ * `Authorization: Bearer <passcode>` on REST, attached per request by the
+ * renderer via `aoMachines:gatewayToken`, and the same `ao_gw_token` cookie
+ * for the two routes a browser cannot put a header on -- the `/mux` terminal
+ * WebSocket and the SSE event stream (see shared/remote-daemon.ts). No new
+ * scheme, just the existing one carrying a passcode instead of a JWT.
+ *
+ * A rotated passcode on the box (docs/adr/0003) presents as a standing 401
+ * against a still-installed cookie. Recovering from that is the re-pair flow
+ * (task 8), not this transport's job.
+ */
+
+const NO_PASSCODE_REASON = "No stored passcode is available for this machine. Re-pair it.";
+
+const errorMessage = (err: unknown): string => (err instanceof Error ? err.message : String(err));
+
+/** The subset of Electron's cookie store this module needs; same shape as machine-transport.ts's, so both can share `session.defaultSession.cookies` untyped-widened. */
+export type PairedGatewayCookieStore = GatewayCookieStore;
+
+export type PairedMachineTransportDeps = {
+	cookies: PairedGatewayCookieStore;
+	/**
+	 * The app's daemon status while this transport's machine is the active one,
+	 * or null once it no longer is. Same shape as machine-transport.ts's
+	 * `onStatus`, so main.ts can point either transport's callback at the same
+	 * sink and switch between them by which one is allowed to write.
+	 */
+	onStatus: (status: DaemonStatus | null) => void;
+};
+
+export type PairedMachineTransport = {
+	/**
+	 * Point the transport at a paired machine and its decrypted passcode, or at
+	 * null to release it. The passcode is asked for by the caller (main.ts, via
+	 * paired-machines.ts's `getPasscode`) rather than looked up in here, so this
+	 * module never touches safeStorage or the encrypted store directly.
+	 */
+	setMachine: (machine: AoMachine | null, passcode: string | null) => void;
+	/**
+	 * The passcode for the current machine, or null when there is none.
+	 * `forceRefresh` is accepted and ignored -- there is nothing to refresh --
+	 * only so main.ts can route the `aoMachines:gatewayToken` IPC handler to
+	 * whichever transport is active without branching on a different shape.
+	 */
+	token: (forceRefresh?: boolean) => string | null;
+};
+
+export function createPairedMachineTransport(deps: PairedMachineTransportDeps): PairedMachineTransport {
+	let target: AoMachine | null = null;
+	let currentPasscode: string | null = null;
+	/**
+	 * Bumped by every setMachine, so a cookie install still in flight from a
+	 * superseded call cannot publish a status for a machine that is no longer
+	 * the target (mirrors machine-transport.ts's generation guard).
+	 */
+	let generation = 0;
+
+	async function installCookie(machine: AoMachine, passcode: string): Promise<void> {
+		await deps.cookies.set({
+			url: machine.baseUrl,
+			name: GATEWAY_COOKIE_NAME,
+			value: passcode,
+			path: "/",
+			// SameSite=None + Secure, same reasoning as machine-transport.ts: without
+			// it the browser will not attach the cookie to the /mux handshake or the
+			// EventSource request at all.
+			secure: true,
+			httpOnly: true,
+			sameSite: "no_restriction",
+		});
+	}
+
+	async function dropCookie(machine: AoMachine): Promise<void> {
+		try {
+			await deps.cookies.remove(machine.baseUrl, GATEWAY_COOKIE_NAME);
+		} catch {
+			// Best effort, mirrors machine-transport.ts's dropCookie: a cookie jar
+			// that refuses removal is not a reason to fail the switch.
+		}
+	}
+
+	return {
+		setMachine(machine, passcode) {
+			generation += 1;
+			const startedAt = generation;
+			const previous = target;
+			target = machine;
+
+			if (previous && previous.baseUrl !== machine?.baseUrl) void dropCookie(previous);
+
+			if (!machine) {
+				currentPasscode = null;
+				deps.onStatus(null);
+				return;
+			}
+
+			if (!passcode) {
+				// Never say why in more detail than this: the caller's failure (a
+				// decrypt error, an unavailable OS credential store) is reported by
+				// paired-machines.ts's own error, not repeated here, and neither
+				// message ever carries the passcode itself.
+				currentPasscode = null;
+				deps.onStatus(machineAuthFailedStatus(machine, NO_PASSCODE_REASON));
+				return;
+			}
+
+			currentPasscode = passcode;
+
+			// Nothing to authenticate to yet, and the status already says why. Mirrors
+			// machine-transport.ts: an unreachable machine must not be given a base
+			// URL, and must not cost a cookie install either.
+			if (machine.reachability !== "online") {
+				deps.onStatus(machineDaemonStatus(machine));
+				return;
+			}
+
+			deps.onStatus(machineConnectingStatus(machine));
+			// The cookie must be in place before the ready status is published, same
+			// ordering rule as machine-transport.ts: a base URL handed out first would
+			// open /mux and the SSE stream against a gateway with no credential
+			// installed yet.
+			void installCookie(machine, passcode)
+				.then(() => {
+					if (generation !== startedAt) return;
+					deps.onStatus(machineDaemonStatus(machine));
+				})
+				.catch((err: unknown) => {
+					if (generation !== startedAt) return;
+					deps.onStatus(machineAuthFailedStatus(machine, errorMessage(err)));
+				});
+		},
+
+		token() {
+			return currentPasscode;
+		},
+	};
+}

--- a/frontend/src/main/paired-machines.test.ts
+++ b/frontend/src/main/paired-machines.test.ts
@@ -61,6 +61,27 @@ const unreachableFetch: typeof fetch = (async () => {
 	throw new Error("connect ECONNREFUSED");
 }) as unknown as typeof fetch;
 
+/**
+ * A box that answers `GET /api/v1/doctor` like the real gateway route would:
+ * 200 with a doctor report when the Authorization header carries `passcode`
+ * as a bearer, 401 otherwise. Records every Authorization header it saw, so a
+ * test can assert the wire shape without inspecting the fetch call directly.
+ */
+function doctorFetch(passcode: string, checks: Array<Record<string, unknown>> = []) {
+	const seenAuthorization: Array<string | null> = [];
+	const requestedUrls: string[] = [];
+	const fetchImpl = (async (input: string, init?: RequestInit) => {
+		requestedUrls.push(String(input));
+		seenAuthorization.push(new Headers(init?.headers).get("Authorization"));
+		if (!String(input).endsWith("/api/v1/doctor")) return new Response("not found", { status: 404 });
+		if (new Headers(init?.headers).get("Authorization") !== `Bearer ${passcode}`) {
+			return new Response(JSON.stringify({ error: "unauthorized" }), { status: 401 });
+		}
+		return new Response(JSON.stringify({ ok: true, failures: 0, checks }), { status: 200 });
+	}) as unknown as typeof fetch;
+	return { fetchImpl, seenAuthorization, requestedUrls };
+}
+
 let stateDir = "";
 
 beforeEach(async () => {
@@ -238,6 +259,104 @@ test("getPinnedFingerprint reports the pin for a registered machine and null oth
 	});
 	expect(machines.getPinnedFingerprint("box_1")).toBe(CERT_FINGERPRINT);
 	expect(machines.getPinnedFingerprint("no_such_machine")).toBeNull();
+});
+
+test("refresh() probes GET /api/v1/doctor with the passcode as a bearer credential and marks the machine online", async () => {
+	const { fetchImpl, seenAuthorization } = doctorFetch("abc123XY");
+	const machines = createPairedMachinesController({ stateDir, safeStorage, netFetch: fetchImpl, probeTimeoutMs: 200 });
+	await machines.load();
+	await machines.add({
+		id: "box_1",
+		name: "Pi",
+		address: "192.168.1.5",
+		port: 8443,
+		passcode: "abc123XY",
+		fingerprint: CERT_FINGERPRINT,
+	});
+	expect(machines.list()[0]).toMatchObject({ reachability: "unknown", lastSeen: null });
+
+	const refreshed = await machines.refresh();
+
+	expect(seenAuthorization).toContain("Bearer abc123XY");
+	expect(refreshed[0]).toMatchObject({ id: "box_1", reachability: "online" });
+	expect(refreshed[0].lastSeen).not.toBeNull();
+	expect(machines.list()[0]).toMatchObject({ reachability: "online" });
+
+	// The refreshed last-seen is persisted, so a relaunch still shows it.
+	const reloaded = createPairedMachinesController({ stateDir, safeStorage });
+	await reloaded.load();
+	expect(reloaded.list()[0].lastSeen).toBe(refreshed[0].lastSeen);
+});
+
+test("refresh() reads agent-harness readiness from the doctor checks", async () => {
+	const { fetchImpl } = doctorFetch("abc123XY", [
+		{ level: "PASS", name: "claude-auth", section: "Agent harnesses", message: "signed in" },
+	]);
+	const machines = createPairedMachinesController({ stateDir, safeStorage, netFetch: fetchImpl, probeTimeoutMs: 200 });
+	await machines.load();
+	await machines.add({
+		id: "box_1",
+		name: "Pi",
+		address: "192.168.1.5",
+		port: 8443,
+		passcode: "abc123XY",
+		fingerprint: CERT_FINGERPRINT,
+	});
+
+	const refreshed = await machines.refresh();
+	expect(refreshed[0]).toMatchObject({ harness: "ready", harnessCommand: null });
+});
+
+test("refresh() marks an unreachable machine offline without bumping last-seen", async () => {
+	const machines = controller(unreachableFetch);
+	await machines.load();
+	await machines.add({
+		id: "box_1",
+		name: "Pi",
+		address: "192.168.1.5",
+		port: 8443,
+		passcode: "abc123XY",
+		fingerprint: CERT_FINGERPRINT,
+	});
+
+	const refreshed = await machines.refresh();
+	expect(refreshed[0]).toMatchObject({ reachability: "offline", lastSeen: null });
+});
+
+test("refresh() marks online even on a 401 (wrong passcode): the box answered, only the credential is bad", async () => {
+	const { fetchImpl } = doctorFetch("the-real-passcode");
+	const machines = createPairedMachinesController({ stateDir, safeStorage, netFetch: fetchImpl, probeTimeoutMs: 200 });
+	await machines.load();
+	await machines.add({
+		id: "box_1",
+		name: "Pi",
+		address: "192.168.1.5",
+		port: 8443,
+		passcode: "a-stale-passcode",
+		fingerprint: CERT_FINGERPRINT,
+	});
+
+	const refreshed = await machines.refresh();
+	expect(refreshed[0]).toMatchObject({ reachability: "online", harness: "unknown" });
+});
+
+test("the passcode never appears in the doctor probe's request path or in refresh()'s result", async () => {
+	const { fetchImpl, requestedUrls } = doctorFetch("abc123XY");
+	const machines = createPairedMachinesController({ stateDir, safeStorage, netFetch: fetchImpl, probeTimeoutMs: 200 });
+	await machines.load();
+	await machines.add({
+		id: "box_1",
+		name: "Pi",
+		address: "192.168.1.5",
+		port: 8443,
+		passcode: "abc123XY",
+		fingerprint: CERT_FINGERPRINT,
+	});
+	const refreshed = await machines.refresh();
+
+	expect(JSON.stringify(refreshed)).not.toContain("abc123XY");
+	const doctorUrl = requestedUrls.find((url) => url.endsWith("/api/v1/doctor"));
+	expect(doctorUrl).not.toContain("abc123XY");
 });
 
 test("add refuses the reserved local machine id, an out-of-range port, and an unusable address", async () => {

--- a/frontend/src/main/paired-machines.ts
+++ b/frontend/src/main/paired-machines.ts
@@ -1,7 +1,14 @@
 import { randomBytes } from "node:crypto";
 import { mkdir, open, readFile, rename, rm } from "node:fs/promises";
 import path from "node:path";
-import { LOCAL_MACHINE_ID, parseMachineOrigin, type AoMachine } from "../shared/ao-machines";
+import {
+	harnessFromDoctorChecks,
+	LOCAL_MACHINE_ID,
+	parseMachineOrigin,
+	type AoMachine,
+	type AoMachineHarness,
+	type AoMachineReachability,
+} from "../shared/ao-machines";
 import type { SafeStorageLike } from "./ao-account-store";
 import { createPairCertificateVerifyProc, type PairCertificateVerifyProc } from "./paired-machine-cert";
 import { fetchWithDeadline } from "./request-deadline";
@@ -68,12 +75,28 @@ export type PairedMachinesControllerDeps = {
 	probeTimeoutMs?: number;
 };
 
+/** Readiness fields from a doctor report; local mirror of the same fields on
+ * `AoMachine` so this module does not need ao-machines.ts's unexported type. */
+type HarnessReadiness = { harness: AoMachineHarness; harnessCommand: string | null };
+const HARNESS_UNKNOWN: HarnessReadiness = { harness: "unknown", harnessCommand: null };
+
 export type PairedMachinesController = {
 	/** Load the registry off disk. Must resolve before `verifyCertificate` can
 	 * see any pin: it runs synchronously off the in-memory cache this builds,
 	 * because Electron calls it from the network service without awaiting it. */
 	load: () => Promise<void>;
 	list: () => AoMachine[];
+	/**
+	 * Probe every registered machine's reachability and agent-harness readiness
+	 * via `GET /api/v1/doctor`, authenticated with its own stored passcode --
+	 * the same route and the same doctor checks `ao-machines.ts`'s hosted
+	 * machines would read if the daemon route existed for them yet (see
+	 * `harnessFromDoctorChecks`), reused here because pair mode's gateway
+	 * already proxies it. Any answer, even a non-2xx one, means the box is up;
+	 * only a transport failure or a timeout counts as offline, mirroring
+	 * ao-machines.ts's own liveness probe. Returns the freshly probed list.
+	 */
+	refresh: () => Promise<AoMachine[]>;
 	/**
 	 * Add a newly paired machine, or update an existing one (matched by id) --
 	 * a re-pair after a fingerprint mismatch is the same call with a fresh
@@ -184,7 +207,11 @@ async function writeAll(stateDir: string, machines: PersistedPairedMachine[]): P
 	}
 }
 
-function toAoMachine(record: PairedMachineRecord): AoMachine | null {
+function toAoMachine(
+	record: PairedMachineRecord,
+	reachability: AoMachineReachability,
+	harness: HarnessReadiness,
+): AoMachine | null {
 	const baseUrl = baseUrlFor(record.address, record.port);
 	if (!baseUrl) return null;
 	return {
@@ -194,9 +221,8 @@ function toAoMachine(record: PairedMachineRecord): AoMachine | null {
 		local: false,
 		createdAt: null,
 		lastSeen: record.lastSeen,
-		reachability: "unknown",
-		harness: "unknown",
-		harnessCommand: null,
+		reachability,
+		...harness,
 	};
 }
 
@@ -219,6 +245,11 @@ export function createPairedMachinesController(deps: PairedMachinesControllerDep
 	/** Latest fingerprint actually presented per hostname, for any host
 	 * `isPairHost` recognises. What `probeFingerprint` reads back. */
 	const presented = new Map<string, string>();
+	/** Reachability and harness readiness from the last `refresh()`, by machine
+	 * id. Ephemeral like ao-machines.ts's own reachability: never persisted,
+	 * defaults to "unknown" for a machine that has never been probed. */
+	let reachabilityById = new Map<string, AoMachineReachability>();
+	let harnessById = new Map<string, HarnessReadiness>();
 
 	function rebuildPinnedByHost(): void {
 		pinnedByHost = new Map(
@@ -233,11 +264,65 @@ export function createPairedMachinesController(deps: PairedMachinesControllerDep
 		await writeAll(deps.stateDir, [...records.values()]);
 	}
 
+	/** Shared by the public `getPasscode` and the reachability probe below, so
+	 * there is exactly one place that decrypts a stored passcode. */
+	async function decryptPasscode(record: PersistedPairedMachine): Promise<string | null> {
+		if (!deps.safeStorage.isEncryptionAvailable()) {
+			throw new Error("This system has no OS credential store available, so the paired machine's passcode cannot be read.");
+		}
+		try {
+			return deps.safeStorage.decryptString(Buffer.from(record.passcode, "base64"));
+		} catch {
+			throw new Error("This paired machine's stored passcode could not be decrypted on this machine. Re-pair it.");
+		}
+	}
+
+	/** One machine's doctor probe: any HTTP answer at all (see the `refresh`
+	 * doc comment) means the box is up. Never throws; a passcode that cannot be
+	 * decrypted or a bad credential just reads as unreachable, since nothing
+	 * useful can be said about a box this process cannot authenticate to. */
+	async function probeReachability(
+		record: PersistedPairedMachine,
+	): Promise<{ reachability: AoMachineReachability; harness: HarnessReadiness; answered: boolean }> {
+		const baseUrl = baseUrlFor(record.address, record.port);
+		if (!baseUrl) return { reachability: "offline", harness: HARNESS_UNKNOWN, answered: false };
+		let passcode: string | null;
+		try {
+			passcode = await decryptPasscode(record);
+		} catch {
+			return { reachability: "offline", harness: HARNESS_UNKNOWN, answered: false };
+		}
+		if (!passcode) return { reachability: "offline", harness: HARNESS_UNKNOWN, answered: false };
+		try {
+			const response = await fetchWithDeadline(
+				netFetch,
+				`${baseUrl}/api/v1/doctor`,
+				{ method: "GET", headers: { Authorization: `Bearer ${passcode}` } },
+				probeTimeoutMs,
+				"Paired machine doctor probe",
+			);
+			if (!response.ok) return { reachability: "online", harness: HARNESS_UNKNOWN, answered: true };
+			return { reachability: "online", harness: harnessFromDoctorChecks(await response.json()), answered: true };
+		} catch {
+			// Transport failure or timeout: the only case that is actually offline,
+			// mirroring ao-machines.ts's own probe() (see its doc comment).
+			return { reachability: "offline", harness: HARNESS_UNKNOWN, answered: false };
+		}
+	}
+
 	const verifyCertificate = createPairCertificateVerifyProc({
 		isPairHost: (hostname) => pendingHosts.has(hostname) || pinnedByHost.has(hostname),
 		getPinnedFingerprint: (hostname) => pinnedByHost.get(hostname) ?? null,
 		onPresented: (hostname, fingerprint) => presented.set(hostname, fingerprint),
 	});
+
+	function list(): AoMachine[] {
+		return [...records.values()]
+			.map((record) =>
+				toAoMachine(record, reachabilityById.get(record.id) ?? "unknown", harnessById.get(record.id) ?? HARNESS_UNKNOWN),
+			)
+			.filter((machine): machine is AoMachine => machine !== null);
+	}
 
 	return {
 		async load(): Promise<void> {
@@ -247,10 +332,28 @@ export function createPairedMachinesController(deps: PairedMachinesControllerDep
 			rebuildPinnedByHost();
 		},
 
-		list(): AoMachine[] {
-			return [...records.values()]
-				.map((record) => toAoMachine(record))
-				.filter((machine): machine is AoMachine => machine !== null);
+		list,
+
+		async refresh(): Promise<AoMachine[]> {
+			const current = [...records.values()];
+			await Promise.all(
+				current.map(async (record) => {
+					const probe = await probeReachability(record);
+					reachabilityById.set(record.id, probe.reachability);
+					harnessById.set(record.id, probe.harness);
+					if (probe.answered) {
+						const previous = records;
+						records = new Map(previous).set(record.id, { ...record, lastSeen: new Date().toISOString() });
+						try {
+							await persist();
+						} catch (err) {
+							records = previous;
+							throw err;
+						}
+					}
+				}),
+			);
+			return list();
 		},
 
 		async add(input): Promise<AoMachine> {
@@ -285,7 +388,11 @@ export function createPairedMachinesController(deps: PairedMachinesControllerDep
 				rebuildPinnedByHost();
 				throw err;
 			}
-			const machine = toAoMachine(record);
+			// A re-pair may point at a different address or hand out a different
+			// passcode; a reachability verdict from before either changed is stale.
+			reachabilityById.delete(record.id);
+			harnessById.delete(record.id);
+			const machine = toAoMachine(record, "unknown", HARNESS_UNKNOWN);
 			if (!machine) throw new Error(`Not a usable address: ${input.address}`);
 			return machine;
 		},
@@ -303,19 +410,14 @@ export function createPairedMachinesController(deps: PairedMachinesControllerDep
 				rebuildPinnedByHost();
 				throw err;
 			}
+			reachabilityById.delete(id);
+			harnessById.delete(id);
 		},
 
 		async getPasscode(id: string): Promise<string | null> {
 			const record = records.get(id);
 			if (!record) return null;
-			if (!deps.safeStorage.isEncryptionAvailable()) {
-				throw new Error("This system has no OS credential store available, so the paired machine's passcode cannot be read.");
-			}
-			try {
-				return deps.safeStorage.decryptString(Buffer.from(record.passcode, "base64"));
-			} catch {
-				throw new Error("This paired machine's stored passcode could not be decrypted on this machine. Re-pair it.");
-			}
+			return decryptPasscode(record);
 		},
 
 		async touchLastSeen(id: string): Promise<void> {

--- a/frontend/src/preload.ts
+++ b/frontend/src/preload.ts
@@ -355,6 +355,10 @@ const api = {
 	// comparison screen are a different task; this is what that UI calls into.
 	pairedMachines: {
 		list: () => ipcRenderer.invoke("pairedMachines:list") as Promise<AoMachine[]>,
+		// Probes every paired machine's reachability and agent-harness readiness
+		// (GET /api/v1/doctor through the gateway) and returns the refreshed list,
+		// mirroring machines.refresh()'s contract for the control-plane list.
+		refresh: () => ipcRenderer.invoke("pairedMachines:refresh") as Promise<AoMachine[]>,
 		// Attempts a connection so the caller can show the presented fingerprint
 		// for comparison against what the box printed. The connection itself is
 		// always denied (trust-on-first-use never auto-accepts); this only ever

--- a/frontend/src/renderer/components/settings/MachinesSection.test.tsx
+++ b/frontend/src/renderer/components/settings/MachinesSection.test.tsx
@@ -5,12 +5,12 @@ import { beforeEach, expect, test, vi } from "vitest";
 import { HARNESS_SETUP_COMMAND, LOCAL_MACHINE_ID, localMachine, type AoMachine, type AoMachinesState } from "../../../shared/ao-machines";
 import { MachinesSection } from "./MachinesSection";
 
-const { refresh, select, writeText, pairedList, pairedRemove, probeFingerprint, getPinnedFingerprint, pairedAdd } =
+const { refresh, select, writeText, pairedRefresh, pairedRemove, probeFingerprint, getPinnedFingerprint, pairedAdd } =
 	vi.hoisted(() => ({
 		refresh: vi.fn(),
 		select: vi.fn(),
 		writeText: vi.fn(),
-		pairedList: vi.fn(),
+		pairedRefresh: vi.fn(),
 		pairedRemove: vi.fn(),
 		probeFingerprint: vi.fn(),
 		getPinnedFingerprint: vi.fn(),
@@ -22,7 +22,7 @@ vi.mock("../../lib/bridge", () => ({
 		machines: { refresh, select },
 		clipboard: { writeText },
 		pairedMachines: {
-			list: pairedList,
+			refresh: pairedRefresh,
 			remove: pairedRemove,
 			probeFingerprint,
 			getPinnedFingerprint,
@@ -102,7 +102,7 @@ beforeEach(() => {
 	refresh.mockReset().mockResolvedValue(READY);
 	select.mockReset().mockResolvedValue({ ...READY, activeMachineId: "mch_1" });
 	writeText.mockReset().mockResolvedValue(undefined);
-	pairedList.mockReset().mockResolvedValue([]);
+	pairedRefresh.mockReset().mockResolvedValue([]);
 	pairedRemove.mockReset().mockResolvedValue(undefined);
 	probeFingerprint.mockReset();
 	getPinnedFingerprint.mockReset();
@@ -230,7 +230,7 @@ test("shows the reason when the refresh fails, instead of spinning forever", asy
 });
 
 test("a paired machine is listed and labelled by origin, distinct from hosted and local", async () => {
-	pairedList.mockResolvedValue([PAIRED_ONLINE]);
+	pairedRefresh.mockResolvedValue([PAIRED_ONLINE]);
 	renderSection();
 	await screen.findAllByTestId("ao-machine");
 
@@ -240,7 +240,7 @@ test("a paired machine is listed and labelled by origin, distinct from hosted an
 });
 
 test("an unreachable paired machine stays listed, marked unreachable with its last-seen time", async () => {
-	pairedList.mockResolvedValue([PAIRED_OFFLINE]);
+	pairedRefresh.mockResolvedValue([PAIRED_OFFLINE]);
 	renderSection();
 	await screen.findAllByTestId("ao-machine");
 
@@ -251,7 +251,7 @@ test("an unreachable paired machine stays listed, marked unreachable with its la
 });
 
 test("removing a paired machine asks for confirmation, then calls remove and refreshes the list", async () => {
-	pairedList.mockResolvedValue([PAIRED_ONLINE]);
+	pairedRefresh.mockResolvedValue([PAIRED_ONLINE]);
 	renderSection();
 	await screen.findAllByTestId("ao-machine");
 
@@ -261,7 +261,7 @@ test("removing a paired machine asks for confirmation, then calls remove and ref
 	const confirmDialog = await screen.findByRole("dialog");
 	expect(within(confirmDialog).getByText(/remove this paired machine/i)).toBeInTheDocument();
 
-	pairedList.mockResolvedValue([]);
+	pairedRefresh.mockResolvedValue([]);
 	await userEvent.click(within(confirmDialog).getByRole("button", { name: "Remove" }));
 
 	expect(pairedRemove).toHaveBeenCalledWith(PAIRED_ONLINE.id);

--- a/frontend/src/renderer/components/settings/MachinesSection.tsx
+++ b/frontend/src/renderer/components/settings/MachinesSection.tsx
@@ -26,12 +26,11 @@ export const aoPairedMachinesQueryKey = ["ao-paired-machines"] as const;
  * one exception, and its own fingerprint comparison step is what stands in for
  * a certificate authority.
  *
- * Paired machines are listed here but are not yet a selectable target: making
- * one active needs the same authenticated transport (REST bearer, /mux cookie,
- * SSE) that registered machines get from the control plane, and pair mode's
- * credential is a locally-held passcode instead, which is main-process wiring
- * this task does not build. See AddPairedMachineDialog and the PR description
- * for the exact seam.
+ * Paired machines are selectable exactly like registered ones: `select`
+ * resolves a paired id and drives the passcode-credentialed transport instead
+ * of the control-plane one (docs/plans/2026-08-16-pair-by-ip-headless-boxes.md
+ * task 9), and `activeMachineId` on the shared state reflects a paired id the
+ * same way it reflects a registered machine's.
  */
 export function MachinesSection() {
 	const { t } = useTranslation();
@@ -44,9 +43,11 @@ export function MachinesSection() {
 		queryFn: () => aoBridge.machines.refresh(),
 		retry: 1,
 	});
+	// refresh(), not list(): reachability and last-seen for a paired box come
+	// from an authenticated GET /api/v1/doctor probe, not the registry alone.
 	const pairedQuery = useQuery({
 		queryKey: aoPairedMachinesQueryKey,
-		queryFn: () => aoBridge.pairedMachines.list(),
+		queryFn: () => aoBridge.pairedMachines.refresh(),
 	});
 	const apply = (next: AoMachinesState) => queryClient.setQueryData(aoMachinesQueryKey, next);
 	const invalidatePaired = () => queryClient.invalidateQueries({ queryKey: aoPairedMachinesQueryKey });
@@ -89,7 +90,14 @@ export function MachinesSection() {
 			))}
 
 			{pairedMachines.map((machine) => (
-				<PairedMachineRow key={machine.id} machine={machine} onRemove={() => setRemoveTarget(machine)} />
+				<PairedMachineRow
+					key={machine.id}
+					machine={machine}
+					active={machine.id === activeMachineId}
+					busy={select.isPending}
+					onSelect={() => select.mutate(machine.id)}
+					onRemove={() => setRemoveTarget(machine)}
+				/>
 			))}
 
 			{query.isLoading ? (
@@ -213,14 +221,27 @@ function MachineRow({
 
 /**
  * A paired box (docs/adr/0003-pair-mode-gateway.md), listed alongside local
- * and hosted machines but rendered as a static row rather than a `MachineRow`
- * button: there is no bridge call yet to make a paired machine the active one
- * (see the module doc comment above), so this row only ever offers removal,
- * never a click-to-select action that would silently do nothing or select the
- * wrong transport. An unreachable paired box still renders here, with its
- * last-seen time, exactly like an offline registered machine does.
+ * and hosted machines and selectable exactly like a `MachineRow`: `onSelect`
+ * carries the same machine id through `machines.select`, which resolves a
+ * paired id and drives the passcode-credentialed transport instead of the
+ * control-plane one (docs/plans/2026-08-16-pair-by-ip-headless-boxes.md task
+ * 9). An unreachable paired box still renders here, with its last-seen time,
+ * exactly like an offline registered machine does; removal stays a separate
+ * action so a click on the row never both selects and deletes it.
  */
-function PairedMachineRow({ machine, onRemove }: { machine: AoMachine; onRemove: () => void }) {
+function PairedMachineRow({
+	machine,
+	active,
+	busy,
+	onSelect,
+	onRemove,
+}: {
+	machine: AoMachine;
+	active: boolean;
+	busy: boolean;
+	onSelect: () => void;
+	onRemove: () => void;
+}) {
 	const { t } = useTranslation();
 	const offline = machine.reachability === "offline";
 	const lastSeen = formatLastSeen(machine.lastSeen);
@@ -233,14 +254,26 @@ function PairedMachineRow({ machine, onRemove }: { machine: AoMachine; onRemove:
 	return (
 		<div className="flex w-full flex-col gap-1.5" data-testid="ao-machine" data-machine-id={machine.id}>
 			<div className="settings-row-bar w-full">
-				<div className="flex shrink-0 items-center gap-(--size-settings-row-icon-gap)">
+				<button
+					type="button"
+					onClick={onSelect}
+					disabled={busy || active}
+					aria-pressed={active}
+					className="flex shrink-0 items-center gap-(--size-settings-row-icon-gap) text-left transition-colors hover:bg-settings-menu-selected disabled:hover:bg-transparent"
+				>
 					<Router className="size-icon-lg shrink-0 text-settings-muted" aria-hidden="true" />
 					<span className="whitespace-nowrap text-sm leading-5 text-settings-label">{machine.name}</span>
 					<Badge variant="outline">{t("pairing.originPaired")}</Badge>
-				</div>
+				</button>
 				<div className="flex min-w-0 flex-1 items-center justify-end gap-2">
 					<span className="min-w-0 truncate text-control text-settings-muted">{detail}</span>
 					{offline ? <Badge variant="error">Offline</Badge> : null}
+					{active ? (
+						<Badge variant="accent">
+							<Check className="size-3" aria-hidden="true" />
+							Active
+						</Badge>
+					) : null}
 					<Button type="button" variant="ghost" size="sm" onClick={onRemove}>
 						<Trash2 className="size-icon-sm" aria-hidden="true" />
 						{t("pairing.remove")}

--- a/frontend/src/renderer/lib/bridge.ts
+++ b/frontend/src/renderer/lib/bridge.ts
@@ -329,6 +329,7 @@ export const aoBridge: AoBridge =
 		// probe or pair.
 		pairedMachines: {
 			list: async () => [],
+			refresh: async () => [],
 			probeFingerprint: async () => ({
 				error: "Pairing needs the desktop app; it is not available in browser preview.",
 			}),

--- a/frontend/src/renderer/test/setup.ts
+++ b/frontend/src/renderer/test/setup.ts
@@ -248,6 +248,7 @@ if (typeof window !== "undefined") {
 		},
 		pairedMachines: {
 			list: async () => [],
+			refresh: async () => [],
 			probeFingerprint: async () => ({ error: "not available in tests" }),
 			getPinnedFingerprint: async () => null,
 			add: async () => {


### PR DESCRIPTION
Refs #86. Closes the gap recorded in #94.

## The gap this closes

A paired machine could be added, pinned, listed and removed, but never selected
or connected to:

- `machineTransport()` returned `null` without a control-plane credential.
- `select()` only searched the control-plane-listed `remote` array.

So the board, terminal mux, SSE and `ao doctor` had no path to a paired box.

## Approach

A passcode-credentialed transport alongside the JWT one, **reusing the existing
credential scheme rather than inventing a second**:

- `Authorization: Bearer <passcode>` on REST.
- The same `ao_gw_token` cookie for the two routes a browser cannot put a header
  on: the `/mux` terminal socket and the SSE event stream.

That is exactly what the gateway's `requirePasscode` accepts, since it reuses the
gateway's existing `extractToken`.

## Certificate pinning is preserved

Every request still goes through the Electron session, so
`setCertificateVerifyProc` continues to cover REST, SSE and the terminal alike.
No path introduced here uses global `fetch`, which would bypass the session and
silently defeat the pin.

## Passcode rotation

A rotated passcode presents as a standing 401 against a still-installed cookie.
Recovery is the re-pair flow, per ADR 0003.

## Verification

`npm run typecheck`, `npm run typecheck:e2e`, and the affected suites all pass
(72 tests across the transport, selection, registry, machines and settings
files, including the pre-existing signed-out no-network-call regression).

Visual verification in the real desktop app has **not** been performed.

## Provenance

The agent building this was killed by a network error during its final diff
review, after the implementation was complete but before it committed anything.
The work was recovered from its worktree, re-verified from scratch (typecheck,
typecheck:e2e, full targeted suites), and audited for the two properties that
mattered most: no global `fetch` bypassing the session, and no passcode reaching
any log or error surface. Both hold.