### PR TITLE
fix(release): do not gate the release on an unset WorkOS client ID

### DIFF
--- a/.github/workflows/frontend-release.yml
+++ b/.github/workflows/frontend-release.yml
@@ -73,12 +73,21 @@ jobs:
           go-version-file: backend/go.mod
           cache-dependency-path: backend/go.sum
       - run: npm ci
+      # Hosted AO pins upstream AO Cloud sign-in off permanently (see
+      # frontend/src/shared/cloud-pin.ts and cloudSignInEnabled in
+      # backend/internal/cli/start.go), so VITE_WORKOS_CLIENT_ID guards a
+      # sign-in surface this fork's builds hide end to end. Requiring it here
+      # would mean shipping a credentialed bundle for dead code, so a missing
+      # value is a skip, not a release-blocking failure. If a value IS set,
+      # keep the original hard verification: AO Cloud is still off (the pin
+      # is code, not config), but nothing downstream should silently swallow
+      # a real misconfiguration if the variable is ever populated by mistake.
       - name: Verify WorkOS build configuration
         shell: bash
         run: |
           if [ -z "$VITE_WORKOS_CLIENT_ID" ]; then
-            echo "::error::Repository variable VITE_WORKOS_CLIENT_ID is required for desktop releases." >&2
-            exit 1
+            echo "VITE_WORKOS_CLIENT_ID unset: AO Cloud sign-in is pinned off in this fork (frontend/src/shared/cloud-pin.ts); skipping WorkOS verification."
+            exit 0
           fi
       - name: macOS signing setup
         if: startsWith(matrix.os, 'macos')
@@ -286,12 +295,15 @@ jobs:
           go-version-file: backend/go.mod
           cache-dependency-path: backend/go.sum
       - run: npm ci
+      # See the matching step in the release job above: this fork pins AO
+      # Cloud sign-in off permanently, so a missing WorkOS client ID is a
+      # skip here too, not a release-blocking failure.
       - name: Verify WorkOS build configuration
         shell: bash
         run: |
           if [ -z "$VITE_WORKOS_CLIENT_ID" ]; then
-            echo "::error::Repository variable VITE_WORKOS_CLIENT_ID is required for desktop releases." >&2
-            exit 1
+            echo "VITE_WORKOS_CLIENT_ID unset: AO Cloud sign-in is pinned off in this fork (frontend/src/shared/cloud-pin.ts); skipping WorkOS verification."
+            exit 0
           fi
       - name: macOS signing setup
         uses: ./.github/actions/macos-signing-setup

--- a/frontend/release-workflows.test.ts
+++ b/frontend/release-workflows.test.ts
@@ -5,19 +5,38 @@ import { describe, expect, it } from "vitest";
 const repositoryRoot = path.resolve(import.meta.dirname, "..");
 
 describe("desktop release workflows", () => {
-  for (const workflow of ["build-artifacts.yml", "frontend-release.yml"]) {
-    it(`${workflow} requires the WorkOS client ID`, async () => {
-      const contents = await readFile(
-        path.join(repositoryRoot, ".github", "workflows", workflow),
-        "utf8",
-      );
+  it("build-artifacts.yml requires the WorkOS client ID", async () => {
+    const contents = await readFile(
+      path.join(repositoryRoot, ".github", "workflows", "build-artifacts.yml"),
+      "utf8",
+    );
 
-      expect(contents).toContain(
-        "VITE_WORKOS_CLIENT_ID: ${{ vars.VITE_WORKOS_CLIENT_ID }}",
-      );
-      expect(contents).toContain(
-        "Repository variable VITE_WORKOS_CLIENT_ID is required",
-      );
-    });
-  }
+    expect(contents).toContain(
+      "VITE_WORKOS_CLIENT_ID: ${{ vars.VITE_WORKOS_CLIENT_ID }}",
+    );
+    expect(contents).toContain(
+      "Repository variable VITE_WORKOS_CLIENT_ID is required",
+    );
+  });
+
+  // frontend-release.yml is the one authorized publisher (AGENTS.md), and this
+  // fork pins AO Cloud sign-in off permanently (frontend/src/shared/cloud-pin.ts),
+  // so a missing WorkOS client ID must not block a release: it guards a sign-in
+  // surface the fork's builds hide end to end.
+  it("frontend-release.yml tolerates a missing WorkOS client ID (AO Cloud sign-in is pinned off in this fork)", async () => {
+    const contents = await readFile(
+      path.join(repositoryRoot, ".github", "workflows", "frontend-release.yml"),
+      "utf8",
+    );
+
+    expect(contents).toContain(
+      "VITE_WORKOS_CLIENT_ID: ${{ vars.VITE_WORKOS_CLIENT_ID }}",
+    );
+    expect(contents).toContain(
+      "AO Cloud sign-in is pinned off in this fork",
+    );
+    expect(contents).not.toContain(
+      "Repository variable VITE_WORKOS_CLIENT_ID is required",
+    );
+  });
 });


### PR DESCRIPTION
## Summary

The first-ever run of frontend-release.yml on this fork (desktop-v0.13.0) failed immediately at "Verify WorkOS build configuration" because the repository variable VITE_WORKOS_CLIENT_ID has never been set here.

We are deliberately not setting it. This fork pins upstream's AO Cloud sign-in off permanently: `frontend/src/shared/cloud-pin.ts` exports `CLOUD_SIGN_IN_ENABLED = false`, and `cloudSignInEnabled` in `backend/internal/cli/start.go` mirrors it. Both the renderer (`cloud-session.ts`) and the main process (`cloud-auth.ts`, `main.ts`) gate every WorkOS-touching code path behind that constant, so `VITE_WORKOS_CLIENT_ID` guards a sign-in surface our builds hide end to end. Requiring a real WorkOS client ID to cut a release would mean shipping a credentialed bundle for dead code.

## Changes

- Both "Verify WorkOS build configuration" steps in `.github/workflows/frontend-release.yml` (the `release` job and the `release-intel` job) now log one clear line and exit 0 when the variable is unset or empty, instead of failing the build. If the variable is ever set, the step's behavior is unchanged from before.
- `frontend/release-workflows.test.ts` updated to match: `build-artifacts.yml` still asserts the hard requirement (untouched, out of scope here), `frontend-release.yml` now asserts the tolerant message and that the old "is required" error text is gone.
- Verified the renderer/main build actually tolerates an empty value: `isCloudSignInConfigured` in `cloud-session.ts` returns `CLOUD_SIGN_IN_ENABLED && Boolean(clientId?.trim())`, which is always `false` regardless of `clientId` since the pin is `false`; `cloud-auth.ts` sets `workos = CLIENT_ID ? createWorkOS(...) : null` and gates every entry point on `CLOUD_SIGN_IN_ENABLED` first. Nothing crashes or misbuilds with the variable absent.

## Test plan

- [x] `npx vitest run release-workflows.test.ts` passes locally.
- [x] `npx vitest run src/renderer/lib/cloud-session.test.ts` passes locally (unaffected, confirms the pin's existing coverage).
- [ ] CI green on this PR.