### PR TITLE
fix(release): unblock the first real frontend-release.yml run on this fork

### DIFF
--- a/.github/workflows/frontend-release.yml
+++ b/.github/workflows/frontend-release.yml
@@ -73,6 +73,17 @@ jobs:
           go-version-file: backend/go.mod
           cache-dependency-path: backend/go.sum
       - run: npm ci
+      # frontend/vite.renderer.config.ts aliases @aoagents/product-ui straight
+      # to packages/product-ui/src (source, not a built dist), so Vite needs
+      # that package's own node_modules (e.g. clsx) on disk to resolve it.
+      # Mirrors frontend.yml's "Install Cloud client dependencies" / "Install
+      # product UI dependencies" steps, which this workflow was missing.
+      - name: Install Cloud client dependencies
+        run: npm ci
+        working-directory: packages/cloud-client
+      - name: Install product UI dependencies
+        run: npm ci
+        working-directory: packages/product-ui
       # Hosted AO pins upstream AO Cloud sign-in off permanently (see
       # frontend/src/shared/cloud-pin.ts and cloudSignInEnabled in
       # backend/internal/cli/start.go), so VITE_WORKOS_CLIENT_ID guards a
@@ -89,8 +100,15 @@ jobs:
             echo "VITE_WORKOS_CLIENT_ID unset: AO Cloud sign-in is pinned off in this fork (frontend/src/shared/cloud-pin.ts); skipping WorkOS verification."
             exit 0
           fi
+      # Skipped when no Developer ID certificate is configured (this fork has
+      # no Apple signing secrets today): forge.config.ts's osxSign/osxNotarize
+      # already fall back to undefined without CSC_LINK/APPLE_SIGNING_IDENTITY,
+      # producing an unsigned build. The apple-actions/import-codesign-certs
+      # step this action wraps hard-fails on an empty p12, so it must not run
+      # at all rather than run and error, or unsigned releases could never
+      # publish.
       - name: macOS signing setup
-        if: startsWith(matrix.os, 'macos')
+        if: startsWith(matrix.os, 'macos') && secrets.CSC_LINK != ''
         uses: ./.github/actions/macos-signing-setup
         with:
           csc-link: ${{ secrets.CSC_LINK }}
@@ -295,6 +313,14 @@ jobs:
           go-version-file: backend/go.mod
           cache-dependency-path: backend/go.sum
       - run: npm ci
+      # See "Install Cloud client dependencies" / "Install product UI
+      # dependencies" in the release job above: same reason, needed here too.
+      - name: Install Cloud client dependencies
+        run: npm ci
+        working-directory: packages/cloud-client
+      - name: Install product UI dependencies
+        run: npm ci
+        working-directory: packages/product-ui
       # See the matching step in the release job above: this fork pins AO
       # Cloud sign-in off permanently, so a missing WorkOS client ID is a
       # skip here too, not a release-blocking failure.
@@ -305,7 +331,11 @@ jobs:
             echo "VITE_WORKOS_CLIENT_ID unset: AO Cloud sign-in is pinned off in this fork (frontend/src/shared/cloud-pin.ts); skipping WorkOS verification."
             exit 0
           fi
+      # See the matching step in the release job above: skipped without a
+      # configured Developer ID certificate so an unsigned build (which
+      # forge.config.ts already supports) can still publish.
       - name: macOS signing setup
+        if: secrets.CSC_LINK != ''
         uses: ./.github/actions/macos-signing-setup
         with:
           csc-link: ${{ secrets.CSC_LINK }}

--- a/.github/workflows/frontend-release.yml
+++ b/.github/workflows/frontend-release.yml
@@ -41,6 +41,11 @@ on:
 
 env:
   VITE_WORKOS_CLIENT_ID: ${{ vars.VITE_WORKOS_CLIENT_ID }}
+  # A step's own `if:` cannot use the `secrets` context directly (only env,
+  # github, inputs, job, matrix, needs, runner, steps, strategy, vars are
+  # allowed there), so resolve it into a plain env var here once, the same
+  # way VITE_WORKOS_CLIENT_ID above is threaded through.
+  AO_HAS_MACOS_CERT: ${{ secrets.CSC_LINK != '' }}
 
 jobs:
   release:
@@ -108,7 +113,7 @@ jobs:
       # at all rather than run and error, or unsigned releases could never
       # publish.
       - name: macOS signing setup
-        if: startsWith(matrix.os, 'macos') && secrets.CSC_LINK != ''
+        if: startsWith(matrix.os, 'macos') && env.AO_HAS_MACOS_CERT == 'true'
         uses: ./.github/actions/macos-signing-setup
         with:
           csc-link: ${{ secrets.CSC_LINK }}
@@ -335,7 +340,7 @@ jobs:
       # configured Developer ID certificate so an unsigned build (which
       # forge.config.ts already supports) can still publish.
       - name: macOS signing setup
-        if: secrets.CSC_LINK != ''
+        if: env.AO_HAS_MACOS_CERT == 'true'
         uses: ./.github/actions/macos-signing-setup
         with:
           csc-link: ${{ secrets.CSC_LINK }}


### PR DESCRIPTION
## Summary

Two pre-existing gaps surfaced when desktop-v0.13.0 ran frontend-release.yml for the first time on this fork (after the WorkOS gate fix in #108 cleared the earlier blocker):

- **macOS signing setup hard-failed on an empty CSC_LINK.** `frontend/forge.config.ts` already falls back to an unsigned build (`osxSign`/`osxNotarize` resolve to `undefined`) when no Developer ID certificate is configured, which is the accepted state on this fork (no Apple signing secrets exist). But the "macOS signing setup" step called `apple-actions/import-codesign-certs@v3` unconditionally, and that action hard-fails on an empty p12 rather than degrading gracefully. Gated the step on `secrets.CSC_LINK != ''` in both the `release` job (macos-latest leg) and `release-intel`.
- **The renderer build could not resolve `clsx` from `packages/product-ui`.** `frontend/vite.renderer.config.ts` aliases `@aoagents/product-ui` straight to `packages/product-ui/src` (source, not a built dist), so that package needs its own `node_modules` on disk at build time. `frontend.yml` (regular CI) already runs `npm ci` in `packages/cloud-client` and `packages/product-ui` for this reason; `frontend-release.yml` never did. Added the same two install steps to both the `release` job and `release-intel`.

Neither gap is related to the WorkOS gate change in #108; they only surfaced because this was the first-ever successful pass through the WorkOS check on this fork's frontend-release.yml.

## Test plan

- [x] `npx vitest run release-workflows.test.ts` still passes (workflow content assertions unaffected).
- [x] YAML parses (`python3 -c "import yaml; yaml.safe_load(...)"`).
- [ ] CI green on this PR.
- [ ] Post-merge: re-tag desktop-v0.13.0 and confirm the release job gets past both the macOS signing step and the renderer build.