### PR TITLE
chore(release): 0.13.1

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "hosted-ao",
-	"version": "0.13.0",
+	"version": "0.13.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "hosted-ao",
-			"version": "0.13.0",
+			"version": "0.13.1",
 			"license": "MIT",
 			"dependencies": {
 				"@aoagents/product-ui": "file:../packages/product-ui",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "hosted-ao",
 	"productName": "Hosted AO",
-	"version": "0.13.0",
+	"version": "0.13.1",
 	"private": true,
 	"description": "Electron + TypeScript frontend for the agent-orchestrator rewrite",
 	"author": "Agent Orchestrator",


### PR DESCRIPTION
## Summary

Bump desktop app version 0.13.0 to 0.13.1 (frontend/package.json, package-lock.json).

Phase 1 (the pairing string) just merged to develop as c1116ff18: the ao CLI now has ao pair / ao pair show and prints the ao-pair:// string at provisioning/rotation time. v0.13.0's published binaries predate that change, and the curl|sh installer downloads releases/latest, so a new tag is needed to carry the updated CLI.

## Test plan

- [ ] CI green on this PR.
- [ ] Post-merge: tag desktop-v0.13.1, watch the release run, confirm the full asset list including ao-linux-x64/arm64 + sha256 sidecars, and confirm the ubuntu leg's version-stamp check reports 0.13.1.