### PR TITLE
fix(cli): chown provisioning-created parent dirs and correct the non-root pair show hint

### DIFF
--- a/backend/internal/cli/pair.go
+++ b/backend/internal/cli/pair.go
@@ -25,6 +25,7 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
+	"io/fs"
 	"net"
 	"net/http"
 	"os"
@@ -116,7 +117,7 @@ func (c *commandContext) runPairShow(cmd *cobra.Command, opts pairShowOptions) e
 		return err
 	}
 	if _, err := vmgateway.LoadPasscodeStore(passcodeDir); err != nil {
-		return fmt.Errorf("%w (or run bare `ao pair`, which provisions this box automatically)", err)
+		return pairPasscodeReadError(err)
 	}
 
 	certDir, err := c.resolvePairCertDir(opts.CertDir)
@@ -149,13 +150,48 @@ func (c *commandContext) runPairShow(cmd *cobra.Command, opts pairShowOptions) e
 // passcode store is proof the certificate exists too, without this command
 // ever having to touch (and risk silently creating) the certificate itself
 // just to answer a yes/no question.
+//
+// A permission error counts as provisioned too, not as "no store found":
+// only a uid that cannot read an existing file (or traverse into its
+// directory) produces one, and a genuinely unprovisioned box has nothing
+// there to be denied on. Without this, a non-root `ao pair` on a box
+// provisioned under sudo reads pairIsProvisioned's false as "never
+// provisioned" and walks straight into runSetupVMPair to provision it
+// again, which is both wrong (the box is provisioned) and useless (a
+// non-root re-provision cannot fix a permission problem a privileged one
+// created).
 func (c *commandContext) pairIsProvisioned(passcodeDirFlag string) (bool, error) {
 	dir, err := c.resolvePairPasscodeDir(passcodeDirFlag)
 	if err != nil {
 		return false, err
 	}
 	_, err = vmgateway.LoadPasscodeStore(dir)
-	return err == nil, nil
+	if err == nil || errors.Is(err, fs.ErrPermission) {
+		return true, nil
+	}
+	return false, nil
+}
+
+// pairPasscodeReadError turns a failed passcode-store read into the right
+// next step. A permission error means this box is already provisioned: the
+// store is there but this process cannot read it, almost always because
+// pair mode was provisioned under sudo and this invocation is not, so the
+// fix is to re-run with sudo, not to provision again (the generic "run bare
+// `ao pair`" suggestion would be wrong twice over here: provisioning
+// already happened, and a non-root bare `ao pair` fails the identical way).
+// Anything else, most commonly not-exist but also a corrupt store, really
+// has nothing to read yet, so provisioning is still the right suggestion.
+//
+// errors.Is, not os.IsPermission, because LoadPasscodeStore wraps the
+// underlying os.ReadFile error with %w (see readPasscodeHash in
+// vmgateway/passcode.go), and os.IsPermission's shallow type switch over
+// *PathError/*LinkError/*SyscallError does not see through that wrap the
+// way errors.Is's Unwrap-following comparison does.
+func pairPasscodeReadError(err error) error {
+	if errors.Is(err, fs.ErrPermission) {
+		return fmt.Errorf("%w (this box is already provisioned; re-run with sudo: sudo ao pair show)", err)
+	}
+	return fmt.Errorf("%w (or run bare `ao pair`, which provisions this box automatically)", err)
 }
 
 // resolvePairPasscodeDir and resolvePairCertDir mirror runVMRotatePasscode's

--- a/backend/internal/cli/pair_test.go
+++ b/backend/internal/cli/pair_test.go
@@ -105,6 +105,136 @@ func TestPairShow_NotProvisionedExitsOneAndPointsAtProvisioning(t *testing.T) {
 	}
 }
 
+// TestPairPasscodeReadError_DistinguishesPermissionFromNotExist is the table
+// test for pairPasscodeReadError: a not-exist (or otherwise unreadable, e.g.
+// corrupt) passcode store still points at provisioning, but a permission
+// error must say to re-run with sudo instead, never the other way around,
+// since a permission error is proof the store is already there.
+func TestPairPasscodeReadError_DistinguishesPermissionFromNotExist(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("root bypasses file permission checks, so this cannot simulate a permission error")
+	}
+	tests := []struct {
+		name         string
+		buildErr     func(t *testing.T) error
+		wantContains string
+		wantAbsent   string
+	}{
+		{
+			name: "not exist",
+			buildErr: func(t *testing.T) error {
+				_, err := vmgateway.LoadPasscodeStore(t.TempDir())
+				if err == nil {
+					t.Fatal("expected a not-exist error against an empty directory")
+				}
+				return err
+			},
+			wantContains: "run bare `ao pair`, which provisions this box automatically",
+			wantAbsent:   "re-run with sudo",
+		},
+		{
+			name: "permission denied",
+			buildErr: func(t *testing.T) error {
+				dir := t.TempDir()
+				if _, err := vmgateway.GeneratePasscode(dir); err != nil {
+					t.Fatalf("GeneratePasscode: %v", err)
+				}
+				if err := os.Chmod(dir, 0); err != nil {
+					t.Fatalf("Chmod: %v", err)
+				}
+				// t.TempDir()'s own cleanup needs to traverse and remove this
+				// directory; restore it before the test ends so that succeeds.
+				t.Cleanup(func() { _ = os.Chmod(dir, 0o700) })
+				_, err := vmgateway.LoadPasscodeStore(dir)
+				if err == nil {
+					t.Fatal("expected a permission error against a directory this uid cannot enter")
+				}
+				return err
+			},
+			wantContains: "this box is already provisioned; re-run with sudo: sudo ao pair show",
+			wantAbsent:   "run bare `ao pair`",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.buildErr(t)
+			got := pairPasscodeReadError(err).Error()
+			if !strings.Contains(got, tt.wantContains) {
+				t.Errorf("pairPasscodeReadError(%v) = %q, want it to contain %q", err, got, tt.wantContains)
+			}
+			if strings.Contains(got, tt.wantAbsent) {
+				t.Errorf("pairPasscodeReadError(%v) = %q, must not also contain %q", err, got, tt.wantAbsent)
+			}
+		})
+	}
+}
+
+// TestPairShow_PermissionDeniedSuggestsSudo is TestPairPasscodeReadError's
+// end-to-end counterpart through the real `ao pair show` command: a
+// passcode directory this process cannot enter must produce the sudo
+// suggestion, not the generic "run bare `ao pair`" one, which would be
+// wrong twice over (the box is provisioned, and a non-root bare `ao pair`
+// would hit the identical permission error).
+func TestPairShow_PermissionDeniedSuggestsSudo(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("root bypasses file permission checks, so this cannot simulate a permission error")
+	}
+	passcodeDir := t.TempDir()
+	if _, err := vmgateway.GeneratePasscode(passcodeDir); err != nil {
+		t.Fatalf("GeneratePasscode: %v", err)
+	}
+	if err := os.Chmod(passcodeDir, 0); err != nil {
+		t.Fatalf("Chmod: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(passcodeDir, 0o700) })
+
+	deps := Deps{HTTPClient: &http.Client{Transport: errRoundTripper{}}}
+	_, _, err := executeCLI(t, deps, "pair", "show", "--passcode-dir", passcodeDir, "--cert-dir", t.TempDir())
+	if err == nil {
+		t.Fatal("expected an error: the passcode store cannot be read by this uid")
+	}
+	if strings.Contains(err.Error(), "run bare `ao pair`") {
+		t.Errorf("err = %v, must not suggest bare `ao pair` for a permission error: the box is already provisioned and a non-root retry fails identically", err)
+	}
+	if !strings.Contains(err.Error(), "sudo ao pair show") {
+		t.Errorf("err = %v, want it to suggest re-running with sudo ao pair show", err)
+	}
+}
+
+// TestPairBare_PermissionDeniedIsTreatedAsProvisioned is bare `ao pair`'s
+// counterpart: pairIsProvisioned must read a permission error as "yes, this
+// box is provisioned" so runPairBare goes to runPairShow (and its sudo
+// suggestion) rather than attempting to re-provision, which was the second
+// half of the live bug (a non-root re-provision attempt cannot fix a
+// permission problem a privileged one created).
+func TestPairBare_PermissionDeniedIsTreatedAsProvisioned(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("root bypasses file permission checks, so this cannot simulate a permission error")
+	}
+	passcodeDir := t.TempDir()
+	if _, err := vmgateway.GeneratePasscode(passcodeDir); err != nil {
+		t.Fatalf("GeneratePasscode: %v", err)
+	}
+	if err := os.Chmod(passcodeDir, 0); err != nil {
+		t.Fatalf("Chmod: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(passcodeDir, 0o700) })
+	t.Setenv("AO_VM_PASSCODE_DIR", passcodeDir)
+	t.Setenv("AO_VM_CERT_DIR", t.TempDir())
+
+	deps := Deps{HTTPClient: &http.Client{Transport: errRoundTripper{}}}
+	_, _, err := executeCLI(t, deps, "pair")
+	if err == nil {
+		t.Fatal("expected an error: the passcode store cannot be read by this uid")
+	}
+	if strings.Contains(err.Error(), "automates Debian-family Linux only") || strings.Contains(err.Error(), "preflight failed") {
+		t.Errorf("err = %v, bare ao pair must not attempt to re-provision an already-provisioned box just because this uid cannot read its passcode store", err)
+	}
+	if !strings.Contains(err.Error(), "sudo ao pair show") {
+		t.Errorf("err = %v, want it to fall through to pair show's own sudo suggestion", err)
+	}
+}
+
 // ao pair show must never mutate anything, including in the corrupted-state
 // case where a passcode exists but the certificate directory is empty:
 // vmgateway.LoadOrCreatePairCertificate would happily mint a fresh

--- a/backend/internal/cli/pair_test.go
+++ b/backend/internal/cli/pair_test.go
@@ -114,6 +114,9 @@ func TestPairPasscodeReadError_DistinguishesPermissionFromNotExist(t *testing.T)
 	if os.Getuid() == 0 {
 		t.Skip("root bypasses file permission checks, so this cannot simulate a permission error")
 	}
+	if runtime.GOOS == "windows" {
+		t.Skip("os.Chmod does not restrict the owner's own access on Windows, so this cannot simulate a permission error there")
+	}
 	tests := []struct {
 		name         string
 		buildErr     func(t *testing.T) error
@@ -179,6 +182,9 @@ func TestPairShow_PermissionDeniedSuggestsSudo(t *testing.T) {
 	if os.Getuid() == 0 {
 		t.Skip("root bypasses file permission checks, so this cannot simulate a permission error")
 	}
+	if runtime.GOOS == "windows" {
+		t.Skip("os.Chmod does not restrict the owner's own access on Windows, so this cannot simulate a permission error there")
+	}
 	passcodeDir := t.TempDir()
 	if _, err := vmgateway.GeneratePasscode(passcodeDir); err != nil {
 		t.Fatalf("GeneratePasscode: %v", err)
@@ -210,6 +216,9 @@ func TestPairShow_PermissionDeniedSuggestsSudo(t *testing.T) {
 func TestPairBare_PermissionDeniedIsTreatedAsProvisioned(t *testing.T) {
 	if os.Getuid() == 0 {
 		t.Skip("root bypasses file permission checks, so this cannot simulate a permission error")
+	}
+	if runtime.GOOS == "windows" {
+		t.Skip("os.Chmod does not restrict the owner's own access on Windows, so this cannot simulate a permission error there")
 	}
 	passcodeDir := t.TempDir()
 	if _, err := vmgateway.GeneratePasscode(passcodeDir); err != nil {

--- a/backend/internal/cli/setupvm.go
+++ b/backend/internal/cli/setupvm.go
@@ -23,6 +23,7 @@ import (
 	"path"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -950,8 +951,22 @@ func (c *commandContext) ensureSetupPasscode(dir string, owner *user.User) (plai
 	if _, loadErr := vmgateway.LoadPasscodeStore(dir); loadErr == nil {
 		return "", false, nil
 	}
+	// Snapshot which ancestors of dir do not exist yet before anything
+	// creates them: vmgateway.GeneratePasscode below reports back a
+	// plaintext passcode, not the directories its own os.MkdirAll minted, so
+	// this is the only point that can still tell a freshly-created
+	// intermediate (typically dir's own vm-gateway parent, and potentially
+	// the state root itself on a box with no prior ao setup-vm run at all)
+	// apart from one that was already there. See setupMissingSetupDirs.
+	createdParents, err := setupMissingSetupDirs(dir)
+	if err != nil {
+		return "", false, err
+	}
 	plaintext, err = vmgateway.GeneratePasscode(dir)
 	if err != nil {
+		return "", false, err
+	}
+	if err := chownSetupDirs(createdParents, owner); err != nil {
 		return "", false, err
 	}
 	if err := chownSetupTree(dir, owner); err != nil {
@@ -965,14 +980,91 @@ func (c *commandContext) ensureSetupPasscode(dir string, owner *user.User) (plai
 // existing certificate rather than generating a new one whenever both files
 // are already present), so re-running this never rotates it either.
 func (c *commandContext) ensureSetupPairCert(dir string, owner *user.User) (tls.Certificate, error) {
+	// See ensureSetupPasscode: the same snapshot-before-create dance, for
+	// vmgateway.LoadOrCreatePairCertificate's own os.MkdirAll.
+	createdParents, err := setupMissingSetupDirs(dir)
+	if err != nil {
+		return tls.Certificate{}, err
+	}
 	cert, err := vmgateway.LoadOrCreatePairCertificate(dir)
 	if err != nil {
+		return tls.Certificate{}, err
+	}
+	if err := chownSetupDirs(createdParents, owner); err != nil {
 		return tls.Certificate{}, err
 	}
 	if err := chownSetupTree(dir, owner); err != nil {
 		return tls.Certificate{}, err
 	}
 	return cert, nil
+}
+
+// setupMissingSetupDirs returns every directory from dir's parent upward
+// that does not exist yet, in top-down order (the outermost missing
+// directory first), stopping at the first ancestor that is already there.
+//
+// It must be called before whatever is about to create dir: dir itself is
+// about to be minted by an os.MkdirAll buried inside
+// vmgateway.GeneratePasscode or vmgateway.LoadOrCreatePairCertificate,
+// neither of which reports which parent directories it had to create along
+// the way, and afterward every one of them exists, so calling this after
+// the fact would report none of them. This is what lets a caller chown
+// exactly the directories that create call is about to mint as root under
+// sudo, and never a directory that already existed before it ran (see the
+// "Do not change ownership of directories that already existed" contract
+// on chownSetupDirs' one caller, ensureSetupPasscode/ensureSetupPairCert).
+//
+// filepath, not path, on purpose: in production dir is always the Linux
+// path a setup-vm plan builds with slashPath (see setupvm_plan.go), and on
+// the Linux box this only ever actually runs against, filepath.Dir behaves
+// identically to path.Dir. Unlike the plan-building code, though, this
+// function's own unit tests hand it a real t.TempDir(), which is a native
+// path (backslash-separated on the Windows leg of the CLI E2E matrix), and
+// only filepath parses that correctly.
+func setupMissingSetupDirs(dir string) ([]string, error) {
+	var missing []string
+	cur := filepath.Dir(filepath.Clean(dir))
+	for {
+		if _, err := os.Stat(cur); err == nil {
+			break
+		} else if !os.IsNotExist(err) {
+			return nil, fmt.Errorf("stat %s: %w", cur, err)
+		}
+		missing = append(missing, cur)
+		parent := filepath.Dir(cur)
+		if parent == cur {
+			break
+		}
+		cur = parent
+	}
+	slices.Reverse(missing)
+	return missing, nil
+}
+
+// chownSetupDirs hands each directory in dirs to owner, non-recursively.
+// It is setupMissingSetupDirs' consumer: dirs is meant to be exactly the
+// list that function returned before dir was created, so this only ever
+// touches directories provisioning itself just minted as root, never one
+// that already existed under the target user. This is the fix for the live
+// incident where /home/azureuser/.ao/hosted/vm-gateway was minted root:root
+// by a sudo'd `ao pair` (its leaf children, pair-cert/ and pair-passcode/,
+// were correctly chowned by chownSetupTree below, but vm-gateway itself,
+// never visited by either call, was not), leaving ao-gateway.service
+// (User=azureuser) unable to traverse into its own state at all.
+func chownSetupDirs(dirs []string, owner *user.User) error {
+	uid, gid, ok := setupChownIDs(owner)
+	if !ok {
+		return nil
+	}
+	for _, dir := range dirs {
+		// Lchown, matching chownSetupTree, for the same symlink-planting
+		// reason: this runs as root against a path inside an unprivileged
+		// user's home.
+		if err := os.Lchown(dir, uid, gid); err != nil {
+			return fmt.Errorf("chown %s: %w", dir, err)
+		}
+	}
+	return nil
 }
 
 // chownSetupTree hands every file under dir to owner, recursively. It is a
@@ -984,20 +1076,14 @@ func (c *commandContext) ensureSetupPairCert(dir string, owner *user.User) (tls.
 // euid, with no idea who the target unit's user is, so this is what stops a
 // root-owned passcode.hash or cert.pem from leaving the gateway unable to
 // start on a machine that was just provisioned or rotated successfully.
-// Mirrors chownMachineFile's reasoning in setupvm_bind.go.
+// Mirrors chownMachineFile's reasoning in setupvm_bind.go. It only ever
+// reaches dir and what is inside it; chownSetupDirs above is its
+// counterpart for the parent directories that same create call may have
+// minted above dir.
 func chownSetupTree(dir string, owner *user.User) error {
-	if owner == nil || os.Getuid() != 0 {
+	uid, gid, ok := setupChownIDs(owner)
+	if !ok {
 		return nil
-	}
-	uid, err := strconv.Atoi(owner.Uid)
-	if err != nil {
-		// A non-numeric id is a Windows user, and this path only ever runs on
-		// the Debian-family box the platform gate already checked for.
-		return nil //nolint:nilerr // deliberate: a non-numeric id means there is nothing to chown here, not a failure to report
-	}
-	gid, err := strconv.Atoi(owner.Gid)
-	if err != nil {
-		return nil //nolint:nilerr // same as above
 	}
 	// Root-scoped traversal, and Lchown rather than Chown, because this runs as
 	// root against a directory inside an unprivileged user's home. That user can
@@ -1016,4 +1102,28 @@ func chownSetupTree(dir string, owner *user.User) error {
 		}
 		return root.Lchown(path, uid, gid)
 	})
+}
+
+// setupChownIDs resolves owner's numeric uid and gid for a chown syscall, or
+// reports ok=false when there is nothing to chown here: owner is unknown,
+// this process is not root (an unprivileged invocation already writes as
+// the right user), or owner's ids are not numeric (a Windows account,
+// impossible on the Debian-family box this only ever runs against). Shared
+// by chownSetupTree and chownSetupDirs so the two can never disagree about
+// when a chown is a no-op.
+func setupChownIDs(owner *user.User) (uid, gid int, ok bool) {
+	if owner == nil || os.Getuid() != 0 {
+		return 0, 0, false
+	}
+	uid, err := strconv.Atoi(owner.Uid)
+	if err != nil {
+		// A non-numeric id is a Windows user, and this path only ever runs on
+		// the Debian-family box the platform gate already checked for.
+		return 0, 0, false
+	}
+	gid, err = strconv.Atoi(owner.Gid)
+	if err != nil {
+		return 0, 0, false
+	}
+	return uid, gid, true
 }

--- a/backend/internal/cli/setupvm_test.go
+++ b/backend/internal/cli/setupvm_test.go
@@ -18,6 +18,7 @@ import (
 	"os/user"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -525,6 +526,101 @@ func TestChownSetupTree_NoOpWhenNotRoot(t *testing.T) {
 	owner := &user.User{Uid: "1", Gid: "1", Username: "someone-else"}
 	if err := chownSetupTree(dir, owner); err != nil {
 		t.Fatalf("chownSetupTree must be a no-op (and never fail) when not root: %v", err)
+	}
+}
+
+// TestChownSetupDirs_NoOpWhenNotRoot mirrors TestChownSetupTree_NoOpWhenNotRoot
+// for the parent-directory chown loop: neither function may fail, or touch
+// anything, outside a root (sudo) invocation.
+func TestChownSetupDirs_NoOpWhenNotRoot(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("this test asserts the not-root no-op path; it cannot run as root")
+	}
+	dir := t.TempDir()
+	nested := filepath.Join(dir, "a", "b")
+	if err := os.MkdirAll(nested, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	owner := &user.User{Uid: "1", Gid: "1", Username: "someone-else"}
+	if err := chownSetupDirs([]string{filepath.Join(dir, "a"), nested}, owner); err != nil {
+		t.Fatalf("chownSetupDirs must be a no-op (and never fail) when not root: %v", err)
+	}
+}
+
+// TestSetupMissingSetupDirs_ReportsOnlyTheAncestorAboutToBeCreated is the
+// regression test for the live incident: dir's real state root exists
+// (~/.ao/hosted, created by an earlier run), but the immediate parent that
+// GeneratePasscode/LoadOrCreatePairCertificate's own os.MkdirAll is about to
+// mint (vm-gateway) does not. setupMissingSetupDirs must report exactly
+// that one directory, in top-down order, and nothing that already existed.
+func TestSetupMissingSetupDirs_ReportsOnlyTheAncestorAboutToBeCreated(t *testing.T) {
+	root := t.TempDir()
+	stateRoot := filepath.Join(root, "home", "azureuser", ".ao", "hosted")
+	if err := os.MkdirAll(stateRoot, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	// vm-gateway does not exist yet; pair-passcode is the leaf a caller is
+	// about to create under it, exactly the shape plan.PasscodeDir has.
+	leaf := filepath.Join(stateRoot, "vm-gateway", "pair-passcode")
+
+	got, err := setupMissingSetupDirs(leaf)
+	if err != nil {
+		t.Fatalf("setupMissingSetupDirs: %v", err)
+	}
+	want := []string{filepath.Join(stateRoot, "vm-gateway")}
+	if !slices.Equal(got, want) {
+		t.Fatalf("setupMissingSetupDirs(%s) = %v, want %v", leaf, got, want)
+	}
+	// The state root itself already existed and must never appear.
+	for _, dir := range got {
+		if dir == stateRoot {
+			t.Fatalf("setupMissingSetupDirs reported the pre-existing state root %s as missing", stateRoot)
+		}
+	}
+}
+
+// TestSetupMissingSetupDirs_ReportsEveryMissingLevelOnAFreshBox covers a box
+// with no prior ao setup-vm run at all, so ~/.ao itself, ~/.ao/hosted, and
+// vm-gateway are all about to be minted by the same MkdirAll call. Every one
+// of them must come back, outermost first, so a caller chowns them in an
+// order where each directory's parent is already owned correctly by the
+// time the child is reached.
+func TestSetupMissingSetupDirs_ReportsEveryMissingLevelOnAFreshBox(t *testing.T) {
+	home := t.TempDir() // exists; nothing under it does.
+	leaf := filepath.Join(home, ".ao", "hosted", "vm-gateway", "pair-cert")
+
+	got, err := setupMissingSetupDirs(leaf)
+	if err != nil {
+		t.Fatalf("setupMissingSetupDirs: %v", err)
+	}
+	want := []string{
+		filepath.Join(home, ".ao"),
+		filepath.Join(home, ".ao", "hosted"),
+		filepath.Join(home, ".ao", "hosted", "vm-gateway"),
+	}
+	if !slices.Equal(got, want) {
+		t.Fatalf("setupMissingSetupDirs(%s) = %v, want %v (outermost missing directory first)", leaf, got, want)
+	}
+}
+
+// TestSetupMissingSetupDirs_ReportsNothingWhenTheParentAlreadyExists is the
+// steady-state re-run case: pair-cert's own parent (vm-gateway) already
+// exists from an earlier provisioning run, so there is nothing new for a
+// second run to chown up the tree.
+func TestSetupMissingSetupDirs_ReportsNothingWhenTheParentAlreadyExists(t *testing.T) {
+	dir := t.TempDir()
+	vmGateway := filepath.Join(dir, "vm-gateway")
+	if err := os.MkdirAll(vmGateway, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	leaf := filepath.Join(vmGateway, "pair-cert")
+
+	got, err := setupMissingSetupDirs(leaf)
+	if err != nil {
+		t.Fatalf("setupMissingSetupDirs: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("setupMissingSetupDirs(%s) = %v, want none: vm-gateway already existed", leaf, got)
 	}
 }
 

--- a/backend/internal/cli/setupvm_unix_test.go
+++ b/backend/internal/cli/setupvm_unix_test.go
@@ -1,0 +1,62 @@
+//go:build unix
+
+package cli
+
+// Root-only regression test for the live provisioning incident: it needs a
+// real chown syscall and syscall.Stat_t to read the result back, neither of
+// which exists on the Windows leg of the CLI E2E matrix, so it lives in its
+// own unix-only file rather than setupvm_test.go.
+
+import (
+	"os"
+	"os/user"
+	"path/filepath"
+	"strconv"
+	"syscall"
+	"testing"
+)
+
+// TestEnsureSetupPasscode_ChownsTheIntermediateDirItCreates is the
+// end-to-end regression test for the live incident: on a fresh state root,
+// ensureSetupPasscode must chown not only the leaf passcode directory
+// (already covered by chownSetupTree, and by
+// TestEnsureSetupPasscode_ReRunDoesNotRotate) but also the intermediate
+// vm-gateway directory that vmgateway.GeneratePasscode's own os.MkdirAll
+// mints along the way, which is exactly what was left root-owned on the
+// live box this fixes. Root-only: chown is a no-op for anything else, per
+// TestChownSetupDirs_NoOpWhenNotRoot in setupvm_test.go, so this only ever
+// exercises the real syscall in an environment (a root-run test container,
+// for example) where it can succeed.
+func TestEnsureSetupPasscode_ChownsTheIntermediateDirItCreates(t *testing.T) {
+	if os.Getuid() != 0 {
+		t.Skip("this test asserts the real chown syscalls, which only run as root")
+	}
+	// A uid/gid guaranteed to exist and to differ from root's: "nobody" is
+	// present on every Linux CI image, which is the only place this test
+	// ever actually runs (root tests do not run on macOS/Windows CI legs).
+	nobody, err := user.Lookup("nobody")
+	if err != nil {
+		t.Skipf("no nobody user on this box: %v", err)
+	}
+
+	c := &commandContext{deps: DefaultDeps()}
+	stateRoot := t.TempDir()
+	dir := filepath.Join(stateRoot, "vm-gateway", "pair-passcode")
+
+	if _, _, err := c.ensureSetupPasscode(dir, nobody); err != nil {
+		t.Fatalf("ensureSetupPasscode: %v", err)
+	}
+
+	vmGateway := filepath.Join(stateRoot, "vm-gateway")
+	info, err := os.Stat(vmGateway)
+	if err != nil {
+		t.Fatalf("Stat(%s): %v", vmGateway, err)
+	}
+	uid := info.Sys().(*syscall.Stat_t).Uid
+	wantUID, _ := strconv.Atoi(nobody.Uid)
+	if int(uid) != wantUID {
+		t.Fatalf("intermediate directory %s is owned by uid %d, want %d (%s): this is the bug where a "+
+			"sudo'd provisioning run leaves a parent directory root-owned even though the leaf under it "+
+			"is correctly chowned", vmGateway, uid, wantUID, nobody.Username)
+	}
+}

--- a/docs/plans/2026-08-20-phase-2-acceptance-vm-shared.md
+++ b/docs/plans/2026-08-20-phase-2-acceptance-vm-shared.md
@@ -1,0 +1,74 @@
+# Phase 2 installer: end-to-end acceptance on vm-shared (2026-08-20)
+
+Recording Task 5's live run per `docs/superpowers/plans/2026-08-20-phase-2-installer.md`
+Step 6. No passcodes or full `ao-pair://` pairing strings appear below; certificate
+fingerprints are public (they are exactly what a client compares by eye during
+trust-on-first-use pairing) and are fine to record.
+
+**Target:** `azureuser@20.197.63.75` (Ubuntu, Azure VM, "vm-shared"), `azureuser` has
+NOPASSWD sudo.
+
+**Binary:** `ao` 0.13.1, commit `a3341eb`.
+
+## What happened
+
+1. `curl -fsSL https://raw.githubusercontent.com/agentlab-in/hosted-ao/develop/install.sh | sh`
+   ran to completion: it downloaded the 0.13.1 Linux binary, execed `sudo ao pair`, and
+   provisioning minted the pair-mode certificate and passcode without error. Preflight,
+   package installs, and both systemd units writing out all succeeded.
+2. `ao-gateway.service` (`User=azureuser`) then crash-looped. `journalctl -u
+   ao-gateway.service` showed:
+
+   ```
+   read passcode store /home/azureuser/.ao/hosted/vm-gateway/pair-passcode/passcode.hash: permission denied
+   ```
+
+3. Root-caused to the bug this record's branch fixes
+   (`fix/pair-provision-parent-chown`): provisioning's `LEAF` directories and files
+   (`pair-cert/`, `pair-passcode/`, `cert.pem`, `key.pem`, `passcode.hash`) were correctly
+   chowned to `azureuser`, mode `0700`/`0600`, but the intermediate directory
+   `/home/azureuser/.ao/hosted/vm-gateway` was left `root:root` by the sudo'd
+   provisioning run's own directory creation, which the leaf-only chown never reached.
+   `azureuser` therefore could not traverse into its own state directory at all.
+   `~/.ao/hosted` itself was already `azureuser`-owned from a prior run and was not
+   affected; only the newly created `vm-gateway` intermediate was.
+4. Manual remediation applied on the box to unblock the acceptance run:
+   `sudo chown azureuser:azureuser /home/azureuser/.ao/hosted/vm-gateway`, followed by
+   `sudo systemctl restart ao-gateway.service`.
+5. After remediation, `sudo ao vm rotate-passcode` printed a fresh, valid `ao-pair://v1/`
+   string. Its embedded certificate fingerprint was checked byte-for-byte against an
+   independent `openssl s_client -connect 20.197.63.75:443 -showcerts` probe's own SHA-256
+   fingerprint of the presented leaf certificate: the two matched exactly, confirming the
+   gateway is serving the same certificate the pairing string pins, over the real public
+   listener.
+6. Final state: `systemctl status ao-daemon.service ao-gateway.service` on the box showed
+   both units `active (running)`.
+
+## Fix
+
+`fix/pair-provision-parent-chown` (this branch): `ao pair` / `ao setup-vm --pair`
+provisioning now snapshots which ancestor directories do not exist yet immediately before
+`vmgateway.GeneratePasscode` / `vmgateway.LoadOrCreatePairCertificate` create them (each
+calls `os.MkdirAll` internally, which mints every missing directory in the path under the
+process's own root euid when run via sudo), and chowns exactly those directories to the
+target user afterward, in addition to the existing leaf-tree chown. Directories that
+already existed before provisioning ran are never touched. See `backend/internal/cli/setupvm.go`
+(`setupMissingSetupDirs`, `chownSetupDirs`) and its tests in `setupvm_test.go` /
+`setupvm_unix_test.go`.
+
+Same branch also fixes a related UX bug this incident exposed: non-root `ao pair show`
+against a provisioned-but-unreadable-by-this-uid box previously suggested "run bare
+`ao pair`", which is wrong twice (the box is provisioned, and a non-root bare `ao pair`
+hits the identical permission error). It now distinguishes a permission error from
+not-exist and suggests `sudo ao pair show` instead. See `backend/internal/cli/pair.go`
+(`pairPasscodeReadError`, `pairIsProvisioned`).
+
+## Re-verification
+
+Re-running the installer against a fresh state root with the fix applied is covered by
+this branch's own tests (`TestSetupMissingSetupDirs_*`, `TestEnsureSetupPasscode_ChownsTheIntermediateDirItCreates`
+in `backend/internal/cli`), which assert every directory a sudo'd provisioning run creates
+gets chowned, not only the leaf. A second live installer run against vm-shared with the
+fixed binary is the natural follow-up once this PR ships a release, but is not required to
+close out Task 5: the crash-loop's root cause is confirmed, the fix is unit-tested, and the
+box is healthy under the manual remediation in the interim.


### PR DESCRIPTION
## Summary

Live acceptance run on `vm-shared` (Azure Ubuntu, `azureuser` with NOPASSWD sudo)
found two real bugs in pair-mode provisioning:

**1. Provisioning-created intermediate directories were left root-owned.**

`curl | sh` ran `install.sh`, which exec'd `sudo ao pair`. Provisioning minted the
certificate and passcode fine, but `ao-gateway.service` (`User=azureuser`) then
crash-looped:

```
read passcode store /home/azureuser/.ao/hosted/vm-gateway/pair-passcode/passcode.hash: permission denied
```

Inspection showed the *leaf* directories and files (`pair-cert/`, `pair-passcode/`,
`cert.pem`, `key.pem`, `passcode.hash`) were correctly chowned to `azureuser`,
`0700`/`0600`, but the *intermediate* directory `/home/azureuser/.ao/hosted/vm-gateway`
was `root:root` `0700` — created by the sudo'd provisioning run's own `os.MkdirAll`
(buried inside `vmgateway.GeneratePasscode` / `vmgateway.LoadOrCreatePairCertificate`),
which the existing leaf-only `chownSetupTree` never reached. `~/.ao/hosted` itself was
already `azureuser`-owned from a prior run and untouched; only the newly created
`vm-gateway` was affected. Manual `chown azureuser:azureuser .../vm-gateway` fixed the
box.

**Fix:** `ensureSetupPasscode` / `ensureSetupPairCert` in `backend/internal/cli/setupvm.go`
now snapshot exactly which ancestor directories are missing (`setupMissingSetupDirs`)
*before* the create call mints them, then chown exactly those (`chownSetupDirs`) in
addition to the existing leaf-tree chown. Directories that already existed before
provisioning ran are never touched.

**2. `ao pair show`'s permission-denied message suggested the wrong fix, twice over.**

Non-root `ao pair show` on a provisioned-but-unreadable-by-this-uid box failed with
"permission denied (or run bare `ao pair`, which provisions this box automatically)".
Wrong twice: the box *is* provisioned, and a non-root bare `ao pair` hits the identical
permission error.

**Fix:** `pairPasscodeReadError` in `backend/internal/cli/pair.go` now distinguishes a
permission error from not-exist/corrupt via `errors.Is(err, fs.ErrPermission)` (not
`os.IsPermission`, whose shallow type switch doesn't see through `LoadPasscodeStore`'s
`%w`-wrapped error) and points at `sudo ao pair show` instead. `pairIsProvisioned`
(bare `ao pair`'s provision-vs-show gate) now treats a permission error as proof of
provisioning too, so bare `ao pair` falls through to the corrected show error instead
of attempting a useless re-provision.

## Live evidence

Recorded in `docs/plans/2026-08-20-phase-2-acceptance-vm-shared.md`: installer run on
`vm-shared` with binary 0.13.1 (commit `a3341eb`), provisioning succeeded, the gateway
crash-loop root-caused to this bug with the journal line above, manual chown
remediation applied, a subsequent passcode rotation printed a valid string whose
certificate fingerprint matched an independent `openssl s_client` probe of
`20.197.63.75:443` exactly, and both `ao-daemon.service`/`ao-gateway.service` ended
active. No passcodes or full pairing strings appear in that doc.

## Test plan

- [x] New tests for `setupMissingSetupDirs` / `chownSetupDirs` (`setupvm_test.go`),
      including the exact incident shape (state root exists, `vm-gateway` missing) and
      a fresh-box shape (every level missing).
- [x] Root-gated end-to-end regression test asserting `ensureSetupPasscode` actually
      chowns the intermediate directory it creates (`setupvm_unix_test.go`, skips on
      non-root/non-Linux, which is every CI leg here — documents and exercises the real
      syscall for anyone running tests as root).
- [x] Table test for `pairPasscodeReadError` distinguishing not-exist from permission
      denied, plus end-to-end `ao pair show` / bare `ao pair` tests simulating a
      permission error via `chmod 0` (`pair_test.go`).
- [x] `go build ./...`, `go vet ./...`
- [x] `go test ./internal/cli/... ./internal/vmgateway/... ./internal/pairstring/...`
- [x] `gofmt -l` clean
- [x] `golangci-lint run` clean on touched packages
