### PR TITLE
fix(desktop): stop pairing probe from wedging a paired box offline

### DIFF
--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1857,14 +1857,18 @@ function aoMachines(): ReturnType<typeof createAoMachinesController> {
  * tries, and again on every manual retry -- for as long as the app stays
  * open. Keying by host instead bounds that to one throwaway session per
  * distinct box ever probed, which is what actually needs isolating from
- * `session.defaultSession`. The cost: a probe of a host that was already
- * probed and rejected once in this session -- still unpinned, the box's cert
- * genuinely rotated between the two attempts -- can hit its own cached
- * rejection and fail to (re)capture the new fingerprint until the app
- * restarts. That is a narrower recurrence of the same class of bug, scoped
- * to an already-rare event (a paired box re-minting its long-lived
- * certificate between two probes of the same unpinned host, in one app
- * session) rather than to the every-single-pairing case #114 was.
+ * `session.defaultSession`.
+ *
+ * The cost: a probe of an unpinned host is always denied, by design (same as
+ * above), so reusing that host's session for a second probe can hit its own
+ * cached rejection and fail to capture anything -- not only when the box's
+ * certificate has actually changed between the two attempts. The realistic
+ * trigger is a retry after an abandoned or failed pairing attempt (compare
+ * the fingerprint, close the dialog without pinning, try again), which can
+ * come back with a misleading "no certificate could be retrieved" until the
+ * app restarts. Re-pairing an already-registered box is unaffected: a pinned
+ * host verifies and accepts on `session.defaultSession`, which this probe
+ * session never touches. Tracked as a follow-up: #121.
  */
 function pairProbeNetFetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
 	const hostname = new URL(String(input)).hostname;

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1830,15 +1830,13 @@ function aoMachines(): ReturnType<typeof createAoMachinesController> {
 // app.whenReady below, is what actually enforces the pin; this controller only
 // holds the data it reads from.
 
-let pairProbeSessionSeq = 0;
-
 /**
- * Fetch for `probeFingerprint`'s capture connection, bound to a fresh,
- * in-memory session every call rather than `session.defaultSession`.
- * `ses.fetch()`, not `net.fetch()`: the latter always issues from the default
- * session (that is the whole reason it exists as a convenience wrapper), so
- * routing through another session requires calling `fetch` on the `Session`
- * instance itself.
+ * Fetch for `probeFingerprint`'s capture connection, bound to a session other
+ * than `session.defaultSession`, keyed by the target host rather than a
+ * fresh partition every call. `ses.fetch()`, not `net.fetch()`: the latter
+ * always issues from the default session (that is the whole reason it exists
+ * as a convenience wrapper), so routing through another session requires
+ * calling `fetch` on the `Session` instance itself.
  *
  * That connection is always denied at the TLS layer (paired-machine-cert.ts
  * has no accept path for a host with nothing pinned yet), and Chromium caches
@@ -1849,12 +1847,28 @@ let pairProbeSessionSeq = 0;
  * rejection: the very next authenticated request to the newly paired host
  * would still be short-circuited to a failure before the verify proc is even
  * consulted, reading as unreachable until the app restarts and the cache is
- * gone (#114). A throwaway partition, discarded after the one probe it was
- * created for, means the poisoned verdict dies with it instead of outliving
- * the pairing flow.
+ * gone (#114).
+ *
+ * The partition is keyed by hostname, not minted fresh per call, because
+ * `session.fromPartition` has no destroy API: Electron holds every partition
+ * it has ever created in an internal map for the life of the process
+ * (electron/electron#27142, #28566), so a fresh name every call would leak
+ * one Session per probe -- one per candidate address `racePairAddresses`
+ * tries, and again on every manual retry -- for as long as the app stays
+ * open. Keying by host instead bounds that to one throwaway session per
+ * distinct box ever probed, which is what actually needs isolating from
+ * `session.defaultSession`. The cost: a probe of a host that was already
+ * probed and rejected once in this session -- still unpinned, the box's cert
+ * genuinely rotated between the two attempts -- can hit its own cached
+ * rejection and fail to (re)capture the new fingerprint until the app
+ * restarts. That is a narrower recurrence of the same class of bug, scoped
+ * to an already-rare event (a paired box re-minting its long-lived
+ * certificate between two probes of the same unpinned host, in one app
+ * session) rather than to the every-single-pairing case #114 was.
  */
 function pairProbeNetFetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
-	const probeSession = session.fromPartition(`pair-probe-${pairProbeSessionSeq++}`);
+	const hostname = new URL(String(input)).hostname;
+	const probeSession = session.fromPartition(`pair-probe-${hostname}`);
 	probeSession.setCertificateVerifyProc(pairedMachines().verifyCertificate);
 	return probeSession.fetch(String(input), init);
 }

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1829,6 +1829,36 @@ function aoMachines(): ReturnType<typeof createAoMachinesController> {
 // plane. session.defaultSession's certificate-verify proc, installed in
 // app.whenReady below, is what actually enforces the pin; this controller only
 // holds the data it reads from.
+
+let pairProbeSessionSeq = 0;
+
+/**
+ * Fetch for `probeFingerprint`'s capture connection, bound to a fresh,
+ * in-memory session every call rather than `session.defaultSession`.
+ * `ses.fetch()`, not `net.fetch()`: the latter always issues from the default
+ * session (that is the whole reason it exists as a convenience wrapper), so
+ * routing through another session requires calling `fetch` on the `Session`
+ * instance itself.
+ *
+ * That connection is always denied at the TLS layer (paired-machine-cert.ts
+ * has no accept path for a host with nothing pinned yet), and Chromium caches
+ * a per-host certificate-error verdict at the network-service level, below
+ * where the verify proc runs, for the life of the session that made the
+ * connection. If the capture probe shared `session.defaultSession` with real
+ * traffic, pinning the fingerprint in `add()` would not undo that cached
+ * rejection: the very next authenticated request to the newly paired host
+ * would still be short-circuited to a failure before the verify proc is even
+ * consulted, reading as unreachable until the app restarts and the cache is
+ * gone (#114). A throwaway partition, discarded after the one probe it was
+ * created for, means the poisoned verdict dies with it instead of outliving
+ * the pairing flow.
+ */
+function pairProbeNetFetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
+	const probeSession = session.fromPartition(`pair-probe-${pairProbeSessionSeq++}`);
+	probeSession.setCertificateVerifyProc(pairedMachines().verifyCertificate);
+	return probeSession.fetch(String(input), init);
+}
+
 let pairedMachinesController: ReturnType<typeof createPairedMachinesController> | null = null;
 function pairedMachines(): ReturnType<typeof createPairedMachinesController> {
 	if (pairedMachinesController) return pairedMachinesController;
@@ -1840,6 +1870,7 @@ function pairedMachines(): ReturnType<typeof createPairedMachinesController> {
 		// stack, which is what verifyCertificate below actually sees. A plain
 		// fetch would bypass the session (and the pin) entirely.
 		netFetch: (input, init) => net.fetch(String(input), init),
+		probeNetFetch: pairProbeNetFetch,
 	});
 	return pairedMachinesController;
 }

--- a/frontend/src/main/paired-machines.test.ts
+++ b/frontend/src/main/paired-machines.test.ts
@@ -127,6 +127,90 @@ test("probing an unreachable address reports an error, not a fingerprint", async
 	expect(result).toEqual({ error: expect.stringContaining("No certificate could be retrieved") });
 });
 
+/**
+ * Regression coverage for #114: a paired machine reading as unreachable
+ * until the app restarts, even though the pin and the box are both fine.
+ *
+ * Stands in for Chromium's per-session certificate-error cache, the
+ * mechanism the issue's root-cause analysis points at: once a session denies
+ * a host's certificate, that session short-circuits every later connection
+ * to the same host straight to a transport failure, without invoking
+ * `session.setCertificateVerifyProc` again. `cache` is what makes two
+ * `typeof fetch` stand-ins here behave like two different Electron sessions
+ * (a shared `cache` Map = the same session; separate Maps = separate
+ * sessions), the same distinction `netFetch` vs. `probeNetFetch` draws in
+ * paired-machines.ts.
+ */
+function sessionLikeFetch(cache: Map<string, boolean>, verify: PairCertificateVerifyProc, pem: string): typeof fetch {
+	return (async (input: string | URL | Request) => {
+		const url = new URL(String(input));
+		if (cache.get(url.hostname)) throw new Error("certificate verification failed (cached)");
+		let verdict: number | undefined;
+		verify({ hostname: url.hostname, certificate: { data: pem } }, (result) => {
+			verdict = result;
+		});
+		if (verdict === 0) return new Response(JSON.stringify({ ok: true, failures: 0, checks: [] }), { status: 200 });
+		cache.set(url.hostname, true);
+		throw new Error("certificate verification failed");
+	}) as unknown as typeof fetch;
+}
+
+test("without a dedicated probe session, the pairing probe's rejection wedges refresh() offline after add() (reproduces #114)", async () => {
+	// probeNetFetch omitted: probeFingerprint falls back to sharing netFetch's
+	// session, exactly the pre-fix wiring in main.ts (both bound to
+	// session.defaultSession).
+	let verify: PairCertificateVerifyProc | undefined;
+	const sharedCache = new Map<string, boolean>();
+	const netFetch = sessionLikeFetch(sharedCache, (request, callback) => verify?.(request, callback), CERT_PEM);
+	const machines = createPairedMachinesController({ stateDir, safeStorage, netFetch, probeTimeoutMs: 200 });
+	verify = machines.verifyCertificate;
+	await machines.load();
+
+	await machines.probeFingerprint("192.168.1.5", 8443);
+	await machines.add({
+		id: "box_1",
+		name: "Pi",
+		address: "192.168.1.5",
+		port: 8443,
+		passcode: "abc123XY",
+		fingerprint: CERT_FINGERPRINT,
+	});
+
+	// The pin is correct and the box is healthy, but the shared session's
+	// cached rejection from the probe short-circuits every connection after
+	// it, so the doctor probe never even reaches verifyCertificate again.
+	const refreshed = await machines.refresh();
+	expect(refreshed[0]).toMatchObject({ reachability: "offline", lastSeen: null });
+});
+
+test("a dedicated probe session keeps the pairing probe's rejection from wedging refresh() after add() (the #114 fix)", async () => {
+	let verify: PairCertificateVerifyProc | undefined;
+	const netCache = new Map<string, boolean>();
+	const probeCache = new Map<string, boolean>();
+	const netFetch = sessionLikeFetch(netCache, (request, callback) => verify?.(request, callback), CERT_PEM);
+	const probeNetFetch = sessionLikeFetch(probeCache, (request, callback) => verify?.(request, callback), CERT_PEM);
+	const machines = createPairedMachinesController({ stateDir, safeStorage, netFetch, probeNetFetch, probeTimeoutMs: 200 });
+	verify = machines.verifyCertificate;
+	await machines.load();
+
+	await machines.probeFingerprint("192.168.1.5", 8443);
+	await machines.add({
+		id: "box_1",
+		name: "Pi",
+		address: "192.168.1.5",
+		port: 8443,
+		passcode: "abc123XY",
+		fingerprint: CERT_FINGERPRINT,
+	});
+
+	// The probe's rejection only poisoned probeCache. netFetch's session sees
+	// this host for the first time here, verifyCertificate is consulted, and
+	// the now-pinned fingerprint matches.
+	const refreshed = await machines.refresh();
+	expect(refreshed[0]).toMatchObject({ reachability: "online" });
+	expect(refreshed[0].lastSeen).not.toBeNull();
+});
+
 test("add persists the pairing and round-trips through disk", async () => {
 	const machines = controller();
 	await machines.load();

--- a/frontend/src/main/paired-machines.ts
+++ b/frontend/src/main/paired-machines.ts
@@ -79,8 +79,28 @@ export type PairedMachinesControllerDeps = {
 	/** Electron's `net.fetch`, which runs through the session's network stack
 	 * and therefore through `verifyCertificate` below. A plain global `fetch`
 	 * would not: it bypasses the session entirely, which is exactly the gap
-	 * this whole module exists to close. */
+	 * this whole module exists to close. Used for every authenticated call
+	 * (`refresh`'s doctor probe) against a host that is expected to already be
+	 * pinned. */
 	netFetch?: typeof fetch;
+	/**
+	 * Electron's `net.fetch` bound to a throwaway session, used only by
+	 * `probeFingerprint`. `probeFingerprint`'s whole point is a connection that
+	 * is *always* denied at the TLS layer (see paired-machine-cert.ts: an
+	 * unpinned host has no accept path), and Chromium caches that per-host
+	 * certificate-error verdict at the network-service level for the life of
+	 * the session -- below where `verifyCertificate` runs, so the verify proc
+	 * is not even re-consulted once the cache is warm. If the capture probe
+	 * shared `netFetch`'s session, pinning the host in `add()` would not undo
+	 * that cached rejection: the very next request against the pinned host
+	 * would still be short-circuited to a failure, reading as "unreachable"
+	 * until the app restarts and the cache is gone. Routing the capture probe
+	 * through a session that is discarded afterward, instead of the one real
+	 * traffic uses, means the poisoned verdict dies with it. Defaults to
+	 * `netFetch` when omitted (tests construct one shared fetch and do not
+	 * exercise this failure mode).
+	 */
+	probeNetFetch?: typeof fetch;
 	probeTimeoutMs?: number;
 };
 
@@ -148,7 +168,10 @@ export type PairedMachinesController = {
 	 * paired machine, so the pairing flow can show the presented fingerprint
 	 * for comparison against what the box printed. The connection is always
 	 * denied at the TLS layer (see paired-machine-cert.ts): this only ever
-	 * captures what was presented, it never trusts it.
+	 * captures what was presented, it never trusts it. Runs over
+	 * `probeNetFetch`, not `netFetch`: see that dep's doc comment for why the
+	 * always-denied capture connection must not share a session with real
+	 * traffic to a pinned host.
 	 */
 	probeFingerprint: (address: string, port: number) => Promise<PairFingerprintResult>;
 	/**
@@ -308,6 +331,7 @@ function toAoMachine(
 
 export function createPairedMachinesController(deps: PairedMachinesControllerDeps): PairedMachinesController {
 	const netFetch = deps.netFetch ?? fetch;
+	const probeNetFetch = deps.probeNetFetch ?? netFetch;
 	const probeTimeoutMs = deps.probeTimeoutMs ?? DEFAULT_PROBE_TIMEOUT_MS;
 
 	/** In-memory mirror of disk, keyed by id. verifyCertificate reads only the
@@ -545,7 +569,7 @@ export function createPairedMachinesController(deps: PairedMachinesControllerDep
 			presented.delete(address);
 			pendingHosts.add(address);
 			try {
-				await fetchWithDeadline(netFetch, `${baseUrl}/`, { method: "GET", redirect: "manual" }, probeTimeoutMs, "Pairing probe");
+				await fetchWithDeadline(probeNetFetch, `${baseUrl}/`, { method: "GET", redirect: "manual" }, probeTimeoutMs, "Pairing probe");
 			} catch {
 				// Expected: an unpinned host is always denied at the TLS layer (see
 				// paired-machine-cert.ts), and a box that is simply unreachable denies


### PR DESCRIPTION
## Summary

Fixes #114: a freshly paired machine reads as unreachable (`daemon_unreachable`) for the rest of the app session, even though the persisted record and the pin are both correct and the box is healthy. Quitting and relaunching fixes it immediately with no other change, which is what the issue's evidence points at -- an in-memory cache that isn't invalidated when a pin is accepted mid-session.

**Root cause**, confirmed against the issue's analysis: `probeFingerprint()` (the trust-on-first-use capture connection the "Add machine" flow uses to show the presented fingerprint for comparison) is *always* denied at the TLS layer -- `paired-machine-cert.ts` has no accept path for a host with nothing pinned yet. That denial ran on `session.defaultSession`, the same session every other authenticated request to the box uses. Chromium caches a per-host certificate-error verdict at the network-service level, below where `session.setCertificateVerifyProc` runs, for the life of the session. Once the probe's rejection landed in that cache, every later connection to the host short-circuited straight to a transport failure -- the verify proc was never consulted again, so pinning the correct fingerprint in `add()` had no effect on already-cached hosts. `probeReachability()`'s doctor probe treats a transport failure as "offline" (correctly -- it's the only path that legitimately means offline), so the machine stayed stuck there until a relaunch cleared the cache.

**Fix**: route `probeFingerprint`'s capture connection through a session other than `session.defaultSession` (`Session.fetch()`, not `net.fetch()` -- the latter always issues from the default session). The probe's rejection now dies with that session instead of poisoning the one real traffic uses; `session.defaultSession` sees the paired host for the first time only *after* `add()` has pinned the correct fingerprint, so it verifies and accepts on the very first connection. This was one of the three options the issue raised and the one it flagged as cleanest, since it avoids the poisoning entirely rather than trying to invalidate a cache after the fact.

`paired-machines.ts` gains an optional `probeNetFetch` dependency (defaults to `netFetch` for existing callers/tests) used only by `probeFingerprint`; `netFetch` itself is now used only for calls against an already-pinned host (`refresh`'s doctor probe). `main.ts`'s `pairProbeNetFetch` keys the throwaway session by target hostname rather than minting a fresh one per call, since `session.fromPartition` has no destroy API (electron/electron#27142, #28566) and a fresh partition every probe would leak one session per candidate address raced, unbounded for the life of the app; keying by host bounds that to one throwaway session per distinct box ever probed.

**Known residual gap**, filed as #121: because the probe session is now reused per host, a *second* probe of a still-unpinned host in the same app session (the realistic case: abandon a pairing attempt after comparing the fingerprint, retry) can hit its own cached rejection and misreport "no certificate could be retrieved." Re-pairing an already-registered box is unaffected. Left as a follow-up rather than folding a second, more involved mitigation (bumping the session key only on a capture miss) into this PR.

**Out of scope**: the issue's secondary note about `daemon.hint.conflict` being a misleading hint for an unreachable *remote* machine (it's written for a local-daemon-conflict) is a separate UI-copy fix unrelated to this root cause; leaving it for a follow-up to keep this PR focused on the reachability bug.

## Test plan

- [x] Added two regression tests to `paired-machines.test.ts` that model Chromium's per-session certificate-error cache: one reproduces #114 by sharing a session between the probe and real traffic (probe's rejection wedges `refresh()` offline after a correct `add()`), the other proves the fix by giving the probe its own session (`refresh()` comes back online with the pin correctly enforced on first contact).
- [x] `npx vitest run src/main` -- 527 passed, 1 skipped (all main-process tests, including every `paired-machine*` suite).
- [x] `cd frontend && npm run typecheck` -- no new errors from this change (pre-existing, unrelated `../packages/product-ui` errors reproduce identically on `develop`).