### PR TITLE
docs: refresh shipped state (installers, Node ceiling, local signing, pairing)

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,12 +61,24 @@ The daemon itself never grows a public listener. That is a hard rule inherited f
 
 ## Getting started
 
+Download the latest signed, notarized installer from the
+[releases page](https://github.com/agentlab-in/hosted-ao/releases): a macOS
+`.dmg` (Apple Silicon and Intel builds), a Windows `.exe`, and a Linux
+`.AppImage`, `.deb`, or `.rpm`. Grab the asset for your platform, install it,
+and open Hosted AO.
+
+### Building from source
+
+Only needed if you are contributing to Hosted AO itself.
+
 ```bash
-# Desktop (macOS)
 npm install
 cd frontend && npm install && npm run make
 open "out/make/Hosted AO-"*.dmg
 ```
+
+See [docs/development.md](docs/development.md) for prerequisites, the full
+build/test loop, and troubleshooting.
 
 ### Add a machine
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -227,10 +227,37 @@ Details, operator redeploy notes, and snapshot restore behavior:
   `ao_hosted_pair` cookie are gone from the desktop. Remote is accounts only.
   `AO_CONTROL_URL` remains the development hatch (which control plane to trust; never
   skips authentication). `deploy/hosted/` documents the old Caddy pairing proxy as
-  retired.
+  retired. (This predates pair mode below; "accounts only" was true at the time and
+  no longer is.)
 - **Account home on the control plane** (`GET /`): lists machines bound to the signed-in
   account, unbind via `POST /machines/unbind` (session + same-origin), and empty-state
   setup copy for `ao setup-vm`. API unbind: `DELETE /api/v1/machines/{id}`.
+
+### Pair mode and the CLI installer (done)
+
+A second, account-free way to add a machine, on `develop`. Design and history:
+[`docs/adr/0003-pair-mode-gateway.md`](adr/0003-pair-mode-gateway.md),
+[`docs/adr/0004-pairing-string-and-cloud-pair-scope.md`](adr/0004-pairing-string-and-cloud-pair-scope.md),
+[`docs/superpowers/specs/2026-08-19-seamless-machine-onboarding-design.md`](superpowers/specs/2026-08-19-seamless-machine-onboarding-design.md).
+
+- **`ao vm serve` pair mode**: self-signed TLS (no ACME, no domain needed),
+  trust-on-first-use SHA-256 certificate-fingerprint pinning, an 8-character
+  passcode credential with per-source lockout, and a hard refusal on a
+  steady-state fingerprint mismatch. No control plane involved at all.
+- **The `ao-pair://v1/<addr>[,<addr>...]#<fingerprint>:<passcode>` string**:
+  printed once by `ao pair` (re-addressable via `ao pair show`), parsed by two
+  golden-vector-tested implementations (`backend/internal/pairstring`,
+  `frontend/src/shared/pair-string.ts`). The desktop pastes it into Add
+  machine, races every listed address (private addresses given a head start),
+  and pins whichever one first presents the matching fingerprint.
+  Address changes never force a re-pair; only a fingerprint change at an
+  already-pinned address does.
+  Reached by bare IP or by domain, local box or cloud VM alike: pairing is the
+  default way to add any machine, not just a LAN box.
+- **`install.sh`**: the `curl | sh` installer in `README.md`'s "Add a machine"
+  section. Detects OS/arch, downloads the `ao` binary and its sha256 sidecar,
+  installs it, and execs `ao pair` to provision the box and print the pairing
+  string.
 
 Three code-review reports covering batches 1 through 4 are preserved in
 [`reviews/`](reviews/), with every finding mapped to the PR that fixed it.

--- a/docs/development.md
+++ b/docs/development.md
@@ -7,9 +7,14 @@ How to set up, build, run, and test Agent Orchestrator locally.
 | Tool       | Minimum version | Notes                                                                  |
 | ---------- | --------------- | ---------------------------------------------------------------------- |
 | Go         | 1.25.7          | `go version` to check; install via [go.dev](https://go.dev/dl/)        |
-| Node.js    | 20.19.0         | `node --version`; install via [nodejs.org](https://nodejs.org/)        |
+| Node.js    | 20.19.0, below 26 for Electron packaging | `node --version`; install via [nodejs.org](https://nodejs.org/) |
 | npm        | 10              | Ships with Node.js                                                     |
 | Nix (opt.) | -               | `nix develop` drops you into a shell with all deps; see `../flake.nix` |
+
+Electron packaging (`cd frontend && npm run package` or `npm run make`) needs
+Node below 26: on Node 26 it exits 0 but produces no `.app`, with no error
+printed. CI pins Node 20, 22, and 24, never 26; Node 22 is the safest local
+choice for packaging work. See the troubleshooting table below.
 
 Additional runtime dependencies for the daemon:
 
@@ -260,6 +265,8 @@ go run ./cmd/ao --help
 | `npm run typecheck` has type errors   | API types out of sync   | Run `npm run api` from repo root to regenerate               |
 | `npm run dev` fails on native modules | Missing build tools     | Install Python + C++ build tools for `node-gyp`              |
 | `npm install` or `npm ci` fails       | Node.js version too old | `node --version`; must be 20.19.0+ (see prerequisites above) |
+| `npm run package` / `npm run make` prints every step through "Finalizing package", exits 0, but `out/` has no `.app` (only `LICENSE`, `LICENSES.chromium.html`, `version`) | Node 26 breaks Electron Forge packaging silently | `node --version`; switch to Node below 26 (22 is verified working) and rerun |
+| Packaging fails with `RequestError: write EPROTO ... ssl3_get_record:wrong version number` | The network breaks TLS to `objects.githubusercontent.com`, which Electron Forge downloads the Electron runtime zip from; `github.com` and `raw.githubusercontent.com` staying reachable is a hint this is the cause | `export ELECTRON_MIRROR="https://npmmirror.com/mirrors/electron/"` and rerun. This changes `@electron/get`'s cache key, so it re-downloads Electron instead of reusing a cached zip |
 
 ### Code generation drift
 

--- a/frontend/docs/desktop-release.md
+++ b/frontend/docs/desktop-release.md
@@ -264,6 +264,66 @@ auto-updater (`update-electron-app` in `src/main.ts`, active only when
 `app.isPackaged`) updates installed apps from the Releases feed. Windows
 code-signing is still a follow-up (issue #401).
 
+## Local signing and notarization runbook
+
+This is the runbook `forge.config.ts` points at for the local (non-CI) signing
+path. It covers producing a signed, and optionally notarized, macOS build on
+your own machine.
+
+### Credentials
+
+- **Signing** uses `APPLE_SIGNING_IDENTITY`, a Developer ID Application
+  identity. Find yours with:
+
+  ```bash
+  security find-identity -v -p codesigning
+  ```
+
+- **Notarization** locally uses `AO_NOTARY_PROFILE`, a notarytool keychain
+  profile rather than a raw API key. Create one once with:
+
+  ```bash
+  xcrun notarytool store-credentials <profile-name> \
+    --apple-id <you@example.com> --team-id <TEAMID> --password <app-specific-password>
+  ```
+
+  Test that a profile works before relying on it in a build:
+
+  ```bash
+  xcrun notarytool history --keychain-profile <profile-name>
+  ```
+
+### The two working combinations
+
+`frontend/makers/maker-dmg.ts` (`sealDmg`, around lines 199-205) hard-fails
+`npm run make` if a signing identity is set but notarization credentials are
+not: "refusing to publish an unnotarized dmg". Set both env vars, or neither.
+There is no partial state that produces a dmg.
+
+| Command | Env vars | Result |
+| --- | --- | --- |
+| `npm run package` | `APPLE_SIGNING_IDENTITY` only | A signed `.app` in `out/`. No dmg, no notarization, no round trip to Apple. Gatekeeper reports "Unnotarized Developer ID" on this app, which is harmless for a locally built copy since it carries no quarantine attribute, but it cannot be distributed to anyone else in this state. |
+| `npm run make` | `APPLE_SIGNING_IDENTITY` and `AO_NOTARY_PROFILE` | The full signed, notarized, stapled dmg, plus the update zip. |
+
+Neither var set at all also works: `npm run package`/`npm run make` produce an
+unsigned local build, useful for quick iteration.
+
+### Notarizing an already-built app
+
+Notarizing a `.app` you already built and signed does not need a rebuild. Zip
+it, submit, then staple:
+
+```bash
+ditto -c -k --keepParent "Hosted AO.app" HostedAO.zip
+xcrun notarytool submit HostedAO.zip --keychain-profile <profile-name> --wait
+xcrun stapler staple "Hosted AO.app"
+```
+
+If packaging itself fails with a TLS error while downloading the Electron
+runtime, that is usually unrelated to signing: see the `ELECTRON_MIRROR`
+entry in [docs/development.md](../../docs/development.md)'s troubleshooting
+table.
+
 ---
 
 ## Feature releases


### PR DESCRIPTION
## Summary
- README's Getting started now leads with the v0.13.1 prebuilt installers on the releases page; building from source is demoted to a clearly-labeled contributor path linking to docs/development.md.
- docs/development.md documents the Node 26 ceiling for Electron packaging (exits 0, no `.app`, no error) and adds troubleshooting rows for it plus the `ELECTRON_MIRROR` workaround for a TLS failure fetching the Electron runtime.
- frontend/docs/desktop-release.md gets the local signing/notarization runbook that `forge.config.ts` already pointed at but never existed: `APPLE_SIGNING_IDENTITY`, `AO_NOTARY_PROFILE`, the maker-dmg hard-fail on a partial signing/notarization env, the two working local-build combinations, and notarizing an already-built app without a rebuild.
- docs/STATUS.md gets a new "Pair mode and the CLI installer" section; the shipped `ao pair` / `ao-pair://` / install.sh work postdates the "remote is accounts only" line, which now carries a note pointing to it.

## Test plan
- [x] Verified all four release asset names against the `v0.13.1` tag before writing the README copy.
- [x] Confirmed https://github.com/agentlab-in/hosted-ao/releases resolves (200).
- [x] Confirmed every relative doc link added resolves on disk (docs/development.md, docs/adr/0003/0004, docs/superpowers/specs/..., ../../docs/development.md from frontend/docs/).
- [x] Re-read the diff for em/en dashes; none present.