### PR TITLE
feat: add self-hosting settings section

### DIFF
--- a/frontend/e2e/pair-string.spec.ts
+++ b/frontend/e2e/pair-string.spec.ts
@@ -48,6 +48,7 @@ test("renderer: pasting a pairing string races the address and pins the machine 
 
 	await page.goto("/#/settings");
 	await expect(page.getByTestId("settings-page")).toBeVisible();
+	await page.getByRole("button", { name: "Self-hosting" }).click();
 	// Not paired yet: the machine picker has nothing at this id.
 	await expect(page.locator(`[data-testid="ao-machine"][data-machine-id="${MACHINE_ID}"]`)).toHaveCount(0);
 

--- a/frontend/e2e/smoke-t0.spec.ts
+++ b/frontend/e2e/smoke-t0.spec.ts
@@ -247,19 +247,24 @@ test("renderer: route nav home to board to session detail and back @T0 @BRD", as
 test("renderer: global settings page renders all sections @T0 @SET", async ({
   page,
 }) => {
-  // The settings modal (#3497) tabs General / Updates / Developer / Help, one
-  // section per tab. AO account sign-in (#25) put Account on the General tab
-  // (the default), while the upstream settings revamp renders Help inline.
-  // "All sections" here means walking the tabs rather than one flat scroll.
+  // The settings modal renders one section per tab. "All sections" here means
+  // walking the relevant tabs rather than one flat scroll.
   await page.goto("/#/settings");
   await expect(page.getByTestId("settings-page")).toBeVisible();
-  // General is the default tab. Hosted AO account UI has been removed; direct
-  // pairing remains available in the machine section.
+  // General is the default tab. Account and machine controls do not live here.
   await expect(
     page.locator('[data-testid="settings-section"][data-section="account"]'),
   ).toHaveCount(0);
   await expect(
     page.locator('[data-testid="settings-section"][data-section="machines"]'),
+  ).toHaveCount(0);
+
+  await page.getByRole("button", { name: "Self-hosting" }).click();
+  await expect(
+    page.locator('[data-testid="settings-section"][data-section="machines"]'),
+  ).toBeVisible();
+  await expect(
+    page.getByText(/paired machines connect directly to remote boxes/i),
   ).toBeVisible();
 
   await page.getByRole("button", { name: "Updates" }).click();

--- a/frontend/src/renderer/components/GlobalSettingsForm.tsx
+++ b/frontend/src/renderer/components/GlobalSettingsForm.tsx
@@ -11,10 +11,9 @@ import { MobileDevicesSection } from "./settings/MobileDevicesSection";
 import { ReportProblemContent } from "./settings/ReportProblemContent";
 import { SettingsSection } from "./settings/SettingsSection";
 
-// ponytail: AO account/machines/cloud settings are hosted-only and not yet
-// wired into react-i18next (their copy is hardcoded English below, matching
-// the section components themselves). Localize together if/when the rest of
-// the hosted settings UI gets translated.
+// ponytail: Machine and cloud settings are not yet wired into react-i18next
+// (their copy is hardcoded English below, matching the section components
+// themselves). Localize together with the rest of the hosted settings UI.
 const UpdatesSection = lazy(async () => {
   const module = await import("./settings/UpdatesSection");
   return { default: module.UpdatesSection };
@@ -52,10 +51,11 @@ export function GlobalSettingsForm({
       {(all || section === "general") && (
         <>
           <GeneralSettingsSection titleHidden={titleHidden} />
-          <MachinesSection />
           <CloudSection />
         </>
       )}
+
+      {(all || section === "self-hosting") && <MachinesSection />}
 
       {(all || section === "mobile") && (
         <SettingsSection title={t("settings.mobile")} titleHidden={titleHidden}>

--- a/frontend/src/renderer/components/SettingsDialog.test.tsx
+++ b/frontend/src/renderer/components/SettingsDialog.test.tsx
@@ -63,4 +63,12 @@ describe("SettingsDialog", () => {
 		expect(await screen.findByTestId("global-settings-section")).toHaveTextContent("mobile");
 		expect(screen.getByRole("button", { name: "Mobile" })).toHaveAttribute("aria-current", "page");
 	});
+
+	it("opens self-hosting from a deep-linked settings request", async () => {
+		useUiStore.getState().openGlobalSettings("self-hosting");
+		render(<SettingsDialog />);
+
+		expect(await screen.findByTestId("global-settings-section")).toHaveTextContent("self-hosting");
+		expect(screen.getByRole("button", { name: "Self-hosting" })).toHaveAttribute("aria-current", "page");
+	});
 });

--- a/frontend/src/renderer/components/SettingsDialog.tsx
+++ b/frontend/src/renderer/components/SettingsDialog.tsx
@@ -1,4 +1,4 @@
-import { Bot, CircleHelp, Cloud, GitBranch, Inbox, Keyboard, MonitorCog, RefreshCw, Settings2, Smartphone, TriangleAlert, X } from "lucide-react";
+import { Bot, CircleHelp, Cloud, GitBranch, HardDrive, Inbox, Keyboard, MonitorCog, RefreshCw, Settings2, Smartphone, TriangleAlert, X } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useCloudGate } from "../hooks/useCloudGate";
@@ -53,6 +53,7 @@ export function SettingsDialog() {
 
 	const globalSections: Array<{ id: GlobalSettingsSection; label: string; icon: typeof Settings2 }> = [
 		{ id: "general", label: t("settings.general"), icon: Settings2 },
+		{ id: "self-hosting", label: t("settings.selfHosting"), icon: HardDrive },
 		// Only deployments with the cloud offering get the Cloud page.
 		...(cloudEnabled ? [{ id: "cloud" as const, label: t("settings.cloud"), icon: Cloud }] : []),
 		{ id: "mobile", label: t("settings.mobile"), icon: Smartphone },

--- a/frontend/src/renderer/components/settings/MachinesSection.test.tsx
+++ b/frontend/src/renderer/components/settings/MachinesSection.test.tsx
@@ -75,6 +75,20 @@ test("lists this computer first and active", async () => {
 	expect(within(rows[0]).getByText("Active")).toBeInTheDocument();
 });
 
+test("first run explains local work and directly paired remote machines", async () => {
+	refresh.mockResolvedValue({
+		status: "ready",
+		machines: [localMachine("This Mac")],
+		activeMachineId: LOCAL_MACHINE_ID,
+	} satisfies AoMachinesState);
+	renderSection();
+
+	expect(await screen.findByText("This Mac")).toBeInTheDocument();
+	expect(screen.getByTestId("self-hosting-empty-state")).toHaveTextContent(/ready for local work/i);
+	expect(screen.getByTestId("self-hosting-empty-state")).toHaveTextContent(/pair another machine/i);
+	expect(screen.queryByText(/account/i)).not.toBeInTheDocument();
+});
+
 test("lists paired machines from the unified machine state", async () => {
 	renderSection();
 	await screen.findAllByTestId("ao-machine");

--- a/frontend/src/renderer/components/settings/MachinesSection.tsx
+++ b/frontend/src/renderer/components/settings/MachinesSection.tsx
@@ -18,19 +18,9 @@ export const aoPairedMachinesQueryKey = ["ao-paired-machines"] as const;
  * The machine picker. One machine is active at a time, and switching re-points
  * the app at that machine's base URL.
  *
- * This computer is machine zero: it is always in the list, it is always
- * selectable, and it never needs an account. Everything below it is either a
- * machine registered with `ao setup-vm`, or a machine paired by address, port,
- * and passcode (docs/adr/0003-pair-mode-gateway.md). No URL and no token is
- * ever typed into this app for a registered machine; a paired machine is the
- * one exception, and its own fingerprint comparison step is what stands in for
- * a certificate authority.
- *
- * Paired machines are selectable exactly like registered ones: `select`
- * resolves a paired id and drives the passcode-credentialed transport instead
- * of the control-plane one (docs/plans/2026-08-16-pair-by-ip-headless-boxes.md
- * task 9), and `activeMachineId` on the shared state reflects a paired id the
- * same way it reflects a registered machine's.
+ * This computer is machine zero: it is always in the list and selectable.
+ * Every remote entry is paired directly by address, port, passcode, and pinned
+ * certificate fingerprint (docs/adr/0003-pair-mode-gateway.md).
  */
 export function MachinesSection() {
 	const { t } = useTranslation();
@@ -67,13 +57,22 @@ export function MachinesSection() {
 	const mutationError = select.error instanceof Error ? select.error.message : null;
 	// A rejected refresh carries its reason on the query, not in `state`, which
 	// is undefined in that case. Without this the pane rendered nothing at all
-	// for a failed refresh, which is how a stalled control plane read as a
-	// permanent "Looking for machines..." spinner.
+	// for a failed refresh, which would otherwise leave a permanent spinner.
 	const refreshError = query.error instanceof Error ? query.error.message : null;
 	const error = state?.error ?? refreshError ?? mutationError;
+	const hasOnlyLocalMachine = state?.status === "ready" && machines.length === 1 && machines[0]?.local;
 
 	return (
 		<SettingsSection title="Machines" sectionId="machines">
+			{hasOnlyLocalMachine ? (
+				<div className="rounded-md bg-raised px-3 py-3" data-testid="self-hosting-empty-state">
+					<p className="text-sm font-medium text-settings-label">This computer is ready for local work</p>
+					<p className="mt-1 text-xs leading-row text-settings-muted">
+						AO runs sessions on this computer by default. Pair another machine to run sessions on a remote box you control.
+					</p>
+				</div>
+			) : null}
+
 			{machines.map((machine) =>
 				machine.local ? (
 					<MachineRow key={machine.id} machine={machine} active={machine.id === activeMachineId}
@@ -87,17 +86,16 @@ export function MachinesSection() {
 
 			{query.isLoading ? (
 				<p className="flex items-center gap-2 px-1 text-xs leading-row text-settings-muted">
-					<Loader2 className="size-icon-sm animate-spin" aria-hidden="true" />
-					Checking paired machines…
+					Checking machine connectivity…
 				</p>
 			) : null}
 
 			<p className="px-1 text-xs leading-row text-settings-muted">
-				One machine is active at a time. Add a machine with its account-free pairing string.
+				One machine is active at a time. This computer is always available; paired machines connect directly to remote boxes you control.
 			</p>
 
 			{/* `ao doctor` is a local command with no HTTP route yet, so nothing
-			    carries a registered machine's readiness here. Saying so once beats
+			    carries a paired machine's readiness here. Saying so once beats
 			    a badge on every machine that would only mean "not asked". */}
 			{machines.some((machine) => !machine.local && machine.harness === "unknown") ? (
 				<p className="px-1 text-xs leading-row text-settings-muted" data-testid="ao-machines-harness-unknown">
@@ -194,14 +192,9 @@ function MachineRow({
 }
 
 /**
- * A paired box (docs/adr/0003-pair-mode-gateway.md), listed alongside local
- * and hosted machines and selectable exactly like a `MachineRow`: `onSelect`
- * carries the same machine id through `machines.select`, which resolves a
- * paired id and drives the passcode-credentialed transport instead of the
- * control-plane one (docs/plans/2026-08-16-pair-by-ip-headless-boxes.md task
- * 9). An unreachable paired box still renders here, with its last-seen time,
- * exactly like an offline registered machine does; removal stays a separate
- * action so a click on the row never both selects and deletes it.
+ * A paired box is selectable through the same machine-selection bridge as the
+ * local machine. An unreachable box remains listed with its last-seen time;
+ * removal stays separate so selecting a row can never delete it.
  */
 function PairedMachineRow({
 	machine,
@@ -259,7 +252,7 @@ function PairedMachineRow({
 }
 
 /**
- * A registered machine with no agent harness cannot run an agent, so it says
+ * A paired machine with no agent harness cannot run an agent, so it says
  * exactly which command to run on it rather than failing later with nothing to
  * act on. The command runs on that machine, over SSH, not here.
  */

--- a/frontend/src/renderer/components/settings/MachinesSection.tsx
+++ b/frontend/src/renderer/components/settings/MachinesSection.tsx
@@ -86,6 +86,7 @@ export function MachinesSection() {
 
 			{query.isLoading ? (
 				<p className="flex items-center gap-2 px-1 text-xs leading-row text-settings-muted">
+					<Loader2 className="size-icon-sm animate-spin" aria-hidden="true" />
 					Checking machine connectivity…
 				</p>
 			) : null}

--- a/frontend/src/renderer/i18n/de.json
+++ b/frontend/src/renderer/i18n/de.json
@@ -644,6 +644,7 @@
   "settings.connectMobile": "Mobile verbinden",
   "settings.developerMode": "Entwicklermodus",
   "settings.general": "Allgemein",
+  "settings.selfHosting": "Selbsthosting",
   "settings.appearance": "Erscheinungsbild",
   "settings.sessions": "Sitzungen",
   "settings.shortcuts": "Tastenkürzel",

--- a/frontend/src/renderer/i18n/en.json
+++ b/frontend/src/renderer/i18n/en.json
@@ -636,6 +636,7 @@
   "settings.connectMobile": "Connect Mobile",
   "settings.developerMode": "Developer Mode",
   "settings.general": "General",
+  "settings.selfHosting": "Self-hosting",
   "settings.appearance": "Appearance",
   "settings.sessions": "Sessions",
   "settings.shortcuts": "Shortcuts",

--- a/frontend/src/renderer/i18n/es.json
+++ b/frontend/src/renderer/i18n/es.json
@@ -653,6 +653,7 @@
   "settings.connectMobile": "Conectar móvil",
   "settings.developerMode": "Modo desarrollador",
   "settings.general": "General",
+  "settings.selfHosting": "Autoalojamiento",
   "settings.appearance": "Apariencia",
   "settings.sessions": "Sesiones",
   "settings.shortcuts": "Atajos",

--- a/frontend/src/renderer/i18n/fr.json
+++ b/frontend/src/renderer/i18n/fr.json
@@ -653,6 +653,7 @@
   "settings.connectMobile": "Connecter le mobile",
   "settings.developerMode": "Mode développeur",
   "settings.general": "Général",
+  "settings.selfHosting": "Auto-hébergement",
   "settings.appearance": "Apparence",
   "settings.sessions": "Sessions",
   "settings.shortcuts": "Raccourcis",

--- a/frontend/src/renderer/i18n/ja.json
+++ b/frontend/src/renderer/i18n/ja.json
@@ -644,6 +644,7 @@
   "settings.connectMobile": "モバイル接続",
   "settings.developerMode": "開発者モード",
   "settings.general": "一般",
+  "settings.selfHosting": "セルフホスティング",
   "settings.appearance": "外観",
   "settings.sessions": "セッション",
   "settings.shortcuts": "ショートカット",

--- a/frontend/src/renderer/i18n/ko.json
+++ b/frontend/src/renderer/i18n/ko.json
@@ -644,6 +644,7 @@
   "settings.connectMobile": "모바일 연결",
   "settings.developerMode": "개발자 모드",
   "settings.general": "일반",
+  "settings.selfHosting": "셀프 호스팅",
   "settings.appearance": "모양",
   "settings.sessions": "세션",
   "settings.shortcuts": "단축키",

--- a/frontend/src/renderer/i18n/pt-BR.json
+++ b/frontend/src/renderer/i18n/pt-BR.json
@@ -653,6 +653,7 @@
   "settings.connectMobile": "Conectar mobile",
   "settings.developerMode": "Modo desenvolvedor",
   "settings.general": "Geral",
+  "settings.selfHosting": "Auto-hospedagem",
   "settings.appearance": "Aparência",
   "settings.sessions": "Sessões",
   "settings.shortcuts": "Atalhos",

--- a/frontend/src/renderer/i18n/zh-CN.json
+++ b/frontend/src/renderer/i18n/zh-CN.json
@@ -626,6 +626,7 @@
   "settings.connectMobile": "连接手机",
   "settings.developerMode": "开发者模式",
   "settings.general": "通用",
+  "settings.selfHosting": "自托管",
   "settings.appearance": "外观",
   "settings.sessions": "会话",
   "settings.shortcuts": "快捷键",

--- a/frontend/src/renderer/stores/ui-store.ts
+++ b/frontend/src/renderer/stores/ui-store.ts
@@ -24,6 +24,7 @@ export {
 
 export type GlobalSettingsSection =
   | "general"
+  | "self-hosting"
   | "cloud"
   | "mobile"
   | "shortcuts"


### PR DESCRIPTION
## Summary
- add a dedicated Self-hosting settings destination
- move machine selection and pairing controls out of General
- add first-run guidance for local and directly paired machines
- preserve loading, offline, error, selection, and deep-linked section state

## Dependency
- Merge-order dependency: #130 must land first. After #130 merges, this branch will be updated from `develop`, retaining account removal and removing any dead account/control-plane code before readiness.
- Do not merge this PR before #130.

## Tests
- `npm run frontend:typecheck`
- `npm --prefix frontend test -- --run src/renderer/components/GlobalSettingsForm.test.tsx src/renderer/components/SettingsDialog.test.tsx src/renderer/components/settings/MachinesSection.test.tsx`
- isolated Electron launch at renderer `http://localhost:5173/`, daemon `127.0.0.1:3002`; macOS screen capture permission prevented pixel-level screenshot verification

Closes #129