### PR TITLE
fix: block system install routes at VM gateway

### DIFF
--- a/backend/internal/vmgateway/passcode_test.go
+++ b/backend/internal/vmgateway/passcode_test.go
@@ -288,6 +288,28 @@ func TestPairGateway_ControlRoutesStayBlocked_EvenWithValidPasscode(t *testing.T
 	}
 }
 
+func TestPairGateway_SystemInstallRouteFamily_NeverReachesDaemon(t *testing.T) {
+	tg := newTestPairGateway(t)
+	for _, tc := range []struct {
+		method string
+		path   string
+	}{
+		{http.MethodGet, "/api/v1/system/install"},
+		{http.MethodPost, "/api/v1/system/install/gh"},
+		{http.MethodDelete, "/api/v1/system/install/gh/history"},
+	} {
+		t.Run(tc.method+" "+tc.path, func(t *testing.T) {
+			rec := tg.request(tc.method, tc.path, tg.passcode, "203.0.113.5:1")
+			if rec.Code != http.StatusNotFound {
+				t.Fatalf("status = %d, want 404 (even with a valid passcode)", rec.Code)
+			}
+		})
+	}
+	if len(tg.daemonCalls) != 0 {
+		t.Errorf("system install route reached daemon %d times, want 0", len(tg.daemonCalls))
+	}
+}
+
 func TestPairGateway_RejectsAValidJWT_ThereIsNoJWKSToVerifyAgainst(t *testing.T) {
 	tg := newTestPairGateway(t)
 	_, priv, _ := ed25519.GenerateKey(nil)

--- a/backend/internal/vmgateway/proxy.go
+++ b/backend/internal/vmgateway/proxy.go
@@ -47,17 +47,19 @@ var upstreamCORSHeaders = []string{
 }
 
 // blockedAPIPrefixes are never proxied even though they sit under the
-// otherwise-allowed /api/v1 prefix: Connect Mobile control and developer
-// maintenance routes are loopback-only. This follows the same precedent as
-// lanControlBlockedPrefixes in internal/httpd/lan_listener.go (a second,
-// non-loopback listener that must never reach these routes), but it is a
-// SUBSET of that list: it blocks mobile and dev, not /api/v1/browser. The
-// LAN listener blocks /api/v1/browser too; the gateway does not yet, and
-// that gap is deliberate for now, tracked as a follow-up hardening issue
-// rather than closed here.
+// otherwise-allowed /api/v1 prefix: Connect Mobile control, developer
+// maintenance, and host-mutating installer routes are loopback-only. This
+// follows the same precedent as lanControlBlockedPrefixes in
+// internal/httpd/lan_listener.go (a second, non-loopback listener that must
+// never reach these routes), but it is a SUBSET of that list: it blocks
+// mobile, dev, and system/install, not /api/v1/browser. The LAN listener
+// blocks /api/v1/browser too; the gateway does not yet, and that gap is
+// deliberate for now, tracked as a follow-up hardening issue rather than
+// closed here.
 var blockedAPIPrefixes = []string{
 	"/api/v1/mobile",
 	"/api/v1/dev",
+	"/api/v1/system/install",
 }
 
 // maxRequestBodyBytes bounds a proxied request body before httputil.ReverseProxy

--- a/backend/internal/vmgateway/proxy_test.go
+++ b/backend/internal/vmgateway/proxy_test.go
@@ -228,6 +228,35 @@ func TestGateway_BlockedRoutes_NeverReachDaemon(t *testing.T) {
 	}
 }
 
+func TestGateway_SystemInstallRouteFamily_NeverReachesDaemon(t *testing.T) {
+	tg := newTestGateway(t)
+	token := tg.validToken(t)
+
+	for _, tc := range []struct {
+		method string
+		path   string
+	}{
+		{http.MethodGet, "/api/v1/system/install"},
+		{http.MethodPost, "/api/v1/system/install/gh"},
+		{http.MethodDelete, "/api/v1/system/install/gh/history"},
+	} {
+		t.Run(tc.method+" "+tc.path, func(t *testing.T) {
+			req := httptest.NewRequest(tc.method, tc.path, nil)
+			req.Header.Set("Authorization", "Bearer "+token)
+			rec := httptest.NewRecorder()
+
+			tg.handler.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusNotFound {
+				t.Errorf("status = %d, want 404 (even with a valid token)", rec.Code)
+			}
+		})
+	}
+	if len(tg.daemonCalls) != 0 {
+		t.Errorf("system install route reached daemon %d times, want 0", len(tg.daemonCalls))
+	}
+}
+
 func TestGateway_AllowsSiblingOfBlockedPrefix(t *testing.T) {
 	tg := newTestGateway(t)
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/devices", nil)


### PR DESCRIPTION
## Summary
- add `/api/v1/system/install` to the VM gateway shared blocked API-prefix policy
- return the existing 404 envelope before auth/proxying in both hosted-token and pair-passcode modes
- cover base, target, and nested paths across GET, POST, and DELETE while asserting zero daemon calls

## Security boundary
`/api/v1/system/install/{target}` mutates the host and is intentionally loopback-only. The LAN listener already denies this route family; this change closes the equivalent remotely exposed VM/pair gateway boundary without changing the loopback daemon route, public bind/auth semantics, or allowed REST/SSE/mux traffic. Existing middleware ordering is preserved.

hao Batch 1 depends on this prerequisite boundary fix after Hosted AO account removal.

## Tests
- `cd backend && go test ./internal/vmgateway`
- `env -u AO_SESSION_ID -u AO_PROJECT_ID -u AO_TMUX_BINARY -u AO_TMUX_SOCKET_NAME npm run lint`