### PR TITLE
Add read-only hao status and doctor commands

### DIFF
--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -504,6 +504,11 @@ func resolveRunFilePath() (string, error) {
 	return filepath.Join(stateDir, "running.json"), nil
 }
 
+// ResolveRunFilePath returns the daemon discovery path without loading
+// unrelated daemon settings or secrets. Read-only companion tools use this
+// narrow resolver instead of reconstructing running.json from the state root.
+func ResolveRunFilePath() (string, error) { return resolveRunFilePath() }
+
 // resolveDataDir picks where durable state (the SQLite DB) lives. An explicit
 // AO_DATA_DIR wins; otherwise it defaults under the same canonical AO home
 // directory as the run-file.

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -53,6 +53,18 @@ func TestLoadDefaults(t *testing.T) {
 	}
 }
 
+func TestResolveRunFilePathPreservesExactOverride(t *testing.T) {
+	want := filepath.Join(t.TempDir(), "custom-discovery-name.json")
+	t.Setenv("AO_RUN_FILE", want)
+	got, err := ResolveRunFilePath()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != want {
+		t.Fatalf("ResolveRunFilePath() = %q, want %q", got, want)
+	}
+}
+
 func TestResolveStateRootPrecedence(t *testing.T) {
 	t.Setenv("AO_RUN_FILE", "")
 	t.Setenv("AO_DATA_DIR", "")

--- a/backend/internal/haocli/doctor.go
+++ b/backend/internal/haocli/doctor.go
@@ -2,8 +2,7 @@ package haocli
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"os"
@@ -136,25 +135,29 @@ func buildDoctor(ctx context.Context, deps Deps, explicit string) (DoctorReport,
 		add(DiagnosticCheck{ID: "ao.doctor", Severity: "warning", Status: "unknown", Evidence: "AO doctor endpoint is unavailable", Remediation: "restore daemon reachability and rerun hao doctor"})
 	} else {
 		normalizedNames := make(map[string]map[string]struct{}, len(d.Doctor.Checks))
+		rawNameCounts := make(map[string]int, len(d.Doctor.Checks))
 		for _, check := range d.Doctor.Checks {
 			normalized := stableID(check.Name)
 			if normalizedNames[normalized] == nil {
 				normalizedNames[normalized] = map[string]struct{}{}
 			}
 			normalizedNames[normalized][check.Name] = struct{}{}
+			rawNameCounts[check.Name]++
 		}
-		seenNames := make(map[string]bool, len(d.Doctor.Checks))
+		duplicateReported := false
 		for _, check := range d.Doctor.Checks {
-			normalized := stableID(check.Name)
-			id := "ao.doctor." + normalized
-			if len(normalizedNames[normalized]) > 1 {
-				id += "-" + shortHash(check.Name)
-			}
-			if seenNames[check.Name] {
-				add(DiagnosticCheck{ID: "ao.doctor.invalid-duplicate-" + shortHash(check.Name), Severity: "error", Status: "error", Evidence: "AO doctor returned a duplicate check name"})
+			if rawNameCounts[check.Name] > 1 {
+				if !duplicateReported {
+					add(DiagnosticCheck{ID: "ao.projection.duplicate-doctor-names", Severity: "error", Status: "error", Evidence: "AO doctor returned duplicate check names"})
+					duplicateReported = true
+				}
 				continue
 			}
-			seenNames[check.Name] = true
+			normalized := stableID(check.Name)
+			id := "ao.doctor." + normalized
+			if len(normalizedNames[normalized]) > 1 || normalized == "" {
+				id += "-" + losslessID(check.Name)
+			}
 			status, severity := "unknown", "warning"
 			if check.Level == "WARN" {
 				status, severity = "warn", "warning"
@@ -279,9 +282,12 @@ func stableID(value string) string {
 	return strings.Trim(b.String(), "-")
 }
 
-func shortHash(value string) string {
-	sum := sha256.Sum256([]byte(value))
-	return hex.EncodeToString(sum[:4])
+func losslessID(value string) string {
+	encoded := base64.RawURLEncoding.EncodeToString([]byte(value))
+	if encoded == "" {
+		return "empty"
+	}
+	return encoded
 }
 
 func writeDoctorReport(cmd *cobra.Command, report DoctorReport) error {

--- a/backend/internal/haocli/doctor.go
+++ b/backend/internal/haocli/doctor.go
@@ -111,7 +111,7 @@ func buildDoctor(ctx context.Context, deps Deps, explicit string) (DoctorReport,
 	}
 
 	add(anyToolCheck(deps, "host.package-manager", []string{"apt-get", "dnf", "yum", "brew", "apk"}, "install a supported package manager or manage dependencies manually"))
-	add(anyToolCheck(deps, "host.service-manager", []string{"systemctl", "launchctl"}, "manage services manually on this platform"))
+	add(serviceManagerCheck(deps, goos))
 	add(diagnosticFromObservation(toolObservation(ctx, deps, "tool.git", "git", true, "--version")))
 	github := configString(object, "workflow", "profile") == "github"
 	add(diagnosticFromObservation(toolObservation(ctx, deps, "tool.gh", "gh", github, "--version")))
@@ -182,6 +182,21 @@ func anyToolCheck(deps Deps, id string, names []string, remediation string) Diag
 		}
 	}
 	return DiagnosticCheck{ID: id, Severity: "warning", Status: "unsupported", Evidence: "no supported implementation found", Remediation: remediation}
+}
+func serviceManagerCheck(deps Deps, goos string) DiagnosticCheck {
+	var manager string
+	switch goos {
+	case "linux":
+		manager = "systemctl"
+	case "darwin":
+		manager = "launchctl"
+	default:
+		return DiagnosticCheck{ID: "host.service-manager", Severity: "warning", Status: "unsupported", Evidence: "no supported service manager is defined for " + goos, Remediation: "manage services manually on this platform"}
+	}
+	if path, err := deps.Observer.LookPath(manager); err == nil {
+		return passCheck("host.service-manager", filepath.Base(path)+" is available")
+	}
+	return DiagnosticCheck{ID: "host.service-manager", Severity: "warning", Status: "unsupported", Evidence: manager + " is unavailable", Remediation: "manage services manually on this platform"}
 }
 func diagnosticFromObservation(o Observation) DiagnosticCheck {
 	status, severity := mapObservationStatus(o.Status), "info"

--- a/backend/internal/haocli/doctor.go
+++ b/backend/internal/haocli/doctor.go
@@ -113,8 +113,18 @@ func buildDoctor(ctx context.Context, deps Deps, explicit string) (DoctorReport,
 	add(diagnosticFromObservation(toolObservation(ctx, deps, "tool.git", "git", true, "--version")))
 	github := configString(object, "workflow", "profile") == "github"
 	add(diagnosticFromObservation(toolObservation(ctx, deps, "tool.gh", "gh", github, "--version")))
+	if github {
+		add(exitOnlyProbe(ctx, deps, "tool.gh.auth", "gh", []string{"auth", "status"}, "run gh auth login directly as the target user"))
+	} else {
+		add(DiagnosticCheck{ID: "tool.gh.auth", Severity: "info", Status: "disabled", Evidence: "GitHub workflow profile is not selected"})
+	}
 	harness := configString(object, "harness", "id")
 	add(diagnosticFromObservation(toolObservation(ctx, deps, "harness."+harness, harnessBinary(harness), true, "--version")))
+	if harness == "claude-code" {
+		add(exitOnlyProbe(ctx, deps, "harness.claude-code.auth", "claude", []string{"auth", "status", "--json"}, "run claude login directly as the target user"))
+	} else {
+		add(DiagnosticCheck{ID: "harness." + stableID(harness) + ".auth", Severity: "warning", Status: "unsupported", Evidence: "no safe authentication probe is defined for the selected harness"})
+	}
 
 	d := observeDaemon(ctx, deps.Observer, discoveryPath(stateRoot), deps.Timeout)
 	if d.State == "healthy" {
@@ -173,6 +183,22 @@ func anyToolCheck(deps Deps, id string, names []string, remediation string) Diag
 		}
 	}
 	return DiagnosticCheck{ID: id, Severity: "warning", Status: "unsupported", Evidence: "no supported implementation found", Remediation: remediation}
+}
+func exitOnlyProbe(ctx context.Context, deps Deps, id, binary string, args []string, remediation string) DiagnosticCheck {
+	path, err := deps.Observer.LookPath(binary)
+	if err != nil {
+		return DiagnosticCheck{ID: id, Severity: "error", Status: "fail", Evidence: binary + " is unavailable", Remediation: remediation}
+	}
+	probeCtx, cancel := boundedContext(ctx, deps.Timeout)
+	defer cancel()
+	_, err = deps.Observer.Run(probeCtx, path, args...)
+	if err == nil {
+		return passCheck(id, "authentication probe succeeded")
+	}
+	if probeCtx.Err() != nil || errors.Is(err, context.DeadlineExceeded) {
+		return DiagnosticCheck{ID: id, Severity: "warning", Status: "unknown", Evidence: "authentication probe timed out", Remediation: remediation}
+	}
+	return DiagnosticCheck{ID: id, Severity: "error", Status: "fail", Evidence: "authentication probe reported not authenticated", Remediation: remediation}
 }
 func diagnosticFromObservation(o Observation) DiagnosticCheck {
 	status, severity := mapObservationStatus(o.Status), "info"

--- a/backend/internal/haocli/doctor.go
+++ b/backend/internal/haocli/doctor.go
@@ -1,0 +1,239 @@
+package haocli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+type DiagnosticCheck struct {
+	ID          string `json:"id"`
+	Severity    string `json:"severity"`
+	Status      string `json:"status"`
+	Evidence    string `json:"evidence"`
+	Remediation string `json:"remediation,omitempty"`
+}
+
+type DoctorReport struct {
+	SchemaVersion     int               `json:"schemaVersion"`
+	Machine           string            `json:"machine"`
+	Mode              string            `json:"mode"`
+	Checks            []DiagnosticCheck `json:"checks"`
+	Failures          int               `json:"failures"`
+	ExecutionFailures int               `json:"executionFailures"`
+}
+
+func newDoctorCommand(deps Deps, opts *options) *cobra.Command {
+	return &cobra.Command{Use: "doctor", Short: "Run read-only machine diagnostics", Args: noArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			report, err := buildDoctor(cmd.Context(), deps, opts.configPath)
+			if err != nil {
+				return err
+			}
+			if opts.json {
+				err = writeJSON(cmd.OutOrStdout(), haocontractRedact(report))
+			} else {
+				err = writeDoctorReport(cmd, report)
+			}
+			if err != nil {
+				return err
+			}
+			if report.Failures > 0 || report.ExecutionFailures > 0 {
+				return commandError{Code: "doctor_failed", ExitStatus: 1, Silent: true}
+			}
+			return nil
+		}}
+}
+
+func buildDoctor(ctx context.Context, deps Deps, explicit string) (DoctorReport, error) {
+	path, object, err := loadConfig(deps, explicit)
+	if err != nil {
+		return DoctorReport{}, err
+	}
+	stateRoot, err := deps.StateDir()
+	if err != nil {
+		return DoctorReport{}, operationalError("resolve state root", err)
+	}
+	report := DoctorReport{SchemaVersion: observationSchemaVersion, Machine: configString(object, "machine", "name"), Mode: configString(object, "mode")}
+	add := func(check DiagnosticCheck) {
+		report.Checks = append(report.Checks, check)
+		if check.Status == "fail" {
+			report.Failures++
+		}
+		if check.Status == "error" {
+			report.ExecutionFailures++
+		}
+	}
+
+	goos, arch := deps.Observer.Platform()
+	if supportedPlatform(goos, arch) {
+		add(passCheck("host.platform", goos+"/"+arch+" is supported"))
+	} else {
+		add(DiagnosticCheck{ID: "host.platform", Severity: "warning", Status: "unsupported", Evidence: goos + "/" + arch + " is not a supported managed platform", Remediation: "use a supported Linux or macOS amd64/arm64 host"})
+	}
+	checkPath := func(id, target string, private bool) {
+		info, statErr := deps.Observer.Stat(target)
+		if statErr != nil {
+			status := "error"
+			severity := "error"
+			if errors.Is(statErr, os.ErrNotExist) {
+				status, severity = "fail", "error"
+			}
+			add(DiagnosticCheck{ID: id, Severity: severity, Status: status, Evidence: "could not inspect " + target, Remediation: "ensure the path exists and is readable by the target user"})
+			return
+		}
+		if !info.Owner {
+			add(DiagnosticCheck{ID: id, Severity: "error", Status: "fail", Evidence: "path is not owned by the current target user", Remediation: "correct ownership outside hao, then retry"})
+			return
+		}
+		if private && info.Mode.Perm()&0o077 != 0 {
+			add(DiagnosticCheck{ID: id, Severity: "error", Status: "fail", Evidence: fmt.Sprintf("permissions %04o are broader than owner-only", info.Mode.Perm()), Remediation: "restrict the path to the target user"})
+			return
+		}
+		add(passCheck(id, "ownership and permissions are acceptable"))
+	}
+	checkPath("state.root", stateRoot, false)
+	checkPath("config.file", path, true)
+	if available, diskErr := deps.Observer.Disk(stateRoot); diskErr != nil {
+		add(errorCheck("host.disk", "disk availability probe failed"))
+	} else if available < 512*1024*1024 {
+		add(DiagnosticCheck{ID: "host.disk", Severity: "error", Status: "fail", Evidence: fmt.Sprintf("%d bytes available", available), Remediation: "free at least 512 MiB on the state volume"})
+	} else {
+		add(passCheck("host.disk", fmt.Sprintf("%d bytes available", available)))
+	}
+
+	add(anyToolCheck(deps, "host.package-manager", []string{"apt-get", "dnf", "yum", "brew", "apk"}, "install a supported package manager or manage dependencies manually"))
+	add(anyToolCheck(deps, "host.service-manager", []string{"systemctl", "launchctl"}, "manage services manually on this platform"))
+	add(diagnosticFromObservation(toolObservation(ctx, deps, "tool.git", "git", true, "--version")))
+	github := configString(object, "workflow", "profile") == "github"
+	add(diagnosticFromObservation(toolObservation(ctx, deps, "tool.gh", "gh", github, "--version")))
+	harness := configString(object, "harness", "id")
+	add(diagnosticFromObservation(toolObservation(ctx, deps, "harness."+harness, harnessBinary(harness), true, "--version")))
+
+	d := observeDaemon(ctx, deps.Observer, discoveryPath(stateRoot), deps.Timeout)
+	if d.State == "healthy" {
+		add(passCheck("ao.daemon", "loopback health and readiness succeeded"))
+	} else if d.State == "unavailable" && !configBool(object, "service", "enabled") {
+		add(DiagnosticCheck{ID: "ao.daemon", Severity: "info", Status: "disabled", Evidence: "daemon is absent and service is intentionally disabled"})
+	} else {
+		add(DiagnosticCheck{ID: "ao.daemon", Severity: "error", Status: mapObservationStatus(d.State), Evidence: d.Evidence, Remediation: "inspect the AO daemon service and logs"})
+	}
+	if d.Doctor == nil {
+		add(DiagnosticCheck{ID: "ao.doctor", Severity: "warning", Status: "unknown", Evidence: "AO doctor endpoint is unavailable", Remediation: "restore daemon reachability and rerun hao doctor"})
+	} else {
+		for _, check := range d.Doctor.Checks {
+			status, severity := "pass", "info"
+			if check.Level == "WARN" {
+				status, severity = "warn", "warning"
+			}
+			if check.Level == "FAIL" {
+				status, severity = "fail", "error"
+			}
+			add(DiagnosticCheck{ID: "ao.doctor." + stableID(check.Name), Severity: severity, Status: status, Evidence: check.Message, Remediation: check.Remediation})
+		}
+	}
+	if report.Mode == "pair" {
+		port := configInt(object, "pair", "listenPort")
+		probeCtx, cancel := boundedContext(ctx, deps.Timeout)
+		available, portErr := deps.Observer.PortAvailable(probeCtx, "127.0.0.1", port)
+		cancel()
+		if portErr != nil {
+			add(errorCheck("gateway.port", "port availability probe failed"))
+		} else if !available {
+			add(DiagnosticCheck{ID: "gateway.port", Severity: "error", Status: "fail", Evidence: fmt.Sprintf("configured port %d is already in use", port), Remediation: "stop the conflicting listener or choose another pair port"})
+		} else {
+			add(passCheck("gateway.port", fmt.Sprintf("configured port %d is available", port)))
+		}
+	} else {
+		add(DiagnosticCheck{ID: "gateway.port", Severity: "info", Status: "disabled", Evidence: "gateway is disabled in local mode"})
+	}
+	sort.SliceStable(report.Checks, func(i, j int) bool { return report.Checks[i].ID < report.Checks[j].ID })
+	return report, nil
+}
+
+func supportedPlatform(goos, arch string) bool {
+	return (goos == "linux" || goos == "darwin") && (arch == "amd64" || arch == "arm64")
+}
+func passCheck(id, evidence string) DiagnosticCheck {
+	return DiagnosticCheck{ID: id, Severity: "info", Status: "pass", Evidence: evidence}
+}
+func errorCheck(id, evidence string) DiagnosticCheck {
+	return DiagnosticCheck{ID: id, Severity: "error", Status: "error", Evidence: evidence, Remediation: "inspect the reported condition and retry"}
+}
+func anyToolCheck(deps Deps, id string, names []string, remediation string) DiagnosticCheck {
+	for _, name := range names {
+		if path, err := deps.Observer.LookPath(name); err == nil {
+			return passCheck(id, filepath.Base(path)+" is available")
+		}
+	}
+	return DiagnosticCheck{ID: id, Severity: "warning", Status: "unsupported", Evidence: "no supported implementation found", Remediation: remediation}
+}
+func diagnosticFromObservation(o Observation) DiagnosticCheck {
+	status, severity := mapObservationStatus(o.Status), "info"
+	if status == "fail" {
+		severity = "error"
+	}
+	if status == "unknown" || status == "unsupported" {
+		severity = "warning"
+	}
+	return DiagnosticCheck{ID: o.ID, Severity: severity, Status: status, Evidence: firstNonempty(o.Evidence, o.Version), Remediation: o.Remediation}
+}
+func mapObservationStatus(status string) string {
+	switch status {
+	case "healthy":
+		return "pass"
+	case "disabled":
+		return "disabled"
+	case "unknown":
+		return "unknown"
+	case "unsupported":
+		return "unsupported"
+	default:
+		return "fail"
+	}
+}
+func firstNonempty(values ...string) string {
+	for _, value := range values {
+		if value != "" {
+			return value
+		}
+	}
+	return "no additional evidence"
+}
+func stableID(value string) string {
+	value = strings.ToLower(value)
+	var b strings.Builder
+	for _, r := range value {
+		if r >= 'a' && r <= 'z' || r >= '0' && r <= '9' || r == '-' || r == '.' {
+			b.WriteRune(r)
+		} else {
+			b.WriteByte('-')
+		}
+	}
+	return strings.Trim(b.String(), "-")
+}
+
+func writeDoctorReport(cmd *cobra.Command, report DoctorReport) error {
+	out := cmd.OutOrStdout()
+	if _, err := fmt.Fprintf(out, "HAO doctor: %s (%s)\n", report.Machine, report.Mode); err != nil {
+		return err
+	}
+	for _, check := range report.Checks {
+		if _, err := fmt.Fprintf(out, "%-28s %-11s %s\n", check.ID+":", check.Status, check.Evidence); err != nil {
+			return err
+		}
+		if check.Remediation != "" {
+			if _, err := fmt.Fprintf(out, "  remediation: %s\n", check.Remediation); err != nil {
+				return err
+			}
+		}
+	}
+	_, err := fmt.Fprintf(out, "Failures: %d; execution failures: %d\n", report.Failures, report.ExecutionFailures)
+	return err
+}

--- a/backend/internal/haocli/doctor.go
+++ b/backend/internal/haocli/doctor.go
@@ -2,6 +2,8 @@ package haocli
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"os"
@@ -111,7 +113,7 @@ func buildDoctor(ctx context.Context, deps Deps, explicit string) (DoctorReport,
 	}
 
 	add(anyToolCheck(deps, "host.package-manager", []string{"apt-get", "dnf", "yum", "brew", "apk"}, "install a supported package manager or manage dependencies manually"))
-	add(serviceManagerCheck(deps, goos))
+	add(serviceManagerCheck(ctx, deps, goos))
 	add(diagnosticFromObservation(toolObservation(ctx, deps, "tool.git", "git", true, "--version")))
 	github := configString(object, "workflow", "profile") == "github"
 	add(diagnosticFromObservation(toolObservation(ctx, deps, "tool.gh", "gh", github, "--version")))
@@ -133,7 +135,26 @@ func buildDoctor(ctx context.Context, deps Deps, explicit string) (DoctorReport,
 	if d.Doctor == nil {
 		add(DiagnosticCheck{ID: "ao.doctor", Severity: "warning", Status: "unknown", Evidence: "AO doctor endpoint is unavailable", Remediation: "restore daemon reachability and rerun hao doctor"})
 	} else {
-		for i, check := range d.Doctor.Checks {
+		normalizedNames := make(map[string]map[string]struct{}, len(d.Doctor.Checks))
+		for _, check := range d.Doctor.Checks {
+			normalized := stableID(check.Name)
+			if normalizedNames[normalized] == nil {
+				normalizedNames[normalized] = map[string]struct{}{}
+			}
+			normalizedNames[normalized][check.Name] = struct{}{}
+		}
+		seenNames := make(map[string]bool, len(d.Doctor.Checks))
+		for _, check := range d.Doctor.Checks {
+			normalized := stableID(check.Name)
+			id := "ao.doctor." + normalized
+			if len(normalizedNames[normalized]) > 1 {
+				id += "-" + shortHash(check.Name)
+			}
+			if seenNames[check.Name] {
+				add(DiagnosticCheck{ID: "ao.doctor.invalid-duplicate-" + shortHash(check.Name), Severity: "error", Status: "error", Evidence: "AO doctor returned a duplicate check name"})
+				continue
+			}
+			seenNames[check.Name] = true
 			status, severity := "unknown", "warning"
 			if check.Level == "WARN" {
 				status, severity = "warn", "warning"
@@ -144,7 +165,10 @@ func buildDoctor(ctx context.Context, deps Deps, explicit string) (DoctorReport,
 			if check.Level == "PASS" {
 				status, severity = "pass", "info"
 			}
-			add(DiagnosticCheck{ID: fmt.Sprintf("ao.doctor.%03d.%s", i+1, stableID(check.Name)), Severity: severity, Status: status, Evidence: check.Message, Remediation: check.Remediation})
+			if check.Level != "PASS" && check.Level != "WARN" && check.Level != "FAIL" {
+				status, severity = "error", "error"
+			}
+			add(DiagnosticCheck{ID: id, Severity: severity, Status: status, Evidence: check.Message, Remediation: check.Remediation})
 		}
 	}
 	if report.Mode == "pair" {
@@ -183,20 +207,32 @@ func anyToolCheck(deps Deps, id string, names []string, remediation string) Diag
 	}
 	return DiagnosticCheck{ID: id, Severity: "warning", Status: "unsupported", Evidence: "no supported implementation found", Remediation: remediation}
 }
-func serviceManagerCheck(deps Deps, goos string) DiagnosticCheck {
+func serviceManagerCheck(ctx context.Context, deps Deps, goos string) DiagnosticCheck {
 	var manager string
+	var args []string
 	switch goos {
 	case "linux":
 		manager = "systemctl"
+		args = []string{"show-environment"}
 	case "darwin":
 		manager = "launchctl"
+		args = []string{"print", "system"}
 	default:
 		return DiagnosticCheck{ID: "host.service-manager", Severity: "warning", Status: "unsupported", Evidence: "no supported service manager is defined for " + goos, Remediation: "manage services manually on this platform"}
 	}
-	if path, err := deps.Observer.LookPath(manager); err == nil {
-		return passCheck("host.service-manager", filepath.Base(path)+" is available")
+	path, err := deps.Observer.LookPath(manager)
+	if err != nil {
+		return DiagnosticCheck{ID: "host.service-manager", Severity: "warning", Status: "unsupported", Evidence: manager + " is unavailable", Remediation: "manage services manually on this platform"}
 	}
-	return DiagnosticCheck{ID: "host.service-manager", Severity: "warning", Status: "unsupported", Evidence: manager + " is unavailable", Remediation: "manage services manually on this platform"}
+	probeCtx, cancel := boundedContext(ctx, deps.Timeout)
+	defer cancel()
+	if _, err := deps.Observer.Run(probeCtx, path, args...); err != nil {
+		if probeCtx.Err() != nil || errors.Is(err, context.DeadlineExceeded) {
+			return DiagnosticCheck{ID: "host.service-manager", Severity: "warning", Status: "unknown", Evidence: manager + " usability probe timed out", Remediation: "inspect the service manager manually"}
+		}
+		return DiagnosticCheck{ID: "host.service-manager", Severity: "warning", Status: "unsupported", Evidence: manager + " is installed but not usable", Remediation: "manage services manually on this platform"}
+	}
+	return passCheck("host.service-manager", filepath.Base(path)+" is available and usable")
 }
 func diagnosticFromObservation(o Observation) DiagnosticCheck {
 	status, severity := mapObservationStatus(o.Status), "info"
@@ -241,6 +277,11 @@ func stableID(value string) string {
 		}
 	}
 	return strings.Trim(b.String(), "-")
+}
+
+func shortHash(value string) string {
+	sum := sha256.Sum256([]byte(value))
+	return hex.EncodeToString(sum[:4])
 }
 
 func writeDoctorReport(cmd *cobra.Command, report DoctorReport) error {

--- a/backend/internal/haocli/doctor.go
+++ b/backend/internal/haocli/doctor.go
@@ -12,6 +12,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// DiagnosticCheck is one stable, independently executable doctor result.
 type DiagnosticCheck struct {
 	ID          string `json:"id"`
 	Severity    string `json:"severity"`
@@ -20,6 +21,7 @@ type DiagnosticCheck struct {
 	Remediation string `json:"remediation,omitempty"`
 }
 
+// DoctorReport is the versioned machine-readable diagnostic document.
 type DoctorReport struct {
 	SchemaVersion     int               `json:"schemaVersion"`
 	Machine           string            `json:"machine"`

--- a/backend/internal/haocli/doctor.go
+++ b/backend/internal/haocli/doctor.go
@@ -115,20 +115,14 @@ func buildDoctor(ctx context.Context, deps Deps, explicit string) (DoctorReport,
 	add(diagnosticFromObservation(toolObservation(ctx, deps, "tool.git", "git", true, "--version")))
 	github := configString(object, "workflow", "profile") == "github"
 	add(diagnosticFromObservation(toolObservation(ctx, deps, "tool.gh", "gh", github, "--version")))
-	if github {
-		add(exitOnlyProbe(ctx, deps, "tool.gh.auth", "gh", []string{"auth", "status"}, "run gh auth login directly as the target user"))
-	} else {
-		add(DiagnosticCheck{ID: "tool.gh.auth", Severity: "info", Status: "disabled", Evidence: "GitHub workflow profile is not selected"})
-	}
 	harness := configString(object, "harness", "id")
 	add(diagnosticFromObservation(toolObservation(ctx, deps, "harness."+harness, harnessBinary(harness), true, "--version")))
-	if harness == "claude-code" {
-		add(exitOnlyProbe(ctx, deps, "harness.claude-code.auth", "claude", []string{"auth", "status", "--json"}, "run claude login directly as the target user"))
-	} else {
-		add(DiagnosticCheck{ID: "harness." + stableID(harness) + ".auth", Severity: "warning", Status: "unsupported", Evidence: "no safe authentication probe is defined for the selected harness"})
-	}
 
-	d := observeDaemon(ctx, deps.Observer, discoveryPath(stateRoot), deps.Timeout)
+	runFile, runFileErr := deps.RunFile()
+	d := daemonProbe{State: "unknown", Evidence: "daemon discovery path could not be resolved"}
+	if runFileErr == nil {
+		d = observeDaemon(ctx, deps.Observer, runFile, deps.Timeout)
+	}
 	if d.State == "healthy" {
 		add(passCheck("ao.daemon", "loopback health and readiness succeeded"))
 	} else if d.State == "unavailable" && !configBool(object, "service", "enabled") {
@@ -139,15 +133,18 @@ func buildDoctor(ctx context.Context, deps Deps, explicit string) (DoctorReport,
 	if d.Doctor == nil {
 		add(DiagnosticCheck{ID: "ao.doctor", Severity: "warning", Status: "unknown", Evidence: "AO doctor endpoint is unavailable", Remediation: "restore daemon reachability and rerun hao doctor"})
 	} else {
-		for _, check := range d.Doctor.Checks {
-			status, severity := "pass", "info"
+		for i, check := range d.Doctor.Checks {
+			status, severity := "unknown", "warning"
 			if check.Level == "WARN" {
 				status, severity = "warn", "warning"
 			}
 			if check.Level == "FAIL" {
 				status, severity = "fail", "error"
 			}
-			add(DiagnosticCheck{ID: "ao.doctor." + stableID(check.Name), Severity: severity, Status: status, Evidence: check.Message, Remediation: check.Remediation})
+			if check.Level == "PASS" {
+				status, severity = "pass", "info"
+			}
+			add(DiagnosticCheck{ID: fmt.Sprintf("ao.doctor.%03d.%s", i+1, stableID(check.Name)), Severity: severity, Status: status, Evidence: check.Message, Remediation: check.Remediation})
 		}
 	}
 	if report.Mode == "pair" {
@@ -185,22 +182,6 @@ func anyToolCheck(deps Deps, id string, names []string, remediation string) Diag
 		}
 	}
 	return DiagnosticCheck{ID: id, Severity: "warning", Status: "unsupported", Evidence: "no supported implementation found", Remediation: remediation}
-}
-func exitOnlyProbe(ctx context.Context, deps Deps, id, binary string, args []string, remediation string) DiagnosticCheck {
-	path, err := deps.Observer.LookPath(binary)
-	if err != nil {
-		return DiagnosticCheck{ID: id, Severity: "error", Status: "fail", Evidence: binary + " is unavailable", Remediation: remediation}
-	}
-	probeCtx, cancel := boundedContext(ctx, deps.Timeout)
-	defer cancel()
-	_, err = deps.Observer.Run(probeCtx, path, args...)
-	if err == nil {
-		return passCheck(id, "authentication probe succeeded")
-	}
-	if probeCtx.Err() != nil || errors.Is(err, context.DeadlineExceeded) {
-		return DiagnosticCheck{ID: id, Severity: "warning", Status: "unknown", Evidence: "authentication probe timed out", Remediation: remediation}
-	}
-	return DiagnosticCheck{ID: id, Severity: "error", Status: "fail", Evidence: "authentication probe reported not authenticated", Remediation: remediation}
 }
 func diagnosticFromObservation(o Observation) DiagnosticCheck {
 	status, severity := mapObservationStatus(o.Status), "info"
@@ -249,15 +230,15 @@ func stableID(value string) string {
 
 func writeDoctorReport(cmd *cobra.Command, report DoctorReport) error {
 	out := cmd.OutOrStdout()
-	if _, err := fmt.Fprintf(out, "HAO doctor: %s (%s)\n", report.Machine, report.Mode); err != nil {
+	if _, err := fmt.Fprintf(out, "HAO doctor: %s (%s)\n", redactedString(report.Machine), redactedString(report.Mode)); err != nil {
 		return err
 	}
 	for _, check := range report.Checks {
-		if _, err := fmt.Fprintf(out, "%-28s %-11s %s\n", check.ID+":", check.Status, check.Evidence); err != nil {
+		if _, err := fmt.Fprintf(out, "%-28s %-11s %s\n", check.ID+":", check.Status, redactedString(check.Evidence)); err != nil {
 			return err
 		}
 		if check.Remediation != "" {
-			if _, err := fmt.Fprintf(out, "  remediation: %s\n", check.Remediation); err != nil {
+			if _, err := fmt.Fprintf(out, "  remediation: %s\n", redactedString(check.Remediation)); err != nil {
 				return err
 			}
 		}

--- a/backend/internal/haocli/errors.go
+++ b/backend/internal/haocli/errors.go
@@ -19,6 +19,7 @@ type commandError struct {
 	Details     map[string]any
 	ExitStatus  int
 	Cause       error
+	Silent      bool
 }
 
 func (e commandError) Error() string {

--- a/backend/internal/haocli/observation_test.go
+++ b/backend/internal/haocli/observation_test.go
@@ -228,11 +228,11 @@ func TestDoctorPartialFailuresStableIDsAndZeroMutation(t *testing.T) {
 	if code != 1 || stderr != "" {
 		t.Fatalf("code=%d stderr=%q", code, stderr)
 	}
-	if !strings.Contains(out, `"id":"ao.doctor.001.terminal-capability"`) || !strings.Contains(out, `"id":"host.disk"`) || !strings.Contains(out, `"status":"error"`) || !strings.Contains(out, `"id":"tool.gh"`) {
+	if !strings.Contains(out, `"id":"ao.doctor.terminal-capability"`) || !strings.Contains(out, `"id":"host.disk"`) || !strings.Contains(out, `"status":"error"`) || !strings.Contains(out, `"id":"tool.gh"`) {
 		t.Fatalf("out=%s", out)
 	}
-	if obs.runCalls != 2 {
-		t.Fatalf("run calls=%d; wanted only available version probes", obs.runCalls)
+	if obs.runCalls != 3 {
+		t.Fatalf("run calls=%d; wanted only service-manager and available version probes", obs.runCalls)
 	}
 }
 
@@ -248,6 +248,15 @@ func TestDoctorRequiresPlatformCorrectServiceManager(t *testing.T) {
 	}
 }
 
+func TestDoctorRejectsInstalledButUnusableServiceManager(t *testing.T) {
+	obs := healthyObserver()
+	obs.runErr["/usr/bin/systemctl show-environment"] = errors.New("not booted with systemd")
+	out, _, code := runCLI(t, observationDeps(t, "local", obs), "--json", "--config", fixturePath("valid", "local.yaml"), "doctor")
+	if code != 0 || !strings.Contains(out, `"id":"host.service-manager"`) || !strings.Contains(out, `"status":"unsupported"`) || !strings.Contains(out, "installed but not usable") {
+		t.Fatalf("code=%d out=%s", code, out)
+	}
+}
+
 func TestDaemonDoctorWireDTOCompatibilityAndCollisionSafety(t *testing.T) {
 	wire := controllers.DoctorReportResponse{OK: true, Checks: []controllers.DoctorCheckResponse{{Level: "PASS", Name: "a b", Message: "ok"}, {Level: "MAYBE", Name: "a-b", Message: "Bearer topsecret"}}}
 	body, err := json.Marshal(wire)
@@ -257,10 +266,12 @@ func TestDaemonDoctorWireDTOCompatibilityAndCollisionSafety(t *testing.T) {
 	obs := healthyObserver()
 	obs.responses["http://127.0.0.1:4321/api/v1/doctor"] = body
 	out, _, code := runCLI(t, observationDeps(t, "local", obs), "--config", fixturePath("valid", "local.yaml"), "--json", "doctor")
-	if code != 0 {
+	if code != 1 {
 		t.Fatalf("code=%d out=%s", code, out)
 	}
-	if !strings.Contains(out, `"id":"ao.doctor.001.a-b"`) || !strings.Contains(out, `"id":"ao.doctor.002.a-b"`) || !strings.Contains(out, `"status":"unknown"`) || strings.Contains(out, "topsecret") {
+	wantA := `"id":"ao.doctor.a-b-` + shortHash("a b") + `"`
+	wantB := `"id":"ao.doctor.a-b-` + shortHash("a-b") + `"`
+	if !strings.Contains(out, wantA) || !strings.Contains(out, wantB) || !strings.Contains(out, `"status":"error"`) || strings.Contains(out, "topsecret") {
 		t.Fatalf("out=%s", out)
 	}
 }

--- a/backend/internal/haocli/observation_test.go
+++ b/backend/internal/haocli/observation_test.go
@@ -269,10 +269,27 @@ func TestDaemonDoctorWireDTOCompatibilityAndCollisionSafety(t *testing.T) {
 	if code != 1 {
 		t.Fatalf("code=%d out=%s", code, out)
 	}
-	wantA := `"id":"ao.doctor.a-b-` + shortHash("a b") + `"`
-	wantB := `"id":"ao.doctor.a-b-` + shortHash("a-b") + `"`
+	wantA := `"id":"ao.doctor.a-b-` + losslessID("a b") + `"`
+	wantB := `"id":"ao.doctor.a-b-` + losslessID("a-b") + `"`
 	if !strings.Contains(out, wantA) || !strings.Contains(out, wantB) || !strings.Contains(out, `"status":"error"`) || strings.Contains(out, "topsecret") {
 		t.Fatalf("out=%s", out)
+	}
+}
+
+func TestDaemonDoctorIDsAreCollisionFreeForHashCollisionAndDuplicates(t *testing.T) {
+	obs := healthyObserver()
+	obs.responses["http://127.0.0.1:4321/api/v1/doctor"] = []byte(`{"ok":true,"checks":[{"level":"PASS","name":"ab","message":"one"},{"level":"PASS","name":"a𒝭b","message":"two"},{"level":"PASS","name":"same","message":"a"},{"level":"PASS","name":"same","message":"b"},{"level":"PASS","name":"same","message":"c"}]}`)
+	out, _, code := runCLI(t, observationDeps(t, "local", obs), "--json", "--config", fixturePath("valid", "local.yaml"), "doctor")
+	if code != 1 {
+		t.Fatalf("code=%d out=%s", code, out)
+	}
+	for _, name := range []string{"ab", "a𒝭b"} {
+		if !strings.Contains(out, `"id":"ao.doctor.a-b-`+losslessID(name)+`"`) {
+			t.Fatalf("missing lossless id for %q: %s", name, out)
+		}
+	}
+	if strings.Count(out, `"id":"ao.projection.duplicate-doctor-names"`) != 1 || strings.Contains(out, `"id":"ao.doctor.same"`) {
+		t.Fatalf("duplicate projection not aggregated: %s", out)
 	}
 }
 

--- a/backend/internal/haocli/observation_test.go
+++ b/backend/internal/haocli/observation_test.go
@@ -238,3 +238,25 @@ func TestProbeTimeoutIsUnknown(t *testing.T) {
 		t.Fatalf("observation=%+v", o)
 	}
 }
+
+func TestSystemObserverRunBoundsNoisyChild(t *testing.T) {
+	if os.Getenv("HAO_TEST_NOISY_CHILD") == "1" {
+		payload := []byte(strings.Repeat("x", maxCommandOutput*8))
+		_, _ = os.Stdout.Write(payload)
+		_, _ = os.Stderr.Write(payload)
+		os.Exit(0)
+	}
+
+	executable, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HAO_TEST_NOISY_CHILD", "1")
+	out, err := (systemObserver{}).Run(context.Background(), executable, "-test.run=^TestSystemObserverRunBoundsNoisyChild$")
+	if err != nil {
+		t.Fatalf("run noisy child: %v", err)
+	}
+	if len(out) != 256 || out != strings.Repeat("x", 256) {
+		t.Fatalf("captured output length=%d, want bounded 256-byte prefix", len(out))
+	}
+}

--- a/backend/internal/haocli/observation_test.go
+++ b/backend/internal/haocli/observation_test.go
@@ -158,6 +158,55 @@ func TestStatusAndDoctorUseExactRunFilePath(t *testing.T) {
 	}
 }
 
+func TestDisabledServiceAndAbsentDaemonAgree(t *testing.T) {
+	obs := healthyObserver()
+	obs.runFile = nil
+	deps := observationDeps(t, "local", obs)
+	configPath := fixturePath("valid", "local.yaml")
+
+	statusOut, statusErr, statusCode := runCLI(t, deps, "--json", "--config", configPath, "status", "--strict")
+	if statusCode != 0 || statusErr != "" {
+		t.Fatalf("status code=%d stderr=%q", statusCode, statusErr)
+	}
+	var status StatusReport
+	if err := json.Unmarshal([]byte(statusOut), &status); err != nil {
+		t.Fatal(err)
+	}
+	statusFound := false
+	for _, observation := range status.Observations {
+		if observation.ID == "ao.daemon" {
+			statusFound = true
+			if observation.Status != "disabled" || observation.Desired {
+				t.Fatalf("status daemon observation=%+v, want disabled and undesired", observation)
+			}
+		}
+	}
+	if !statusFound {
+		t.Fatal("status report missing ao.daemon observation")
+	}
+
+	doctorOut, doctorErr, doctorCode := runCLI(t, deps, "--json", "--config", configPath, "doctor")
+	if doctorCode != 0 || doctorErr != "" {
+		t.Fatalf("doctor code=%d stderr=%q", doctorCode, doctorErr)
+	}
+	var doctor DoctorReport
+	if err := json.Unmarshal([]byte(doctorOut), &doctor); err != nil {
+		t.Fatal(err)
+	}
+	doctorFound := false
+	for _, check := range doctor.Checks {
+		if check.ID == "ao.daemon" {
+			doctorFound = true
+			if check.Status != "disabled" {
+				t.Fatalf("doctor daemon status=%q, want disabled", check.Status)
+			}
+		}
+	}
+	if !doctorFound {
+		t.Fatal("doctor report missing ao.daemon check")
+	}
+}
+
 func TestStatusUnknownAndConditionalTools(t *testing.T) {
 	obs := healthyObserver()
 	delete(obs.paths, "gh")

--- a/backend/internal/haocli/observation_test.go
+++ b/backend/internal/haocli/observation_test.go
@@ -1,0 +1,210 @@
+package haocli
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/runfile"
+)
+
+type fakeObserver struct {
+	platform, arch string
+	files          map[string]FileObservation
+	statErr        map[string]error
+	paths          map[string]string
+	runs           map[string]string
+	runErr         map[string]error
+	runFile        *runfile.Info
+	runFileErr     error
+	alive          bool
+	responses      map[string][]byte
+	getErr         map[string]error
+	urls           []string
+	disk           uint64
+	diskErr        error
+	portAvailable  bool
+	portErr        error
+	runCalls       int
+}
+
+func (f *fakeObserver) Platform() (string, string) { return f.platform, f.arch }
+func (f *fakeObserver) Stat(path string) (FileObservation, error) {
+	if err := f.statErr[path]; err != nil {
+		return FileObservation{}, err
+	}
+	if v, ok := f.files[path]; ok {
+		return v, nil
+	}
+	return FileObservation{Mode: 0o700, Owner: true}, nil
+}
+func (f *fakeObserver) Disk(string) (uint64, error) { return f.disk, f.diskErr }
+func (f *fakeObserver) LookPath(name string) (string, error) {
+	if p, ok := f.paths[name]; ok {
+		return p, nil
+	}
+	return "", os.ErrNotExist
+}
+func (f *fakeObserver) Run(ctx context.Context, name string, args ...string) (string, error) {
+	f.runCalls++
+	key := name + " " + strings.Join(args, " ")
+	if err := f.runErr[key]; err != nil {
+		return "", err
+	}
+	if v, ok := f.runs[key]; ok {
+		return v, nil
+	}
+	return "version 1.0.0", nil
+}
+func (f *fakeObserver) ReadRunFile(string) (*runfile.Info, error) { return f.runFile, f.runFileErr }
+func (f *fakeObserver) ProcessAlive(int) bool                     { return f.alive }
+func (f *fakeObserver) GET(_ context.Context, url string) ([]byte, error) {
+	f.urls = append(f.urls, url)
+	if err := f.getErr[url]; err != nil {
+		return nil, err
+	}
+	return f.responses[url], nil
+}
+func (f *fakeObserver) PortAvailable(context.Context, string, int) (bool, error) {
+	return f.portAvailable, f.portErr
+}
+
+func healthyObserver() *fakeObserver {
+	return &fakeObserver{platform: "linux", arch: "amd64", files: map[string]FileObservation{}, statErr: map[string]error{}, paths: map[string]string{"git": "/usr/bin/git", "gh": "/usr/bin/gh", "claude": "/usr/bin/claude", "apt-get": "/usr/bin/apt-get", "systemctl": "/usr/bin/systemctl"}, runs: map[string]string{}, runErr: map[string]error{}, runFile: &runfile.Info{PID: 42, Port: 4321}, alive: true, disk: 2 << 30, portAvailable: true, responses: map[string][]byte{
+		"http://127.0.0.1:4321/healthz":       []byte(`{"status":"ok","service":"agent-orchestrator-daemon","pid":42}`),
+		"http://127.0.0.1:4321/readyz":        []byte(`{"status":"ready","service":"agent-orchestrator-daemon","pid":42}`),
+		"http://127.0.0.1:4321/api/v1/doctor": []byte(`{"ok":true,"failures":0,"checks":[{"level":"PASS","section":"Core","name":"runtime","message":"available"}]}`),
+	}, getErr: map[string]error{}}
+}
+
+func observationDeps(t *testing.T, fixture string, obs *fakeObserver) Deps {
+	t.Helper()
+	root := t.TempDir()
+	path := fixturePath("valid", fixture+".yaml")
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return Deps{StateDir: func() (string, error) { return root, nil }, ReadFile: func(got string) ([]byte, error) {
+		if got != absPath {
+			t.Fatalf("config path=%q want %q", got, absPath)
+		}
+		return os.ReadFile(got)
+	}, Observer: obs, Timeout: 25 * time.Millisecond}
+}
+
+func TestStatusLocalPairJSONAndStrict(t *testing.T) {
+	for _, fixture := range []string{"local", "pair"} {
+		t.Run(fixture, func(t *testing.T) {
+			obs := healthyObserver()
+			deps := observationDeps(t, fixture, obs)
+			out, stderr, code := runCLI(t, deps, "--config", fixturePath("valid", fixture+".yaml"), "--json", "status", "--strict")
+			if code != 0 || stderr != "" {
+				t.Fatalf("code=%d stderr=%s", code, stderr)
+			}
+			var report StatusReport
+			if err := json.Unmarshal([]byte(out), &report); err != nil {
+				t.Fatal(err)
+			}
+			if report.SchemaVersion != 1 || report.Mode != fixture || report.Machine == "" {
+				t.Fatalf("report=%+v", report)
+			}
+			for _, url := range obs.urls {
+				if !strings.HasPrefix(url, "http://127.0.0.1:4321/") {
+					t.Fatalf("off-loopback URL %q", url)
+				}
+			}
+		})
+	}
+
+	obs := healthyObserver()
+	obs.runFile = nil
+	_, stderr, code := runCLI(t, observationDeps(t, "pair", obs), "--config", fixturePath("valid", "pair.yaml"), "--json", "status", "--strict")
+	if code != 1 || stderr != "" {
+		t.Fatalf("strict code=%d stderr=%q", code, stderr)
+	}
+}
+
+func TestStatusUnknownAndConditionalTools(t *testing.T) {
+	obs := healthyObserver()
+	delete(obs.paths, "gh")
+	delete(obs.paths, "claude")
+	obs.getErr["http://127.0.0.1:4321/readyz"] = errors.New("timeout token=secret")
+	out, _, code := runCLI(t, observationDeps(t, "local", obs), "--config", fixturePath("valid", "local.yaml"), "--json", "status")
+	if code != 0 || strings.Contains(out, "secret") || !strings.Contains(out, "unknown") || !strings.Contains(out, `"id":"tool.gh","status":"disabled"`) {
+		t.Fatalf("code=%d out=%s", code, out)
+	}
+}
+
+func TestDoctorPartialFailuresStableIDsAndZeroMutation(t *testing.T) {
+	obs := healthyObserver()
+	obs.statErr = map[string]error{}
+	delete(obs.paths, "gh")
+	obs.diskErr = errors.New("disk probe failed")
+	obs.responses["http://127.0.0.1:4321/api/v1/doctor"] = []byte(`{"ok":false,"failures":1,"checks":[{"level":"FAIL","name":"terminal capability","message":"missing","remediation":"repair AO"}]}`)
+	out, stderr, code := runCLI(t, observationDeps(t, "pair", obs), "--config", fixturePath("valid", "pair.yaml"), "--json", "doctor")
+	if code != 1 || stderr != "" {
+		t.Fatalf("code=%d stderr=%q", code, stderr)
+	}
+	if !strings.Contains(out, `"id":"ao.doctor.terminal-capability"`) || !strings.Contains(out, `"id":"host.disk"`) || !strings.Contains(out, `"status":"error"`) || !strings.Contains(out, `"id":"tool.gh"`) {
+		t.Fatalf("out=%s", out)
+	}
+	if obs.runCalls != 2 {
+		t.Fatalf("run calls=%d; wanted only git and selected harness version probes", obs.runCalls)
+	}
+}
+
+func TestMalformedAndMissingConfigRemainConfigurationBoundaries(t *testing.T) {
+	for _, tc := range []struct {
+		name, path string
+		code       int
+	}{{"missing", filepath.Join(t.TempDir(), "missing.yaml"), 1}, {"malformed", fixturePath("invalid", "future-version.yaml"), 2}} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, _, code := runCLI(t, Deps{}, "--config", tc.path, "status")
+			if code != tc.code {
+				t.Fatalf("code=%d want=%d", code, tc.code)
+			}
+		})
+	}
+}
+
+func TestHTTPObserverRejectsRedirectAndOversizedBody(t *testing.T) {
+	t.Run("redirect", func(t *testing.T) {
+		targetHit := false
+		target := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) { targetHit = true }))
+		defer target.Close()
+		source := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { http.Redirect(w, r, target.URL, http.StatusFound) }))
+		defer source.Close()
+		_, err := (systemObserver{}).GET(context.Background(), source.URL)
+		if err == nil || targetHit {
+			t.Fatalf("err=%v targetHit=%v", err, targetHit)
+		}
+	})
+	t.Run("oversized", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte(strings.Repeat("x", maxHTTPBody+1)))
+		}))
+		defer server.Close()
+		_, err := (systemObserver{}).GET(context.Background(), server.URL)
+		if err == nil || !strings.Contains(err.Error(), "size limit") {
+			t.Fatalf("err=%v", err)
+		}
+	})
+}
+
+func TestProbeTimeoutIsUnknown(t *testing.T) {
+	obs := healthyObserver()
+	obs.Run(context.Background(), "noop")
+	obs.runErr["/usr/bin/git --version"] = context.DeadlineExceeded
+	o := toolObservation(context.Background(), Deps{Observer: obs, Timeout: time.Nanosecond}.withDefaults(), "tool.git", "git", true, "--version")
+	if o.Status != "unknown" {
+		t.Fatalf("observation=%+v", o)
+	}
+}

--- a/backend/internal/haocli/observation_test.go
+++ b/backend/internal/haocli/observation_test.go
@@ -156,8 +156,8 @@ func TestDoctorPartialFailuresStableIDsAndZeroMutation(t *testing.T) {
 	if !strings.Contains(out, `"id":"ao.doctor.terminal-capability"`) || !strings.Contains(out, `"id":"host.disk"`) || !strings.Contains(out, `"status":"error"`) || !strings.Contains(out, `"id":"tool.gh"`) {
 		t.Fatalf("out=%s", out)
 	}
-	if obs.runCalls != 2 {
-		t.Fatalf("run calls=%d; wanted only git and selected harness version probes", obs.runCalls)
+	if obs.runCalls != 3 {
+		t.Fatalf("run calls=%d; wanted only available version and exit-only auth probes", obs.runCalls)
 	}
 }
 

--- a/backend/internal/haocli/observation_test.go
+++ b/backend/internal/haocli/observation_test.go
@@ -236,6 +236,18 @@ func TestDoctorPartialFailuresStableIDsAndZeroMutation(t *testing.T) {
 	}
 }
 
+func TestDoctorRequiresPlatformCorrectServiceManager(t *testing.T) {
+	obs := healthyObserver()
+	obs.platform, obs.arch = "darwin", "arm64"
+	delete(obs.paths, "systemctl")
+	obs.paths["systemctl"] = "/usr/local/bin/systemctl"
+	delete(obs.paths, "launchctl")
+	out, _, code := runCLI(t, observationDeps(t, "local", obs), "--json", "--config", fixturePath("valid", "local.yaml"), "doctor")
+	if code != 0 || !strings.Contains(out, `"id":"host.service-manager"`) || !strings.Contains(out, `"status":"unsupported"`) || !strings.Contains(out, "launchctl is unavailable") {
+		t.Fatalf("code=%d out=%s", code, out)
+	}
+}
+
 func TestDaemonDoctorWireDTOCompatibilityAndCollisionSafety(t *testing.T) {
 	wire := controllers.DoctorReportResponse{OK: true, Checks: []controllers.DoctorCheckResponse{{Level: "PASS", Name: "a b", Message: "ok"}, {Level: "MAYBE", Name: "a-b", Message: "Bearer topsecret"}}}
 	body, err := json.Marshal(wire)

--- a/backend/internal/haocli/observation_test.go
+++ b/backend/internal/haocli/observation_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/aoagents/agent-orchestrator/backend/internal/httpd/controllers"
 	"github.com/aoagents/agent-orchestrator/backend/internal/runfile"
 )
 
@@ -87,12 +88,13 @@ func healthyObserver() *fakeObserver {
 func observationDeps(t *testing.T, fixture string, obs *fakeObserver) Deps {
 	t.Helper()
 	root := t.TempDir()
+	runPath := filepath.Join(root, "custom-discovery.json")
 	path := fixturePath("valid", fixture+".yaml")
 	absPath, err := filepath.Abs(path)
 	if err != nil {
 		t.Fatal(err)
 	}
-	return Deps{StateDir: func() (string, error) { return root, nil }, ReadFile: func(got string) ([]byte, error) {
+	return Deps{StateDir: func() (string, error) { return root, nil }, RunFile: func() (string, error) { return runPath, nil }, ReadFile: func(got string) ([]byte, error) {
 		if got != absPath {
 			t.Fatalf("config path=%q want %q", got, absPath)
 		}
@@ -153,11 +155,39 @@ func TestDoctorPartialFailuresStableIDsAndZeroMutation(t *testing.T) {
 	if code != 1 || stderr != "" {
 		t.Fatalf("code=%d stderr=%q", code, stderr)
 	}
-	if !strings.Contains(out, `"id":"ao.doctor.terminal-capability"`) || !strings.Contains(out, `"id":"host.disk"`) || !strings.Contains(out, `"status":"error"`) || !strings.Contains(out, `"id":"tool.gh"`) {
+	if !strings.Contains(out, `"id":"ao.doctor.001.terminal-capability"`) || !strings.Contains(out, `"id":"host.disk"`) || !strings.Contains(out, `"status":"error"`) || !strings.Contains(out, `"id":"tool.gh"`) {
 		t.Fatalf("out=%s", out)
 	}
-	if obs.runCalls != 3 {
-		t.Fatalf("run calls=%d; wanted only available version and exit-only auth probes", obs.runCalls)
+	if obs.runCalls != 2 {
+		t.Fatalf("run calls=%d; wanted only available version probes", obs.runCalls)
+	}
+}
+
+func TestDaemonDoctorWireDTOCompatibilityAndCollisionSafety(t *testing.T) {
+	wire := controllers.DoctorReportResponse{OK: true, Checks: []controllers.DoctorCheckResponse{{Level: "PASS", Name: "a b", Message: "ok"}, {Level: "MAYBE", Name: "a-b", Message: "Bearer topsecret"}}}
+	body, err := json.Marshal(wire)
+	if err != nil {
+		t.Fatal(err)
+	}
+	obs := healthyObserver()
+	obs.responses["http://127.0.0.1:4321/api/v1/doctor"] = body
+	out, _, code := runCLI(t, observationDeps(t, "local", obs), "--config", fixturePath("valid", "local.yaml"), "--json", "doctor")
+	if code != 0 {
+		t.Fatalf("code=%d out=%s", code, out)
+	}
+	if !strings.Contains(out, `"id":"ao.doctor.001.a-b"`) || !strings.Contains(out, `"id":"ao.doctor.002.a-b"`) || !strings.Contains(out, `"status":"unknown"`) || strings.Contains(out, "topsecret") {
+		t.Fatalf("out=%s", out)
+	}
+}
+
+func TestHumanAndJSONEvidenceRedaction(t *testing.T) {
+	obs := healthyObserver()
+	obs.responses["http://127.0.0.1:4321/api/v1/doctor"] = []byte(`{"ok":true,"checks":[{"level":"WARN","name":"safe","message":"{\"token\":\"json-secret\"} Bearer bearer-secret","remediation":"ao-pair://private"}]}`)
+	for _, args := range [][]string{{"--config", fixturePath("valid", "local.yaml"), "doctor"}, {"--json", "--config", fixturePath("valid", "local.yaml"), "doctor"}} {
+		out, _, _ := runCLI(t, observationDeps(t, "local", obs), args...)
+		if strings.Contains(out, "json-secret") || strings.Contains(out, "bearer-secret") || strings.Contains(out, "ao-pair://") || !strings.Contains(out, "[REDACTED]") {
+			t.Fatalf("args=%v out=%s", args, out)
+		}
 	}
 }
 

--- a/backend/internal/haocli/observation_test.go
+++ b/backend/internal/haocli/observation_test.go
@@ -29,6 +29,7 @@ type fakeObserver struct {
 	responses      map[string][]byte
 	getErr         map[string]error
 	urls           []string
+	runFiles       []string
 	disk           uint64
 	diskErr        error
 	portAvailable  bool
@@ -64,8 +65,11 @@ func (f *fakeObserver) Run(ctx context.Context, name string, args ...string) (st
 	}
 	return "version 1.0.0", nil
 }
-func (f *fakeObserver) ReadRunFile(string) (*runfile.Info, error) { return f.runFile, f.runFileErr }
-func (f *fakeObserver) ProcessAlive(int) bool                     { return f.alive }
+func (f *fakeObserver) ReadRunFile(path string) (*runfile.Info, error) {
+	f.runFiles = append(f.runFiles, path)
+	return f.runFile, f.runFileErr
+}
+func (f *fakeObserver) ProcessAlive(int) bool { return f.alive }
 func (f *fakeObserver) GET(_ context.Context, url string) ([]byte, error) {
 	f.urls = append(f.urls, url)
 	if err := f.getErr[url]; err != nil {
@@ -131,6 +135,26 @@ func TestStatusLocalPairJSONAndStrict(t *testing.T) {
 	_, stderr, code := runCLI(t, observationDeps(t, "pair", obs), "--config", fixturePath("valid", "pair.yaml"), "--json", "status", "--strict")
 	if code != 1 || stderr != "" {
 		t.Fatalf("strict code=%d stderr=%q", code, stderr)
+	}
+}
+
+func TestStatusAndDoctorUseExactRunFilePath(t *testing.T) {
+	for _, command := range []string{"status", "doctor"} {
+		t.Run(command, func(t *testing.T) {
+			obs := healthyObserver()
+			deps := observationDeps(t, "local", obs)
+			custom := filepath.Join(t.TempDir(), "custom-daemon.json")
+			t.Setenv("AO_RUN_FILE", custom)
+			deps.RunFile = DefaultDeps().RunFile
+
+			_, stderr, code := runCLI(t, deps, "--config", fixturePath("valid", "local.yaml"), command)
+			if code != 0 || stderr != "" {
+				t.Fatalf("code=%d stderr=%q", code, stderr)
+			}
+			if len(obs.runFiles) != 1 || obs.runFiles[0] != custom {
+				t.Fatalf("discovery paths=%q, want exact override %q", obs.runFiles, custom)
+			}
+		})
 	}
 }
 

--- a/backend/internal/haocli/observe.go
+++ b/backend/internal/haocli/observe.go
@@ -154,6 +154,9 @@ func observeDaemon(ctx context.Context, obs Observer, runFile string, timeout ti
 		if getErr != nil {
 			return getErr
 		}
+		if len(body) > maxHTTPBody {
+			return errors.New("response exceeds size limit")
+		}
 		if err := json.Unmarshal(body, target); err != nil {
 			return fmt.Errorf("malformed response")
 		}

--- a/backend/internal/haocli/observe.go
+++ b/backend/internal/haocli/observe.go
@@ -11,7 +11,6 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"runtime"
 	"strconv"
 	"strings"
@@ -47,6 +46,23 @@ type FileObservation struct {
 
 type systemObserver struct{}
 
+type boundedBuffer struct {
+	bytes.Buffer
+	remaining int
+}
+
+func (b *boundedBuffer) Write(p []byte) (int, error) {
+	original := len(p)
+	if len(p) > b.remaining {
+		p = p[:b.remaining]
+	}
+	if len(p) > 0 {
+		_, _ = b.Buffer.Write(p)
+		b.remaining -= len(p)
+	}
+	return original, nil
+}
+
 func (systemObserver) Platform() (string, string)                     { return runtime.GOOS, runtime.GOARCH }
 func (systemObserver) Stat(path string) (FileObservation, error)      { return statFile(path) }
 func (systemObserver) Disk(path string) (uint64, error)               { return diskAvailable(path) }
@@ -57,7 +73,7 @@ func (systemObserver) ProcessAlive(pid int) bool                      { return p
 func (systemObserver) Run(ctx context.Context, name string, args ...string) (string, error) {
 	cmd := exec.CommandContext(ctx, name, args...)
 	cmd.Stdin = nil
-	var out bytes.Buffer
+	out := boundedBuffer{remaining: 4096}
 	cmd.Stdout, cmd.Stderr = &out, &out
 	err := cmd.Run()
 	text := strings.TrimSpace(out.String())
@@ -154,6 +170,9 @@ func observeDaemon(ctx context.Context, obs Observer, runFile string, timeout ti
 	read := func(path string, target any) error {
 		body, getErr := obs.GET(probeCtx, base+path)
 		if getErr != nil {
+			if probeCtx.Err() != nil || errors.Is(getErr, context.DeadlineExceeded) {
+				return fmt.Errorf("probe timed out: %w", context.DeadlineExceeded)
+			}
 			return getErr
 		}
 		if len(body) > maxHTTPBody {
@@ -166,6 +185,9 @@ func observeDaemon(ctx context.Context, obs Observer, runFile string, timeout ti
 	}
 	var health probePayload
 	if err := read("/healthz", &health); err != nil {
+		if errors.Is(err, context.DeadlineExceeded) {
+			result.State = "unknown"
+		}
 		result.Evidence = "health probe failed: " + safeDiagnostic(err)
 		return result
 	}
@@ -180,7 +202,11 @@ func observeDaemon(ctx context.Context, obs Observer, runFile string, timeout ti
 	}
 	var ready probePayload
 	if err := read("/readyz", &ready); err != nil {
-		result.State = "unhealthy"
+		if errors.Is(err, context.DeadlineExceeded) {
+			result.State = "unknown"
+		} else {
+			result.State = "unhealthy"
+		}
 		result.Evidence = "readiness probe failed: " + safeDiagnostic(err)
 		return result
 	}
@@ -245,5 +271,3 @@ func configInt(object map[string]any, keys ...string) int {
 	}
 	return 0
 }
-
-func discoveryPath(stateRoot string) string { return filepath.Join(stateRoot, "running.json") }

--- a/backend/internal/haocli/observe.go
+++ b/backend/internal/haocli/observe.go
@@ -38,6 +38,7 @@ type Observer interface {
 	PortAvailable(ctx context.Context, host string, port int) (bool, error)
 }
 
+// FileObservation contains only ownership and permission facts needed by doctor.
 type FileObservation struct {
 	Mode  os.FileMode
 	UID   int
@@ -95,6 +96,7 @@ func (systemObserver) PortAvailable(ctx context.Context, host string, port int) 
 	lc := net.ListenConfig{}
 	ln, err := lc.Listen(ctx, "tcp", net.JoinHostPort(host, strconv.Itoa(port)))
 	if err != nil {
+		//nolint:nilerr // A bind failure proves unavailability; OS socket text is not useful evidence.
 		return false, nil
 	}
 	return true, ln.Close()

--- a/backend/internal/haocli/observe.go
+++ b/backend/internal/haocli/observe.go
@@ -1,0 +1,244 @@
+package haocli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/daemonmeta"
+	"github.com/aoagents/agent-orchestrator/backend/internal/processalive"
+	"github.com/aoagents/agent-orchestrator/backend/internal/runfile"
+)
+
+const maxHTTPBody = 1 << 20
+
+// Observer is the complete read-only machine boundary used by status and doctor.
+// Tests inject it so no probe depends on the developer's machine or network.
+type Observer interface {
+	Platform() (string, string)
+	Stat(path string) (FileObservation, error)
+	Disk(path string) (uint64, error)
+	LookPath(name string) (string, error)
+	Run(ctx context.Context, name string, args ...string) (string, error)
+	ReadRunFile(path string) (*runfile.Info, error)
+	ProcessAlive(pid int) bool
+	GET(ctx context.Context, url string) ([]byte, error)
+	PortAvailable(ctx context.Context, host string, port int) (bool, error)
+}
+
+type FileObservation struct {
+	Mode  os.FileMode
+	UID   int
+	Owner bool
+}
+
+type systemObserver struct{}
+
+func (systemObserver) Platform() (string, string)                     { return runtime.GOOS, runtime.GOARCH }
+func (systemObserver) Stat(path string) (FileObservation, error)      { return statFile(path) }
+func (systemObserver) Disk(path string) (uint64, error)               { return diskAvailable(path) }
+func (systemObserver) LookPath(name string) (string, error)           { return exec.LookPath(name) }
+func (systemObserver) ReadRunFile(path string) (*runfile.Info, error) { return runfile.Read(path) }
+func (systemObserver) ProcessAlive(pid int) bool                      { return processalive.Alive(pid) }
+
+func (systemObserver) Run(ctx context.Context, name string, args ...string) (string, error) {
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Stdin = nil
+	var out bytes.Buffer
+	cmd.Stdout, cmd.Stderr = &out, &out
+	err := cmd.Run()
+	text := strings.TrimSpace(out.String())
+	if len(text) > 256 {
+		text = text[:256]
+	}
+	return text, err
+}
+
+func (systemObserver) GET(ctx context.Context, rawURL string) ([]byte, error) {
+	client := &http.Client{CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, http.NoBody)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("HTTP %d", resp.StatusCode)
+	}
+	limited := io.LimitReader(resp.Body, maxHTTPBody+1)
+	body, err := io.ReadAll(limited)
+	if err != nil {
+		return nil, err
+	}
+	if len(body) > maxHTTPBody {
+		return nil, errors.New("response exceeds size limit")
+	}
+	return body, nil
+}
+
+func (systemObserver) PortAvailable(ctx context.Context, host string, port int) (bool, error) {
+	lc := net.ListenConfig{}
+	ln, err := lc.Listen(ctx, "tcp", net.JoinHostPort(host, strconv.Itoa(port)))
+	if err != nil {
+		return false, nil
+	}
+	return true, ln.Close()
+}
+
+type daemonProbe struct {
+	State    string
+	PID      int
+	Health   string
+	Ready    string
+	Doctor   *aoDoctorReport
+	Evidence string
+}
+
+type probePayload struct {
+	Status  string `json:"status"`
+	Service string `json:"service"`
+	PID     int    `json:"pid"`
+}
+
+type aoDoctorReport struct {
+	OK       bool            `json:"ok"`
+	Failures int             `json:"failures"`
+	Checks   []aoDoctorCheck `json:"checks"`
+}
+
+type aoDoctorCheck struct {
+	Level       string `json:"level"`
+	Section     string `json:"section,omitempty"`
+	Name        string `json:"name"`
+	Message     string `json:"message"`
+	Remediation string `json:"remediation,omitempty"`
+}
+
+func observeDaemon(ctx context.Context, obs Observer, runFile string, timeout time.Duration) daemonProbe {
+	probeCtx, cancel := boundedContext(ctx, timeout)
+	defer cancel()
+	info, err := obs.ReadRunFile(runFile)
+	if err != nil {
+		return daemonProbe{State: "unknown", Evidence: safeDiagnostic(err)}
+	}
+	if info == nil {
+		return daemonProbe{State: "unavailable", Evidence: "daemon discovery file is absent"}
+	}
+	result := daemonProbe{State: "unhealthy", PID: info.PID}
+	if info.Port < 1 || info.Port > 65535 {
+		result.Evidence = "daemon discovery contains an invalid port"
+		return result
+	}
+	if !obs.ProcessAlive(info.PID) {
+		result.Evidence = "daemon discovery points to a process that is not running"
+		return result
+	}
+	base := "http://127.0.0.1:" + strconv.Itoa(info.Port)
+	read := func(path string, target any) error {
+		body, getErr := obs.GET(probeCtx, base+path)
+		if getErr != nil {
+			return getErr
+		}
+		if err := json.Unmarshal(body, target); err != nil {
+			return fmt.Errorf("malformed response")
+		}
+		return nil
+	}
+	var health probePayload
+	if err := read("/healthz", &health); err != nil {
+		result.Evidence = "health probe failed: " + safeDiagnostic(err)
+		return result
+	}
+	if health.Service != daemonmeta.ServiceName || health.PID != info.PID {
+		result.Evidence = "health response did not match discovered AO daemon"
+		return result
+	}
+	result.Health = health.Status
+	if health.Status != "ok" {
+		result.Evidence = "daemon health is not ok"
+		return result
+	}
+	var ready probePayload
+	if err := read("/readyz", &ready); err != nil {
+		result.State = "unhealthy"
+		result.Evidence = "readiness probe failed: " + safeDiagnostic(err)
+		return result
+	}
+	if ready.Service != daemonmeta.ServiceName || ready.PID != info.PID {
+		result.Evidence = "readiness response did not match discovered AO daemon"
+		return result
+	}
+	result.Ready = ready.Status
+	if ready.Status == "ready" {
+		result.State = "healthy"
+	} else {
+		result.State = "unhealthy"
+		result.Evidence = "daemon is not ready"
+	}
+	var report aoDoctorReport
+	if err := read("/api/v1/doctor", &report); err == nil {
+		result.Doctor = &report
+	}
+	return result
+}
+
+func configString(object map[string]any, keys ...string) string {
+	var current any = object
+	for _, key := range keys {
+		m, ok := current.(map[string]any)
+		if !ok {
+			return ""
+		}
+		current = m[key]
+	}
+	value, _ := current.(string)
+	return value
+}
+
+func configBool(object map[string]any, keys ...string) bool {
+	var current any = object
+	for _, key := range keys {
+		m, ok := current.(map[string]any)
+		if !ok {
+			return false
+		}
+		current = m[key]
+	}
+	value, _ := current.(bool)
+	return value
+}
+
+func configInt(object map[string]any, keys ...string) int {
+	var current any = object
+	for _, key := range keys {
+		m, ok := current.(map[string]any)
+		if !ok {
+			return 0
+		}
+		current = m[key]
+	}
+	switch v := current.(type) {
+	case int:
+		return v
+	case float64:
+		return int(v)
+	}
+	return 0
+}
+
+func discoveryPath(stateRoot string) string { return filepath.Join(stateRoot, "running.json") }

--- a/backend/internal/haocli/observe.go
+++ b/backend/internal/haocli/observe.go
@@ -21,7 +21,10 @@ import (
 	"github.com/aoagents/agent-orchestrator/backend/internal/runfile"
 )
 
-const maxHTTPBody = 1 << 20
+const (
+	maxHTTPBody      = 1 << 20
+	maxCommandOutput = 4096
+)
 
 // Observer is the complete read-only machine boundary used by status and doctor.
 // Tests inject it so no probe depends on the developer's machine or network.
@@ -73,7 +76,7 @@ func (systemObserver) ProcessAlive(pid int) bool                      { return p
 func (systemObserver) Run(ctx context.Context, name string, args ...string) (string, error) {
 	cmd := exec.CommandContext(ctx, name, args...)
 	cmd.Stdin = nil
-	out := boundedBuffer{remaining: 4096}
+	out := boundedBuffer{remaining: maxCommandOutput}
 	cmd.Stdout, cmd.Stderr = &out, &out
 	err := cmd.Run()
 	text := strings.TrimSpace(out.String())

--- a/backend/internal/haocli/observe_unix.go
+++ b/backend/internal/haocli/observe_unix.go
@@ -24,5 +24,5 @@ func diskAvailable(path string) (uint64, error) {
 	if err := syscall.Statfs(path, &stat); err != nil {
 		return 0, err
 	}
-	return uint64(stat.Bavail) * uint64(stat.Bsize), nil
+	return stat.Bavail * uint64(stat.Bsize), nil
 }

--- a/backend/internal/haocli/observe_unix.go
+++ b/backend/internal/haocli/observe_unix.go
@@ -1,0 +1,28 @@
+//go:build !windows
+
+package haocli
+
+import (
+	"os"
+	"syscall"
+)
+
+func statFile(path string) (FileObservation, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return FileObservation{}, err
+	}
+	uid := -1
+	if stat, ok := info.Sys().(*syscall.Stat_t); ok {
+		uid = int(stat.Uid)
+	}
+	return FileObservation{Mode: info.Mode(), UID: uid, Owner: uid < 0 || uid == os.Geteuid()}, nil
+}
+
+func diskAvailable(path string) (uint64, error) {
+	var stat syscall.Statfs_t
+	if err := syscall.Statfs(path, &stat); err != nil {
+		return 0, err
+	}
+	return uint64(stat.Bavail) * uint64(stat.Bsize), nil
+}

--- a/backend/internal/haocli/observe_unix.go
+++ b/backend/internal/haocli/observe_unix.go
@@ -24,5 +24,10 @@ func diskAvailable(path string) (uint64, error) {
 	if err := syscall.Statfs(path, &stat); err != nil {
 		return 0, err
 	}
+	if stat.Bsize <= 0 {
+		return 0, nil
+	}
+	// Bsize is non-negative after the guard above. Its signedness differs by OS.
+	//nolint:gosec,unconvert // Linux uses int64 while Darwin uses uint32.
 	return stat.Bavail * uint64(stat.Bsize), nil
 }

--- a/backend/internal/haocli/observe_windows.go
+++ b/backend/internal/haocli/observe_windows.go
@@ -1,0 +1,20 @@
+//go:build windows
+
+package haocli
+
+import (
+	"errors"
+	"os"
+)
+
+func statFile(path string) (FileObservation, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return FileObservation{}, err
+	}
+	return FileObservation{Mode: info.Mode(), UID: -1, Owner: true}, nil
+}
+
+func diskAvailable(string) (uint64, error) {
+	return 0, errors.New("disk availability probe unsupported on windows")
+}

--- a/backend/internal/haocli/root.go
+++ b/backend/internal/haocli/root.go
@@ -34,6 +34,7 @@ type Deps struct {
 	Err      io.Writer
 	ReadFile func(string) ([]byte, error)
 	StateDir func() (string, error)
+	RunFile  func() (string, error)
 	Observer Observer
 	Timeout  time.Duration
 	Now      func() time.Time
@@ -41,7 +42,7 @@ type Deps struct {
 
 // DefaultDeps returns the production read-only CLI dependencies.
 func DefaultDeps() Deps {
-	return Deps{In: os.Stdin, Out: os.Stdout, Err: os.Stderr, ReadFile: os.ReadFile, StateDir: stateDir, Observer: systemObserver{}, Timeout: 2 * time.Second, Now: time.Now}
+	return Deps{In: os.Stdin, Out: os.Stdout, Err: os.Stderr, ReadFile: os.ReadFile, StateDir: stateDir, RunFile: config.ResolveRunFilePath, Observer: systemObserver{}, Timeout: 2 * time.Second, Now: time.Now}
 }
 
 func (d Deps) withDefaults() Deps {
@@ -60,6 +61,9 @@ func (d Deps) withDefaults() Deps {
 	}
 	if d.StateDir == nil {
 		d.StateDir = defaults.StateDir
+	}
+	if d.RunFile == nil {
+		d.RunFile = defaults.RunFile
 	}
 	if d.Observer == nil {
 		d.Observer = defaults.Observer

--- a/backend/internal/haocli/root.go
+++ b/backend/internal/haocli/root.go
@@ -2,6 +2,7 @@
 package haocli
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -9,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
@@ -32,11 +34,14 @@ type Deps struct {
 	Err      io.Writer
 	ReadFile func(string) ([]byte, error)
 	StateDir func() (string, error)
+	Observer Observer
+	Timeout  time.Duration
+	Now      func() time.Time
 }
 
 // DefaultDeps returns the production read-only CLI dependencies.
 func DefaultDeps() Deps {
-	return Deps{In: os.Stdin, Out: os.Stdout, Err: os.Stderr, ReadFile: os.ReadFile, StateDir: stateDir}
+	return Deps{In: os.Stdin, Out: os.Stdout, Err: os.Stderr, ReadFile: os.ReadFile, StateDir: stateDir, Observer: systemObserver{}, Timeout: 2 * time.Second, Now: time.Now}
 }
 
 func (d Deps) withDefaults() Deps {
@@ -56,6 +61,15 @@ func (d Deps) withDefaults() Deps {
 	if d.StateDir == nil {
 		d.StateDir = defaults.StateDir
 	}
+	if d.Observer == nil {
+		d.Observer = defaults.Observer
+	}
+	if d.Timeout <= 0 {
+		d.Timeout = defaults.Timeout
+	}
+	if d.Now == nil {
+		d.Now = defaults.Now
+	}
 	return d
 }
 
@@ -73,6 +87,9 @@ func ExecuteArgs(deps Deps, args []string) int {
 		return 0
 	}
 	cliErr := classifyError(err, operationFromArgs(args))
+	if cliErr.Silent {
+		return cliErr.ExitStatus
+	}
 	if emitErr := emitError(deps.Err, cliErr, jsonOutput); emitErr != nil {
 		_, _ = fmt.Fprintln(deps.Err, "hao: could not render error")
 	}
@@ -114,7 +131,13 @@ func NewRootCommand(deps Deps) *cobra.Command {
 	})
 	root.AddCommand(newVersionCommand(opts))
 	root.AddCommand(newConfigCommand(deps, opts))
+	root.AddCommand(newStatusCommand(deps, opts))
+	root.AddCommand(newDoctorCommand(deps, opts))
 	return root
+}
+
+func boundedContext(parent context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(parent, timeout)
 }
 
 func versionString() string {

--- a/backend/internal/haocli/root_test.go
+++ b/backend/internal/haocli/root_test.go
@@ -220,7 +220,7 @@ func TestCommandSurfaceContainsNoAOOrchestration(t *testing.T) {
 	for _, cmd := range root.Commands() {
 		got = append(got, cmd.Name())
 	}
-	if want := []string{"config", "version"}; !reflect.DeepEqual(got, want) {
+	if want := []string{"config", "doctor", "status", "version"}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("hao commands = %v, want %v", got, want)
 	}
 	for _, forbidden := range []string{"spawn", "session", "send", "project", "review", "terminal", "daemon", "vm"} {

--- a/backend/internal/haocli/status.go
+++ b/backend/internal/haocli/status.go
@@ -1,0 +1,176 @@
+package haocli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/haocontract"
+	"github.com/spf13/cobra"
+)
+
+const observationSchemaVersion = 1
+
+type Observation struct {
+	ID          string `json:"id"`
+	Status      string `json:"status"`
+	Desired     bool   `json:"desired"`
+	Version     string `json:"version,omitempty"`
+	Evidence    string `json:"evidence,omitempty"`
+	Remediation string `json:"remediation,omitempty"`
+	Drift       bool   `json:"drift"`
+}
+
+type StatusReport struct {
+	SchemaVersion    int           `json:"schemaVersion"`
+	Machine          string        `json:"machine"`
+	Mode             string        `json:"mode"`
+	ConfigPath       string        `json:"configPath"`
+	ConfigVersion    int           `json:"configVersion"`
+	HAOVersion       string        `json:"haoVersion"`
+	DesiredAOVersion string        `json:"desiredAoVersion"`
+	Observations     []Observation `json:"observations"`
+	StrictFailure    bool          `json:"strictFailure"`
+}
+
+func newStatusCommand(deps Deps, opts *options) *cobra.Command {
+	var strict bool
+	cmd := &cobra.Command{Use: "status", Short: "Show desired and observed machine state", Args: noArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			report, err := buildStatus(cmd.Context(), deps, opts.configPath)
+			if err != nil {
+				return err
+			}
+			if opts.json {
+				err = writeJSON(cmd.OutOrStdout(), haocontractRedact(report))
+			} else {
+				err = writeStatusReport(cmd, report)
+			}
+			if err != nil {
+				return err
+			}
+			if strict && report.StrictFailure {
+				return commandError{Code: "strict_failure", ExitStatus: 1, Silent: true}
+			}
+			return nil
+		}}
+	cmd.Flags().BoolVar(&strict, "strict", false, "exit 1 for proven unhealthy or drifted desired state")
+	return cmd
+}
+
+func buildStatus(ctx context.Context, deps Deps, explicit string) (StatusReport, error) {
+	path, object, err := loadConfig(deps, explicit)
+	if err != nil {
+		return StatusReport{}, err
+	}
+	stateRoot, err := deps.StateDir()
+	if err != nil {
+		return StatusReport{}, operationalError("resolve state root", err)
+	}
+	report := StatusReport{SchemaVersion: observationSchemaVersion, Machine: configString(object, "machine", "name"), Mode: configString(object, "mode"), ConfigPath: path, ConfigVersion: 1, HAOVersion: Version, DesiredAOVersion: configString(object, "components", "aoVersion")}
+	d := observeDaemon(ctx, deps.Observer, discoveryPath(stateRoot), deps.Timeout)
+	desiredService := configBool(object, "service", "enabled")
+	report.Observations = append(report.Observations, Observation{ID: "ao.daemon", Status: d.State, Desired: desiredService, Evidence: d.Evidence})
+	if d.Doctor != nil {
+		failed := d.Doctor.Failures > 0 || !d.Doctor.OK
+		status := "healthy"
+		if failed {
+			status = "unhealthy"
+		}
+		report.Observations = append(report.Observations, Observation{ID: "ao.readiness", Status: status, Desired: true, Evidence: fmt.Sprintf("AO doctor reported %d failing check(s)", d.Doctor.Failures)})
+	} else {
+		report.Observations = append(report.Observations, Observation{ID: "ao.readiness", Status: "unknown", Desired: true, Evidence: "AO doctor report unavailable"})
+	}
+	report.Observations = append(report.Observations, toolObservation(ctx, deps, "tool.git", "git", true, "--version"))
+	profileGitHub := configString(object, "workflow", "profile") == "github"
+	report.Observations = append(report.Observations, toolObservation(ctx, deps, "tool.gh", "gh", profileGitHub, "--version"))
+	harness := configString(object, "harness", "id")
+	report.Observations = append(report.Observations, toolObservation(ctx, deps, "harness."+harness, harnessBinary(harness), true, "--version"))
+	if report.Mode == "pair" {
+		report.Observations = append(report.Observations, Observation{ID: "gateway", Status: "unknown", Desired: desiredService, Evidence: "gateway service state is not available through a supported read-only contract"})
+	} else {
+		report.Observations = append(report.Observations, Observation{ID: "gateway", Status: "disabled", Desired: false})
+	}
+	for i := range report.Observations {
+		o := &report.Observations[i]
+		if o.Desired && (o.Status == "unhealthy" || o.Status == "unavailable" || o.Drift) {
+			report.StrictFailure = true
+		}
+	}
+	sort.SliceStable(report.Observations, func(i, j int) bool { return report.Observations[i].ID < report.Observations[j].ID })
+	return report, nil
+}
+
+func toolObservation(ctx context.Context, deps Deps, id, binary string, desired bool, args ...string) Observation {
+	if !desired {
+		return Observation{ID: id, Status: "disabled", Desired: false}
+	}
+	path, err := deps.Observer.LookPath(binary)
+	if err != nil {
+		return Observation{ID: id, Status: "unavailable", Desired: true, Evidence: binary + " was not found on PATH"}
+	}
+	probeCtx, cancel := boundedContext(ctx, deps.Timeout)
+	defer cancel()
+	out, err := deps.Observer.Run(probeCtx, path, args...)
+	if err != nil {
+		if probeCtx.Err() != nil {
+			return Observation{ID: id, Status: "unknown", Desired: true, Evidence: "version probe timed out"}
+		}
+		return Observation{ID: id, Status: "unhealthy", Desired: true, Evidence: "version probe failed"}
+	}
+	return Observation{ID: id, Status: "healthy", Desired: true, Version: safeVersion(out)}
+}
+
+func harnessBinary(id string) string {
+	if id == "claude-code" {
+		return "claude"
+	}
+	return id
+}
+
+func safeVersion(value string) string {
+	line := strings.Split(strings.TrimSpace(value), "\n")[0]
+	if len(line) > 128 {
+		line = line[:128]
+	}
+	return safeDiagnostic(fmt.Errorf("%s", line))
+}
+
+func writeStatusReport(cmd *cobra.Command, report StatusReport) error {
+	out := cmd.OutOrStdout()
+	if _, err := fmt.Fprintf(out, "Machine: %s (%s)\nConfig: v%d %s\nhao: %s\nDesired AO: %s\n", report.Machine, report.Mode, report.ConfigVersion, report.ConfigPath, report.HAOVersion, report.DesiredAOVersion); err != nil {
+		return err
+	}
+	for _, observation := range report.Observations {
+		version := ""
+		if observation.Version != "" {
+			version = " (" + observation.Version + ")"
+		}
+		if _, err := fmt.Fprintf(out, "%-20s %s%s", observation.ID+":", observation.Status, version); err != nil {
+			return err
+		}
+		if observation.Evidence != "" {
+			if _, err := fmt.Fprintf(out, " — %s", observation.Evidence); err != nil {
+				return err
+			}
+		}
+		if _, err := fmt.Fprintln(out); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func haocontractRedact(value any) any {
+	data, err := json.Marshal(value)
+	if err != nil {
+		return map[string]any{"schemaVersion": observationSchemaVersion}
+	}
+	var object map[string]any
+	if json.Unmarshal(data, &object) != nil {
+		return map[string]any{"schemaVersion": observationSchemaVersion}
+	}
+	return haocontract.Redact(object)
+}

--- a/backend/internal/haocli/status.go
+++ b/backend/internal/haocli/status.go
@@ -3,6 +3,7 @@ package haocli
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -115,7 +116,7 @@ func toolObservation(ctx context.Context, deps Deps, id, binary string, desired 
 	defer cancel()
 	out, err := deps.Observer.Run(probeCtx, path, args...)
 	if err != nil {
-		if probeCtx.Err() != nil {
+		if probeCtx.Err() != nil || errors.Is(err, context.DeadlineExceeded) {
 			return Observation{ID: id, Status: "unknown", Desired: true, Evidence: "version probe timed out"}
 		}
 		return Observation{ID: id, Status: "unhealthy", Desired: true, Evidence: "version probe failed"}

--- a/backend/internal/haocli/status.go
+++ b/backend/internal/haocli/status.go
@@ -8,12 +8,14 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/aoagents/agent-orchestrator/backend/internal/haocontract"
 	"github.com/spf13/cobra"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/haocontract"
 )
 
 const observationSchemaVersion = 1
 
+// Observation is one stable desired-versus-observed status fact.
 type Observation struct {
 	ID          string `json:"id"`
 	Status      string `json:"status"`
@@ -24,6 +26,7 @@ type Observation struct {
 	Drift       bool   `json:"drift"`
 }
 
+// StatusReport is the versioned machine-readable status document.
 type StatusReport struct {
 	SchemaVersion    int           `json:"schemaVersion"`
 	Machine          string        `json:"machine"`

--- a/backend/internal/haocli/status.go
+++ b/backend/internal/haocli/status.go
@@ -69,13 +69,16 @@ func buildStatus(ctx context.Context, deps Deps, explicit string) (StatusReport,
 	if err != nil {
 		return StatusReport{}, err
 	}
-	stateRoot, err := deps.StateDir()
+	runFile, err := deps.RunFile()
 	if err != nil {
-		return StatusReport{}, operationalError("resolve state root", err)
+		return StatusReport{}, operationalError("resolve daemon discovery path", err)
 	}
 	report := StatusReport{SchemaVersion: observationSchemaVersion, Machine: configString(object, "machine", "name"), Mode: configString(object, "mode"), ConfigPath: path, ConfigVersion: 1, HAOVersion: Version, DesiredAOVersion: configString(object, "components", "aoVersion")}
-	d := observeDaemon(ctx, deps.Observer, discoveryPath(stateRoot), deps.Timeout)
+	d := observeDaemon(ctx, deps.Observer, runFile, deps.Timeout)
 	desiredService := configBool(object, "service", "enabled")
+	if !desiredService && d.State == "unavailable" {
+		d.State, d.Evidence = "disabled", "daemon is absent and service is intentionally disabled"
+	}
 	report.Observations = append(report.Observations, Observation{ID: "ao.daemon", Status: d.State, Desired: desiredService, Evidence: d.Evidence})
 	if d.Doctor != nil {
 		failed := d.Doctor.Failures > 0 || !d.Doctor.OK
@@ -144,7 +147,7 @@ func safeVersion(value string) string {
 
 func writeStatusReport(cmd *cobra.Command, report StatusReport) error {
 	out := cmd.OutOrStdout()
-	if _, err := fmt.Fprintf(out, "Machine: %s (%s)\nConfig: v%d %s\nhao: %s\nDesired AO: %s\n", report.Machine, report.Mode, report.ConfigVersion, report.ConfigPath, report.HAOVersion, report.DesiredAOVersion); err != nil {
+	if _, err := fmt.Fprintf(out, "Machine: %s (%s)\nConfig: v%d %s\nhao: %s\nDesired AO: %s\n", redactedString(report.Machine), redactedString(report.Mode), report.ConfigVersion, redactedString(report.ConfigPath), redactedString(report.HAOVersion), redactedString(report.DesiredAOVersion)); err != nil {
 		return err
 	}
 	for _, observation := range report.Observations {
@@ -156,7 +159,7 @@ func writeStatusReport(cmd *cobra.Command, report StatusReport) error {
 			return err
 		}
 		if observation.Evidence != "" {
-			if _, err := fmt.Fprintf(out, " — %s", observation.Evidence); err != nil {
+			if _, err := fmt.Fprintf(out, " — %s", redactedString(observation.Evidence)); err != nil {
 				return err
 			}
 		}
@@ -177,4 +180,9 @@ func haocontractRedact(value any) any {
 		return map[string]any{"schemaVersion": observationSchemaVersion}
 	}
 	return haocontract.Redact(object)
+}
+
+func redactedString(value string) string {
+	redacted, _ := haocontract.Redact(value).(string)
+	return redacted
 }

--- a/backend/internal/haocontract/config.go
+++ b/backend/internal/haocontract/config.go
@@ -91,6 +91,8 @@ var secretKeyParts = []string{
 }
 
 var secretAssignmentPattern = regexp.MustCompile(`(?i)(pass(code|word)?|token|secret|credential|api[_-]?key|private[_-]?key)\s*[:=]\s*[^/\\\s,;]+`)
+var bearerPattern = regexp.MustCompile(`(?i)\bbearer\s+[A-Za-z0-9._~+/=-]+`)
+var jsonSecretPattern = regexp.MustCompile(`(?i)("(?:passcode|password|token|secret|credential|api[_-]?key|private[_-]?key)"\s*:\s*")[^"]*(")`)
 
 // IsSecretLookingKey reports whether a key may name credential material.
 func IsSecretLookingKey(key string) bool {
@@ -147,6 +149,11 @@ func Redact(value any) any {
 		return out
 	default:
 		if text, ok := value.(string); ok {
+			if strings.Contains(strings.ToUpper(text), "PRIVATE KEY") || strings.Contains(strings.ToLower(text), "ao-pair://") {
+				return "[REDACTED]"
+			}
+			text = bearerPattern.ReplaceAllString(text, "Bearer [REDACTED]")
+			text = jsonSecretPattern.ReplaceAllString(text, `$1[REDACTED]$2`)
 			return secretAssignmentPattern.ReplaceAllString(text, "$1=[REDACTED]")
 		}
 		return value

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -34,8 +34,20 @@ surface (`npm run sqlc`, `npm run api`).
   commands resolve configuration under the shared Hosted AO state root, parse
   YAML v1 configuration, fail closed against the published contract, redact
   secret-looking values, and use the published v1 exit/error envelope.
-- Configuration mutation, setup, initialization, service lifecycle, pairing,
-  gateway changes, and host mutation are not part of this foundation.
+- Read-only `hao status` reports the validated desired machine state alongside
+  bounded observations of the loopback AO daemon, AO-reported readiness, Git,
+  profile-conditional GitHub CLI, the selected harness, and gateway support.
+  Its versioned JSON output distinguishes unknown or unsupported facts from
+  proven unhealthy state; `--strict` fails only for proven unhealthy or drifted
+  desired state.
+- Read-only `hao doctor` checks the host, state/config permissions, disk,
+  package/service manager availability, relevant local ports, and safe
+  time-bounded tool authentication probes. When the daemon is reachable it
+  aggregates the daemon's shared doctor report instead of redefining AO runtime
+  or terminal readiness.
+- Configuration mutation, setup, initialization, service lifecycle changes,
+  pairing, gateway changes, authentication flows, and other host mutation are
+  not performed by these observation commands.
 
 ### Backend (Go daemon)
 


### PR DESCRIPTION
## Summary
- add versioned read-only `hao status` observations with strict exit semantics
- add independent `hao doctor` host checks and aggregate AO daemon doctor truth
- confine daemon HTTP probes to discovered loopback with timeouts, redirect rejection, and response bounds
- add injected observer coverage for deterministic machine/network tests

## Tests
- `cd backend && go test ./internal/haocli`

## Review focus
Please focus on observation truthfulness, loopback confinement/SSRF, timeout/body bounds, recursive redaction, strict exit semantics, AO doctor reuse, platform/service behavior, and artifact packaging.

Closes #139