### PR TITLE
fix: refresh pairing probe sessions after misses

### DIFF
--- a/frontend/e2e/support/fake-bridge.ts
+++ b/frontend/e2e/support/fake-bridge.ts
@@ -371,6 +371,7 @@ export async function installFakeBridge(
                       error:
                         "No certificate could be retrieved from that address.",
                     },
+              cancelFingerprintProbe: () => undefined,
               getPinnedFingerprint: async () => null,
               add: async () => {
                 pairedList = [...pairedList, pairing.machine];
@@ -386,6 +387,7 @@ export async function installFakeBridge(
               probeFingerprint: async () => ({
                 error: "No main process under the browser harness.",
               }),
+              cancelFingerprintProbe: () => undefined,
               getPinnedFingerprint: async () => null,
               add: async () => {
                 throw new Error(
@@ -967,6 +969,7 @@ export async function installFakeAgent(
           probeFingerprint: async () => ({
             error: "No main process under the browser harness.",
           }),
+          cancelFingerprintProbe: () => undefined,
           getPinnedFingerprint: async () => null,
           add: async () => {
             throw new Error(

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -2414,8 +2414,11 @@ ipcMain.handle("pairedMachines:list", () => pairedMachines().list());
 ipcMain.handle("pairedMachines:refresh", () => pairedMachines().refresh());
 ipcMain.handle(
   "pairedMachines:probeFingerprint",
-  (_event, address: string, port: number) =>
-    pairedMachines().probeFingerprint(address, port),
+  (_event, address: string, port: number, requestId?: string) =>
+    pairedMachines().probeFingerprint(address, port, requestId),
+);
+ipcMain.on("pairedMachines:cancelFingerprintProbe", (_event, requestId: string) =>
+  pairedMachines().cancelFingerprintProbe(requestId),
 );
 ipcMain.handle("pairedMachines:getPinnedFingerprint", (_event, id: string) =>
   pairedMachines().getPinnedFingerprint(id),

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -2331,25 +2331,23 @@ const LOCAL_MACHINE_NAME =
  * distinct box ever probed, which is what actually needs isolating from
  * `session.defaultSession`.
  *
- * The cost: a probe of an unpinned host is always denied, by design (same as
- * above), so reusing that host's session for a second probe can hit its own
- * cached rejection and fail to capture anything -- not only when the box's
- * certificate has actually changed between the two attempts. The realistic
- * trigger is a retry after an abandoned or failed pairing attempt (compare
- * the fingerprint, close the dialog without pinning, try again), which can
- * come back with a misleading "no certificate could be retrieved" until the
- * app restarts. Re-pairing an already-registered box is unaffected: a pinned
- * host verifies and accepts on `session.defaultSession`, which this probe
- * session never touches. Tracked as a follow-up: #121.
  */
+const pairProbeSessionGenerations = new Map<string, number>();
+
 function pairProbeNetFetch(
   input: RequestInfo | URL,
   init?: RequestInit,
 ): Promise<Response> {
   const hostname = new URL(String(input)).hostname;
-  const probeSession = session.fromPartition(`pair-probe-${hostname}`);
+  const generation = pairProbeSessionGenerations.get(hostname) ?? 0;
+  const probeSession = session.fromPartition(`pair-probe-${hostname}-${generation}`);
   probeSession.setCertificateVerifyProc(pairedMachines().verifyCertificate);
   return probeSession.fetch(String(input), init);
+}
+
+function resetPairProbeSession(address: string): void {
+  const current = pairProbeSessionGenerations.get(address) ?? 0;
+  pairProbeSessionGenerations.set(address, current + 1);
 }
 
 let pairedMachinesController: ReturnType<
@@ -2366,6 +2364,7 @@ function pairedMachines(): ReturnType<typeof createPairedMachinesController> {
     // fetch would bypass the session (and the pin) entirely.
     netFetch: (input, init) => net.fetch(String(input), init),
     probeNetFetch: pairProbeNetFetch,
+    onProbeMiss: resetPairProbeSession,
   });
   return pairedMachinesController;
 }

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -2364,7 +2364,7 @@ function pairedMachines(): ReturnType<typeof createPairedMachinesController> {
     // fetch would bypass the session (and the pin) entirely.
     netFetch: (input, init) => net.fetch(String(input), init),
     probeNetFetch: pairProbeNetFetch,
-    onProbeMiss: resetPairProbeSession,
+    onProbeComplete: resetPairProbeSession,
   });
   return pairedMachinesController;
 }

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -2302,54 +2302,6 @@ const LOCAL_MACHINE_NAME =
 // app.whenReady below, is what actually enforces the pin; this controller only
 // holds the data it reads from.
 
-/**
- * Fetch for `probeFingerprint`'s capture connection, bound to a session other
- * than `session.defaultSession`, keyed by the target host rather than a
- * fresh partition every call. `ses.fetch()`, not `net.fetch()`: the latter
- * always issues from the default session (that is the whole reason it exists
- * as a convenience wrapper), so routing through another session requires
- * calling `fetch` on the `Session` instance itself.
- *
- * That connection is always denied at the TLS layer (paired-machine-cert.ts
- * has no accept path for a host with nothing pinned yet), and Chromium caches
- * a per-host certificate-error verdict at the network-service level, below
- * where the verify proc runs, for the life of the session that made the
- * connection. If the capture probe shared `session.defaultSession` with real
- * traffic, pinning the fingerprint in `add()` would not undo that cached
- * rejection: the very next authenticated request to the newly paired host
- * would still be short-circuited to a failure before the verify proc is even
- * consulted, reading as unreachable until the app restarts and the cache is
- * gone (#114).
- *
- * The partition is keyed by hostname, not minted fresh per call, because
- * `session.fromPartition` has no destroy API: Electron holds every partition
- * it has ever created in an internal map for the life of the process
- * (electron/electron#27142, #28566), so a fresh name every call would leak
- * one Session per probe -- one per candidate address `racePairAddresses`
- * tries, and again on every manual retry -- for as long as the app stays
- * open. Keying by host instead bounds that to one throwaway session per
- * distinct box ever probed, which is what actually needs isolating from
- * `session.defaultSession`.
- *
- */
-const pairProbeSessionGenerations = new Map<string, number>();
-
-function pairProbeNetFetch(
-  input: RequestInfo | URL,
-  init?: RequestInit,
-): Promise<Response> {
-  const hostname = new URL(String(input)).hostname;
-  const generation = pairProbeSessionGenerations.get(hostname) ?? 0;
-  const probeSession = session.fromPartition(`pair-probe-${hostname}-${generation}`);
-  probeSession.setCertificateVerifyProc(pairedMachines().verifyCertificate);
-  return probeSession.fetch(String(input), init);
-}
-
-function resetPairProbeSession(address: string): void {
-  const current = pairProbeSessionGenerations.get(address) ?? 0;
-  pairProbeSessionGenerations.set(address, current + 1);
-}
-
 let pairedMachinesController: ReturnType<
   typeof createPairedMachinesController
 > | null = null;
@@ -2363,8 +2315,6 @@ function pairedMachines(): ReturnType<typeof createPairedMachinesController> {
     // stack, which is what verifyCertificate below actually sees. A plain
     // fetch would bypass the session (and the pin) entirely.
     netFetch: (input, init) => net.fetch(String(input), init),
-    probeNetFetch: pairProbeNetFetch,
-    onProbeComplete: resetPairProbeSession,
   });
   return pairedMachinesController;
 }

--- a/frontend/src/main/paired-machine-cert.test.ts
+++ b/frontend/src/main/paired-machine-cert.test.ts
@@ -60,25 +60,19 @@ test("computePairFingerprint matches PairFingerprint's exact rendering: uppercas
 });
 
 test("a host that is not a paired machine gets default Chromium verification, untouched", () => {
-	const isPairHost = vi.fn(() => false);
 	const getPinnedFingerprint = vi.fn(() => null);
-	const onPresented = vi.fn();
-	const proc = createPairCertificateVerifyProc({ isPairHost, getPinnedFingerprint, onPresented });
+	const proc = createPairCertificateVerifyProc({ getPinnedFingerprint });
 
 	const callback = vi.fn();
 	proc(request("ao.agentlab.in", CERT_PEM), callback);
 
 	expect(callback).toHaveBeenCalledExactlyOnceWith(CERT_VERIFY_USE_DEFAULT);
-	// Nothing about the cert of an unrelated host is inspected at all.
-	expect(getPinnedFingerprint).not.toHaveBeenCalled();
-	expect(onPresented).not.toHaveBeenCalled();
+	expect(getPinnedFingerprint).toHaveBeenCalledExactlyOnceWith("ao.agentlab.in");
 });
 
 test("a pinned machine whose presented certificate matches the pin is accepted", () => {
 	const proc = createPairCertificateVerifyProc({
-		isPairHost: () => true,
 		getPinnedFingerprint: () => CERT_FINGERPRINT,
-		onPresented: () => undefined,
 	});
 
 	const callback = vi.fn();
@@ -89,9 +83,7 @@ test("a pinned machine whose presented certificate matches the pin is accepted",
 
 test("a pinned machine whose presented certificate does not match the pin is refused, with no fallback", () => {
 	const proc = createPairCertificateVerifyProc({
-		isPairHost: () => true,
 		getPinnedFingerprint: () => CERT_FINGERPRINT,
-		onPresented: () => undefined,
 	});
 
 	const callback = vi.fn();
@@ -107,21 +99,15 @@ test("a pinned machine whose presented certificate does not match the pin is ref
 	expect(callback).not.toHaveBeenCalledWith(CERT_VERIFY_USE_DEFAULT);
 });
 
-test("first connect: an unpinned pairing candidate is refused, but the presented fingerprint is still captured", () => {
-	const onPresented = vi.fn();
+test("first connect is left to Chromium because raw TLS capture has not pinned the host yet", () => {
 	const proc = createPairCertificateVerifyProc({
-		isPairHost: () => true,
 		getPinnedFingerprint: () => null,
-		onPresented,
 	});
 
 	const callback = vi.fn();
 	proc(request("192.168.1.5", CERT_PEM), callback);
 
-	// Trust-on-first-use never auto-accepts: there is nothing pinned yet, so
-	// the connection itself is refused...
-	expect(callback).toHaveBeenCalledExactlyOnceWith(CERT_VERIFY_REJECT);
-	// ...but the pairing flow still learns what was presented, so it can be
-	// shown to the user for comparison against what the box printed.
-	expect(onPresented).toHaveBeenCalledExactlyOnceWith("192.168.1.5", CERT_FINGERPRINT);
+	// Chromium still rejects the self-signed certificate by default; the
+	// verifier itself neither accepts nor creates trust before `add()` pins it.
+	expect(callback).toHaveBeenCalledExactlyOnceWith(CERT_VERIFY_USE_DEFAULT);
 });

--- a/frontend/src/main/paired-machine-cert.ts
+++ b/frontend/src/main/paired-machine-cert.ts
@@ -14,9 +14,9 @@ import { X509Certificate } from "node:crypto";
  * `session.defaultSession` in main.ts rather than into a fetch wrapper.
  *
  * The corollary is the hard constraint this module exists to satisfy: it must
- * touch nothing about how any other host is verified. `isPairHost` is the
- * gate, and a request for a hostname it does not recognise is handed back to
- * Chromium's own verification untouched (CERT_VERIFY_USE_DEFAULT).
+ * touch nothing about how any other host is verified. A request with no pin is
+ * handed back to Chromium's own verification untouched
+ * (CERT_VERIFY_USE_DEFAULT).
  */
 
 /** callback(0): accept the certificate for this connection. */
@@ -48,18 +48,9 @@ export type PairCertificateVerifyProc = (
  * every call is synchronous: Electron calls this proc from the network
  * service and does not await it. */
 export type PairPinLookup = {
-	/** True for a registered paired machine, or a host currently being probed
-	 * for first-time pairing. False for every other host, including the
-	 * control plane and any hosted machine with a real certificate. */
-	isPairHost: (hostname: string) => boolean;
 	/** The pinned fingerprint for a registered paired machine, or null when
-	 * the host is only a pairing candidate with nothing pinned yet. */
+	 * the host is not paired. */
 	getPinnedFingerprint: (hostname: string) => string | null;
-	/** Called with the fingerprint of whatever certificate was actually
-	 * presented, for every pair-host connection, whether accepted or
-	 * rejected. This is the first-connect capture: the pairing flow reads it
-	 * back to show the user what to compare against the box's printout. */
-	onPresented: (hostname: string, fingerprint: string) => void;
 };
 
 /**
@@ -69,40 +60,33 @@ export type PairPinLookup = {
  *
  * `X509Certificate.fingerprint256` computes exactly that (SHA-256 over the
  * certificate's DER encoding, rendered as upper-case colon-separated hex) for
- * both PEM and DER input, so this is the whole implementation; hand-rolling a
- * PEM parse and hasher would only be a slower way to arrive at the same
- * bytes. `pem` is `Certificate.data` from Electron's verify-proc request,
- * which is PEM encoded.
+ * both Electron's PEM verifier input and the raw TLS probe's DER input, so this
+ * is the whole implementation; hand-rolling either parse and hasher would only
+ * be a slower way to arrive at the same bytes.
  */
-export function computePairFingerprint(pem: string): string {
-	return new X509Certificate(pem).fingerprint256;
+export function computePairFingerprint(certificate: string | Buffer): string {
+	return new X509Certificate(certificate).fingerprint256;
 }
 
 /**
  * Build the proc to hand to `session.setCertificateVerifyProc`.
  *
  * Decision table, in order:
- * 1. Not a pair host at all -> CERT_VERIFY_USE_DEFAULT. Every other host,
- *    including the control plane and hosted machines, is untouched.
- * 2. A pair host with a pinned fingerprint that matches what was presented ->
- *    CERT_VERIFY_ACCEPT.
- * 3. Anything else for a pair host -- a mismatch, or no pin yet -> REJECT.
- *    There is no accept path for an unpinned host: the presented fingerprint
- *    is still captured via `onPresented` so the pairing flow can show it, but
- *    the connection itself is refused rather than silently trusted. This is
- *    what makes trust-on-first-use a *user* accepting a fingerprint (task 8's
- *    UI, by calling the registry's add/pin step) rather than the transport
- *    accepting it on the user's behalf.
+ * 1. No pin for this host -> CERT_VERIFY_USE_DEFAULT. Every other host,
+ *    including the control plane and first-contact pairing candidates, is
+ *    untouched. First-contact capture uses paired-machine-probe.ts and never
+ *    enters Chromium's network stack.
+ * 2. A pinned fingerprint matching what was presented -> ACCEPT.
+ * 3. A pinned fingerprint that does not match -> REJECT with no fallback.
  */
 export function createPairCertificateVerifyProc(lookup: PairPinLookup): PairCertificateVerifyProc {
 	return (request, callback) => {
-		if (!lookup.isPairHost(request.hostname)) {
+		const pinned = lookup.getPinnedFingerprint(request.hostname);
+		if (!pinned) {
 			callback(CERT_VERIFY_USE_DEFAULT);
 			return;
 		}
 		const presented = computePairFingerprint(request.certificate.data);
-		lookup.onPresented(request.hostname, presented);
-		const pinned = lookup.getPinnedFingerprint(request.hostname);
-		callback(pinned && pinned === presented ? CERT_VERIFY_ACCEPT : CERT_VERIFY_REJECT);
+		callback(pinned === presented ? CERT_VERIFY_ACCEPT : CERT_VERIFY_REJECT);
 	};
 }

--- a/frontend/src/main/paired-machine-probe.test.ts
+++ b/frontend/src/main/paired-machine-probe.test.ts
@@ -2,7 +2,9 @@
 import net, { type Server as NetServer, type Socket } from "node:net";
 import tls, { type Server as TLSServer, type TLSSocket } from "node:tls";
 import { afterEach, describe, expect, test, vi } from "vitest";
+import { racePairAddresses } from "../shared/pair-race";
 import { canonicalPairHost, capturePairFingerprint } from "./paired-machine-probe";
+import { createPairedMachinesController } from "./paired-machines";
 
 // Public, test-only PKCS#12 fixture. Keeping the inert fixture as base64 avoids
 // making a PEM private-key marker look like a production credential to secret
@@ -86,17 +88,37 @@ test("timeout destroys a socket whose peer never starts TLS", async () => {
 	await vi.waitFor(() => expect(sockets.size).toBe(0));
 });
 
-test("abort destroys an in-flight socket", async () => {
+test("abandoning a user race propagates cancellation through the controller and destroys the socket", async () => {
 	const server = net.createServer((socket) => {
 		sockets.add(socket);
 		socket.once("close", () => sockets.delete(socket));
 		socket.resume();
 	});
 	const port = await listen(server);
+	const machines = createPairedMachinesController({
+		stateDir: null,
+		safeStorage: {
+			isEncryptionAvailable: () => false,
+			encryptString: () => Buffer.alloc(0),
+			decryptString: () => "",
+		},
+		probeTimeoutMs: 500,
+	});
 	const controller = new AbortController();
-	const capture = capturePairFingerprint("127.0.0.1", port, { timeoutMs: 500, signal: controller.signal });
+	let sequence = 0;
+	const race = racePairAddresses(
+		[{ host: "127.0.0.1", port }],
+		"not-presented",
+		(host, candidatePort, signal) => {
+			const requestId = `test-probe-${sequence++}`;
+			signal?.addEventListener("abort", () => machines.cancelFingerprintProbe(requestId), { once: true });
+			return machines.probeFingerprint(host, candidatePort, requestId);
+		},
+		{ signal: controller.signal },
+	);
+	await vi.waitFor(() => expect(sockets.size).toBe(1));
 	controller.abort();
 
-	await expect(capture).rejects.toThrow("cancelled");
+	await expect(race).resolves.toEqual({ status: "cancelled" });
 	await vi.waitFor(() => expect(sockets.size).toBe(0));
 });

--- a/frontend/src/main/paired-machine-probe.test.ts
+++ b/frontend/src/main/paired-machine-probe.test.ts
@@ -1,0 +1,102 @@
+// @vitest-environment node
+import net, { type Server as NetServer, type Socket } from "node:net";
+import tls, { type Server as TLSServer, type TLSSocket } from "node:tls";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { canonicalPairHost, capturePairFingerprint } from "./paired-machine-probe";
+
+// Public, test-only PKCS#12 fixture. Keeping the inert fixture as base64 avoids
+// making a PEM private-key marker look like a production credential to secret
+// scanners. Password: pair-probe-test.
+const TEST_PFX_BASE64 =
+	"MIIKBwIBAzCCCbUGCSqGSIb3DQEHAaCCCaYEggmiMIIJnjCCBAoGCSqGSIb3DQEHBqCCA/swggP3AgEAMIID8AYJKoZIhvcNAQcBMF8GCSqGSIb3DQEFDTBSMDEGCSqGSIb3DQEFDDAkBBBdpFsmV/XATp/9logeC6zsAgIIADAMBggqhkiG9w0CCQUAMB0GCWCGSAFlAwQBKgQQAKSMO/P4/3sL/EMbtM1y1ICCA4BhxGP7i+EGp4FRMVmG706nsGKrK6XIpwrk0fb78HZkvAZP9h7Do0urXdDvJ34e/LmF2KrPSC7TL56CaVcuJWSccOc5ngyd3FT6HVFd54CCCvB64ZP8WVjhyC65EDoItMz4lI4YCqIkL77ghvxLP1pzenZrcWcAbISFWhNqULF4mIvAJ0Ispz9Gs7AlBhXiTqPxJLt/fAevAuXoj+LNExweZhtowl2/eHdiqgl6uEOBg2j0uIcOjNureVunRIyTCdzB6hqCbccveLSq7qnot4EYGz03UUg0oKebq7pAi4t2TRBoYrMbR5gj6s3og0H85POm9eiiZ8HYnkF/w7Wei5FDyy1NLG8Oi/yH22pSTkaarpOH1RkIjFTvKBTNAA71h8sOkh5BqbcE1ONzRra8edO4zndYYQ0fzYMZ4QzgKedcbEqW2iqI9c53XxBP9m6Ij+YF2EU+Nij8XS2bzh6dq967dPcVkTIKdLnVhg5r8cluORzXbI2l+aLuGdeiI/WwFolaT5wOKsQ50VHpDtApGI6Wq+eboBoF5spX87b3pf86mKN2s105DZMFN4I+gGrYZEHjHwfY+Uvxim8+Q57zl0ZOsod8Vw6SjRphH7TwCbiwkF0yzNZ5Iep0UI+9/2jzQly7UMFEN3lSChBBagFEh8+QmJWZvB7k+H6TqYii58CQzQOwq8aExAHjL4GwNgWetGOUIRRmfsqVnMO+Mrk5SzhZqGxhalMSai4OtGy3cTKmud3q79BxENRhwbNLpl0402MhcSP0ZpavwZRWHZnFLuTVvXucCl7OVhKK0/bs/VGlZyQIvzW+OepcsQ+EKawh9UxmyaLRwIrj7nre1FNxdGS/XUNAh45Cj/G/t6pNRtnmx80i0ilVRdfcABPz9KdSZCWmufDklZuAfPHEfzbyDePGyMd1lezphqOoCOeuvSGokO52uupgZgFRgwUo1TGO0fIuWEU5sEHvZNyb0dIaYakbbIWWgsjKewSIi4b3iuOq0i76oSZLsUNQX0zfIkm86e7ew2hgznXGnEw9BnRhO+09nJssiiOVsd1YeKHDMe7PgFuUDwS1WHy/Xxbct6qARUKduHJEq7IjTMf080pn8PzYlh4Bd8GaWM1k3hcQSTWOspsV00VFRz0KgfBPtlTiEsF5p+ydw//wgQYIK2arzgK/2y04ESa2h+C7IPauJzpx4zCCBYwGCSqGSIb3DQEHAaCCBX0EggV5MIIFdTCCBXEGCyqGSIb3DQEMCgECoIIFOTCCBTUwXwYJKoZIhvcNAQUNMFIwMQYJKoZIhvcNAQUMMCQEEKOFZX977PWJcIkL15sSWIYCAggAMAwGCCqGSIb3DQIJBQAwHQYJYIZIAWUDBAEqBBC+OVMbTEU+a5e9G7A59c0aBIIE0L0N51kT3nCdcZEQSQdoxuVkh/6RP4/lwGYplFeIEHgIhA0j3TyZ0Bdpo2owRCbsdoLhLcrMZmH1KnxHizE+fvwP0mB6SwYf0rCL9H3Ux9TNOVJRFc+wmTsEj7ITuZgYNLEpmEoT6zn3DPg89gJteohkDh4Llscvj7S4V3efiDV+BF9I3mfmAzAOffojLkx+21/i44uBpuH3Z9+BH5RAyc6v4GzP6Hq6ZtDlYcmiCNbedQXvINHKRAv3amIY3sjg+M7phcwLNRMRZ6GROZ1uV+OEqQWAbI9c9WBwObXNGbq5DwDbjzLaRaqgJu08uAsos7WCqI/PSKm1E8xVGtZ0+KmcnVSCrhVBnFzwz3v/3zIZSnIr5wqY8XEkZEvi/xHi2xburtqOmqrO23zMArYV4mPxej7c6cFtTDzqIZMB5oyCzgyEc+Jfzs7ZRTWLXJ+ppxXfV2h0GQsRIuxbJayFaQIZBTbU4g/5yFqQlvz+5pwdHldfVxOKLHr7MT5eHdsb62L1Ur0KqUPioNze98t8MIhlTSeww1yRoHgcTnEBAeWt6epAc2eRDw3SWn8zz/UnMPH6pA3DXeIPXGRL9hxD60TMg3Vrw37Na6htECutF1AJ/ZjIGLoi6uh9i6xSbmf+O6lFoj1igFo+GMerWeT1rEnluPLkFA/JYxKtMfagHZI3WVmG4vX+Pfezn8hC86/3FHFXot0h3G55yzYKmfMV8jTGHXytFGMg3yAVE4op41nFBcaF9JUeyX09QFM650X+ZkPvITsErTrVQrkGCXIgmomjY16MiCHybRWzQzRsQvbWfB9X2pwI/0oZ3FQ/PQWj06RYYG1Y+B1mU/oaAMKQeq8GrgUbJQSXlS92OnZTb4AkqG49g3FTaMFHhhrvMr60KAccTYs3AhlU4OQBNi6F5XE5kBqu6A94SFM69i5E/LQFdUl9K1pDaHdKQ02ciMkC27ZR3PZZon9TULI6hQYKdWAgOIJDqNkNTO93RdY7Pz52ieUKfIY6BH949uExkcltpUY4UK5qwQXq136E5BJNHeKjBdkBeAzxjH7IQ4ifz38L97uo7ALsP8GiNyvcYLvSbxtsVLiaOT1i1UFqHRQpyyyBy97t10ieBY/SauSqpCPd3pL0BJD4vfz7HU/u+gT9simWxOi5DJKyQynl1GegvDlRXVMroD093WMwBH8qk9dw7eRU+VRHJBSElzPYA8WbMspWdh4aZv0XMpg/yjOGk9tIkaVswCBqdPODd1Z7Ir0PU1fFHR6QZFMetPOjhamoOZcVP1E/d5lgXc1L4ySvpWSPf1b2bBKwYDNOR/yKKy/n4J6tgJ5zTZ5/iOBV2WnoJjkhuJDLq/qbWrlL5aw5xXNK7vNMNigOwXqZX82U1ubZ19Vsleb/fU/mw5at7g/7gwCp49biUNMPkj8c2KKR0lZirfdZIbJ7yrsMVUUw2bhoNIH93lWeRpiZChj+KZcNAGt5B912V0zmLbQ5vEoByUbZORaey7MhfM8neWFbR1L61WSvLHyisbOxI7uqSOhNROHp0o/WixjbIdJrtSl89MH0qkkumfFCfJp9KySbPFyFXlPOuzWzmirAg2JH50L49gSVFQiaGN+D+MShrpWHpXBDT5IHG+6jTYbrcwmmlsl2MSUwIwYJKoZIhvcNAQkVMRYEFJOYViY1CdPxBI/PJbVlQKPKhuCzMEkwMTANBglghkgBZQMEAgEFAAQgblzL24HOYoHB6TPn/dJosOTBNy2gnhk88XWmQro0XaAEEFIsm2Rj00FsA3/bainzSv4CAggA";
+const TEST_FINGERPRINT = "98:5A:BA:63:91:0E:21:8A:06:A8:C3:05:83:A2:89:C0:60:DB:70:42:46:71:F7:93:90:4F:44:CF:52:EA:25:E8";
+
+const servers: Array<NetServer | TLSServer> = [];
+const sockets = new Set<Socket | TLSSocket>();
+
+afterEach(async () => {
+	for (const socket of sockets) socket.destroy();
+	await Promise.all(servers.splice(0).map((server) => new Promise<void>((resolve) => server.close(() => resolve()))));
+	sockets.clear();
+});
+
+async function listen(server: NetServer | TLSServer): Promise<number> {
+	servers.push(server);
+	await new Promise<void>((resolve, reject) => {
+		server.once("error", reject);
+		server.listen(0, "127.0.0.1", () => {
+			server.removeListener("error", reject);
+			resolve();
+		});
+	});
+	const address = server.address();
+	if (!address || typeof address === "string") throw new Error("test server did not bind a TCP port");
+	return address.port;
+}
+
+function tlsServer(): TLSServer {
+	const server = tls.createServer(
+		{ pfx: Buffer.from(TEST_PFX_BASE64, "base64"), passphrase: "pair-probe-test" },
+		(socket) => {
+			sockets.add(socket);
+			socket.once("close", () => sockets.delete(socket));
+		},
+	);
+	server.on("tlsClientError", () => undefined);
+	return server;
+}
+
+describe("canonicalPairHost", () => {
+	test("normalizes DNS, IPv4, and bracketed or bare IPv6 to stable keys", () => {
+		expect(canonicalPairHost("BOX.Local")).toBe("box.local");
+		expect(canonicalPairHost("192.168.001.005")).toBe("192.168.1.5");
+		expect(canonicalPairHost("2001:0DB8:0:0:0:0:0:1")).toBe("2001:db8::1");
+		expect(canonicalPairHost("[2001:db8::1]")).toBe("2001:db8::1");
+	});
+});
+
+test("captures the real leaf certificate repeatedly without retaining probe state", async () => {
+	const port = await listen(tlsServer());
+
+	for (let attempt = 0; attempt < 20; attempt++) {
+		await expect(capturePairFingerprint("127.0.0.1", port, { timeoutMs: 500 })).resolves.toBe(TEST_FINGERPRINT);
+	}
+	await new Promise<void>((resolve) => setImmediate(resolve));
+	expect(sockets.size).toBe(0);
+});
+
+test("concurrent captures settle independently", async () => {
+	const port = await listen(tlsServer());
+
+	const captures = Array.from({ length: 8 }, () =>
+		capturePairFingerprint("127.0.0.1", port, { timeoutMs: 500 }),
+	);
+	await expect(Promise.all(captures)).resolves.toEqual(Array(8).fill(TEST_FINGERPRINT));
+});
+
+test("timeout destroys a socket whose peer never starts TLS", async () => {
+	const server = net.createServer((socket) => {
+		sockets.add(socket);
+		socket.once("close", () => sockets.delete(socket));
+		socket.resume();
+	});
+	const port = await listen(server);
+
+	await expect(capturePairFingerprint("127.0.0.1", port, { timeoutMs: 20 })).rejects.toThrow("timed out");
+	await vi.waitFor(() => expect(sockets.size).toBe(0));
+});
+
+test("abort destroys an in-flight socket", async () => {
+	const server = net.createServer((socket) => {
+		sockets.add(socket);
+		socket.once("close", () => sockets.delete(socket));
+		socket.resume();
+	});
+	const port = await listen(server);
+	const controller = new AbortController();
+	const capture = capturePairFingerprint("127.0.0.1", port, { timeoutMs: 500, signal: controller.signal });
+	controller.abort();
+
+	await expect(capture).rejects.toThrow("cancelled");
+	await vi.waitFor(() => expect(sockets.size).toBe(0));
+});

--- a/frontend/src/main/paired-machine-probe.ts
+++ b/frontend/src/main/paired-machine-probe.ts
@@ -1,0 +1,109 @@
+import { isIP } from "node:net";
+import { connect, type TLSSocket } from "node:tls";
+import { computePairFingerprint } from "./paired-machine-cert";
+
+export type PairFingerprintProbeOptions = {
+	timeoutMs: number;
+	signal?: AbortSignal;
+};
+
+export type PairFingerprintProbe = (
+	address: string,
+	port: number,
+	options: PairFingerprintProbeOptions,
+) => Promise<string>;
+
+/**
+ * Canonical hostname shared by the raw TLS probe and Electron's certificate
+ * verifier. URL.hostname includes brackets around IPv6 literals in Node, while
+ * pairing records store them bare; returning the bare form keeps both paths on
+ * one key. URL parsing also lower-cases DNS names for us.
+ */
+export function canonicalPairHost(address: string): string | null {
+	const trimmed = address.trim();
+	if (!trimmed) return null;
+	const unbracketed = trimmed.startsWith("[") && trimmed.endsWith("]") ? trimmed.slice(1, -1) : trimmed;
+	const candidate = isIP(unbracketed) === 6 ? `[${unbracketed}]` : unbracketed;
+	try {
+		const url = new URL(`https://${candidate}`);
+		if (url.username || url.password || url.port || url.pathname !== "/" || url.search || url.hash) return null;
+		const hostname = url.hostname;
+		return hostname.startsWith("[") && hostname.endsWith("]")
+			? hostname.slice(1, -1).toLowerCase()
+			: hostname.toLowerCase();
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Capture the leaf certificate presented by a pair-mode gateway without
+ * issuing an HTTP request or involving Chromium's network stack. The socket is
+ * intentionally allowed to complete a handshake with a self-signed peer only
+ * long enough to read its certificate; no application data or credentials are
+ * sent, and the caller still has to compare and explicitly pin the returned
+ * fingerprint before normal Electron traffic can be accepted.
+ */
+export const capturePairFingerprint: PairFingerprintProbe = (address, port, options) => {
+	const host = canonicalPairHost(address);
+	if (!host) return Promise.reject(new Error(`Not a usable address: ${address}`));
+	if (!Number.isInteger(port) || port < 1 || port > 65535) {
+		return Promise.reject(new Error(`Not a valid port: ${port}`));
+	}
+	if (!Number.isFinite(options.timeoutMs) || options.timeoutMs <= 0) {
+		return Promise.reject(new Error("Pairing probe timeout must be positive."));
+	}
+	if (options.signal?.aborted) return Promise.reject(new Error("Pairing probe was cancelled."));
+
+	return new Promise<string>((resolve, reject) => {
+		let settled = false;
+		let socket: TLSSocket;
+		let timer: ReturnType<typeof setTimeout> | undefined;
+
+		const finish = (settle: () => void) => {
+			if (settled) return;
+			settled = true;
+			clearTimeout(timer);
+			options.signal?.removeEventListener("abort", onAbort);
+			socket.removeListener("secureConnect", onSecureConnect);
+			socket.removeListener("error", onError);
+			socket.destroy();
+			settle();
+		};
+		const onAbort = () => finish(() => reject(new Error("Pairing probe was cancelled.")));
+		const onError = (err: Error) => finish(() => reject(err));
+		const onSecureConnect = () => {
+			const certificate = socket.getPeerCertificate();
+			if (!certificate.raw) {
+				finish(() => reject(new Error("The peer did not present a certificate.")));
+				return;
+			}
+			let fingerprint: string;
+			try {
+				fingerprint = computePairFingerprint(certificate.raw);
+			} catch (err) {
+				finish(() => reject(err));
+				return;
+			}
+			finish(() => resolve(fingerprint));
+		};
+
+		socket = connect({
+			host,
+			port,
+			rejectUnauthorized: false,
+			...(isIP(host) === 0 ? { servername: host } : {}),
+		});
+		socket.once("secureConnect", onSecureConnect);
+		socket.once("error", onError);
+		options.signal?.addEventListener("abort", onAbort, { once: true });
+		if (options.signal?.aborted) {
+			onAbort();
+			return;
+		}
+		timer = setTimeout(
+			() => finish(() => reject(new Error(`Pairing probe timed out after ${Math.round(options.timeoutMs / 1000)}s.`))),
+			options.timeoutMs,
+		);
+	});
+};

--- a/frontend/src/main/paired-machines.test.ts
+++ b/frontend/src/main/paired-machines.test.ts
@@ -127,6 +127,29 @@ test("probing an unreachable address reports an error, not a fingerprint", async
 	expect(result).toEqual({ error: expect.stringContaining("No certificate could be retrieved") });
 });
 
+test("probe misses notify the caller so the next attempt can use a fresh session", async () => {
+	const onProbeMiss = vi.fn();
+	const machines = createPairedMachinesController({ stateDir, safeStorage, netFetch: unreachableFetch, onProbeMiss, probeTimeoutMs: 200 });
+	await machines.load();
+
+	await machines.probeFingerprint("192.168.1.9", 8443);
+
+	expect(onProbeMiss).toHaveBeenCalledExactlyOnceWith("192.168.1.9");
+});
+
+test("successful fingerprint probes do not rotate the probe session", async () => {
+	let verify: PairCertificateVerifyProc | undefined;
+	const onProbeMiss = vi.fn();
+	const netFetch = netFetchPresenting(CERT_PEM, (request, callback) => verify?.(request, callback));
+	const machines = createPairedMachinesController({ stateDir, safeStorage, netFetch, onProbeMiss, probeTimeoutMs: 200 });
+	verify = machines.verifyCertificate;
+	await machines.load();
+
+	await machines.probeFingerprint("192.168.1.5", 8443);
+
+	expect(onProbeMiss).not.toHaveBeenCalled();
+});
+
 /**
  * Regression coverage for #114: a paired machine reading as unreachable
  * until the app restarts, even though the pin and the box are both fine.

--- a/frontend/src/main/paired-machines.test.ts
+++ b/frontend/src/main/paired-machines.test.ts
@@ -128,26 +128,13 @@ test("probing an unreachable address reports an error, not a fingerprint", async
 });
 
 test("probe misses notify the caller so the next attempt can use a fresh session", async () => {
-	const onProbeMiss = vi.fn();
-	const machines = createPairedMachinesController({ stateDir, safeStorage, netFetch: unreachableFetch, onProbeMiss, probeTimeoutMs: 200 });
+	const onProbeComplete = vi.fn();
+	const machines = createPairedMachinesController({ stateDir, safeStorage, netFetch: unreachableFetch, onProbeComplete, probeTimeoutMs: 200 });
 	await machines.load();
 
 	await machines.probeFingerprint("192.168.1.9", 8443);
 
-	expect(onProbeMiss).toHaveBeenCalledExactlyOnceWith("192.168.1.9");
-});
-
-test("successful fingerprint probes do not rotate the probe session", async () => {
-	let verify: PairCertificateVerifyProc | undefined;
-	const onProbeMiss = vi.fn();
-	const netFetch = netFetchPresenting(CERT_PEM, (request, callback) => verify?.(request, callback));
-	const machines = createPairedMachinesController({ stateDir, safeStorage, netFetch, onProbeMiss, probeTimeoutMs: 200 });
-	verify = machines.verifyCertificate;
-	await machines.load();
-
-	await machines.probeFingerprint("192.168.1.5", 8443);
-
-	expect(onProbeMiss).not.toHaveBeenCalled();
+	expect(onProbeComplete).toHaveBeenCalledExactlyOnceWith("192.168.1.9");
 });
 
 /**
@@ -177,6 +164,31 @@ function sessionLikeFetch(cache: Map<string, boolean>, verify: PairCertificateVe
 		throw new Error("certificate verification failed");
 	}) as unknown as typeof fetch;
 }
+
+test("a successful fingerprint probe rotates the poisoned session before retry", async () => {
+	let verify: PairCertificateVerifyProc | undefined;
+	let generation = 0;
+	const caches = [new Map<string, boolean>(), new Map<string, boolean>()];
+	const probeNetFetch = ((input: string | URL | Request, init?: RequestInit) => {
+		const fetchFromSession = sessionLikeFetch(caches[generation], (request, callback) => verify?.(request, callback), CERT_PEM);
+		return fetchFromSession(input, init);
+	}) as typeof fetch;
+	const machines = createPairedMachinesController({
+		stateDir,
+		safeStorage,
+		probeNetFetch,
+		onProbeComplete: () => {
+			generation += 1;
+		},
+		probeTimeoutMs: 200,
+	});
+	verify = machines.verifyCertificate;
+	await machines.load();
+
+	expect(await machines.probeFingerprint("192.168.1.5", 8443)).toEqual({ fingerprint: CERT_FINGERPRINT });
+	expect(await machines.probeFingerprint("192.168.1.5", 8443)).toEqual({ fingerprint: CERT_FINGERPRINT });
+	expect(generation).toBe(2);
+});
 
 test("without a dedicated probe session, the pairing probe's rejection wedges refresh() offline after add() (reproduces #114)", async () => {
 	// probeNetFetch omitted: probeFingerprint falls back to sharing netFetch's

--- a/frontend/src/main/paired-machines.test.ts
+++ b/frontend/src/main/paired-machines.test.ts
@@ -4,7 +4,6 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, expect, test, vi } from "vitest";
 import type { SafeStorageLike } from "./paired-machines";
-import type { PairCertificateVerifyProc } from "./paired-machine-cert";
 import { AO_PAIRED_MACHINES_FILE_NAME, createPairedMachinesController } from "./paired-machines";
 
 // Same fixture certificate and fingerprint as paired-machine-cert.test.ts.
@@ -36,25 +35,6 @@ const safeStorage: SafeStorageLike = {
 	encryptString: (plain) => Buffer.from(`enc:${plain}`, "utf8"),
 	decryptString: (cipher) => cipher.toString("utf8").replace(/^enc:/, ""),
 };
-
-/**
- * Stands in for Electron's net.fetch: runs the same certificate through the
- * controller's own verifyCertificate, exactly as Chromium's network service
- * would during a real TLS handshake, then resolves or rejects the way a real
- * fetch would given that verdict. This is what lets probeFingerprint and the
- * pin-enforcement paths be exercised without a real network stack.
- */
-function netFetchPresenting(pem: string, verify: PairCertificateVerifyProc): typeof fetch {
-	return (async (input: string | URL | Request) => {
-		const url = new URL(String(input));
-		let verdict: number | undefined;
-		verify({ hostname: url.hostname, certificate: { data: pem } }, (result) => {
-			verdict = result;
-		});
-		if (verdict === 0) return new Response("ok", { status: 200 });
-		throw new Error("certificate verification failed");
-	}) as unknown as typeof fetch;
-}
 
 /** A box that never answers at all: no TLS handshake, nothing presented. */
 const unreachableFetch: typeof fetch = (async () => {
@@ -102,106 +82,71 @@ test("starts empty", async () => {
 });
 
 test("probing a box with no pin yet captures the presented fingerprint without pairing it", async () => {
-	// netFetch must run the SAME controller's verifyCertificate that
-	// probeFingerprint marks the host pending on, exactly as Electron's
-	// network service and session.setCertificateVerifyProc share one session
-	// in the real app. The indirection here only exists because the
-	// controller and its netFetch dependency would otherwise be a
-	// construction cycle.
-	let verify: PairCertificateVerifyProc | undefined;
-	const netFetch = netFetchPresenting(CERT_PEM, (request, callback) => verify?.(request, callback));
-	const machines = createPairedMachinesController({ stateDir, safeStorage, netFetch, probeTimeoutMs: 200 });
-	verify = machines.verifyCertificate;
+	const fingerprintProbe = vi.fn(async () => CERT_FINGERPRINT);
+	const machines = createPairedMachinesController({ stateDir, safeStorage, fingerprintProbe, probeTimeoutMs: 200 });
 	await machines.load();
 
 	const result = await machines.probeFingerprint("192.168.1.5", 8443);
 	expect(result).toEqual({ fingerprint: CERT_FINGERPRINT });
+	expect(fingerprintProbe).toHaveBeenCalledExactlyOnceWith("192.168.1.5", 8443, { timeoutMs: 200 });
 	// Nothing was pinned by the probe alone.
 	expect(machines.list()).toEqual([]);
 });
 
 test("probing an unreachable address reports an error, not a fingerprint", async () => {
-	const machines = controller(unreachableFetch);
+	const fingerprintProbe = vi.fn(async () => Promise.reject(new Error("connect ECONNREFUSED")));
+	const machines = createPairedMachinesController({ stateDir, safeStorage, fingerprintProbe, probeTimeoutMs: 200 });
 	await machines.load();
 	const result = await machines.probeFingerprint("192.168.1.9", 8443);
 	expect(result).toEqual({ error: expect.stringContaining("No certificate could be retrieved") });
 });
 
-test("probe misses notify the caller so the next attempt can use a fresh session", async () => {
-	const onProbeComplete = vi.fn();
-	const machines = createPairedMachinesController({ stateDir, safeStorage, netFetch: unreachableFetch, onProbeComplete, probeTimeoutMs: 200 });
+test("a retry after either a miss or a successful capture runs a fresh stateless probe", async () => {
+	const fingerprintProbe = vi
+		.fn()
+		.mockRejectedValueOnce(new Error("connect ECONNREFUSED"))
+		.mockResolvedValueOnce(CERT_FINGERPRINT)
+		.mockResolvedValueOnce(CERT_FINGERPRINT);
+	const machines = createPairedMachinesController({ stateDir, safeStorage, fingerprintProbe, probeTimeoutMs: 200 });
 	await machines.load();
 
-	await machines.probeFingerprint("192.168.1.9", 8443);
-
-	expect(onProbeComplete).toHaveBeenCalledExactlyOnceWith("192.168.1.9");
+	expect(await machines.probeFingerprint("192.168.1.5", 8443)).toEqual({ error: expect.any(String) });
+	expect(await machines.probeFingerprint("192.168.1.5", 8443)).toEqual({ fingerprint: CERT_FINGERPRINT });
+	expect(await machines.probeFingerprint("192.168.1.5", 8443)).toEqual({ fingerprint: CERT_FINGERPRINT });
+	expect(fingerprintProbe).toHaveBeenCalledTimes(3);
 });
 
-/**
- * Regression coverage for #114: a paired machine reading as unreachable
- * until the app restarts, even though the pin and the box are both fine.
- *
- * Stands in for Chromium's per-session certificate-error cache, the
- * mechanism the issue's root-cause analysis points at: once a session denies
- * a host's certificate, that session short-circuits every later connection
- * to the same host straight to a transport failure, without invoking
- * `session.setCertificateVerifyProc` again. `cache` is what makes two
- * `typeof fetch` stand-ins here behave like two different Electron sessions
- * (a shared `cache` Map = the same session; separate Maps = separate
- * sessions), the same distinction `netFetch` vs. `probeNetFetch` draws in
- * paired-machines.ts.
- */
-function sessionLikeFetch(cache: Map<string, boolean>, verify: PairCertificateVerifyProc, pem: string): typeof fetch {
-	return (async (input: string | URL | Request) => {
-		const url = new URL(String(input));
-		if (cache.get(url.hostname)) throw new Error("certificate verification failed (cached)");
-		let verdict: number | undefined;
-		verify({ hostname: url.hostname, certificate: { data: pem } }, (result) => {
-			verdict = result;
-		});
-		if (verdict === 0) return new Response(JSON.stringify({ ok: true, failures: 0, checks: [] }), { status: 200 });
-		cache.set(url.hostname, true);
-		throw new Error("certificate verification failed");
-	}) as unknown as typeof fetch;
-}
-
-test("a successful fingerprint probe rotates the poisoned session before retry", async () => {
-	let verify: PairCertificateVerifyProc | undefined;
-	let generation = 0;
-	const caches = [new Map<string, boolean>(), new Map<string, boolean>()];
-	const probeNetFetch = ((input: string | URL | Request, init?: RequestInit) => {
-		const fetchFromSession = sessionLikeFetch(caches[generation], (request, callback) => verify?.(request, callback), CERT_PEM);
-		return fetchFromSession(input, init);
-	}) as typeof fetch;
+test("concurrent probes return their own result without stale shared capture state", async () => {
+	const resolvers = new Map<string, (fingerprint: string) => void>();
+	const fingerprintProbe = vi.fn(
+		(address: string) => new Promise<string>((resolve) => resolvers.set(address, resolve)),
+	);
 	const machines = createPairedMachinesController({
 		stateDir,
 		safeStorage,
-		probeNetFetch,
-		onProbeComplete: () => {
-			generation += 1;
-		},
+		fingerprintProbe,
 		probeTimeoutMs: 200,
 	});
-	verify = machines.verifyCertificate;
 	await machines.load();
 
-	expect(await machines.probeFingerprint("192.168.1.5", 8443)).toEqual({ fingerprint: CERT_FINGERPRINT });
-	expect(await machines.probeFingerprint("192.168.1.5", 8443)).toEqual({ fingerprint: CERT_FINGERPRINT });
-	expect(generation).toBe(2);
+	const first = machines.probeFingerprint("192.168.1.5", 8443);
+	const second = machines.probeFingerprint("192.168.1.6", 8443);
+	resolvers.get("192.168.1.6")?.("second");
+	resolvers.get("192.168.1.5")?.("first");
+
+	await expect(first).resolves.toEqual({ fingerprint: "first" });
+	await expect(second).resolves.toEqual({ fingerprint: "second" });
 });
 
-test("without a dedicated probe session, the pairing probe's rejection wedges refresh() offline after add() (reproduces #114)", async () => {
-	// probeNetFetch omitted: probeFingerprint falls back to sharing netFetch's
-	// session, exactly the pre-fix wiring in main.ts (both bound to
-	// session.defaultSession).
-	let verify: PairCertificateVerifyProc | undefined;
-	const sharedCache = new Map<string, boolean>();
-	const netFetch = sessionLikeFetch(sharedCache, (request, callback) => verify?.(request, callback), CERT_PEM);
-	const machines = createPairedMachinesController({ stateDir, safeStorage, netFetch, probeTimeoutMs: 200 });
-	verify = machines.verifyCertificate;
+test("fingerprint capture never touches the Electron fetch used by pinned traffic", async () => {
+	const { fetchImpl } = doctorFetch("abc123XY");
+	const netFetch = vi.fn(fetchImpl);
+	const fingerprintProbe = vi.fn(async () => CERT_FINGERPRINT);
+	const machines = createPairedMachinesController({ stateDir, safeStorage, netFetch, fingerprintProbe, probeTimeoutMs: 200 });
 	await machines.load();
 
 	await machines.probeFingerprint("192.168.1.5", 8443);
+	expect(netFetch).not.toHaveBeenCalled();
 	await machines.add({
 		id: "box_1",
 		name: "Pi",
@@ -211,39 +156,9 @@ test("without a dedicated probe session, the pairing probe's rejection wedges re
 		fingerprint: CERT_FINGERPRINT,
 	});
 
-	// The pin is correct and the box is healthy, but the shared session's
-	// cached rejection from the probe short-circuits every connection after
-	// it, so the doctor probe never even reaches verifyCertificate again.
-	const refreshed = await machines.refresh();
-	expect(refreshed[0]).toMatchObject({ reachability: "offline", lastSeen: null });
-});
-
-test("a dedicated probe session keeps the pairing probe's rejection from wedging refresh() after add() (the #114 fix)", async () => {
-	let verify: PairCertificateVerifyProc | undefined;
-	const netCache = new Map<string, boolean>();
-	const probeCache = new Map<string, boolean>();
-	const netFetch = sessionLikeFetch(netCache, (request, callback) => verify?.(request, callback), CERT_PEM);
-	const probeNetFetch = sessionLikeFetch(probeCache, (request, callback) => verify?.(request, callback), CERT_PEM);
-	const machines = createPairedMachinesController({ stateDir, safeStorage, netFetch, probeNetFetch, probeTimeoutMs: 200 });
-	verify = machines.verifyCertificate;
-	await machines.load();
-
-	await machines.probeFingerprint("192.168.1.5", 8443);
-	await machines.add({
-		id: "box_1",
-		name: "Pi",
-		address: "192.168.1.5",
-		port: 8443,
-		passcode: "abc123XY",
-		fingerprint: CERT_FINGERPRINT,
-	});
-
-	// The probe's rejection only poisoned probeCache. netFetch's session sees
-	// this host for the first time here, verifyCertificate is consulted, and
-	// the now-pinned fingerprint matches.
 	const refreshed = await machines.refresh();
 	expect(refreshed[0]).toMatchObject({ reachability: "online" });
-	expect(refreshed[0].lastSeen).not.toBeNull();
+	expect(netFetch).toHaveBeenCalledOnce();
 });
 
 test("add persists the pairing and round-trips through disk", async () => {
@@ -328,6 +243,23 @@ test("after pairing, the pin is enforced: the same certificate is accepted", asy
 
 	const callback = vi.fn();
 	machines.verifyCertificate({ hostname: "192.168.1.5", certificate: { data: CERT_PEM } }, callback);
+	expect(callback).toHaveBeenCalledExactlyOnceWith(0);
+});
+
+test("a bare IPv6 pairing address matches Electron's bracketed certificate hostname", async () => {
+	const machines = controller();
+	await machines.load();
+	await machines.add({
+		id: "box_ipv6",
+		name: "IPv6 box",
+		address: "2001:db8::1",
+		port: 8443,
+		passcode: "abc123XY",
+		fingerprint: CERT_FINGERPRINT,
+	});
+
+	const callback = vi.fn();
+	machines.verifyCertificate({ hostname: "[2001:0DB8:0:0:0:0:0:1]", certificate: { data: CERT_PEM } }, callback);
 	expect(callback).toHaveBeenCalledExactlyOnceWith(0);
 });
 

--- a/frontend/src/main/paired-machines.test.ts
+++ b/frontend/src/main/paired-machines.test.ts
@@ -88,7 +88,10 @@ test("probing a box with no pin yet captures the presented fingerprint without p
 
 	const result = await machines.probeFingerprint("192.168.1.5", 8443);
 	expect(result).toEqual({ fingerprint: CERT_FINGERPRINT });
-	expect(fingerprintProbe).toHaveBeenCalledExactlyOnceWith("192.168.1.5", 8443, { timeoutMs: 200 });
+	expect(fingerprintProbe).toHaveBeenCalledExactlyOnceWith("192.168.1.5", 8443, {
+		timeoutMs: 200,
+		signal: expect.any(AbortSignal),
+	});
 	// Nothing was pinned by the probe alone.
 	expect(machines.list()).toEqual([]);
 });
@@ -136,6 +139,47 @@ test("concurrent probes return their own result without stale shared capture sta
 
 	await expect(first).resolves.toEqual({ fingerprint: "first" });
 	await expect(second).resolves.toEqual({ fingerprint: "second" });
+});
+
+test("cancelling a probe aborts the in-flight TLS capture", async () => {
+	let observedSignal: AbortSignal | undefined;
+	const fingerprintProbe = vi.fn(
+		(_address: string, _port: number, options: { timeoutMs: number; signal?: AbortSignal }) =>
+			new Promise<string>((_resolve, reject) => {
+				observedSignal = options.signal;
+				options.signal?.addEventListener("abort", () => reject(new Error("cancelled")), { once: true });
+			}),
+	);
+	const machines = createPairedMachinesController({ stateDir, safeStorage, fingerprintProbe, probeTimeoutMs: 200 });
+	await machines.load();
+
+	const result = machines.probeFingerprint("192.168.1.5", 8443, "probe-1");
+	machines.cancelFingerprintProbe("probe-1");
+
+	expect(observedSignal?.aborted).toBe(true);
+	await expect(result).resolves.toEqual({ error: expect.stringContaining("No certificate") });
+});
+
+test("limits aggregate in-flight fingerprint probes", async () => {
+	const fingerprintProbe = vi.fn(
+		(_address: string, _port: number, options: { timeoutMs: number; signal?: AbortSignal }) =>
+			new Promise<string>((_resolve, reject) => {
+				options.signal?.addEventListener("abort", () => reject(new Error("cancelled")), { once: true });
+			}),
+	);
+	const machines = createPairedMachinesController({ stateDir, safeStorage, fingerprintProbe, probeTimeoutMs: 200 });
+	await machines.load();
+
+	const active = Array.from({ length: 8 }, (_, index) =>
+		machines.probeFingerprint(`192.168.1.${index + 1}`, 8443, `probe-${index}`),
+	);
+	await expect(machines.probeFingerprint("192.168.1.99", 8443, "probe-overflow")).resolves.toEqual({
+		error: expect.stringContaining("Too many pairing probes"),
+	});
+	expect(fingerprintProbe).toHaveBeenCalledTimes(8);
+
+	for (let index = 0; index < 8; index++) machines.cancelFingerprintProbe(`probe-${index}`);
+	await Promise.all(active);
 });
 
 test("fingerprint capture never touches the Electron fetch used by pinned traffic", async () => {

--- a/frontend/src/main/paired-machines.ts
+++ b/frontend/src/main/paired-machines.ts
@@ -15,6 +15,11 @@ export type SafeStorageLike = {
 	decryptString: (encrypted: Buffer) => string;
 };
 import { createPairCertificateVerifyProc, type PairCertificateVerifyProc } from "./paired-machine-cert";
+import {
+	canonicalPairHost,
+	capturePairFingerprint,
+	type PairFingerprintProbe,
+} from "./paired-machine-probe";
 import { fetchWithDeadline } from "./request-deadline";
 
 /**
@@ -40,9 +45,8 @@ export const AO_PAIRED_MACHINES_FILE_NAME = "ao-paired-machines.json";
 
 const SCHEMA_VERSION = 2;
 
-/** A probe attempt is denied by design (see paired-machine-cert.ts); this just
- * bounds how long the app waits for the TLS handshake that captures the
- * presented fingerprint before giving up. */
+/** Bounds how long the app waits for the TLS handshake that presents the
+ * candidate box's certificate. */
 const DEFAULT_PROBE_TIMEOUT_MS = 8000;
 
 export type PairedMachineRecord = {
@@ -87,25 +91,10 @@ export type PairedMachinesControllerDeps = {
 	 * (`refresh`'s doctor probe) against a host that is expected to already be
 	 * pinned. */
 	netFetch?: typeof fetch;
-	/**
-	 * Electron's `net.fetch` bound to a throwaway session, used only by
-	 * `probeFingerprint`. `probeFingerprint`'s whole point is a connection that
-	 * is *always* denied at the TLS layer (see paired-machine-cert.ts: an
-	 * unpinned host has no accept path), and Chromium caches that per-host
-	 * certificate-error verdict at the network-service level for the life of
-	 * the session -- below where `verifyCertificate` runs, so the verify proc
-	 * is not even re-consulted once the cache is warm. If the capture probe
-	 * shared `netFetch`'s session, pinning the host in `add()` would not undo
-	 * that cached rejection: the very next request against the pinned host
-	 * would still be short-circuited to a failure, reading as "unreachable"
-	 * until the app restarts and the cache is gone. Routing the capture probe
-	 * through a session that is discarded afterward, instead of the one real
-	 * traffic uses, means the poisoned verdict dies with it. Defaults to
-	 * `netFetch` when omitted (tests construct one shared fetch and do not
-	 * exercise this failure mode).
-	 */
-	probeNetFetch?: typeof fetch;
-	onProbeComplete?: (address: string) => void;
+	/** Raw TLS certificate capture, injectable so controller tests do not open
+	 * sockets. The production implementation never enters Chromium's network
+	 * stack, so probing cannot poison the session used by paired traffic. */
+	fingerprintProbe?: PairFingerprintProbe;
 	probeTimeoutMs?: number;
 };
 
@@ -171,12 +160,10 @@ export type PairedMachinesController = {
 	/**
 	 * Attempt a connection to an address:port that is not (yet) a registered
 	 * paired machine, so the pairing flow can show the presented fingerprint
-	 * for comparison against what the box printed. The connection is always
-	 * denied at the TLS layer (see paired-machine-cert.ts): this only ever
-	 * captures what was presented, it never trusts it. Runs over
-	 * `probeNetFetch`, not `netFetch`: see that dep's doc comment for why the
-	 * always-denied capture connection must not share a session with real
-	 * traffic to a pinned host.
+	 * for comparison against what the box printed. This opens a raw TLS socket,
+	 * reads the leaf certificate, and closes it without sending HTTP or
+	 * credentials. The result is not trusted until `add()` pins the value the
+	 * user accepted.
 	 */
 	probeFingerprint: (address: string, port: number) => Promise<PairFingerprintResult>;
 	/**
@@ -336,7 +323,7 @@ function toAoMachine(
 
 export function createPairedMachinesController(deps: PairedMachinesControllerDeps): PairedMachinesController {
 	const netFetch = deps.netFetch ?? fetch;
-	const probeNetFetch = deps.probeNetFetch ?? netFetch;
+	const fingerprintProbe = deps.fingerprintProbe ?? capturePairFingerprint;
 	const probeTimeoutMs = deps.probeTimeoutMs ?? DEFAULT_PROBE_TIMEOUT_MS;
 
 	/** In-memory mirror of disk, keyed by id. verifyCertificate reads only the
@@ -346,14 +333,6 @@ export function createPairedMachinesController(deps: PairedMachinesControllerDep
 	/** hostname -> pinned fingerprint, for every record that has one. Rebuilt
 	 * whenever `records` changes. */
 	let pinnedByHost = new Map<string, string>();
-	/** Hosts currently mid-probe for first-time pairing: not yet in `records`,
-	 * but connections to them must still be intercepted so the presented
-	 * fingerprint can be captured instead of falling through to default
-	 * verification (which would fail anyway, and would capture nothing). */
-	const pendingHosts = new Set<string>();
-	/** Latest fingerprint actually presented per hostname, for any host
-	 * `isPairHost` recognises. What `probeFingerprint` reads back. */
-	const presented = new Map<string, string>();
 	/** Reachability and harness readiness from the last `refresh()`, by machine
 	 * id. Ephemeral like ao-machines.ts's own reachability: never persisted,
 	 * defaults to "unknown" for a machine that has never been probed. */
@@ -364,7 +343,8 @@ export function createPairedMachinesController(deps: PairedMachinesControllerDep
 		pinnedByHost = new Map(
 			[...records.values()]
 				.filter((record) => record.pinnedFingerprint)
-				.map((record) => [record.address, record.pinnedFingerprint as string]),
+				.map((record) => [canonicalPairHost(record.address), record.pinnedFingerprint as string])
+				.filter((entry): entry is [string, string] => entry[0] !== null),
 		);
 	}
 
@@ -420,9 +400,10 @@ export function createPairedMachinesController(deps: PairedMachinesControllerDep
 	}
 
 	const verifyCertificate = createPairCertificateVerifyProc({
-		isPairHost: (hostname) => pendingHosts.has(hostname) || pinnedByHost.has(hostname),
-		getPinnedFingerprint: (hostname) => pinnedByHost.get(hostname) ?? null,
-		onPresented: (hostname, fingerprint) => presented.set(hostname, fingerprint),
+		getPinnedFingerprint: (hostname) => {
+			const canonical = canonicalPairHost(hostname);
+			return canonical ? (pinnedByHost.get(canonical) ?? null) : null;
+		},
 	});
 
 	function list(): AoMachine[] {
@@ -571,24 +552,11 @@ export function createPairedMachinesController(deps: PairedMachinesControllerDep
 			const baseUrl = baseUrlFor(address, port);
 			if (!baseUrl) return { error: `Not a usable address: ${address}` };
 
-			presented.delete(address);
-			pendingHosts.add(address);
 			try {
-				await fetchWithDeadline(probeNetFetch, `${baseUrl}/`, { method: "GET", redirect: "manual" }, probeTimeoutMs, "Pairing probe");
+				return { fingerprint: await fingerprintProbe(address, port, { timeoutMs: probeTimeoutMs }) };
 			} catch {
-				// Expected: an unpinned host is always denied at the TLS layer (see
-				// paired-machine-cert.ts), and a box that is simply unreachable denies
-				// nothing to capture at all. Either way, the fingerprint map below is
-				// the source of truth for whether anything was actually presented.
-			} finally {
-				pendingHosts.delete(address);
+				return { error: "No certificate could be retrieved from that address. Check the address, port, and that the box is reachable." };
 			}
-
-			const fingerprint = presented.get(address);
-			deps.onProbeComplete?.(address);
-			return fingerprint
-				? { fingerprint }
-				: { error: "No certificate could be retrieved from that address. Check the address, port, and that the box is reachable." };
 		},
 
 		getPinnedFingerprint(id: string): string | null {

--- a/frontend/src/main/paired-machines.ts
+++ b/frontend/src/main/paired-machines.ts
@@ -105,7 +105,7 @@ export type PairedMachinesControllerDeps = {
 	 * exercise this failure mode).
 	 */
 	probeNetFetch?: typeof fetch;
-	onProbeMiss?: (address: string) => void;
+	onProbeComplete?: (address: string) => void;
 	probeTimeoutMs?: number;
 };
 
@@ -585,7 +585,7 @@ export function createPairedMachinesController(deps: PairedMachinesControllerDep
 			}
 
 			const fingerprint = presented.get(address);
-			if (!fingerprint) deps.onProbeMiss?.(address);
+			deps.onProbeComplete?.(address);
 			return fingerprint
 				? { fingerprint }
 				: { error: "No certificate could be retrieved from that address. Check the address, port, and that the box is reachable." };

--- a/frontend/src/main/paired-machines.ts
+++ b/frontend/src/main/paired-machines.ts
@@ -48,6 +48,7 @@ const SCHEMA_VERSION = 2;
 /** Bounds how long the app waits for the TLS handshake that presents the
  * candidate box's certificate. */
 const DEFAULT_PROBE_TIMEOUT_MS = 8000;
+const MAX_ACTIVE_FINGERPRINT_PROBES = 8;
 
 export type PairedMachineRecord = {
 	id: string;
@@ -165,7 +166,9 @@ export type PairedMachinesController = {
 	 * credentials. The result is not trusted until `add()` pins the value the
 	 * user accepted.
 	 */
-	probeFingerprint: (address: string, port: number) => Promise<PairFingerprintResult>;
+	probeFingerprint: (address: string, port: number, requestId?: string) => Promise<PairFingerprintResult>;
+	/** Cancel one in-flight probe by the renderer-generated request id. */
+	cancelFingerprintProbe: (requestId: string) => void;
 	/**
 	 * The fingerprint currently pinned for a registered machine id, or null if
 	 * that id is not registered or has no pin yet. Read-only, synchronous off
@@ -338,6 +341,7 @@ export function createPairedMachinesController(deps: PairedMachinesControllerDep
 	 * defaults to "unknown" for a machine that has never been probed. */
 	let reachabilityById = new Map<string, AoMachineReachability>();
 	let harnessById = new Map<string, HarnessReadiness>();
+	const activeFingerprintProbes = new Map<string, AbortController>();
 
 	function rebuildPinnedByHost(): void {
 		pinnedByHost = new Map(
@@ -547,16 +551,29 @@ export function createPairedMachinesController(deps: PairedMachinesControllerDep
 			}
 		},
 
-		async probeFingerprint(address: string, port: number): Promise<PairFingerprintResult> {
+		async probeFingerprint(address: string, port: number, requestId?: string): Promise<PairFingerprintResult> {
 			if (!validatePort(port)) return { error: `Not a valid port: ${port}` };
 			const baseUrl = baseUrlFor(address, port);
 			if (!baseUrl) return { error: `Not a usable address: ${address}` };
+			if (activeFingerprintProbes.size >= MAX_ACTIVE_FINGERPRINT_PROBES) {
+				return { error: "Too many pairing probes are already running. Cancel an attempt or wait for it to finish." };
+			}
+			const probeId = requestId || randomBytes(16).toString("hex");
+			if (activeFingerprintProbes.has(probeId)) return { error: "This pairing probe is already running." };
+			const controller = new AbortController();
+			activeFingerprintProbes.set(probeId, controller);
 
 			try {
-				return { fingerprint: await fingerprintProbe(address, port, { timeoutMs: probeTimeoutMs }) };
+				return { fingerprint: await fingerprintProbe(address, port, { timeoutMs: probeTimeoutMs, signal: controller.signal }) };
 			} catch {
 				return { error: "No certificate could be retrieved from that address. Check the address, port, and that the box is reachable." };
+			} finally {
+				if (activeFingerprintProbes.get(probeId) === controller) activeFingerprintProbes.delete(probeId);
 			}
+		},
+
+		cancelFingerprintProbe(requestId: string): void {
+			activeFingerprintProbes.get(requestId)?.abort();
 		},
 
 		getPinnedFingerprint(id: string): string | null {

--- a/frontend/src/main/paired-machines.ts
+++ b/frontend/src/main/paired-machines.ts
@@ -105,6 +105,7 @@ export type PairedMachinesControllerDeps = {
 	 * exercise this failure mode).
 	 */
 	probeNetFetch?: typeof fetch;
+	onProbeMiss?: (address: string) => void;
 	probeTimeoutMs?: number;
 };
 
@@ -584,6 +585,7 @@ export function createPairedMachinesController(deps: PairedMachinesControllerDep
 			}
 
 			const fingerprint = presented.get(address);
+			if (!fingerprint) deps.onProbeMiss?.(address);
 			return fingerprint
 				? { fingerprint }
 				: { error: "No certificate could be retrieved from that address. Check the address, port, and that the box is reachable." };

--- a/frontend/src/preload.ts
+++ b/frontend/src/preload.ts
@@ -447,8 +447,10 @@ const api = {
 		// for comparison against what the box printed. The connection itself is
 		// always denied (trust-on-first-use never auto-accepts); this only ever
 		// reports what was seen, or an error when nothing was.
-		probeFingerprint: (address: string, port: number) =>
-			ipcRenderer.invoke("pairedMachines:probeFingerprint", address, port) as Promise<PairFingerprintResult>,
+		probeFingerprint: (address: string, port: number, requestId?: string) =>
+			ipcRenderer.invoke("pairedMachines:probeFingerprint", address, port, requestId) as Promise<PairFingerprintResult>,
+		cancelFingerprintProbe: (requestId: string) =>
+			ipcRenderer.send("pairedMachines:cancelFingerprintProbe", requestId),
 		// The fingerprint already pinned for a machine id, or null. Read-only:
 		// what the add-machine flow compares a fresh probe against so it can tell
 		// a genuine re-pair from a fingerprint mismatch before offering anything

--- a/frontend/src/renderer/components/settings/AddPairedMachineDialog.test.tsx
+++ b/frontend/src/renderer/components/settings/AddPairedMachineDialog.test.tsx
@@ -5,8 +5,9 @@ import { useState } from "react";
 import { beforeEach, expect, test, vi } from "vitest";
 import { AddPairedMachineDialog } from "./AddPairedMachineDialog";
 
-const { probeFingerprint, getPinnedFingerprint, add, remove } = vi.hoisted(() => ({
+const { probeFingerprint, cancelFingerprintProbe, getPinnedFingerprint, add, remove } = vi.hoisted(() => ({
 	probeFingerprint: vi.fn(),
+	cancelFingerprintProbe: vi.fn(),
 	getPinnedFingerprint: vi.fn(),
 	add: vi.fn(),
 	remove: vi.fn(),
@@ -14,7 +15,7 @@ const { probeFingerprint, getPinnedFingerprint, add, remove } = vi.hoisted(() =>
 
 vi.mock("../../lib/bridge", () => ({
 	aoBridge: {
-		pairedMachines: { probeFingerprint, getPinnedFingerprint, add, list: vi.fn(), remove },
+		pairedMachines: { probeFingerprint, cancelFingerprintProbe, getPinnedFingerprint, add, list: vi.fn(), remove },
 	},
 }));
 
@@ -108,6 +109,7 @@ async function pasteString(pairString: string) {
 
 beforeEach(() => {
 	probeFingerprint.mockReset();
+	cancelFingerprintProbe.mockReset();
 	getPinnedFingerprint.mockReset().mockResolvedValue(null);
 	add.mockReset();
 	remove.mockReset().mockResolvedValue(undefined);
@@ -343,6 +345,7 @@ test("paste: dismissing the dialog mid-race cancels it, so a later winner is nev
 	// Cancel is no longer blocked while the race is in flight: dismissing here
 	// must cancel the race, not just hide the dialog around it.
 	await userEvent.click(screen.getByRole("button", { name: "Cancel" }));
+	expect(cancelFingerprintProbe).toHaveBeenCalledOnce();
 
 	// The probe that would have won only answers now, well after dismissal.
 	resolveWinner({ fingerprint: FINGERPRINT });

--- a/frontend/src/renderer/components/settings/AddPairedMachineDialog.tsx
+++ b/frontend/src/renderer/components/settings/AddPairedMachineDialog.tsx
@@ -161,6 +161,15 @@ export function AddPairedMachineDialog({ open, onOpenChange, onPaired }: AddPair
 		raceControllerRef.current?.abort();
 	};
 
+	const probePairAddress = (host: string, port: number, signal?: AbortSignal) => {
+		const requestId = crypto.randomUUID();
+		const cancel = () => aoBridge.pairedMachines.cancelFingerprintProbe(requestId);
+		signal?.addEventListener("abort", cancel, { once: true });
+		return aoBridge.pairedMachines
+			.probeFingerprint(host, port, requestId)
+			.finally(() => signal?.removeEventListener("abort", cancel));
+	};
+
 	useEffect(() => {
 		if (open) return;
 		cancelRace();
@@ -189,7 +198,7 @@ export function AddPairedMachineDialog({ open, onOpenChange, onPaired }: AddPair
 		mutationFn: async ({ parsed, signal }: { parsed: ParsedPairString; signal: AbortSignal }) => {
 			setStep("racing");
 			const wantFingerprint = toPinnedFingerprintFormat(parsed.fingerprintHex);
-			const outcome = await racePairAddresses(parsed.addrs, wantFingerprint, aoBridge.pairedMachines.probeFingerprint, { signal });
+			const outcome = await racePairAddresses(parsed.addrs, wantFingerprint, probePairAddress, { signal });
 			if (outcome.status !== "matched") return outcome;
 			// Belt-and-suspenders: racePairAddresses already treats a cancel as
 			// winning over a same-tick match internally, but re-checking this

--- a/frontend/src/renderer/lib/bridge.ts
+++ b/frontend/src/renderer/lib/bridge.ts
@@ -372,6 +372,7 @@ export const aoBridge: AoBridge =
         error:
           "Pairing needs the desktop app; it is not available in browser preview.",
       }),
+      cancelFingerprintProbe: () => undefined,
       getPinnedFingerprint: async () => null,
       add: async () => {
         throw new Error(

--- a/frontend/src/renderer/test/setup.ts
+++ b/frontend/src/renderer/test/setup.ts
@@ -308,6 +308,7 @@ if (typeof window !== "undefined") {
 			list: async () => [],
 			refresh: async () => [],
 			probeFingerprint: async () => ({ error: "not available in tests" }),
+			cancelFingerprintProbe: () => undefined,
 			getPinnedFingerprint: async () => null,
 			add: async () => {
 				throw new Error("not available in tests");

--- a/frontend/src/shared/pair-race.test.ts
+++ b/frontend/src/shared/pair-race.test.ts
@@ -179,4 +179,52 @@ describe("racePairAddresses", () => {
 		resolveWinner({ fingerprint: WANT });
 		await new Promise((r) => setTimeout(r, 10));
 	});
+
+	test("passes the race abort signal to every started probe", async () => {
+		const seenSignals: AbortSignal[] = [];
+		const probe: ProbeFn = (_host, _port, signal) =>
+			new Promise((_resolve, reject) => {
+				if (!signal) return reject(new Error("missing signal"));
+				seenSignals.push(signal);
+				signal.addEventListener("abort", () => reject(new Error("cancelled")), { once: true });
+			});
+		const controller = new AbortController();
+		const race = racePairAddresses(
+			[
+				{ host: "10.0.0.1", port: 8443 },
+				{ host: "10.0.0.2", port: 8443 },
+			],
+			WANT,
+			probe,
+			{ signal: controller.signal },
+		);
+		controller.abort();
+
+		await expect(race).resolves.toEqual({ status: "cancelled" });
+		expect(seenSignals).toHaveLength(2);
+		expect(seenSignals.every((signal) => signal.aborted)).toBe(true);
+	});
+
+	test("aborts losing probes as soon as another candidate wins", async () => {
+		let loserSignal: AbortSignal | undefined;
+		const probe: ProbeFn = (host, _port, signal) => {
+			if (host === "10.0.0.2") return Promise.resolve({ fingerprint: WANT });
+			loserSignal = signal;
+			return new Promise((_resolve, reject) => {
+				signal?.addEventListener("abort", () => reject(new Error("cancelled")), { once: true });
+			});
+		};
+
+		await expect(
+			racePairAddresses(
+				[
+					{ host: "10.0.0.1", port: 8443 },
+					{ host: "10.0.0.2", port: 8443 },
+				],
+				WANT,
+				probe,
+			),
+		).resolves.toEqual({ status: "matched", host: "10.0.0.2", port: 8443 });
+		expect(loserSignal?.aborted).toBe(true);
+	});
 });

--- a/frontend/src/shared/pair-race.ts
+++ b/frontend/src/shared/pair-race.ts
@@ -11,7 +11,7 @@
 
 import type { PairAddr } from "./pair-string";
 
-export type ProbeFn = (host: string, port: number) => Promise<{ fingerprint: string } | { error: string }>;
+export type ProbeFn = (host: string, port: number, signal?: AbortSignal) => Promise<{ fingerprint: string } | { error: string }>;
 
 export type RaceAttempt = { host: string; port: number; outcome: "mismatch" | "unreachable" };
 
@@ -30,9 +30,8 @@ export type RaceOptions = {
 	isPrivate?: (host: string) => boolean;
 	/** Abort the whole race in flight -- the dialog that started it was
 	 * dismissed, or the caller switched to manual entry. The race settles to
-	 * `{ status: "cancelled" }` the instant this fires, not on the next probe
-	 * to answer; every in-flight probe's eventual result is discarded by the
-	 * same `settled` guard that protects a normal win from a late loser. */
+	 * `{ status: "cancelled" }` the instant this fires and aborts every started
+	 * probe. The same cleanup also runs after a win or timeout. */
 	signal?: AbortSignal;
 };
 
@@ -80,9 +79,9 @@ export function isPrivateHost(host: string): boolean {
  * traffic on a LAN is not an attack. Resolves the instant one candidate
  * wins, every candidate is exhausted, `opts.signal` aborts, or `timeoutMs`
  * elapses, whichever comes first; a probe that answers after the race has
- * already settled -- a win, an exhaustion, or a cancellation -- is ignored,
- * so a slow loser can never double-resolve, overwrite a win, or complete a
- * pairing the caller already abandoned. */
+	 * already settled -- a win, an exhaustion, or a cancellation -- is aborted;
+	 * a non-cooperative late result is still ignored, so it cannot double-resolve,
+	 * overwrite a win, or complete a pairing the caller already abandoned. */
 export function racePairAddresses(addrs: PairAddr[], wantFingerprint: string, probe: ProbeFn, opts: RaceOptions = {}): Promise<RaceOutcome> {
 	const headStartMs = opts.headStartMs ?? DEFAULT_HEAD_START_MS;
 	const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
@@ -94,12 +93,14 @@ export function racePairAddresses(addrs: PairAddr[], wantFingerprint: string, pr
 		let pending = addrs.length;
 		const timers: ReturnType<typeof setTimeout>[] = [];
 		const signal = opts.signal;
+		const probeController = new AbortController();
 
 		const finish = (outcome: RaceOutcome) => {
 			if (settled) return;
 			settled = true;
 			for (const timer of timers) clearTimeout(timer);
 			if (signal) signal.removeEventListener("abort", onAbort);
+			probeController.abort();
 			resolve(outcome);
 		};
 
@@ -138,7 +139,7 @@ export function racePairAddresses(addrs: PairAddr[], wantFingerprint: string, pr
 
 		for (const addr of addrs) {
 			const start = () => {
-				probe(addr.host, addr.port)
+					probe(addr.host, addr.port, probeController.signal)
 					.then((result) => {
 						if (settled) return;
 						if ("fingerprint" in result && result.fingerprint === wantFingerprint) {


### PR DESCRIPTION
## Summary
- capture pair-mode leaf certificates over a short-lived raw TLS socket, outside Chromium
- remove generated Electron probe partitions and their process-lifetime growth
- canonicalize DNS, IPv4, and bracketed/bare IPv6 host keys for pin lookup
- keep Electron certificate verification focused on steady-state pinned traffic
- add real TLS regression coverage for retries, concurrency, timeout/abort cleanup, and host normalization

## Tests
- `npm exec vitest run src/main/paired-machine-probe.test.ts src/main/paired-machines.test.ts src/main/paired-machine-cert.test.ts`
- `npm run typecheck`
- `npm run typecheck:e2e`

## Notes
The capture socket sends no HTTP request or credentials. It reads the presented leaf certificate, computes the existing SHA-256 fingerprint format, and closes. The user must still compare and explicitly pin that fingerprint before Electron traffic can be accepted.