### PR TITLE
test: keep renderer API client mocks complete

### DIFF
--- a/frontend/src/renderer/__tests__/integration/board-empty-states.test.tsx
+++ b/frontend/src/renderer/__tests__/integration/board-empty-states.test.tsx
@@ -30,7 +30,7 @@ vi.mock("../../lib/api-client", () => ({
 	// folder picker. Loopback keeps these tests on the local-machine path, which
 	// is what the folder-picker assertions here already assume.
 	getApiBaseUrl: () => "http://127.0.0.1:3001",
-	subscribeApiBaseUrl: () => () => {},
+	subscribeApiBaseUrl: () => (() => {}),
 }));
 
 vi.mock("../../lib/bridge", () => ({

--- a/frontend/src/renderer/__tests__/integration/board-empty-states.test.tsx
+++ b/frontend/src/renderer/__tests__/integration/board-empty-states.test.tsx
@@ -21,7 +21,8 @@ vi.mock("../../lib/spawn-orchestrator", () => ({
 	spawnOrchestrator: spawnOrchestratorMock,
 }));
 
-vi.mock("../../lib/api-client", () => ({
+vi.mock("../../lib/api-client", async (importOriginal) => ({
+	...(await importOriginal<typeof import("../../lib/api-client")>()),
 	apiClient: { GET: getMock, POST: vi.fn() },
 	apiErrorMessage: (e: unknown) => (e instanceof Error ? e.message : "error"),
 	hasTrustedApiBaseUrl: () => true,

--- a/frontend/src/renderer/__tests__/integration/pr-hydration.test.tsx
+++ b/frontend/src/renderer/__tests__/integration/pr-hydration.test.tsx
@@ -12,6 +12,8 @@ vi.mock("../../lib/api-client", () => ({
 	apiClient: { GET: getMock, POST: vi.fn() },
 	apiErrorMessage: (e: unknown) => (e instanceof Error ? e.message : "error"),
 	hasTrustedApiBaseUrl: () => true,
+	getApiBaseUrl: () => "http://127.0.0.1:3001",
+	subscribeApiBaseUrl: () => (() => {}),
 }));
 
 vi.mock("@tanstack/react-router", async (importOriginal) => {

--- a/frontend/src/renderer/__tests__/integration/pr-hydration.test.tsx
+++ b/frontend/src/renderer/__tests__/integration/pr-hydration.test.tsx
@@ -8,12 +8,11 @@ import type { ReactNode } from "react";
 // on the session list flow through the shared workspace cache into the board.
 const { getMock, navigateMock } = vi.hoisted(() => ({ getMock: vi.fn(), navigateMock: vi.fn() }));
 
-vi.mock("../../lib/api-client", () => ({
+vi.mock("../../lib/api-client", async (importOriginal) => ({
+	...(await importOriginal<typeof import("../../lib/api-client")>()),
 	apiClient: { GET: getMock, POST: vi.fn() },
 	apiErrorMessage: (e: unknown) => (e instanceof Error ? e.message : "error"),
 	hasTrustedApiBaseUrl: () => true,
-	getApiBaseUrl: () => "http://127.0.0.1:3001",
-	subscribeApiBaseUrl: () => (() => {}),
 }));
 
 vi.mock("@tanstack/react-router", async (importOriginal) => {

--- a/frontend/src/renderer/components/BrowserPanel.test.tsx
+++ b/frontend/src/renderer/components/BrowserPanel.test.tsx
@@ -20,6 +20,8 @@ vi.mock("../lib/api-client", () => ({
 		typeof error === "object" && error !== null && "message" in error
 			? String((error as { message: unknown }).message)
 			: fallback,
+	getApiBaseUrl: () => "http://127.0.0.1:3001",
+	subscribeApiBaseUrl: () => (() => {}),
 }));
 
 const hookState = vi.hoisted(() => ({

--- a/frontend/src/renderer/components/BrowserPanel.test.tsx
+++ b/frontend/src/renderer/components/BrowserPanel.test.tsx
@@ -14,14 +14,13 @@ import type {
 
 const postMock = vi.hoisted(() => vi.fn());
 
-vi.mock("../lib/api-client", () => ({
+vi.mock("../lib/api-client", async (importOriginal) => ({
+	...(await importOriginal<typeof import("../lib/api-client")>()),
 	apiClient: { POST: postMock },
 	apiErrorMessage: (error: unknown, fallback = "Request failed") =>
 		typeof error === "object" && error !== null && "message" in error
 			? String((error as { message: unknown }).message)
 			: fallback,
-	getApiBaseUrl: () => "http://127.0.0.1:3001",
-	subscribeApiBaseUrl: () => (() => {}),
 }));
 
 const hookState = vi.hoisted(() => ({

--- a/frontend/src/renderer/components/CommandPalette.test.tsx
+++ b/frontend/src/renderer/components/CommandPalette.test.tsx
@@ -122,7 +122,7 @@ vi.mock("../lib/api-client", () => ({
 	// desktop's folder picker. Loopback keeps this suite on the local-machine
 	// path, matching Sidebar.test.tsx's mock for the same reason.
 	getApiBaseUrl: () => "http://127.0.0.1:3001",
-	subscribeApiBaseUrl: () => () => {},
+	subscribeApiBaseUrl: () => (() => {}),
 	apiErrorMessage: (error: unknown, fallback = "Request failed") => {
 		if (error instanceof Error) return error.message;
 		if (typeof error === "object" && error !== null && "message" in error) {

--- a/frontend/src/renderer/components/CommandPalette.test.tsx
+++ b/frontend/src/renderer/components/CommandPalette.test.tsx
@@ -112,7 +112,8 @@ vi.mock("../lib/shell-context", () => ({
 
 vi.mock("../lib/spawn-orchestrator", () => ({ spawnOrchestrator: spawnMock }));
 
-vi.mock("../lib/api-client", () => ({
+vi.mock("../lib/api-client", async (importOriginal) => ({
+	...(await importOriginal<typeof import("../lib/api-client")>()),
 	apiClient: {
 		GET: getMock,
 		POST: postMock,

--- a/frontend/src/renderer/components/ConnectMobileModal.telemetry.test.tsx
+++ b/frontend/src/renderer/components/ConnectMobileModal.telemetry.test.tsx
@@ -28,6 +28,8 @@ vi.mock("../lib/api-client", () => ({
 		POST: post,
 	},
 	apiErrorMessage: () => "failed",
+	getApiBaseUrl: () => "http://127.0.0.1:3001",
+	subscribeApiBaseUrl: () => (() => {}),
 }));
 
 import { ConnectMobileContent } from "./settings/ConnectMobileContent";

--- a/frontend/src/renderer/components/ConnectMobileModal.telemetry.test.tsx
+++ b/frontend/src/renderer/components/ConnectMobileModal.telemetry.test.tsx
@@ -19,7 +19,8 @@ const { captureRendererEvent, mobileStatus, post } = vi.hoisted(() => ({
 }));
 
 vi.mock("../lib/telemetry", () => ({ captureRendererEvent }));
-vi.mock("../lib/api-client", () => ({
+vi.mock("../lib/api-client", async (importOriginal) => ({
+	...(await importOriginal<typeof import("../lib/api-client")>()),
 	apiClient: {
 		GET: async (path: string) =>
 			path === "/api/v1/mobile/devices"
@@ -28,8 +29,6 @@ vi.mock("../lib/api-client", () => ({
 		POST: post,
 	},
 	apiErrorMessage: () => "failed",
-	getApiBaseUrl: () => "http://127.0.0.1:3001",
-	subscribeApiBaseUrl: () => (() => {}),
 }));
 
 import { ConnectMobileContent } from "./settings/ConnectMobileContent";

--- a/frontend/src/renderer/components/ConnectMobileModal.test.tsx
+++ b/frontend/src/renderer/components/ConnectMobileModal.test.tsx
@@ -36,6 +36,8 @@ vi.mock("../lib/api-client", () => ({
 		POST: vi.fn(async () => ({ data: {}, error: undefined })),
 	},
 	apiErrorMessage: () => "failed",
+	getApiBaseUrl: () => "http://127.0.0.1:3001",
+	subscribeApiBaseUrl: () => (() => {}),
 }));
 
 import { ConnectMobileContent, pairingPayload } from "./settings/ConnectMobileContent";

--- a/frontend/src/renderer/components/ConnectMobileModal.test.tsx
+++ b/frontend/src/renderer/components/ConnectMobileModal.test.tsx
@@ -27,7 +27,8 @@ const { mobileStatus } = vi.hoisted(() => ({
 }));
 
 vi.mock("../lib/telemetry", () => ({ captureRendererEvent: vi.fn() }));
-vi.mock("../lib/api-client", () => ({
+vi.mock("../lib/api-client", async (importOriginal) => ({
+	...(await importOriginal<typeof import("../lib/api-client")>()),
 	apiClient: {
 		GET: async (path: string) =>
 			path === "/api/v1/mobile/devices"
@@ -36,8 +37,6 @@ vi.mock("../lib/api-client", () => ({
 		POST: vi.fn(async () => ({ data: {}, error: undefined })),
 	},
 	apiErrorMessage: () => "failed",
-	getApiBaseUrl: () => "http://127.0.0.1:3001",
-	subscribeApiBaseUrl: () => (() => {}),
 }));
 
 import { ConnectMobileContent, pairingPayload } from "./settings/ConnectMobileContent";

--- a/frontend/src/renderer/components/DiffSelectionMenu.test.tsx
+++ b/frontend/src/renderer/components/DiffSelectionMenu.test.tsx
@@ -12,6 +12,8 @@ vi.mock("../lib/api-client", () => ({
 		typeof error === "object" && error !== null && "message" in error
 			? String((error as { message: unknown }).message)
 			: fallback,
+	getApiBaseUrl: () => "http://127.0.0.1:3001",
+	subscribeApiBaseUrl: () => (() => {}),
 }));
 
 const writeTextMock = vi.hoisted(() => vi.fn());

--- a/frontend/src/renderer/components/DiffSelectionMenu.test.tsx
+++ b/frontend/src/renderer/components/DiffSelectionMenu.test.tsx
@@ -6,14 +6,13 @@ import type { DiffSelectionLine } from "../../shared/diff-selection";
 
 const postMock = vi.hoisted(() => vi.fn());
 
-vi.mock("../lib/api-client", () => ({
+vi.mock("../lib/api-client", async (importOriginal) => ({
+	...(await importOriginal<typeof import("../lib/api-client")>()),
 	apiClient: { POST: postMock },
 	apiErrorMessage: (error: unknown, fallback = "Request failed") =>
 		typeof error === "object" && error !== null && "message" in error
 			? String((error as { message: unknown }).message)
 			: fallback,
-	getApiBaseUrl: () => "http://127.0.0.1:3001",
-	subscribeApiBaseUrl: () => (() => {}),
 }));
 
 const writeTextMock = vi.hoisted(() => vi.fn());

--- a/frontend/src/renderer/components/FileTree.test.tsx
+++ b/frontend/src/renderer/components/FileTree.test.tsx
@@ -8,14 +8,13 @@ import type { TreeNode } from "../hooks/useSessionWorkspaceTree";
 
 const { getMock } = vi.hoisted(() => ({ getMock: vi.fn() }));
 
-vi.mock("../lib/api-client", () => ({
+vi.mock("../lib/api-client", async (importOriginal) => ({
+	...(await importOriginal<typeof import("../lib/api-client")>()),
 	apiClient: { GET: getMock },
 	apiErrorMessage: (error: unknown, fallback = "Request failed") => {
 		if (error instanceof Error) return error.message;
 		return fallback;
 	},
-	getApiBaseUrl: () => "http://127.0.0.1:3001",
-	subscribeApiBaseUrl: () => (() => {}),
 }));
 
 function renderWithQuery(children: ReactNode) {

--- a/frontend/src/renderer/components/FileTree.test.tsx
+++ b/frontend/src/renderer/components/FileTree.test.tsx
@@ -14,6 +14,8 @@ vi.mock("../lib/api-client", () => ({
 		if (error instanceof Error) return error.message;
 		return fallback;
 	},
+	getApiBaseUrl: () => "http://127.0.0.1:3001",
+	subscribeApiBaseUrl: () => (() => {}),
 }));
 
 function renderWithQuery(children: ReactNode) {

--- a/frontend/src/renderer/components/MigrationPopup.test.tsx
+++ b/frontend/src/renderer/components/MigrationPopup.test.tsx
@@ -11,12 +11,11 @@ const { getMock, postMock, getMigration, setMigration } = vi.hoisted(() => ({
 	setMigration: vi.fn(),
 }));
 
-vi.mock("../lib/api-client", () => ({
+vi.mock("../lib/api-client", async (importOriginal) => ({
+	...(await importOriginal<typeof import("../lib/api-client")>()),
 	apiClient: { GET: getMock, POST: postMock },
 	apiErrorMessage: (e: unknown, fb = "Request failed") =>
 		e instanceof Error ? e.message : ((e as { message?: string })?.message ?? fb),
-	getApiBaseUrl: () => "http://127.0.0.1:3001",
-	subscribeApiBaseUrl: () => (() => {}),
 }));
 vi.mock("../lib/bridge", () => ({ aoBridge: { appState: { getMigration, setMigration } } }));
 

--- a/frontend/src/renderer/components/MigrationPopup.test.tsx
+++ b/frontend/src/renderer/components/MigrationPopup.test.tsx
@@ -15,6 +15,8 @@ vi.mock("../lib/api-client", () => ({
 	apiClient: { GET: getMock, POST: postMock },
 	apiErrorMessage: (e: unknown, fb = "Request failed") =>
 		e instanceof Error ? e.message : ((e as { message?: string })?.message ?? fb),
+	getApiBaseUrl: () => "http://127.0.0.1:3001",
+	subscribeApiBaseUrl: () => (() => {}),
 }));
 vi.mock("../lib/bridge", () => ({ aoBridge: { appState: { getMigration, setMigration } } }));
 

--- a/frontend/src/renderer/components/NewTaskDialog.test.tsx
+++ b/frontend/src/renderer/components/NewTaskDialog.test.tsx
@@ -9,7 +9,8 @@ const { getMock, postMock } = vi.hoisted(() => ({
 	postMock: vi.fn(),
 }));
 
-vi.mock("../lib/api-client", () => ({
+vi.mock("../lib/api-client", async (importOriginal) => ({
+	...(await importOriginal<typeof import("../lib/api-client")>()),
 	apiClient: {
 		GET: (...args: unknown[]) => getMock(...args),
 		POST: (...args: unknown[]) => postMock(...args),
@@ -26,8 +27,6 @@ vi.mock("../lib/api-client", () => ({
 		typeof error === "object" && error !== null && "code" in error
 			? String((error as { code: unknown }).code)
 			: undefined,
-	getApiBaseUrl: () => "http://127.0.0.1:3001",
-	subscribeApiBaseUrl: () => (() => {}),
 }));
 
 function renderDialog() {

--- a/frontend/src/renderer/components/NewTaskDialog.test.tsx
+++ b/frontend/src/renderer/components/NewTaskDialog.test.tsx
@@ -26,6 +26,8 @@ vi.mock("../lib/api-client", () => ({
 		typeof error === "object" && error !== null && "code" in error
 			? String((error as { code: unknown }).code)
 			: undefined,
+	getApiBaseUrl: () => "http://127.0.0.1:3001",
+	subscribeApiBaseUrl: () => (() => {}),
 }));
 
 function renderDialog() {

--- a/frontend/src/renderer/components/ProjectSettingsForm.test.tsx
+++ b/frontend/src/renderer/components/ProjectSettingsForm.test.tsx
@@ -40,7 +40,8 @@ vi.mock("../lib/orchestrator-replacement-telemetry", () => ({
 	captureOrchestratorReplacementFailure: captureOrchestratorReplacementFailureMock,
 }));
 
-vi.mock("../lib/api-client", () => ({
+vi.mock("../lib/api-client", async (importOriginal) => ({
+	...(await importOriginal<typeof import("../lib/api-client")>()),
 	apiClient: {
 		GET: getMock,
 		PUT: putMock,
@@ -61,8 +62,6 @@ vi.mock("../lib/api-client", () => ({
 		}
 		return "Request failed";
 	},
-	getApiBaseUrl: () => "http://127.0.0.1:3001",
-	subscribeApiBaseUrl: () => (() => {}),
 }));
 
 import { ProjectSettingsForm, type ProjectSettingsSaveState, type ProjectSettingsSection } from "./ProjectSettingsForm";

--- a/frontend/src/renderer/components/ProjectSettingsForm.test.tsx
+++ b/frontend/src/renderer/components/ProjectSettingsForm.test.tsx
@@ -61,6 +61,8 @@ vi.mock("../lib/api-client", () => ({
 		}
 		return "Request failed";
 	},
+	getApiBaseUrl: () => "http://127.0.0.1:3001",
+	subscribeApiBaseUrl: () => (() => {}),
 }));
 
 import { ProjectSettingsForm, type ProjectSettingsSaveState, type ProjectSettingsSection } from "./ProjectSettingsForm";

--- a/frontend/src/renderer/components/SessionInspector.test.tsx
+++ b/frontend/src/renderer/components/SessionInspector.test.tsx
@@ -50,16 +50,15 @@ vi.mock("../lib/preview-mode", () => ({
   usesPreviewWorkspaceData: false,
 }));
 
-vi.mock("../lib/api-client", () => ({
+vi.mock("../lib/api-client", async (importOriginal) => ({
+	...(await importOriginal<typeof import("../lib/api-client")>()),
   apiClient: {
     GET: getMock,
     PATCH: patchMock,
     POST: postMock,
     PUT: putMock,
   },
-  getApiBaseUrl: () => "http://127.0.0.1:3001",
   hasTrustedApiBaseUrl: () => false,
-  subscribeApiBaseUrl: () => (() => {}),
   apiErrorMessage: (error: unknown, fallback = "Request failed") => {
     if (error instanceof Error) return error.message;
     if (typeof error === "object" && error !== null && "message" in error) {

--- a/frontend/src/renderer/components/SessionInspector.test.tsx
+++ b/frontend/src/renderer/components/SessionInspector.test.tsx
@@ -59,7 +59,7 @@ vi.mock("../lib/api-client", () => ({
   },
   getApiBaseUrl: () => "http://127.0.0.1:3001",
   hasTrustedApiBaseUrl: () => false,
-  subscribeApiBaseUrl: () => () => {},
+  subscribeApiBaseUrl: () => (() => {}),
   apiErrorMessage: (error: unknown, fallback = "Request failed") => {
     if (error instanceof Error) return error.message;
     if (typeof error === "object" && error !== null && "message" in error) {

--- a/frontend/src/renderer/components/SessionView.test.tsx
+++ b/frontend/src/renderer/components/SessionView.test.tsx
@@ -87,13 +87,12 @@ vi.mock("../hooks/useSessionInterfaceTransition", () => ({
 	}),
 }));
 
-vi.mock("../lib/api-client", () => ({
+vi.mock("../lib/api-client", async (importOriginal) => ({
+	...(await importOriginal<typeof import("../lib/api-client")>()),
 	apiClient: {
 		GET: reviewGetMock,
 	},
 	apiErrorMessage: (_error: unknown, fallback: string) => fallback,
-	getApiBaseUrl: () => "http://127.0.0.1:3001",
-	subscribeApiBaseUrl: () => (() => {}),
 }));
 
 const { workspaces, workspaceQueryState, shellTerminalsState } = vi.hoisted(() => {

--- a/frontend/src/renderer/components/SessionView.test.tsx
+++ b/frontend/src/renderer/components/SessionView.test.tsx
@@ -92,6 +92,8 @@ vi.mock("../lib/api-client", () => ({
 		GET: reviewGetMock,
 	},
 	apiErrorMessage: (_error: unknown, fallback: string) => fallback,
+	getApiBaseUrl: () => "http://127.0.0.1:3001",
+	subscribeApiBaseUrl: () => (() => {}),
 }));
 
 const { workspaces, workspaceQueryState, shellTerminalsState } = vi.hoisted(() => {

--- a/frontend/src/renderer/components/SessionsBoard.test.tsx
+++ b/frontend/src/renderer/components/SessionsBoard.test.tsx
@@ -49,11 +49,10 @@ vi.mock("../hooks/useSessionUsageSummaries", () => ({
 	useSessionUsageSummaries: usageQueryMock,
 }));
 
-vi.mock("../lib/api-client", () => ({
+vi.mock("../lib/api-client", async (importOriginal) => ({
+	...(await importOriginal<typeof import("../lib/api-client")>()),
 	apiClient: { POST: (...args: unknown[]) => postMock(...args) },
 	apiErrorMessage: (_error: unknown, fallback: string) => fallback,
-	getApiBaseUrl: () => "http://127.0.0.1:3001",
-	subscribeApiBaseUrl: () => (() => {}),
 }));
 
 vi.mock("../lib/bridge", () => ({

--- a/frontend/src/renderer/components/SessionsBoard.test.tsx
+++ b/frontend/src/renderer/components/SessionsBoard.test.tsx
@@ -52,6 +52,8 @@ vi.mock("../hooks/useSessionUsageSummaries", () => ({
 vi.mock("../lib/api-client", () => ({
 	apiClient: { POST: (...args: unknown[]) => postMock(...args) },
 	apiErrorMessage: (_error: unknown, fallback: string) => fallback,
+	getApiBaseUrl: () => "http://127.0.0.1:3001",
+	subscribeApiBaseUrl: () => (() => {}),
 }));
 
 vi.mock("../lib/bridge", () => ({

--- a/frontend/src/renderer/components/ShellTopbar.test.tsx
+++ b/frontend/src/renderer/components/ShellTopbar.test.tsx
@@ -31,7 +31,8 @@ vi.mock("../hooks/useWorkspaceQuery", () => ({
 	workspaceQueryKey: ["workspaces"],
 }));
 
-vi.mock("../lib/api-client", () => ({
+vi.mock("../lib/api-client", async (importOriginal) => ({
+	...(await importOriginal<typeof import("../lib/api-client")>()),
 	apiClient: {
 		POST: postMock,
 	},
@@ -42,8 +43,6 @@ vi.mock("../lib/api-client", () => ({
 		}
 		return fallback;
 	},
-	getApiBaseUrl: () => "http://127.0.0.1:3001",
-	subscribeApiBaseUrl: () => (() => {}),
 }));
 
 vi.mock("../lib/spawn-orchestrator", () => ({ spawnOrchestrator: spawnMock }));

--- a/frontend/src/renderer/components/ShellTopbar.test.tsx
+++ b/frontend/src/renderer/components/ShellTopbar.test.tsx
@@ -42,6 +42,8 @@ vi.mock("../lib/api-client", () => ({
 		}
 		return fallback;
 	},
+	getApiBaseUrl: () => "http://127.0.0.1:3001",
+	subscribeApiBaseUrl: () => (() => {}),
 }));
 
 vi.mock("../lib/spawn-orchestrator", () => ({ spawnOrchestrator: spawnMock }));

--- a/frontend/src/renderer/components/Sidebar.test.tsx
+++ b/frontend/src/renderer/components/Sidebar.test.tsx
@@ -135,7 +135,7 @@ vi.mock("../lib/api-client", () => ({
 	// what they already assume; the remote path is covered in
 	// CreateProjectFlow.test.tsx and CloneRepositoryDialog.test.tsx.
 	getApiBaseUrl: () => "http://127.0.0.1:3001",
-	subscribeApiBaseUrl: () => () => {},
+	subscribeApiBaseUrl: () => (() => {}),
 	apiErrorMessage: (error: unknown) => {
 		if (error instanceof Error) return error.message;
 		if (typeof error === "object" && error !== null && "message" in error && typeof error.message === "string") {

--- a/frontend/src/renderer/components/Sidebar.test.tsx
+++ b/frontend/src/renderer/components/Sidebar.test.tsx
@@ -127,7 +127,8 @@ vi.mock("../lib/bridge", async (importOriginal) => {
 	};
 });
 
-vi.mock("../lib/api-client", () => ({
+vi.mock("../lib/api-client", async (importOriginal) => ({
+	...(await importOriginal<typeof import("../lib/api-client")>()),
 	apiClient: { GET: getMock },
 	// The sidebar mounts CreateProjectFlow, which subscribes to the active
 	// machine's base URL to decide whether a clone can use this desktop's folder

--- a/frontend/src/renderer/components/TaskComposer.test.tsx
+++ b/frontend/src/renderer/components/TaskComposer.test.tsx
@@ -49,6 +49,8 @@ vi.mock("../lib/api-client", () => ({
 	},
 	apiErrorCode: (error: { code?: string }) => error?.code,
 	apiErrorMessage: (error: { message?: string }, fallback = "err") => error?.message ?? fallback,
+	getApiBaseUrl: () => "http://127.0.0.1:3001",
+	subscribeApiBaseUrl: () => (() => {}),
 }));
 
 vi.mock("../lib/telemetry", () => ({ captureRendererEvent: h.capture }));

--- a/frontend/src/renderer/components/TaskComposer.test.tsx
+++ b/frontend/src/renderer/components/TaskComposer.test.tsx
@@ -42,15 +42,14 @@ vi.mock("./CreateProjectAgentSheet", () => ({
 	},
 }));
 
-vi.mock("../lib/api-client", () => ({
+vi.mock("../lib/api-client", async (importOriginal) => ({
+	...(await importOriginal<typeof import("../lib/api-client")>()),
 	apiClient: {
 		GET: h.get,
 		POST: h.post,
 	},
 	apiErrorCode: (error: { code?: string }) => error?.code,
 	apiErrorMessage: (error: { message?: string }, fallback = "err") => error?.message ?? fallback,
-	getApiBaseUrl: () => "http://127.0.0.1:3001",
-	subscribeApiBaseUrl: () => (() => {}),
 }));
 
 vi.mock("../lib/telemetry", () => ({ captureRendererEvent: h.capture }));

--- a/frontend/src/renderer/components/TerminalPane.test.tsx
+++ b/frontend/src/renderer/components/TerminalPane.test.tsx
@@ -53,6 +53,8 @@ vi.mock("../lib/api-client", () => ({
 		POST: (...args: unknown[]) => postMock(...args),
 	},
 	apiErrorMessage: (_error: unknown, fallback: string) => fallback,
+	getApiBaseUrl: () => "http://127.0.0.1:3001",
+	subscribeApiBaseUrl: () => (() => {}),
 }));
 
 vi.mock("./XtermTerminal", () => ({

--- a/frontend/src/renderer/components/TerminalPane.test.tsx
+++ b/frontend/src/renderer/components/TerminalPane.test.tsx
@@ -44,7 +44,8 @@ const {
 );
 let terminalLinkHandler: ((uri: string) => void) | undefined;
 
-vi.mock("../lib/api-client", () => ({
+vi.mock("../lib/api-client", async (importOriginal) => ({
+	...(await importOriginal<typeof import("../lib/api-client")>()),
 	apiClient: {
 		GET: (
 			path: string,
@@ -53,8 +54,6 @@ vi.mock("../lib/api-client", () => ({
 		POST: (...args: unknown[]) => postMock(...args),
 	},
 	apiErrorMessage: (_error: unknown, fallback: string) => fallback,
-	getApiBaseUrl: () => "http://127.0.0.1:3001",
-	subscribeApiBaseUrl: () => (() => {}),
 }));
 
 vi.mock("./XtermTerminal", () => ({

--- a/frontend/src/renderer/components/TerminalSwitchAgentButton.test.tsx
+++ b/frontend/src/renderer/components/TerminalSwitchAgentButton.test.tsx
@@ -17,7 +17,8 @@ const { getMock, postMock } = vi.hoisted(() => ({
 	postMock: vi.fn(),
 }));
 
-vi.mock("../lib/api-client", () => ({
+vi.mock("../lib/api-client", async (importOriginal) => ({
+	...(await importOriginal<typeof import("../lib/api-client")>()),
 	apiClient: {
 		GET: getMock,
 		POST: postMock,
@@ -29,8 +30,6 @@ vi.mock("../lib/api-client", () => ({
 		}
 		return fallback;
 	},
-	getApiBaseUrl: () => "http://127.0.0.1:3001",
-	subscribeApiBaseUrl: () => (() => {}),
 }));
 
 const worker: WorkspaceSession = {

--- a/frontend/src/renderer/components/TerminalSwitchAgentButton.test.tsx
+++ b/frontend/src/renderer/components/TerminalSwitchAgentButton.test.tsx
@@ -29,6 +29,8 @@ vi.mock("../lib/api-client", () => ({
 		}
 		return fallback;
 	},
+	getApiBaseUrl: () => "http://127.0.0.1:3001",
+	subscribeApiBaseUrl: () => (() => {}),
 }));
 
 const worker: WorkspaceSession = {

--- a/frontend/src/renderer/components/chat/SessionChatSurface.test.tsx
+++ b/frontend/src/renderer/components/chat/SessionChatSurface.test.tsx
@@ -51,6 +51,8 @@ const { getMock, postMock, conversationState, agentSwitchState } = vi.hoisted(()
 vi.mock("../../lib/api-client", () => ({
 	apiClient: { GET: getMock, POST: postMock },
 	apiErrorMessage: (_error: unknown, fallback: string) => fallback,
+	getApiBaseUrl: () => "http://127.0.0.1:3001",
+	subscribeApiBaseUrl: () => (() => {}),
 }));
 
 vi.mock("../../hooks/useConversation", () => ({

--- a/frontend/src/renderer/components/chat/SessionChatSurface.test.tsx
+++ b/frontend/src/renderer/components/chat/SessionChatSurface.test.tsx
@@ -48,11 +48,10 @@ const { getMock, postMock, conversationState, agentSwitchState } = vi.hoisted(()
 	},
 }));
 
-vi.mock("../../lib/api-client", () => ({
+vi.mock("../../lib/api-client", async (importOriginal) => ({
+	...(await importOriginal<typeof import("../../lib/api-client")>()),
 	apiClient: { GET: getMock, POST: postMock },
 	apiErrorMessage: (_error: unknown, fallback: string) => fallback,
-	getApiBaseUrl: () => "http://127.0.0.1:3001",
-	subscribeApiBaseUrl: () => (() => {}),
 }));
 
 vi.mock("../../hooks/useConversation", () => ({

--- a/frontend/src/renderer/hooks/useConversation.test.tsx
+++ b/frontend/src/renderer/hooks/useConversation.test.tsx
@@ -11,12 +11,11 @@ const { getMock, postMock, apiErrorCodeMock, apiErrorMessageMock } = vi.hoisted(
 	apiErrorMessageMock: vi.fn(),
 }));
 
-vi.mock("../lib/api-client", () => ({
+vi.mock("../lib/api-client", async (importOriginal) => ({
+	...(await importOriginal<typeof import("../lib/api-client")>()),
 	apiClient: { GET: getMock, POST: postMock, PATCH: vi.fn() },
 	apiErrorCode: apiErrorCodeMock,
 	apiErrorMessage: apiErrorMessageMock,
-	getApiBaseUrl: () => "http://127.0.0.1:3001",
-	subscribeApiBaseUrl: () => (() => {}),
 }));
 
 import { useConversation, useConversationCommands } from "./useConversation";

--- a/frontend/src/renderer/hooks/useConversation.test.tsx
+++ b/frontend/src/renderer/hooks/useConversation.test.tsx
@@ -15,6 +15,8 @@ vi.mock("../lib/api-client", () => ({
 	apiClient: { GET: getMock, POST: postMock, PATCH: vi.fn() },
 	apiErrorCode: apiErrorCodeMock,
 	apiErrorMessage: apiErrorMessageMock,
+	getApiBaseUrl: () => "http://127.0.0.1:3001",
+	subscribeApiBaseUrl: () => (() => {}),
 }));
 
 import { useConversation, useConversationCommands } from "./useConversation";

--- a/frontend/src/renderer/hooks/useDaemonStatus.test.tsx
+++ b/frontend/src/renderer/hooks/useDaemonStatus.test.tsx
@@ -29,11 +29,10 @@ vi.mock("../lib/event-transport", () => ({
 	createEventTransport: vi.fn(() => ({ connect: connectMock })),
 }));
 
-vi.mock("../lib/api-client", () => ({
+vi.mock("../lib/api-client", async (importOriginal) => ({
+	...(await importOriginal<typeof import("../lib/api-client")>()),
 	setApiBaseUrl: setApiBaseUrlMock,
 	setApiDaemonStatus: setApiDaemonStatusMock,
-	getApiBaseUrl: () => "http://127.0.0.1:3001",
-	subscribeApiBaseUrl: () => (() => {}),
 }));
 
 import { useDaemonStatus } from "./useDaemonStatus";

--- a/frontend/src/renderer/hooks/useDaemonStatus.test.tsx
+++ b/frontend/src/renderer/hooks/useDaemonStatus.test.tsx
@@ -32,6 +32,8 @@ vi.mock("../lib/event-transport", () => ({
 vi.mock("../lib/api-client", () => ({
 	setApiBaseUrl: setApiBaseUrlMock,
 	setApiDaemonStatus: setApiDaemonStatusMock,
+	getApiBaseUrl: () => "http://127.0.0.1:3001",
+	subscribeApiBaseUrl: () => (() => {}),
 }));
 
 import { useDaemonStatus } from "./useDaemonStatus";

--- a/frontend/src/renderer/hooks/useSessionInterfaceTransition.test.tsx
+++ b/frontend/src/renderer/hooks/useSessionInterfaceTransition.test.tsx
@@ -5,12 +5,11 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const { getMock, putMock } = vi.hoisted(() => ({ getMock: vi.fn(), putMock: vi.fn() }));
 
-vi.mock("../lib/api-client", () => ({
+vi.mock("../lib/api-client", async (importOriginal) => ({
+	...(await importOriginal<typeof import("../lib/api-client")>()),
 	apiClient: { GET: getMock, POST: vi.fn(), PUT: putMock, DELETE: vi.fn() },
 	apiErrorMessage: () => "request failed",
 	hasTrustedApiBaseUrl: () => true,
-	getApiBaseUrl: () => "http://127.0.0.1:3001",
-	subscribeApiBaseUrl: () => (() => {}),
 }));
 
 import { useSessionInterfaceTransition } from "./useSessionInterfaceTransition";

--- a/frontend/src/renderer/hooks/useSessionInterfaceTransition.test.tsx
+++ b/frontend/src/renderer/hooks/useSessionInterfaceTransition.test.tsx
@@ -9,6 +9,8 @@ vi.mock("../lib/api-client", () => ({
 	apiClient: { GET: getMock, POST: vi.fn(), PUT: putMock, DELETE: vi.fn() },
 	apiErrorMessage: () => "request failed",
 	hasTrustedApiBaseUrl: () => true,
+	getApiBaseUrl: () => "http://127.0.0.1:3001",
+	subscribeApiBaseUrl: () => (() => {}),
 }));
 
 import { useSessionInterfaceTransition } from "./useSessionInterfaceTransition";

--- a/frontend/src/renderer/hooks/useSessionUsageSummaries.test.ts
+++ b/frontend/src/renderer/hooks/useSessionUsageSummaries.test.ts
@@ -2,10 +2,9 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const getMock = vi.hoisted(() => vi.fn());
 
-vi.mock("../lib/api-client", () => ({
+vi.mock("../lib/api-client", async (importOriginal) => ({
+	...(await importOriginal<typeof import("../lib/api-client")>()),
 	apiClient: { GET: (...args: unknown[]) => getMock(...args) },
-	getApiBaseUrl: () => "http://127.0.0.1:3001",
-	subscribeApiBaseUrl: () => (() => {}),
 }));
 
 import { sessionUsageDetailQueryKey } from "./useSessionUsage";

--- a/frontend/src/renderer/hooks/useSessionUsageSummaries.test.ts
+++ b/frontend/src/renderer/hooks/useSessionUsageSummaries.test.ts
@@ -4,6 +4,8 @@ const getMock = vi.hoisted(() => vi.fn());
 
 vi.mock("../lib/api-client", () => ({
 	apiClient: { GET: (...args: unknown[]) => getMock(...args) },
+	getApiBaseUrl: () => "http://127.0.0.1:3001",
+	subscribeApiBaseUrl: () => (() => {}),
 }));
 
 import { sessionUsageDetailQueryKey } from "./useSessionUsage";

--- a/frontend/src/renderer/hooks/useShellTerminals.test.tsx
+++ b/frontend/src/renderer/hooks/useShellTerminals.test.tsx
@@ -10,6 +10,8 @@ vi.mock("../lib/api-client", () => ({
 	apiErrorCode: (error: unknown) =>
 		typeof error === "object" && error !== null && "code" in error ? (error as { code?: string }).code : undefined,
 	hasTrustedApiBaseUrl: () => true,
+	getApiBaseUrl: () => "http://127.0.0.1:3001",
+	subscribeApiBaseUrl: () => (() => {}),
 }));
 
 import {

--- a/frontend/src/renderer/hooks/useShellTerminals.test.tsx
+++ b/frontend/src/renderer/hooks/useShellTerminals.test.tsx
@@ -5,13 +5,12 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const { deleteMock, postMock } = vi.hoisted(() => ({ deleteMock: vi.fn(), postMock: vi.fn() }));
 
-vi.mock("../lib/api-client", () => ({
+vi.mock("../lib/api-client", async (importOriginal) => ({
+	...(await importOriginal<typeof import("../lib/api-client")>()),
 	apiClient: { DELETE: deleteMock, POST: postMock },
 	apiErrorCode: (error: unknown) =>
 		typeof error === "object" && error !== null && "code" in error ? (error as { code?: string }).code : undefined,
 	hasTrustedApiBaseUrl: () => true,
-	getApiBaseUrl: () => "http://127.0.0.1:3001",
-	subscribeApiBaseUrl: () => (() => {}),
 }));
 
 import {

--- a/frontend/src/renderer/hooks/useSwitchAgent.test.tsx
+++ b/frontend/src/renderer/hooks/useSwitchAgent.test.tsx
@@ -6,11 +6,10 @@ import type { WorkspaceSession } from "../types/workspace";
 
 const { postMock } = vi.hoisted(() => ({ postMock: vi.fn() }));
 
-vi.mock("../lib/api-client", () => ({
+vi.mock("../lib/api-client", async (importOriginal) => ({
+	...(await importOriginal<typeof import("../lib/api-client")>()),
 	apiClient: { POST: postMock },
 	apiErrorMessage: () => "request failed",
-	getApiBaseUrl: () => "http://127.0.0.1:3001",
-	subscribeApiBaseUrl: () => (() => {}),
 }));
 
 import { useSwitchAgent } from "./useSwitchAgent";

--- a/frontend/src/renderer/hooks/useSwitchAgent.test.tsx
+++ b/frontend/src/renderer/hooks/useSwitchAgent.test.tsx
@@ -9,6 +9,8 @@ const { postMock } = vi.hoisted(() => ({ postMock: vi.fn() }));
 vi.mock("../lib/api-client", () => ({
 	apiClient: { POST: postMock },
 	apiErrorMessage: () => "request failed",
+	getApiBaseUrl: () => "http://127.0.0.1:3001",
+	subscribeApiBaseUrl: () => (() => {}),
 }));
 
 import { useSwitchAgent } from "./useSwitchAgent";

--- a/frontend/src/renderer/hooks/useWorkspaceQuery.test.tsx
+++ b/frontend/src/renderer/hooks/useWorkspaceQuery.test.tsx
@@ -16,6 +16,8 @@ const { captureRendererEventMock, cloudState, getMock, hasTrustedApiBaseUrlMock,
 vi.mock("../lib/api-client", () => ({
 	apiClient: { GET: getMock },
 	hasTrustedApiBaseUrl: hasTrustedApiBaseUrlMock,
+	getApiBaseUrl: () => "http://127.0.0.1:3001",
+	subscribeApiBaseUrl: () => (() => {}),
 }));
 
 vi.mock("../lib/telemetry", () => ({ captureRendererEvent: captureRendererEventMock }));

--- a/frontend/src/renderer/hooks/useWorkspaceQuery.test.tsx
+++ b/frontend/src/renderer/hooks/useWorkspaceQuery.test.tsx
@@ -13,11 +13,10 @@ const { captureRendererEventMock, cloudState, getMock, hasTrustedApiBaseUrlMock,
 	}),
 );
 
-vi.mock("../lib/api-client", () => ({
+vi.mock("../lib/api-client", async (importOriginal) => ({
+	...(await importOriginal<typeof import("../lib/api-client")>()),
 	apiClient: { GET: getMock },
 	hasTrustedApiBaseUrl: hasTrustedApiBaseUrlMock,
-	getApiBaseUrl: () => "http://127.0.0.1:3001",
-	subscribeApiBaseUrl: () => (() => {}),
 }));
 
 vi.mock("../lib/telemetry", () => ({ captureRendererEvent: captureRendererEventMock }));

--- a/frontend/src/renderer/lib/spawn-orchestrator.test.ts
+++ b/frontend/src/renderer/lib/spawn-orchestrator.test.ts
@@ -3,7 +3,8 @@ import { isChatPreflightError, OrchestratorSpawnError, spawnOrchestrator } from 
 import { apiClient } from "./api-client";
 import { captureRendererEvent } from "./telemetry";
 
-vi.mock("./api-client", () => ({
+vi.mock("./api-client", async (importOriginal) => ({
+	...(await importOriginal<typeof import("./api-client")>()),
 	apiClient: { POST: vi.fn() },
 	apiErrorCode: (error: unknown) =>
 		typeof error === "object" && error !== null && "code" in error
@@ -21,8 +22,6 @@ vi.mock("./api-client", () => ({
 		}
 		return fallback;
 	},
-	getApiBaseUrl: () => "http://127.0.0.1:3001",
-	subscribeApiBaseUrl: () => (() => {}),
 }));
 
 vi.mock("./telemetry", () => ({

--- a/frontend/src/renderer/lib/spawn-orchestrator.test.ts
+++ b/frontend/src/renderer/lib/spawn-orchestrator.test.ts
@@ -21,6 +21,8 @@ vi.mock("./api-client", () => ({
 		}
 		return fallback;
 	},
+	getApiBaseUrl: () => "http://127.0.0.1:3001",
+	subscribeApiBaseUrl: () => (() => {}),
 }));
 
 vi.mock("./telemetry", () => ({


### PR DESCRIPTION
## Summary
- add `getApiBaseUrl` and `subscribeApiBaseUrl` to renderer API-client mocks
- keep wholesale mocks aligned with the API client contract
- cover all current renderer component, hook, integration, and orchestration mocks

Closes #104

## Validation
- `npm exec vitest run src/renderer/components src/renderer/hooks src/renderer/__tests__/integration` (108 files, 1630 tests)
- `npm run typecheck`
- `git diff --check