### PR TITLE
feat: add hao setup dry-run planner

### DIFF
--- a/.github/workflows/frontend-release.yml
+++ b/.github/workflows/frontend-release.yml
@@ -293,6 +293,7 @@ jobs:
             "$VERSION "*) ;;
             *) echo "::error::hao version stamp missing: got '$hao_reported', expected it to start with '$VERSION '"; exit 1 ;;
           esac
+          ./hao-linux-x64 setup --help | grep -Fq -- '--dry-run'
 
       - name: Upload Linux CLI binaries
         if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/linux-cli-binaries.yml
+++ b/.github/workflows/linux-cli-binaries.yml
@@ -141,6 +141,7 @@ jobs:
               "$VERSION "*) ;;
               *) echo "::error::hao version stamp missing: got '$hao_reported', expected it to start with '$VERSION '"; exit 1 ;;
             esac
+            dist/hao setup --help | grep -Fq -- '--dry-run'
           fi
           ao_hash="$(sha256sum dist/ao | awk '{print $1}')"
           hao_hash="$(sha256sum dist/hao | awk '{print $1}')"

--- a/backend/internal/agentlaunch/env.go
+++ b/backend/internal/agentlaunch/env.go
@@ -2,6 +2,7 @@ package agentlaunch
 
 import (
 	"context"
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -10,6 +11,58 @@ import (
 	"strconv"
 	"strings"
 )
+
+// LookPath resolves an executable using an explicit PATH value. The session
+// manager uses it with its process PATH, while service verification can feed
+// it the exact PATH parsed from a rendered unit.
+func LookPath(name, pathValue string) (string, error) {
+	if filepath.IsAbs(name) {
+		for _, candidate := range executableCandidates(name) {
+			if executableFile(candidate) {
+				return candidate, nil
+			}
+		}
+		return "", os.ErrNotExist
+	}
+	if name == "" || filepath.Base(name) != name {
+		return "", errors.New("executable name must be a base name")
+	}
+	for _, directory := range filepath.SplitList(pathValue) {
+		if !filepath.IsAbs(directory) {
+			continue
+		}
+		for _, candidate := range executableCandidates(filepath.Join(directory, name)) {
+			if executableFile(candidate) {
+				return candidate, nil
+			}
+		}
+	}
+	return "", os.ErrNotExist
+}
+
+func executableCandidates(path string) []string {
+	if runtime.GOOS != "windows" || filepath.Ext(path) != "" {
+		return []string{path}
+	}
+	exts := filepath.SplitList(os.Getenv("PATHEXT"))
+	if len(exts) == 0 {
+		exts = []string{".com", ".exe", ".bat", ".cmd"}
+	}
+	result := make([]string, 0, len(exts)+1)
+	result = append(result, path)
+	for _, ext := range exts {
+		result = append(result, path+strings.ToLower(ext))
+	}
+	return result
+}
+
+func executableFile(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil || !info.Mode().IsRegular() {
+		return false
+	}
+	return runtime.GOOS == "windows" || info.Mode().Perm()&0o111 != 0
+}
 
 // AugmentRuntimePATHForLaunchBinary prepends the resolved launch binary
 // directory to the child PATH. For Node-backed CLI shims, it also prepends a

--- a/backend/internal/haocli/errors.go
+++ b/backend/internal/haocli/errors.go
@@ -78,7 +78,7 @@ func operationFromArgs(args []string) string {
 	parts := make([]string, 0, 2)
 	for i := 0; i < len(args); i++ {
 		arg := args[i]
-		if arg == "--config" {
+		if arg == "--config" || arg == "--install" {
 			i++
 			continue
 		}

--- a/backend/internal/haocli/managed_open_unix.go
+++ b/backend/internal/haocli/managed_open_unix.go
@@ -1,0 +1,58 @@
+//go:build !windows
+
+package haocli
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"golang.org/x/sys/unix"
+)
+
+func openManagedRegular(path string, maxSize int64) (*os.File, error) {
+	abs, err := filepath.Abs(filepath.Clean(path))
+	if err != nil {
+		return nil, err
+	}
+	parts := strings.FieldsFunc(abs, func(r rune) bool { return r == filepath.Separator })
+	if len(parts) == 0 {
+		return nil, errors.New("managed path has no file component")
+	}
+	fd, err := unix.Open(string(filepath.Separator), unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC, 0)
+	if err != nil {
+		return nil, err
+	}
+	for _, part := range parts[:len(parts)-1] {
+		next, openErr := unix.Openat(fd, part, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_NOFOLLOW|unix.O_CLOEXEC, 0)
+		_ = unix.Close(fd)
+		if openErr != nil {
+			return nil, errors.New("managed path contains an inaccessible or linked ancestor")
+		}
+		fd = next
+	}
+	defer func() { _ = unix.Close(fd) }()
+	name := parts[len(parts)-1]
+	var before unix.Stat_t
+	if err := unix.Fstatat(fd, name, &before, unix.AT_SYMLINK_NOFOLLOW); err != nil {
+		return nil, err
+	}
+	if before.Mode&unix.S_IFMT != unix.S_IFREG || before.Size > maxSize {
+		return nil, errors.New("managed file is not a bounded regular file")
+	}
+	fileFD, err := unix.Openat(fd, name, unix.O_RDONLY|unix.O_NOFOLLOW|unix.O_CLOEXEC, 0)
+	if err != nil {
+		return nil, errors.New("managed file could not be opened without following links")
+	}
+	var opened, after unix.Stat_t
+	if err := unix.Fstat(fileFD, &opened); err != nil {
+		_ = unix.Close(fileFD)
+		return nil, err
+	}
+	if err := unix.Fstatat(fd, name, &after, unix.AT_SYMLINK_NOFOLLOW); err != nil || opened.Dev != before.Dev || opened.Ino != before.Ino || opened.Dev != after.Dev || opened.Ino != after.Ino || opened.Mode&unix.S_IFMT != unix.S_IFREG || opened.Size > maxSize {
+		_ = unix.Close(fileFD)
+		return nil, errors.New("managed file changed while it was opened")
+	}
+	return os.NewFile(uintptr(fileFD), abs), nil
+}

--- a/backend/internal/haocli/managed_open_unix_test.go
+++ b/backend/internal/haocli/managed_open_unix_test.go
@@ -1,0 +1,65 @@
+//go:build !windows
+
+package haocli
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestOpenManagedRegularRejectsConcurrentLinkSwap(t *testing.T) {
+	root, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	managed := filepath.Join(root, "managed")
+	safe := filepath.Join(root, "safe")
+	outside := filepath.Join(root, "outside")
+	if err := os.WriteFile(safe, []byte("safe"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(outside, []byte("outside"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Link(safe, managed); err != nil {
+		t.Fatal(err)
+	}
+
+	stop := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			_ = os.Remove(managed)
+			_ = os.Symlink(outside, managed)
+			_ = os.Remove(managed)
+			_ = os.Link(safe, managed)
+		}
+	}()
+	defer func() {
+		close(stop)
+		<-done
+	}()
+
+	for i := 0; i < 2_000; i++ {
+		file, openErr := openManagedRegular(managed, 16)
+		if openErr != nil {
+			continue
+		}
+		data, readErr := io.ReadAll(file)
+		_ = file.Close()
+		if readErr != nil {
+			t.Fatal(readErr)
+		}
+		if string(data) != "safe" {
+			t.Fatalf("managed open escaped during link swap: %q", data)
+		}
+	}
+}

--- a/backend/internal/haocli/managed_open_windows.go
+++ b/backend/internal/haocli/managed_open_windows.go
@@ -1,0 +1,46 @@
+//go:build windows
+
+package haocli
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+
+	"golang.org/x/sys/windows"
+)
+
+func openManagedRegular(path string, maxSize int64) (*os.File, error) {
+	clean := filepath.Clean(path)
+	for current := clean; ; current = filepath.Dir(current) {
+		pointer, err := windows.UTF16PtrFromString(current)
+		if err != nil {
+			return nil, err
+		}
+		attrs, err := windows.GetFileAttributes(pointer)
+		if err != nil {
+			return nil, err
+		}
+		if attrs&windows.FILE_ATTRIBUTE_REPARSE_POINT != 0 {
+			return nil, errors.New("managed path contains a reparse point")
+		}
+		parent := filepath.Dir(current)
+		if parent == current {
+			break
+		}
+	}
+	before, err := os.Lstat(clean)
+	if err != nil || !before.Mode().IsRegular() || before.Size() > maxSize {
+		return nil, errors.New("managed file is not a bounded regular file")
+	}
+	file, err := os.Open(clean)
+	if err != nil {
+		return nil, err
+	}
+	after, err := file.Stat()
+	if err != nil || !os.SameFile(before, after) || !after.Mode().IsRegular() || after.Size() > maxSize {
+		_ = file.Close()
+		return nil, errors.New("managed file changed while it was opened")
+	}
+	return file, nil
+}

--- a/backend/internal/haocli/managed_open_windows.go
+++ b/backend/internal/haocli/managed_open_windows.go
@@ -6,41 +6,39 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
+	"unsafe"
 
 	"golang.org/x/sys/windows"
 )
 
 func openManagedRegular(path string, maxSize int64) (*os.File, error) {
-	clean := filepath.Clean(path)
-	for current := clean; ; current = filepath.Dir(current) {
-		pointer, err := windows.UTF16PtrFromString(current)
-		if err != nil {
-			return nil, err
-		}
-		attrs, err := windows.GetFileAttributes(pointer)
-		if err != nil {
-			return nil, err
-		}
-		if attrs&windows.FILE_ATTRIBUTE_REPARSE_POINT != 0 {
-			return nil, errors.New("managed path contains a reparse point")
-		}
-		parent := filepath.Dir(current)
-		if parent == current {
-			break
-		}
-	}
-	before, err := os.Lstat(clean)
-	if err != nil || !before.Mode().IsRegular() || before.Size() > maxSize {
-		return nil, errors.New("managed file is not a bounded regular file")
-	}
-	file, err := os.Open(clean)
+	abs, err := filepath.Abs(filepath.Clean(path))
 	if err != nil {
 		return nil, err
 	}
-	after, err := file.Stat()
-	if err != nil || !os.SameFile(before, after) || !after.Mode().IsRegular() || after.Size() > maxSize {
+	ntPath := `\??\` + abs
+	if strings.HasPrefix(abs, `\\`) {
+		ntPath = `\??\UNC\` + strings.TrimPrefix(abs, `\\`)
+	}
+	name, err := windows.NewNTUnicodeString(ntPath)
+	if err != nil {
+		return nil, err
+	}
+	attributes := &windows.OBJECT_ATTRIBUTES{ObjectName: name, Attributes: windows.OBJ_CASE_INSENSITIVE | windows.OBJ_DONT_REPARSE}
+	attributes.Length = uint32(unsafe.Sizeof(*attributes))
+	var handle windows.Handle
+	var status windows.IO_STATUS_BLOCK
+	if err := windows.NtCreateFile(&handle, windows.FILE_GENERIC_READ|windows.SYNCHRONIZE, attributes, &status, nil, 0,
+		windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE|windows.FILE_SHARE_DELETE, windows.FILE_OPEN,
+		windows.FILE_NON_DIRECTORY_FILE|windows.FILE_SYNCHRONOUS_IO_NONALERT, 0, 0); err != nil {
+		return nil, errors.New("managed file could not be opened without traversing a reparse point")
+	}
+	file := os.NewFile(uintptr(handle), abs)
+	info, err := file.Stat()
+	if err != nil || !info.Mode().IsRegular() || info.Size() > maxSize {
 		_ = file.Close()
-		return nil, errors.New("managed file changed while it was opened")
+		return nil, errors.New("managed file is not a bounded regular file")
 	}
 	return file, nil
 }

--- a/backend/internal/haocli/managed_open_windows_test.go
+++ b/backend/internal/haocli/managed_open_windows_test.go
@@ -23,3 +23,78 @@ func TestOpenManagedRegularRejectsWindowsReparsePoint(t *testing.T) {
 		t.Fatal("reparse point unexpectedly opened")
 	}
 }
+
+func TestOpenManagedRegularRejectsWindowsReparseAncestor(t *testing.T) {
+	root := t.TempDir()
+	target := filepath.Join(root, "target")
+	if err := os.Mkdir(target, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(target, "artifact"), []byte("outside"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	ancestor := filepath.Join(root, "reparse-parent")
+	if err := os.Symlink(target, ancestor); err != nil {
+		t.Skipf("Windows symlink creation unavailable: %v", err)
+	}
+	if file, err := openManagedRegular(filepath.Join(ancestor, "artifact"), 1024); err == nil {
+		_ = file.Close()
+		t.Fatal("artifact through reparse ancestor unexpectedly opened")
+	}
+}
+
+func TestOpenManagedRegularRejectsWindowsAncestorSwap(t *testing.T) {
+	root := t.TempDir()
+	outside := filepath.Join(root, "outside")
+	if err := os.Mkdir(outside, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(outside, "artifact"), []byte("outside"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	ancestor := filepath.Join(root, "managed-parent")
+	if err := os.Symlink(outside, ancestor); err != nil {
+		t.Skipf("Windows symlink creation unavailable: %v", err)
+	}
+	if err := os.Remove(ancestor); err != nil {
+		t.Fatal(err)
+	}
+
+	stop := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			_ = os.Remove(ancestor)
+			_ = os.Symlink(outside, ancestor)
+			_ = os.Remove(ancestor)
+			if os.Mkdir(ancestor, 0o700) == nil {
+				_ = os.WriteFile(filepath.Join(ancestor, "artifact"), []byte("safe"), 0o600)
+				_ = os.Remove(filepath.Join(ancestor, "artifact"))
+				_ = os.Remove(ancestor)
+			}
+		}
+	}()
+	defer func() {
+		close(stop)
+		<-done
+	}()
+
+	for i := 0; i < 2_000; i++ {
+		file, err := openManagedRegular(filepath.Join(ancestor, "artifact"), 16)
+		if err != nil {
+			continue
+		}
+		data := make([]byte, 16)
+		n, readErr := file.Read(data)
+		_ = file.Close()
+		if readErr != nil || string(data[:n]) != "safe" {
+			t.Fatalf("managed open escaped during ancestor swap: data=%q err=%v", data[:n], readErr)
+		}
+	}
+}

--- a/backend/internal/haocli/managed_open_windows_test.go
+++ b/backend/internal/haocli/managed_open_windows_test.go
@@ -1,0 +1,25 @@
+//go:build windows
+
+package haocli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestOpenManagedRegularRejectsWindowsReparsePoint(t *testing.T) {
+	root := t.TempDir()
+	target := filepath.Join(root, "target")
+	if err := os.WriteFile(target, []byte("outside"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(root, "reparse")
+	if err := os.Symlink(target, link); err != nil {
+		t.Skipf("Windows symlink creation unavailable: %v", err)
+	}
+	if file, err := openManagedRegular(link, 1024); err == nil {
+		_ = file.Close()
+		t.Fatal("reparse point unexpectedly opened")
+	}
+}

--- a/backend/internal/haocli/observation_test.go
+++ b/backend/internal/haocli/observation_test.go
@@ -59,7 +59,7 @@ func (f *fakeObserver) ReadFile(path string) ([]byte, error) {
 	}
 	return append([]byte(nil), data...), nil
 }
-func (f *fakeObserver) InspectArtifact(path string) (ArtifactMetadata, error) {
+func (f *fakeObserver) InspectArtifact(_ context.Context, path string) (ArtifactMetadata, error) {
 	if err := f.artifactErr[path]; err != nil {
 		return ArtifactMetadata{}, err
 	}

--- a/backend/internal/haocli/observation_test.go
+++ b/backend/internal/haocli/observation_test.go
@@ -23,6 +23,7 @@ type fakeObserver struct {
 	files           map[string]FileObservation
 	statErr         map[string]error
 	paths           map[string]string
+	pathErr         map[string]error
 	runs            map[string]string
 	runErr          map[string]error
 	runFile         *runfile.Info
@@ -37,10 +38,37 @@ type fakeObserver struct {
 	portAvailable   bool
 	portErr         error
 	runCalls        int
+	user            UserObservation
+	userErr         error
+	readFiles       map[string][]byte
+	readErr         map[string]error
+	artifacts       map[string]ArtifactMetadata
+	artifactErr     map[string]error
 }
 
-func (f *fakeObserver) Platform() (string, string)    { return f.platform, f.arch }
-func (f *fakeObserver) Distribution() (string, error) { return f.distribution, f.distributionErr }
+func (f *fakeObserver) Platform() (string, string)            { return f.platform, f.arch }
+func (f *fakeObserver) Distribution() (string, error)         { return f.distribution, f.distributionErr }
+func (f *fakeObserver) CurrentUser() (UserObservation, error) { return f.user, f.userErr }
+func (f *fakeObserver) ReadFile(path string) ([]byte, error) {
+	if err := f.readErr[path]; err != nil {
+		return nil, err
+	}
+	data, ok := f.readFiles[path]
+	if !ok {
+		return nil, os.ErrNotExist
+	}
+	return append([]byte(nil), data...), nil
+}
+func (f *fakeObserver) InspectArtifact(path string) (ArtifactMetadata, error) {
+	if err := f.artifactErr[path]; err != nil {
+		return ArtifactMetadata{}, err
+	}
+	metadata, ok := f.artifacts[path]
+	if !ok {
+		return ArtifactMetadata{}, os.ErrNotExist
+	}
+	return metadata, nil
+}
 func (f *fakeObserver) Stat(path string) (FileObservation, error) {
 	if err := f.statErr[path]; err != nil {
 		return FileObservation{}, err
@@ -52,6 +80,9 @@ func (f *fakeObserver) Stat(path string) (FileObservation, error) {
 }
 func (f *fakeObserver) Disk(string) (uint64, error) { return f.disk, f.diskErr }
 func (f *fakeObserver) LookPath(name string) (string, error) {
+	if err := f.pathErr[name]; err != nil {
+		return "", err
+	}
 	if p, ok := f.paths[name]; ok {
 		return p, nil
 	}
@@ -85,7 +116,7 @@ func (f *fakeObserver) PortAvailable(context.Context, string, int) (bool, error)
 }
 
 func healthyObserver() *fakeObserver {
-	return &fakeObserver{platform: "linux", arch: "amd64", distribution: "ubuntu", files: map[string]FileObservation{}, statErr: map[string]error{}, paths: map[string]string{"git": "/usr/bin/git", "gh": "/usr/bin/gh", "claude": "/usr/bin/claude", "apt-get": "/usr/bin/apt-get", "systemctl": "/usr/bin/systemctl"}, runs: map[string]string{}, runErr: map[string]error{}, runFile: &runfile.Info{PID: 42, Port: 4321}, alive: true, disk: 2 << 30, portAvailable: true, responses: map[string][]byte{
+	return &fakeObserver{platform: "linux", arch: "amd64", distribution: "ubuntu", user: UserObservation{Name: "ubuntu", UID: 1000, Home: "/home/ubuntu"}, files: map[string]FileObservation{}, statErr: map[string]error{}, readFiles: map[string][]byte{}, readErr: map[string]error{}, artifacts: map[string]ArtifactMetadata{}, artifactErr: map[string]error{}, paths: map[string]string{"git": "/usr/bin/git", "gh": "/usr/bin/gh", "claude": "/usr/bin/claude", "apt-get": "/usr/bin/apt-get", "systemctl": "/usr/bin/systemctl"}, pathErr: map[string]error{}, runs: map[string]string{}, runErr: map[string]error{}, runFile: &runfile.Info{PID: 42, Port: 4321}, alive: true, disk: 2 << 30, portAvailable: true, responses: map[string][]byte{
 		"http://127.0.0.1:4321/healthz":       []byte(`{"status":"ok","service":"agent-orchestrator-daemon","pid":42}`),
 		"http://127.0.0.1:4321/readyz":        []byte(`{"status":"ready","service":"agent-orchestrator-daemon","pid":42}`),
 		"http://127.0.0.1:4321/api/v1/doctor": []byte(`{"ok":true,"failures":0,"checks":[{"level":"PASS","section":"Core","name":"runtime","message":"available"}]}`),

--- a/backend/internal/haocli/observation_test.go
+++ b/backend/internal/haocli/observation_test.go
@@ -17,27 +17,30 @@ import (
 )
 
 type fakeObserver struct {
-	platform, arch string
-	files          map[string]FileObservation
-	statErr        map[string]error
-	paths          map[string]string
-	runs           map[string]string
-	runErr         map[string]error
-	runFile        *runfile.Info
-	runFileErr     error
-	alive          bool
-	responses      map[string][]byte
-	getErr         map[string]error
-	urls           []string
-	runFiles       []string
-	disk           uint64
-	diskErr        error
-	portAvailable  bool
-	portErr        error
-	runCalls       int
+	platform, arch  string
+	distribution    string
+	distributionErr error
+	files           map[string]FileObservation
+	statErr         map[string]error
+	paths           map[string]string
+	runs            map[string]string
+	runErr          map[string]error
+	runFile         *runfile.Info
+	runFileErr      error
+	alive           bool
+	responses       map[string][]byte
+	getErr          map[string]error
+	urls            []string
+	runFiles        []string
+	disk            uint64
+	diskErr         error
+	portAvailable   bool
+	portErr         error
+	runCalls        int
 }
 
-func (f *fakeObserver) Platform() (string, string) { return f.platform, f.arch }
+func (f *fakeObserver) Platform() (string, string)    { return f.platform, f.arch }
+func (f *fakeObserver) Distribution() (string, error) { return f.distribution, f.distributionErr }
 func (f *fakeObserver) Stat(path string) (FileObservation, error) {
 	if err := f.statErr[path]; err != nil {
 		return FileObservation{}, err
@@ -45,7 +48,7 @@ func (f *fakeObserver) Stat(path string) (FileObservation, error) {
 	if v, ok := f.files[path]; ok {
 		return v, nil
 	}
-	return FileObservation{Mode: 0o700, Owner: true}, nil
+	return FileObservation{Mode: 0o700, Owner: true, IsDir: true}, nil
 }
 func (f *fakeObserver) Disk(string) (uint64, error) { return f.disk, f.diskErr }
 func (f *fakeObserver) LookPath(name string) (string, error) {
@@ -82,7 +85,7 @@ func (f *fakeObserver) PortAvailable(context.Context, string, int) (bool, error)
 }
 
 func healthyObserver() *fakeObserver {
-	return &fakeObserver{platform: "linux", arch: "amd64", files: map[string]FileObservation{}, statErr: map[string]error{}, paths: map[string]string{"git": "/usr/bin/git", "gh": "/usr/bin/gh", "claude": "/usr/bin/claude", "apt-get": "/usr/bin/apt-get", "systemctl": "/usr/bin/systemctl"}, runs: map[string]string{}, runErr: map[string]error{}, runFile: &runfile.Info{PID: 42, Port: 4321}, alive: true, disk: 2 << 30, portAvailable: true, responses: map[string][]byte{
+	return &fakeObserver{platform: "linux", arch: "amd64", distribution: "ubuntu", files: map[string]FileObservation{}, statErr: map[string]error{}, paths: map[string]string{"git": "/usr/bin/git", "gh": "/usr/bin/gh", "claude": "/usr/bin/claude", "apt-get": "/usr/bin/apt-get", "systemctl": "/usr/bin/systemctl"}, runs: map[string]string{}, runErr: map[string]error{}, runFile: &runfile.Info{PID: 42, Port: 4321}, alive: true, disk: 2 << 30, portAvailable: true, responses: map[string][]byte{
 		"http://127.0.0.1:4321/healthz":       []byte(`{"status":"ok","service":"agent-orchestrator-daemon","pid":42}`),
 		"http://127.0.0.1:4321/readyz":        []byte(`{"status":"ready","service":"agent-orchestrator-daemon","pid":42}`),
 		"http://127.0.0.1:4321/api/v1/doctor": []byte(`{"ok":true,"failures":0,"checks":[{"level":"PASS","section":"Core","name":"runtime","message":"available"}]}`),

--- a/backend/internal/haocli/observe.go
+++ b/backend/internal/haocli/observe.go
@@ -13,7 +13,6 @@ import (
 	"os"
 	"os/exec"
 	"os/user"
-	"path/filepath"
 	"runtime"
 	"strconv"
 	"strings"
@@ -38,7 +37,7 @@ type Observer interface {
 	CurrentUser() (UserObservation, error)
 	Stat(path string) (FileObservation, error)
 	ReadFile(path string) ([]byte, error)
-	InspectArtifact(path string) (ArtifactMetadata, error)
+	InspectArtifact(ctx context.Context, path string) (ArtifactMetadata, error)
 	Disk(path string) (uint64, error)
 	LookPath(name string) (string, error)
 	Run(ctx context.Context, name string, args ...string) (string, error)
@@ -119,7 +118,14 @@ func (systemObserver) ReadFile(path string) ([]byte, error) {
 	}
 	return data, nil
 }
-func (systemObserver) InspectArtifact(path string) (ArtifactMetadata, error) {
+func (systemObserver) InspectArtifact(ctx context.Context, path string) (ArtifactMetadata, error) {
+	return inspectArtifact(ctx, path)
+}
+
+func inspectArtifact(ctx context.Context, path string) (ArtifactMetadata, error) {
+	if err := ctx.Err(); err != nil {
+		return ArtifactMetadata{}, err
+	}
 	manifestPath := path + ".hao-manifest.json"
 	manifest, err := openManagedRegular(manifestPath, 16*1024)
 	if err != nil {
@@ -140,7 +146,7 @@ func (systemObserver) InspectArtifact(path string) (ArtifactMetadata, error) {
 	}
 	defer func() { _ = file.Close() }()
 	hash := sha256.New()
-	if _, err := io.Copy(hash, io.LimitReader(file, maxArtifactSize+1)); err != nil {
+	if _, err := io.Copy(hash, io.LimitReader(contextReader{ctx: ctx, reader: file}, maxArtifactSize+1)); err != nil {
 		return ArtifactMetadata{}, err
 	}
 	actual := fmt.Sprintf("%x", hash.Sum(nil))
@@ -150,28 +156,18 @@ func (systemObserver) InspectArtifact(path string) (ArtifactMetadata, error) {
 	return metadata, nil
 }
 
-// openManagedRegular rejects links in the path and verifies the opened handle is
-// the same bounded regular object observed before opening. It never executes it.
-func openManagedRegular(path string, maxSize int64) (*os.File, error) {
-	clean := filepath.Clean(path)
-	before, err := os.Lstat(clean)
-	if err != nil {
-		return nil, err
-	}
-	if !before.Mode().IsRegular() || before.Size() > maxSize {
-		return nil, errors.New("managed file is not a bounded regular file")
-	}
-	file, err := os.Open(clean)
-	if err != nil {
-		return nil, err
-	}
-	after, err := file.Stat()
-	if err != nil || !after.Mode().IsRegular() || after.Size() > maxSize || !os.SameFile(before, after) {
-		_ = file.Close()
-		return nil, errors.New("managed file changed while it was opened")
-	}
-	return file, nil
+type contextReader struct {
+	ctx    context.Context
+	reader io.Reader
 }
+
+func (r contextReader) Read(p []byte) (int, error) {
+	if err := r.ctx.Err(); err != nil {
+		return 0, err
+	}
+	return r.reader.Read(p)
+}
+
 func (systemObserver) Disk(path string) (uint64, error)               { return diskAvailable(path) }
 func (systemObserver) LookPath(name string) (string, error)           { return exec.LookPath(name) }
 func (systemObserver) ReadRunFile(path string) (*runfile.Info, error) { return runfile.Read(path) }

--- a/backend/internal/haocli/observe.go
+++ b/backend/internal/haocli/observe.go
@@ -103,9 +103,27 @@ func (systemObserver) CurrentUser() (UserObservation, error) {
 	return UserObservation{Name: u.Username, UID: uid, Home: u.HomeDir}, nil
 }
 func (systemObserver) Stat(path string) (FileObservation, error) { return statFile(path) }
-func (systemObserver) ReadFile(path string) ([]byte, error)      { return os.ReadFile(path) }
+func (systemObserver) ReadFile(path string) ([]byte, error) {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return nil, err
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() || info.Size() > maxHTTPBody {
+		return nil, errors.New("managed file is not a bounded regular file")
+	}
+	return os.ReadFile(path)
+}
 func (systemObserver) InspectArtifact(path string) (ArtifactMetadata, error) {
-	data, err := os.ReadFile(path + ".hao-manifest.json")
+	artifactInfo, err := os.Lstat(path)
+	if err != nil || artifactInfo.Mode()&os.ModeSymlink != 0 || !artifactInfo.Mode().IsRegular() {
+		return ArtifactMetadata{}, errors.New("artifact is not a regular non-link file")
+	}
+	manifestPath := path + ".hao-manifest.json"
+	manifestInfo, err := os.Lstat(manifestPath)
+	if err != nil || manifestInfo.Mode()&os.ModeSymlink != 0 || !manifestInfo.Mode().IsRegular() || manifestInfo.Size() > 16*1024 {
+		return ArtifactMetadata{}, errors.New("artifact manifest is not a bounded regular file")
+	}
+	data, err := os.ReadFile(manifestPath)
 	if err != nil {
 		return ArtifactMetadata{}, err
 	}

--- a/backend/internal/haocli/observe.go
+++ b/backend/internal/haocli/observe.go
@@ -3,6 +3,7 @@ package haocli
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -11,6 +12,8 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"os/user"
+	"path/filepath"
 	"runtime"
 	"strconv"
 	"strings"
@@ -31,7 +34,10 @@ const (
 type Observer interface {
 	Platform() (string, string)
 	Distribution() (string, error)
+	CurrentUser() (UserObservation, error)
 	Stat(path string) (FileObservation, error)
+	ReadFile(path string) ([]byte, error)
+	InspectArtifact(path string) (ArtifactMetadata, error)
 	Disk(path string) (uint64, error)
 	LookPath(name string) (string, error)
 	Run(ctx context.Context, name string, args ...string) (string, error)
@@ -47,6 +53,21 @@ type FileObservation struct {
 	UID   int
 	Owner bool
 	IsDir bool
+	Link  bool
+}
+
+// UserObservation is the non-secret identity used by managed services.
+type UserObservation struct {
+	Name string
+	UID  int
+	Home string
+}
+
+// ArtifactMetadata is provenance from the adjacent hao-owned manifest.
+type ArtifactMetadata struct {
+	Version string `json:"version"`
+	SHA256  string `json:"sha256"`
+	Source  string `json:"source"`
 }
 
 type systemObserver struct{}
@@ -68,9 +89,45 @@ func (b *boundedBuffer) Write(p []byte) (int, error) {
 	return original, nil
 }
 
-func (systemObserver) Platform() (string, string)                     { return runtime.GOOS, runtime.GOARCH }
-func (systemObserver) Distribution() (string, error)                  { return distributionID() }
-func (systemObserver) Stat(path string) (FileObservation, error)      { return statFile(path) }
+func (systemObserver) Platform() (string, string)    { return runtime.GOOS, runtime.GOARCH }
+func (systemObserver) Distribution() (string, error) { return distributionID() }
+func (systemObserver) CurrentUser() (UserObservation, error) {
+	u, err := user.Current()
+	if err != nil {
+		return UserObservation{}, err
+	}
+	uid, err := strconv.Atoi(u.Uid)
+	if err != nil {
+		return UserObservation{}, err
+	}
+	return UserObservation{Name: u.Username, UID: uid, Home: u.HomeDir}, nil
+}
+func (systemObserver) Stat(path string) (FileObservation, error) { return statFile(path) }
+func (systemObserver) ReadFile(path string) ([]byte, error)      { return os.ReadFile(path) }
+func (systemObserver) InspectArtifact(path string) (ArtifactMetadata, error) {
+	data, err := os.ReadFile(path + ".hao-manifest.json")
+	if err != nil {
+		return ArtifactMetadata{}, err
+	}
+	var metadata ArtifactMetadata
+	if err := json.Unmarshal(data, &metadata); err != nil {
+		return ArtifactMetadata{}, err
+	}
+	file, err := os.Open(filepath.Clean(path))
+	if err != nil {
+		return ArtifactMetadata{}, err
+	}
+	defer func() { _ = file.Close() }()
+	hash := sha256.New()
+	if _, err := io.Copy(hash, file); err != nil {
+		return ArtifactMetadata{}, err
+	}
+	actual := fmt.Sprintf("%x", hash.Sum(nil))
+	if metadata.Version == "" || metadata.Source == "" || metadata.SHA256 == "" || !strings.EqualFold(actual, metadata.SHA256) {
+		return ArtifactMetadata{}, errors.New("artifact manifest is missing provenance or does not match the artifact")
+	}
+	return metadata, nil
+}
 func (systemObserver) Disk(path string) (uint64, error)               { return diskAvailable(path) }
 func (systemObserver) LookPath(name string) (string, error)           { return exec.LookPath(name) }
 func (systemObserver) ReadRunFile(path string) (*runfile.Info, error) { return runfile.Read(path) }

--- a/backend/internal/haocli/observe.go
+++ b/backend/internal/haocli/observe.go
@@ -105,7 +105,7 @@ func (systemObserver) CurrentUser() (UserObservation, error) {
 }
 func (systemObserver) Stat(path string) (FileObservation, error) { return statFile(path) }
 func (systemObserver) ReadFile(path string) ([]byte, error) {
-	file, _, err := openManagedRegular(path, maxHTTPBody)
+	file, err := openManagedRegular(path, maxHTTPBody)
 	if err != nil {
 		return nil, err
 	}
@@ -121,7 +121,7 @@ func (systemObserver) ReadFile(path string) ([]byte, error) {
 }
 func (systemObserver) InspectArtifact(path string) (ArtifactMetadata, error) {
 	manifestPath := path + ".hao-manifest.json"
-	manifest, _, err := openManagedRegular(manifestPath, 16*1024)
+	manifest, err := openManagedRegular(manifestPath, 16*1024)
 	if err != nil {
 		return ArtifactMetadata{}, err
 	}
@@ -134,7 +134,7 @@ func (systemObserver) InspectArtifact(path string) (ArtifactMetadata, error) {
 	if err := json.Unmarshal(data, &metadata); err != nil {
 		return ArtifactMetadata{}, err
 	}
-	file, _, err := openManagedRegular(path, maxArtifactSize)
+	file, err := openManagedRegular(path, maxArtifactSize)
 	if err != nil {
 		return ArtifactMetadata{}, err
 	}
@@ -152,25 +152,25 @@ func (systemObserver) InspectArtifact(path string) (ArtifactMetadata, error) {
 
 // openManagedRegular rejects links in the path and verifies the opened handle is
 // the same bounded regular object observed before opening. It never executes it.
-func openManagedRegular(path string, maxSize int64) (*os.File, os.FileInfo, error) {
+func openManagedRegular(path string, maxSize int64) (*os.File, error) {
 	clean := filepath.Clean(path)
 	before, err := os.Lstat(clean)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 	if !before.Mode().IsRegular() || before.Size() > maxSize {
-		return nil, nil, errors.New("managed file is not a bounded regular file")
+		return nil, errors.New("managed file is not a bounded regular file")
 	}
 	file, err := os.Open(clean)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 	after, err := file.Stat()
 	if err != nil || !after.Mode().IsRegular() || after.Size() > maxSize || !os.SameFile(before, after) {
 		_ = file.Close()
-		return nil, nil, errors.New("managed file changed while it was opened")
+		return nil, errors.New("managed file changed while it was opened")
 	}
-	return file, after, nil
+	return file, nil
 }
 func (systemObserver) Disk(path string) (uint64, error)               { return diskAvailable(path) }
 func (systemObserver) LookPath(name string) (string, error)           { return exec.LookPath(name) }

--- a/backend/internal/haocli/observe.go
+++ b/backend/internal/haocli/observe.go
@@ -30,6 +30,7 @@ const (
 // Tests inject it so no probe depends on the developer's machine or network.
 type Observer interface {
 	Platform() (string, string)
+	Distribution() (string, error)
 	Stat(path string) (FileObservation, error)
 	Disk(path string) (uint64, error)
 	LookPath(name string) (string, error)
@@ -45,6 +46,7 @@ type FileObservation struct {
 	Mode  os.FileMode
 	UID   int
 	Owner bool
+	IsDir bool
 }
 
 type systemObserver struct{}
@@ -67,6 +69,7 @@ func (b *boundedBuffer) Write(p []byte) (int, error) {
 }
 
 func (systemObserver) Platform() (string, string)                     { return runtime.GOOS, runtime.GOARCH }
+func (systemObserver) Distribution() (string, error)                  { return distributionID() }
 func (systemObserver) Stat(path string) (FileObservation, error)      { return statFile(path) }
 func (systemObserver) Disk(path string) (uint64, error)               { return diskAvailable(path) }
 func (systemObserver) LookPath(name string) (string, error)           { return exec.LookPath(name) }

--- a/backend/internal/haocli/observe.go
+++ b/backend/internal/haocli/observe.go
@@ -27,6 +27,7 @@ import (
 const (
 	maxHTTPBody      = 1 << 20
 	maxCommandOutput = 4096
+	maxArtifactSize  = 256 << 20
 )
 
 // Observer is the complete read-only machine boundary used by status and doctor.
@@ -104,40 +105,42 @@ func (systemObserver) CurrentUser() (UserObservation, error) {
 }
 func (systemObserver) Stat(path string) (FileObservation, error) { return statFile(path) }
 func (systemObserver) ReadFile(path string) ([]byte, error) {
-	info, err := os.Lstat(path)
+	file, _, err := openManagedRegular(path, maxHTTPBody)
 	if err != nil {
 		return nil, err
 	}
-	if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() || info.Size() > maxHTTPBody {
-		return nil, errors.New("managed file is not a bounded regular file")
+	defer func() { _ = file.Close() }()
+	data, err := io.ReadAll(io.LimitReader(file, maxHTTPBody+1))
+	if err != nil {
+		return nil, err
 	}
-	return os.ReadFile(path)
+	if len(data) > maxHTTPBody {
+		return nil, errors.New("managed file exceeds size limit")
+	}
+	return data, nil
 }
 func (systemObserver) InspectArtifact(path string) (ArtifactMetadata, error) {
-	artifactInfo, err := os.Lstat(path)
-	if err != nil || artifactInfo.Mode()&os.ModeSymlink != 0 || !artifactInfo.Mode().IsRegular() {
-		return ArtifactMetadata{}, errors.New("artifact is not a regular non-link file")
-	}
 	manifestPath := path + ".hao-manifest.json"
-	manifestInfo, err := os.Lstat(manifestPath)
-	if err != nil || manifestInfo.Mode()&os.ModeSymlink != 0 || !manifestInfo.Mode().IsRegular() || manifestInfo.Size() > 16*1024 {
-		return ArtifactMetadata{}, errors.New("artifact manifest is not a bounded regular file")
-	}
-	data, err := os.ReadFile(manifestPath)
+	manifest, _, err := openManagedRegular(manifestPath, 16*1024)
 	if err != nil {
 		return ArtifactMetadata{}, err
+	}
+	defer func() { _ = manifest.Close() }()
+	data, err := io.ReadAll(io.LimitReader(manifest, 16*1024+1))
+	if err != nil || len(data) > 16*1024 {
+		return ArtifactMetadata{}, errors.New("artifact manifest exceeds size limit")
 	}
 	var metadata ArtifactMetadata
 	if err := json.Unmarshal(data, &metadata); err != nil {
 		return ArtifactMetadata{}, err
 	}
-	file, err := os.Open(filepath.Clean(path))
+	file, _, err := openManagedRegular(path, maxArtifactSize)
 	if err != nil {
 		return ArtifactMetadata{}, err
 	}
 	defer func() { _ = file.Close() }()
 	hash := sha256.New()
-	if _, err := io.Copy(hash, file); err != nil {
+	if _, err := io.Copy(hash, io.LimitReader(file, maxArtifactSize+1)); err != nil {
 		return ArtifactMetadata{}, err
 	}
 	actual := fmt.Sprintf("%x", hash.Sum(nil))
@@ -145,6 +148,29 @@ func (systemObserver) InspectArtifact(path string) (ArtifactMetadata, error) {
 		return ArtifactMetadata{}, errors.New("artifact manifest is missing provenance or does not match the artifact")
 	}
 	return metadata, nil
+}
+
+// openManagedRegular rejects links in the path and verifies the opened handle is
+// the same bounded regular object observed before opening. It never executes it.
+func openManagedRegular(path string, maxSize int64) (*os.File, os.FileInfo, error) {
+	clean := filepath.Clean(path)
+	before, err := os.Lstat(clean)
+	if err != nil {
+		return nil, nil, err
+	}
+	if !before.Mode().IsRegular() || before.Size() > maxSize {
+		return nil, nil, errors.New("managed file is not a bounded regular file")
+	}
+	file, err := os.Open(clean)
+	if err != nil {
+		return nil, nil, err
+	}
+	after, err := file.Stat()
+	if err != nil || !after.Mode().IsRegular() || after.Size() > maxSize || !os.SameFile(before, after) {
+		_ = file.Close()
+		return nil, nil, errors.New("managed file changed while it was opened")
+	}
+	return file, after, nil
 }
 func (systemObserver) Disk(path string) (uint64, error)               { return diskAvailable(path) }
 func (systemObserver) LookPath(name string) (string, error)           { return exec.LookPath(name) }

--- a/backend/internal/haocli/observe_unix.go
+++ b/backend/internal/haocli/observe_unix.go
@@ -34,7 +34,7 @@ func distributionID() (string, error) {
 }
 
 func statFile(path string) (FileObservation, error) {
-	info, err := os.Stat(path)
+	info, err := os.Lstat(path)
 	if err != nil {
 		return FileObservation{}, err
 	}
@@ -42,7 +42,7 @@ func statFile(path string) (FileObservation, error) {
 	if stat, ok := info.Sys().(*syscall.Stat_t); ok {
 		uid = int(stat.Uid)
 	}
-	return FileObservation{Mode: info.Mode(), UID: uid, Owner: uid < 0 || uid == os.Geteuid(), IsDir: info.IsDir()}, nil
+	return FileObservation{Mode: info.Mode(), UID: uid, Owner: uid < 0 || uid == os.Geteuid(), IsDir: info.IsDir(), Link: info.Mode()&os.ModeSymlink != 0}, nil
 }
 
 func diskAvailable(path string) (uint64, error) {

--- a/backend/internal/haocli/observe_unix.go
+++ b/backend/internal/haocli/observe_unix.go
@@ -3,9 +3,35 @@
 package haocli
 
 import (
+	"bufio"
+	"errors"
 	"os"
+	"runtime"
+	"strings"
 	"syscall"
 )
+
+func distributionID() (string, error) {
+	if runtime.GOOS != "linux" {
+		return runtime.GOOS, nil
+	}
+	file, err := os.Open("/etc/os-release")
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = file.Close() }()
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		key, value, ok := strings.Cut(scanner.Text(), "=")
+		if ok && key == "ID" {
+			return strings.Trim(strings.TrimSpace(value), `"`), nil
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return "", err
+	}
+	return "", errors.New("distribution ID is absent")
+}
 
 func statFile(path string) (FileObservation, error) {
 	info, err := os.Stat(path)
@@ -16,7 +42,7 @@ func statFile(path string) (FileObservation, error) {
 	if stat, ok := info.Sys().(*syscall.Stat_t); ok {
 		uid = int(stat.Uid)
 	}
-	return FileObservation{Mode: info.Mode(), UID: uid, Owner: uid < 0 || uid == os.Geteuid()}, nil
+	return FileObservation{Mode: info.Mode(), UID: uid, Owner: uid < 0 || uid == os.Geteuid(), IsDir: info.IsDir()}, nil
 }
 
 func diskAvailable(path string) (uint64, error) {

--- a/backend/internal/haocli/observe_windows.go
+++ b/backend/internal/haocli/observe_windows.go
@@ -12,9 +12,11 @@ func statFile(path string) (FileObservation, error) {
 	if err != nil {
 		return FileObservation{}, err
 	}
-	return FileObservation{Mode: info.Mode(), UID: -1, Owner: true}, nil
+	return FileObservation{Mode: info.Mode(), UID: -1, Owner: true, IsDir: info.IsDir()}, nil
 }
 
 func diskAvailable(string) (uint64, error) {
 	return 0, errors.New("disk availability probe unsupported on windows")
 }
+
+func distributionID() (string, error) { return "windows", nil }

--- a/backend/internal/haocli/observe_windows.go
+++ b/backend/internal/haocli/observe_windows.go
@@ -8,11 +8,11 @@ import (
 )
 
 func statFile(path string) (FileObservation, error) {
-	info, err := os.Stat(path)
+	info, err := os.Lstat(path)
 	if err != nil {
 		return FileObservation{}, err
 	}
-	return FileObservation{Mode: info.Mode(), UID: -1, Owner: true, IsDir: info.IsDir()}, nil
+	return FileObservation{Mode: info.Mode(), UID: -1, Owner: true, IsDir: info.IsDir(), Link: info.Mode()&os.ModeSymlink != 0}, nil
 }
 
 func diskAvailable(string) (uint64, error) {

--- a/backend/internal/haocli/root.go
+++ b/backend/internal/haocli/root.go
@@ -137,6 +137,7 @@ func NewRootCommand(deps Deps) *cobra.Command {
 	root.AddCommand(newConfigCommand(deps, opts))
 	root.AddCommand(newStatusCommand(deps, opts))
 	root.AddCommand(newDoctorCommand(deps, opts))
+	root.AddCommand(newSetupCommand(deps, opts))
 	return root
 }
 

--- a/backend/internal/haocli/root.go
+++ b/backend/internal/haocli/root.go
@@ -36,8 +36,11 @@ type Deps struct {
 	StateDir func() (string, error)
 	RunFile  func() (string, error)
 	Observer Observer
-	Timeout  time.Duration
-	Now      func() time.Time
+	// TrustedArtifact supplies immutable release metadata from an injected
+	// authority. Production leaves it nil until the Batch 5 resolver exists.
+	TrustedArtifact func(goos, arch, version string) (ArtifactMetadata, bool)
+	Timeout         time.Duration
+	Now             func() time.Time
 }
 
 // DefaultDeps returns the production read-only CLI dependencies.

--- a/backend/internal/haocli/root_test.go
+++ b/backend/internal/haocli/root_test.go
@@ -220,7 +220,7 @@ func TestCommandSurfaceContainsNoAOOrchestration(t *testing.T) {
 	for _, cmd := range root.Commands() {
 		got = append(got, cmd.Name())
 	}
-	if want := []string{"config", "doctor", "status", "version"}; !reflect.DeepEqual(got, want) {
+	if want := []string{"config", "doctor", "setup", "status", "version"}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("hao commands = %v, want %v", got, want)
 	}
 	for _, forbidden := range []string{"spawn", "session", "send", "project", "review", "terminal", "daemon", "vm"} {

--- a/backend/internal/haocli/setup.go
+++ b/backend/internal/haocli/setup.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"net"
 	"os"
+	pathpkg "path"
 	"path/filepath"
 	"regexp"
 	"strconv"
@@ -675,8 +676,11 @@ func systemdInputsSafe(d setupDesired, user UserObservation) bool {
 		return false
 	}
 	for _, value := range []string{user.Home, d.StateRoot} {
+		if !pathpkg.IsAbs(value) {
+			return false
+		}
 		for _, r := range value {
-			if r <= 0x20 || r == 0x7f {
+			if r <= 0x20 || r == 0x7f || r == '%' || r == '\\' {
 				return false
 			}
 		}

--- a/backend/internal/haocli/setup.go
+++ b/backend/internal/haocli/setup.go
@@ -1,9 +1,14 @@
 package haocli
 
 import (
+	"bytes"
+	"context"
 	"crypto/sha256"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+	"net"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -23,17 +28,54 @@ type SetupPrivilege struct {
 
 // SetupAction is a structured, shell-free future execution description.
 type SetupAction struct {
-	SchemaVersion int      `json:"schemaVersion"`
-	Kind          string   `json:"kind"`
-	Executable    string   `json:"executable,omitempty"`
-	Argv          []string `json:"argv,omitempty"`
-	Path          string   `json:"path,omitempty"`
-	Mode          string   `json:"mode,omitempty"`
-	Version       string   `json:"version,omitempty"`
-	Source        string   `json:"source,omitempty"`
-	VerifyWith    string   `json:"verifyWith,omitempty"`
-	Content       string   `json:"content,omitempty"`
-	SHA256        string   `json:"sha256,omitempty"`
+	SchemaVersion int                  `json:"schemaVersion"`
+	Kind          string               `json:"kind"`
+	File          *SetupFileAction     `json:"file,omitempty"`
+	Package       *SetupPackageAction  `json:"package,omitempty"`
+	Artifact      *SetupArtifactAction `json:"artifact,omitempty"`
+	Vendor        *SetupVendorAction   `json:"vendor,omitempty"`
+	Service       *SetupServiceAction  `json:"service,omitempty"`
+}
+
+// SetupFileAction is the payload for one managed file operation.
+type SetupFileAction struct {
+	Path string `json:"path"`
+	Mode string `json:"mode"`
+}
+
+// SetupPackageAction is the payload for an allowlisted system package operation.
+type SetupPackageAction struct {
+	Executable string   `json:"executable"`
+	Argv       []string `json:"argv"`
+	Version    string   `json:"version"`
+	Source     string   `json:"source"`
+	SHA256     string   `json:"sha256"`
+}
+
+// SetupArtifactAction identifies one immutable release artifact.
+type SetupArtifactAction struct {
+	Path    string `json:"path"`
+	Version string `json:"version"`
+	Source  string `json:"source"`
+	SHA256  string `json:"sha256"`
+}
+
+// SetupVendorAction identifies one immutable vendor package.
+type SetupVendorAction struct {
+	Executable string   `json:"executable"`
+	Argv       []string `json:"argv"`
+	Version    string   `json:"version"`
+	Source     string   `json:"source"`
+	SHA256     string   `json:"sha256"`
+}
+
+// SetupServiceAction contains a complete canonical service definition.
+type SetupServiceAction struct {
+	Path    string `json:"path"`
+	Mode    string `json:"mode"`
+	Version string `json:"version"`
+	Content string `json:"content"`
+	SHA256  string `json:"sha256"`
 }
 
 // SetupStep is one stable desired-versus-observed reconciliation decision.
@@ -80,12 +122,13 @@ type setupDesired struct {
 }
 
 type observedItem struct {
-	State, Evidence, Version, Path string
-	Mode                           os.FileMode
-	UID                            int
-	Owner                          bool
-	IsDir                          bool
-	Link                           bool
+	State, Evidence, Version, Path, Source, SHA256 string
+	Mode                                           os.FileMode
+	UID                                            int
+	Owner                                          bool
+	IsDir                                          bool
+	Link                                           bool
+	Trusted                                        bool
 }
 
 type setupSnapshot struct {
@@ -118,8 +161,12 @@ func newSetupCommand(deps Deps, opts *options) *cobra.Command {
 		if err != nil {
 			return err
 		}
-		plan := planSetup(desired, observeSetup(deps, desired))
-		if err := validateSetupPlan(plan); err != nil {
+		plan := planSetup(desired, observeSetup(cmd.Context(), deps, desired))
+		serializedPlan, err := json.Marshal(plan)
+		if err != nil {
+			return operationalError("serialize setup plan", err)
+		}
+		if _, err := consumeSetupPlanJSON(serializedPlan); err != nil {
 			return operationalError("validate setup plan", err)
 		}
 		if opts.json {
@@ -161,7 +208,7 @@ func resolveSetupDesired(deps Deps, path string, object map[string]any, install 
 	return d, nil
 }
 
-func observeSetup(deps Deps, desired setupDesired) setupSnapshot {
+func observeSetup(ctx context.Context, deps Deps, desired setupDesired) setupSnapshot {
 	osName, arch := deps.Observer.Platform()
 	s := setupSnapshot{OS: osName, Arch: arch, Directories: map[string]observedItem{}, Tools: map[string]observedItem{}, ServiceFiles: map[string]observedItem{}}
 	if distro, err := deps.Observer.Distribution(); err != nil {
@@ -192,11 +239,16 @@ func observeSetup(deps Deps, desired setupDesired) setupSnapshot {
 		s.Artifact.State, s.Artifact.Evidence = "unknown", "managed artifact ancestry is not a proven owned non-link directory chain"
 	}
 	if s.Artifact.State == "present" && s.Artifact.Owner && !s.Artifact.IsDir && !s.Artifact.Link && s.Artifact.Mode.Perm()&0o022 == 0 && s.Artifact.Mode.Perm()&0o111 != 0 {
-		metadata, err := deps.Observer.InspectArtifact(artifactPath)
+		metadata, err := deps.Observer.InspectArtifact(ctx, artifactPath)
 		if err != nil {
 			s.Artifact.State, s.Artifact.Evidence = "unknown", "artifact provenance probe failed: "+safeDiagnostic(err)
 		} else {
-			s.Artifact.Version, s.Artifact.Evidence = metadata.Version, "verified hao manifest from "+metadata.Source
+			s.Artifact.Version, s.Artifact.Source, s.Artifact.SHA256 = metadata.Version, metadata.Source, metadata.SHA256
+			s.Artifact.Evidence = "observed hao artifact provenance from " + metadata.Source
+			if deps.TrustedArtifact != nil {
+				trusted, ok := deps.TrustedArtifact(osName, arch, desired.AOVersion)
+				s.Artifact.Trusted = ok && matchesTrustedArtifact(metadata, trusted)
+			}
 		}
 		s.Artifact.Path = artifactPath
 	}
@@ -215,6 +267,10 @@ func observeSetup(deps Deps, desired setupDesired) setupSnapshot {
 		}
 	}
 	return s
+}
+
+func matchesTrustedArtifact(observed, trusted ArtifactMetadata) bool {
+	return trusted.Version == observed.Version && trusted.Source == observed.Source && strings.EqualFold(trusted.SHA256, observed.SHA256) && validSHA256(strings.ToLower(trusted.SHA256)) && strings.Contains(trusted.Source, "/releases/download/v"+trusted.Version+"/")
 }
 
 func observeFile(obs Observer, path string) observedItem {
@@ -379,7 +435,7 @@ func planDirectory(id string, item observedItem) SetupStep {
 		return blockedStep(id, component, "reconcile-directory", "directory state is unknown", item.Evidence, "inspect the path and its parent permissions manually")
 	}
 	if item.State == "absent" {
-		return SetupStep{ID: id, Component: component, Operation: "create-directory", Disposition: "create", Reason: "required directory is absent", Evidence: item.Evidence, Action: &SetupAction{SchemaVersion: 1, Kind: "directory", Path: item.Path, Mode: "0700"}}
+		return SetupStep{ID: id, Component: component, Operation: "create-directory", Disposition: "create", Reason: "required directory is absent", Evidence: item.Evidence, Action: &SetupAction{SchemaVersion: 1, Kind: "directory", File: &SetupFileAction{Path: item.Path, Mode: "0700"}}}
 	}
 	if !item.IsDir {
 		return blockedStep(id, component, "reconcile-directory", "required directory path is occupied by a non-directory", item.Evidence, "move the conflicting path outside hao, then retry")
@@ -391,7 +447,7 @@ func planDirectory(id string, item observedItem) SetupStep {
 		return blockedStep(id, component, "reconcile-directory", "existing directory has unsafe ownership", item.Evidence, "correct ownership outside hao, then retry")
 	}
 	if item.Mode.Perm()&0o077 != 0 {
-		return SetupStep{ID: id, Component: component, Operation: "set-directory-mode", Disposition: "update", Reason: "directory permissions are broader than owner-only", Evidence: item.Evidence, Action: &SetupAction{SchemaVersion: 1, Kind: "file-mode", Path: item.Path, Mode: "0700"}}
+		return SetupStep{ID: id, Component: component, Operation: "set-directory-mode", Disposition: "update", Reason: "directory permissions are broader than owner-only", Evidence: item.Evidence, Action: &SetupAction{SchemaVersion: 1, Kind: "file-mode", File: &SetupFileAction{Path: item.Path, Mode: "0700"}}}
 	}
 	return noopStep(id, component, "verify-directory", "directory ownership and permissions already match", item.Evidence)
 }
@@ -399,12 +455,8 @@ func planArtifact(d setupDesired, item observedItem) SetupStep {
 	if item.State == "unknown" {
 		return blockedStep("artifact.ao", "ao-gateway-artifact", "reconcile-artifact", "artifact state or version is unknown", item.Evidence, "inspect the hao-owned AO artifact manually")
 	}
-	action := artifactReleaseAction(d, item.Path)
 	if item.State == "absent" {
-		if d.Install == "none" {
-			return blockedStep("artifact.ao", "ao-gateway-artifact", "manual-install", "audit-only policy forbids planning artifact installation", item.Evidence, "install the requested hao-owned AO artifact manually, then rerun setup")
-		}
-		return SetupStep{ID: "artifact.ao", Component: "ao-gateway-artifact", Operation: "install-artifact", Disposition: "create", Reason: "hao-owned AO/gateway artifact is absent", Evidence: item.Evidence, Action: action}
+		return blockedStep("artifact.ao", "ao-gateway-artifact", "manual-install", "trusted immutable release metadata is unavailable", item.Evidence, "install the requested hao-owned AO artifact manually, then rerun setup")
 	}
 	if item.IsDir {
 		return blockedStep("artifact.ao", "ao-gateway-artifact", "reconcile-artifact", "artifact path is occupied by a directory", item.Evidence, "move the conflicting directory outside hao")
@@ -419,13 +471,13 @@ func planArtifact(d setupDesired, item observedItem) SetupStep {
 		return blockedStep("artifact.ao", "ao-gateway-artifact", "reconcile-artifact", "existing artifact is writable by group or other users", item.Evidence, "secure or remove the conflicting artifact outside hao")
 	}
 	if item.Mode.Perm()&0o111 == 0 {
-		return SetupStep{ID: "artifact.ao", Component: "ao-gateway-artifact", Operation: "replace-artifact", Disposition: "update", Reason: "existing artifact is not executable", Evidence: item.Evidence, Action: action}
+		return blockedStep("artifact.ao", "ao-gateway-artifact", "manual-update", "trusted immutable release metadata is unavailable for replacement", item.Evidence, "replace the artifact manually from a trusted release")
+	}
+	if !item.Trusted || !validSHA256(strings.ToLower(item.SHA256)) || !strings.Contains(item.Source, "/releases/download/v"+item.Version+"/") {
+		return blockedStep("artifact.ao", "ao-gateway-artifact", "verify-provenance", "trusted immutable release metadata is unavailable", item.Evidence, "verify the artifact against trusted immutable release metadata")
 	}
 	if !versionMatches(item.Version, d.AOVersion) {
-		if d.Install == "none" {
-			return blockedStep("artifact.ao", "ao-gateway-artifact", "manual-update", "audit-only policy forbids planning artifact replacement", "observed "+item.Version+"; desired "+d.AOVersion, "install the requested hao-owned AO artifact version manually, then rerun setup")
-		}
-		return SetupStep{ID: "artifact.ao", Component: "ao-gateway-artifact", Operation: "replace-artifact", Disposition: "update", Reason: "installed artifact version differs from desired version", Evidence: "observed " + item.Version + "; desired " + d.AOVersion, Action: action}
+		return blockedStep("artifact.ao", "ao-gateway-artifact", "manual-update", "trusted immutable metadata for the desired artifact is unavailable", "observed "+item.Version+"; desired "+d.AOVersion, "install the requested artifact version manually from a trusted release")
 	}
 	return noopStep("artifact.ao", "ao-gateway-artifact", "verify-artifact", "hao-owned AO/gateway artifact version already matches", item.Version)
 }
@@ -444,16 +496,12 @@ func planPrerequisite(d setupDesired, s setupSnapshot, id, component string, ite
 		return blockedStep(stepID, component, "manual-install", "selected harness has no allowlisted installer", item.Evidence, "install the selected harness using its vendor documentation")
 	}
 	if id == "harness" {
-		return SetupStep{ID: stepID, Component: component, Operation: "install-vendor-artifact", Disposition: "create", Reason: "required allowlisted harness is absent", Evidence: item.Evidence, Action: &SetupAction{SchemaVersion: 1, Kind: "vendor-package", Executable: "npm", Argv: []string{"install", "--global", "@anthropic-ai/claude-code@latest"}, Source: "https://registry.npmjs.org/@anthropic-ai/claude-code", Version: "latest"}}
+		return blockedStep(stepID, component, "manual-install", "trusted immutable vendor package metadata is unavailable", item.Evidence, "install the selected harness from pinned trusted vendor metadata")
 	}
 	if s.PackageManager.State != "present" {
 		return blockedStep(stepID, component, "install-prerequisite", "a supported package manager is not proven usable", s.PackageManager.Evidence, "install the prerequisite manually or restore the supported package manager")
 	}
-	privilege := SetupPrivilege{}
-	if filepath.Base(s.PackageManager.Path) == "apt-get" {
-		privilege = SetupPrivilege{Required: true, Scope: "package-install"}
-	}
-	return SetupStep{ID: stepID, Component: component, Operation: "install-package", Disposition: "create", Privilege: privilege, Reason: "required prerequisite is absent", Evidence: item.Evidence, Action: &SetupAction{SchemaVersion: 1, Kind: "package-manager", Executable: s.PackageManager.Path, Argv: []string{"install", id}}}
+	return blockedStep(stepID, component, "manual-install", "trusted immutable package metadata is unavailable", item.Evidence, "install "+component+" manually from pinned trusted package metadata")
 }
 
 func planServices(d setupDesired, s setupSnapshot) []SetupStep {
@@ -509,7 +557,7 @@ func planServices(d setupDesired, s setupSnapshot) []SetupStep {
 		var step SetupStep
 		desiredContent := renderSystemdDefinition(id, d, s.User)
 		digest := sha256.Sum256([]byte(desiredContent))
-		action := &SetupAction{SchemaVersion: 1, Kind: "service-definition-v1", Path: item.Path, Mode: "0644", Version: "1", Content: desiredContent, SHA256: fmt.Sprintf("%x", digest[:])}
+		action := &SetupAction{SchemaVersion: 1, Kind: "service-definition-v1", Service: &SetupServiceAction{Path: item.Path, Mode: "0644", Version: "1", Content: desiredContent, SHA256: fmt.Sprintf("%x", digest[:])}}
 		switch item.State {
 		case "absent":
 			step = SetupStep{ID: id, Component: component, Operation: "install-definition", Disposition: "create", Privilege: SetupPrivilege{Required: true, Scope: "system-service-definition"}, Reason: "supported service definition is absent", Evidence: item.Evidence, Action: action}
@@ -552,6 +600,86 @@ func renderSystemdDefinition(id string, d setupDesired, user UserObservation) st
 	}
 	b.WriteString("Restart=on-failure\n\n[Install]\nWantedBy=multi-user.target\n")
 	return b.String()
+}
+
+type systemdDefinitionConsumer struct {
+	Environment          map[string]string
+	HasNetBindCapability bool
+	ExecStart            string
+}
+
+// consumeSystemdDefinition parses the exact subset emitted by the planner and
+// verifies the gateway/daemon values a later service-file writer would use.
+func consumeSystemdDefinition(content string) (systemdDefinitionConsumer, error) {
+	parsed := systemdDefinitionConsumer{Environment: map[string]string{}}
+	ambient, bounding := false, false
+	for _, line := range strings.Split(content, "\n") {
+		switch {
+		case strings.HasPrefix(line, "Environment="):
+			value, err := strconv.Unquote(strings.TrimPrefix(line, "Environment="))
+			if err != nil {
+				return parsed, fmt.Errorf("parse systemd environment: %w", err)
+			}
+			key, value, ok := strings.Cut(value, "=")
+			if !ok || key == "" {
+				return parsed, errors.New("invalid systemd environment entry")
+			}
+			parsed.Environment[key] = value
+		case strings.HasPrefix(line, "ExecStart="):
+			parsed.ExecStart = strings.TrimPrefix(line, "ExecStart=")
+		case line == "AmbientCapabilities=CAP_NET_BIND_SERVICE":
+			ambient = true
+		case line == "CapabilityBoundingSet=CAP_NET_BIND_SERVICE":
+			bounding = true
+		}
+	}
+	if parsed.ExecStart == "" {
+		return parsed, errors.New("systemd definition has no ExecStart")
+	}
+	pathValue := parsed.Environment["PATH"]
+	if pathValue == "" {
+		return parsed, errors.New("systemd definition has no controlled PATH")
+	}
+	for _, entry := range filepath.SplitList(pathValue) {
+		if !filepath.IsAbs(entry) {
+			return parsed, errors.New("systemd PATH contains a non-absolute entry")
+		}
+	}
+	parsed.HasNetBindCapability = ambient && bounding
+	if ambient != bounding {
+		return parsed, errors.New("systemd network bind capability is incomplete")
+	}
+	if addr := parsed.Environment["AO_VM_HTTPS_ADDR"]; addr != "" {
+		_, rawPort, err := net.SplitHostPort(addr)
+		if err != nil {
+			return parsed, fmt.Errorf("parse gateway HTTPS address: %w", err)
+		}
+		port, err := strconv.Atoi(rawPort)
+		if err != nil || port < 1 || port > 65535 {
+			return parsed, errors.New("gateway HTTPS port is invalid")
+		}
+		if (port < 1024) != parsed.HasNetBindCapability {
+			return parsed, errors.New("gateway capability does not match HTTPS port privilege")
+		}
+		if !strings.HasSuffix(parsed.ExecStart, " vm serve") {
+			return parsed, errors.New("gateway ExecStart does not invoke vm serve")
+		}
+	}
+	return parsed, nil
+}
+
+func lookPathInService(name, pathValue string) (string, error) {
+	if name == "" || filepath.Base(name) != name {
+		return "", errors.New("service executable name must be a base name")
+	}
+	for _, directory := range filepath.SplitList(pathValue) {
+		candidate := filepath.Join(directory, name)
+		info, err := os.Stat(candidate)
+		if err == nil && info.Mode().IsRegular() && info.Mode().Perm()&0o111 != 0 {
+			return candidate, nil
+		}
+	}
+	return "", os.ErrNotExist
 }
 
 var systemdUserPattern = regexp.MustCompile(`^[A-Za-z0-9_.-]+$`)
@@ -604,13 +732,6 @@ func versionMatches(observed, desired string) bool {
 	return false
 }
 
-func artifactReleaseAction(d setupDesired, path string) *SetupAction {
-	arch := map[string]string{"amd64": "x64", "arm64": "arm64"}[d.Arch]
-	asset := "ao-" + d.OS + "-" + arch
-	source := "https://github.com/agentlab-in/hosted-ao/releases/download/v" + d.AOVersion + "/" + asset
-	return &SetupAction{SchemaVersion: 1, Kind: "verified-release-artifact", Path: path, Version: d.AOVersion, Source: source, VerifyWith: source + ".sha256"}
-}
-
 // validateSetupPlan is the non-mutating consumer boundary for the future executor.
 // It rejects ambiguous action variants without opening files, executing programs,
 // contacting networks, or changing machine state.
@@ -618,34 +739,112 @@ func validateSetupPlan(plan SetupPlan) error {
 	for _, step := range plan.Steps {
 		a := step.Action
 		if a == nil {
+			if step.Disposition == "create" || step.Disposition == "update" {
+				return fmt.Errorf("step %s is executable but has no action", step.ID)
+			}
 			continue
+		}
+		if step.Disposition != "create" && step.Disposition != "update" {
+			return fmt.Errorf("step %s has an action for non-executable disposition %q", step.ID, step.Disposition)
 		}
 		if a.SchemaVersion != 1 {
 			return fmt.Errorf("step %s has unsupported action schema", step.ID)
 		}
+		variants := 0
+		for _, present := range []bool{a.File != nil, a.Package != nil, a.Artifact != nil, a.Vendor != nil, a.Service != nil} {
+			if present {
+				variants++
+			}
+		}
+		if variants != 1 {
+			return fmt.Errorf("step %s action must contain exactly one variant", step.ID)
+		}
 		switch a.Kind {
 		case "directory", "file-mode":
-			if a.Path == "" || a.Mode == "" {
+			if a.File == nil || !filepath.IsAbs(a.File.Path) || (a.File.Mode != "0700" && a.File.Mode != "0644") {
 				return fmt.Errorf("step %s has incomplete file action", step.ID)
 			}
-		case "package-manager", "vendor-package":
-			if a.Executable == "" || len(a.Argv) == 0 || a.Source == "" && a.Kind == "vendor-package" {
-				return fmt.Errorf("step %s has incomplete installer action", step.ID)
+		case "package-manager":
+			if a.Package == nil || !filepath.IsAbs(a.Package.Executable) || len(a.Package.Argv) == 0 || a.Package.Version == "" || a.Package.Version == "latest" || a.Package.Source == "" || !validSHA256(a.Package.SHA256) || !strings.Contains(a.Package.Source, a.Package.Version) || !strings.Contains(strings.Join(a.Package.Argv, "\x00"), a.Package.Version) {
+				return fmt.Errorf("step %s has mutable package provenance", step.ID)
+			}
+		case "vendor-package":
+			if a.Vendor == nil || !filepath.IsAbs(a.Vendor.Executable) || len(a.Vendor.Argv) == 0 || a.Vendor.Source == "" || a.Vendor.Version == "" || a.Vendor.Version == "latest" || !validSHA256(a.Vendor.SHA256) || !strings.Contains(a.Vendor.Source, a.Vendor.Version) || !strings.Contains(strings.Join(a.Vendor.Argv, "\x00"), "@"+a.Vendor.Version) {
+				return fmt.Errorf("step %s has mutable vendor provenance", step.ID)
 			}
 		case "verified-release-artifact":
-			if a.Path == "" || a.Version == "" || a.Source == "" || a.VerifyWith == "" {
+			if a.Artifact == nil || !filepath.IsAbs(a.Artifact.Path) || a.Artifact.Version == "" || a.Artifact.Source == "" || !validSHA256(a.Artifact.SHA256) || !strings.Contains(a.Artifact.Source, a.Artifact.Version) || strings.Contains(a.Artifact.Source, "/latest/") {
 				return fmt.Errorf("step %s has incomplete artifact provenance", step.ID)
 			}
 		case "service-definition-v1":
-			digest := sha256.Sum256([]byte(a.Content))
-			if a.Path == "" || a.Mode == "" || a.Version != "1" || a.Content == "" || a.SHA256 != fmt.Sprintf("%x", digest[:]) {
+			if a.Service == nil {
+				return fmt.Errorf("step %s has no service definition variant", step.ID)
+			}
+			digest := sha256.Sum256([]byte(a.Service.Content))
+			if !filepath.IsAbs(a.Service.Path) || a.Service.Mode != "0644" || a.Service.Version != "1" || a.Service.Content == "" || a.Service.SHA256 != fmt.Sprintf("%x", digest[:]) {
 				return fmt.Errorf("step %s has invalid service definition contract", step.ID)
+			}
+			if _, err := consumeSystemdDefinition(a.Service.Content); err != nil {
+				return fmt.Errorf("step %s has unusable service definition: %w", step.ID, err)
 			}
 		default:
 			return fmt.Errorf("step %s has unsupported action kind %q", step.ID, a.Kind)
 		}
 	}
 	return nil
+}
+
+// consumeSetupPlanJSON is the planning-only consumer boundary. It strictly
+// decodes, validates, and renders every action variant without performing it.
+func consumeSetupPlanJSON(data []byte) ([]string, error) {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	var plan SetupPlan
+	if err := decoder.Decode(&plan); err != nil {
+		return nil, err
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		return nil, errors.New("setup plan contains trailing JSON")
+	}
+	if plan.SchemaVersion != setupPlanSchemaVersion || !plan.DryRun {
+		return nil, errors.New("unsupported or executable setup plan")
+	}
+	if err := validateSetupPlan(plan); err != nil {
+		return nil, err
+	}
+	operations := make([]string, 0)
+	for _, step := range plan.Steps {
+		if step.Action == nil {
+			continue
+		}
+		a := step.Action
+		switch a.Kind {
+		case "verified-release-artifact":
+			operations = append(operations, fmt.Sprintf("artifact source=%s version=%s sha256=%s path=%s", a.Artifact.Source, a.Artifact.Version, a.Artifact.SHA256, a.Artifact.Path))
+		case "vendor-package":
+			operations = append(operations, fmt.Sprintf("vendor source=%s version=%s sha256=%s", a.Vendor.Source, a.Vendor.Version, a.Vendor.SHA256))
+		case "service-definition-v1":
+			operations = append(operations, fmt.Sprintf("service path=%s mode=%s version=%s sha256=%s", a.Service.Path, a.Service.Mode, a.Service.Version, a.Service.SHA256))
+		case "directory", "file-mode":
+			operations = append(operations, fmt.Sprintf("file kind=%s path=%s mode=%s", a.Kind, a.File.Path, a.File.Mode))
+		case "package-manager":
+			operations = append(operations, fmt.Sprintf("package executable=%s source=%s version=%s sha256=%s argv=%q", a.Package.Executable, a.Package.Source, a.Package.Version, a.Package.SHA256, a.Package.Argv))
+		}
+	}
+	return operations, nil
+}
+
+func validSHA256(value string) bool {
+	if len(value) != sha256.Size*2 {
+		return false
+	}
+	for _, r := range value {
+		if (r < '0' || r > '9') && (r < 'a' || r > 'f') {
+			return false
+		}
+	}
+	return true
 }
 
 func writeSetupPlan(cmd *cobra.Command, plan SetupPlan, yes bool) error {

--- a/backend/internal/haocli/setup.go
+++ b/backend/internal/haocli/setup.go
@@ -588,7 +588,7 @@ func renderSystemdDefinition(id string, d setupDesired, user UserObservation) st
 		b.WriteString("daemon\nAfter=network-online.target\n")
 	}
 	path := filepath.Join(user.Home, ".local", "bin") + ":" + filepath.Join(user.Home, "bin") + ":/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
-	b.WriteString("\n[Service]\nType=simple\nUser=" + user.Name + "\nWorkingDirectory=" + systemdQuote(dataDir) + "\nEnvironment=" + systemdQuote("HOME="+user.Home) + "\nEnvironment=" + systemdQuote("PATH="+path) + "\n")
+	b.WriteString("\n[Service]\nType=simple\nUser=" + user.Name + "\nWorkingDirectory=" + dataDir + "\nEnvironment=" + systemdQuote("HOME="+user.Home) + "\nEnvironment=" + systemdQuote("PATH="+path) + "\n")
 	if id == "service.gateway" {
 		b.WriteString("Environment=" + systemdQuote("AO_VM_PAIR=on") + "\nEnvironment=" + systemdQuote("AO_VM_HTTPS_ADDR=:"+strconv.Itoa(d.PairPort)) + "\nEnvironment=" + systemdQuote("AO_VM_CERT_DIR="+filepath.Join(d.StateRoot, "vm-gateway", "pair-cert")) + "\nEnvironment=" + systemdQuote("AO_VM_PASSCODE_DIR="+filepath.Join(d.StateRoot, "vm-gateway", "pair-passcode")) + "\n")
 		if d.PairPort < 1024 {
@@ -676,7 +676,7 @@ func systemdInputsSafe(d setupDesired, user UserObservation) bool {
 	}
 	for _, value := range []string{user.Home, d.StateRoot} {
 		for _, r := range value {
-			if r < 0x20 || r == 0x7f {
+			if r <= 0x20 || r == 0x7f {
 				return false
 			}
 		}

--- a/backend/internal/haocli/setup.go
+++ b/backend/internal/haocli/setup.go
@@ -362,6 +362,9 @@ func planArtifact(d setupDesired, item observedItem) SetupStep {
 	}
 	action := &SetupAction{Kind: "artifact-install", Path: item.Path, Argv: []string{"ao", d.AOVersion}}
 	if item.State == "absent" {
+		if d.Install == "none" {
+			return blockedStep("artifact.ao", "ao-gateway-artifact", "manual-install", "audit-only policy forbids planning artifact installation", item.Evidence, "install the requested hao-owned AO artifact manually, then rerun setup")
+		}
 		return SetupStep{ID: "artifact.ao", Component: "ao-gateway-artifact", Operation: "install-artifact", Disposition: "create", Reason: "hao-owned AO/gateway artifact is absent", Evidence: item.Evidence, Action: action}
 	}
 	if item.IsDir {
@@ -377,6 +380,9 @@ func planArtifact(d setupDesired, item observedItem) SetupStep {
 		return SetupStep{ID: "artifact.ao", Component: "ao-gateway-artifact", Operation: "replace-artifact", Disposition: "update", Reason: "existing artifact is not executable", Evidence: item.Evidence, Action: action}
 	}
 	if !versionMatches(item.Version, d.AOVersion) {
+		if d.Install == "none" {
+			return blockedStep("artifact.ao", "ao-gateway-artifact", "manual-update", "audit-only policy forbids planning artifact replacement", "observed "+item.Version+"; desired "+d.AOVersion, "install the requested hao-owned AO artifact version manually, then rerun setup")
+		}
 		return SetupStep{ID: "artifact.ao", Component: "ao-gateway-artifact", Operation: "replace-artifact", Disposition: "update", Reason: "installed artifact version differs from desired version", Evidence: "observed " + item.Version + "; desired " + d.AOVersion, Action: action}
 	}
 	return noopStep("artifact.ao", "ao-gateway-artifact", "verify-artifact", "hao-owned AO/gateway artifact version already matches", item.Version)

--- a/backend/internal/haocli/setup.go
+++ b/backend/internal/haocli/setup.go
@@ -1,28 +1,520 @@
 package haocli
 
 import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
 	"github.com/spf13/cobra"
 )
 
-func newSetupCommand(_ Deps, _ *options) *cobra.Command {
-	var dryRun bool
-	var nonInteractive bool
+const setupPlanSchemaVersion = 1
+
+// SetupPrivilege describes the narrow elevated boundary a future executor needs.
+type SetupPrivilege struct {
+	Required bool   `json:"required"`
+	Scope    string `json:"scope,omitempty"`
+}
+
+// SetupAction is a structured, shell-free future execution description.
+type SetupAction struct {
+	Kind       string   `json:"kind"`
+	Executable string   `json:"executable,omitempty"`
+	Argv       []string `json:"argv,omitempty"`
+	Path       string   `json:"path,omitempty"`
+	Mode       string   `json:"mode,omitempty"`
+}
+
+// SetupStep is one stable desired-versus-observed reconciliation decision.
+type SetupStep struct {
+	ID           string         `json:"id"`
+	Component    string         `json:"component"`
+	Operation    string         `json:"operation"`
+	Disposition  string         `json:"disposition"`
+	Privilege    SetupPrivilege `json:"privilege"`
+	Reason       string         `json:"reason"`
+	Evidence     string         `json:"evidence"`
+	Remediation  string         `json:"remediation,omitempty"`
+	Dependencies []string       `json:"dependencies,omitempty"`
+	Action       *SetupAction   `json:"action,omitempty"`
+}
+
+// SetupSummary counts each disposition and reports whether the plan is complete.
+type SetupSummary struct {
+	Create  int  `json:"create"`
+	Update  int  `json:"update"`
+	NoOp    int  `json:"noOp"`
+	Blocked int  `json:"blocked"`
+	Ready   bool `json:"ready"`
+}
+
+// SetupPlan is the versioned deterministic output of setup dry-run.
+type SetupPlan struct {
+	SchemaVersion int          `json:"schemaVersion"`
+	DryRun        bool         `json:"dryRun"`
+	Machine       string       `json:"machine"`
+	Mode          string       `json:"mode"`
+	Platform      string       `json:"platform"`
+	InstallPolicy string       `json:"installPolicy"`
+	Steps         []SetupStep  `json:"steps"`
+	Summary       SetupSummary `json:"summary"`
+}
+
+type setupDesired struct {
+	Machine, Mode, AOVersion, Harness, Profile, Install string
+	ServiceEnabled                                      bool
+	PairPort                                            int
+	StateRoot, ConfigPath                               string
+}
+
+type observedItem struct {
+	State, Evidence, Version, Path string
+	Mode                           os.FileMode
+	UID                            int
+	Owner                          bool
+	IsDir                          bool
+}
+
+type setupSnapshot struct {
+	OS, Arch, Distribution, DistributionState string
+	Directories                               map[string]observedItem
+	Artifact                                  observedItem
+	Tools                                     map[string]observedItem
+	PackageManager, ServiceManager            observedItem
+	ServiceFiles                              map[string]observedItem
+}
+
+func newSetupCommand(deps Deps, opts *options) *cobra.Command {
+	var dryRun, nonInteractive, yes bool
 	var install string
-	var yes bool
-	cmd := &cobra.Command{
-		Use:   "setup",
-		Short: "Plan machine preparation",
-		Args:  noArgs,
-		RunE: func(*cobra.Command, []string) error {
-			if !dryRun {
-				return commandError{Code: "feature_deferred", Message: "hao setup mutation is not yet supported", Remediation: "rerun with --dry-run to inspect the setup plan", ExitStatus: 2}
-			}
-			return commandError{Code: "operation_failed", Message: "setup planning is being implemented", Remediation: "retry with a completed Batch 4 build", ExitStatus: 1}
-		},
-	}
+	cmd := &cobra.Command{Use: "setup", Short: "Plan machine preparation", Args: noArgs, RunE: func(cmd *cobra.Command, _ []string) error {
+		// This guard intentionally precedes config loading and every observation.
+		if !dryRun {
+			return commandError{Code: "feature_deferred", Message: "hao setup mutation is not yet supported", Remediation: "rerun with --dry-run to inspect the setup plan", ExitStatus: 2}
+		}
+		if install != "" && install != "missing" && install != "none" {
+			return commandError{Code: "invalid_usage", Message: "--install must be missing or none", Remediation: "pass --install missing or --install none", ExitStatus: 2}
+		}
+		path, object, err := loadConfig(deps, opts.configPath)
+		if err != nil {
+			return err
+		}
+		desired, err := resolveSetupDesired(deps, path, object, install, nonInteractive)
+		if err != nil {
+			return err
+		}
+		plan := planSetup(desired, observeSetup(cmd.Context(), deps, desired))
+		if opts.json {
+			err = writeJSON(cmd.OutOrStdout(), haocontractRedact(plan))
+		} else {
+			err = writeSetupPlan(cmd, plan, yes)
+		}
+		if err != nil {
+			return err
+		}
+		if plan.Summary.Blocked > 0 {
+			return commandError{Code: "setup_blocked", ExitStatus: 1, Silent: true}
+		}
+		return nil
+	}}
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "display the setup plan without changing the machine")
 	cmd.Flags().BoolVar(&nonInteractive, "non-interactive", false, "never prompt for input")
 	cmd.Flags().StringVar(&install, "install", "", "dependency policy: missing or none")
 	cmd.Flags().BoolVar(&yes, "yes", false, "approve the displayed plan for future setup execution")
 	return cmd
+}
+
+func resolveSetupDesired(deps Deps, path string, object map[string]any, install string, nonInteractive bool) (setupDesired, error) {
+	if install == "" {
+		install = configString(object, "install", "dependencies")
+	}
+	d := setupDesired{Machine: configString(object, "machine", "name"), Mode: configString(object, "mode"), AOVersion: configString(object, "components", "aoVersion"), Harness: configString(object, "harness", "id"), Profile: configString(object, "workflow", "profile"), Install: install, ServiceEnabled: configBool(object, "service", "enabled"), PairPort: configInt(object, "pair", "listenPort"), ConfigPath: path}
+	if d.Profile == "" {
+		d.Profile = "general"
+	}
+	if nonInteractive && (d.Machine == "" || d.Harness == "" || d.AOVersion == "" || d.Install == "") {
+		return setupDesired{}, commandError{Code: "invalid_usage", Message: "non-interactive setup is missing required desired state", Remediation: "provide a complete v1 configuration", ExitStatus: 2}
+	}
+	root, err := deps.StateDir()
+	if err != nil {
+		return setupDesired{}, operationalError("resolve state root", err)
+	}
+	d.StateRoot = root
+	return d, nil
+}
+
+func observeSetup(ctx context.Context, deps Deps, desired setupDesired) setupSnapshot {
+	osName, arch := deps.Observer.Platform()
+	s := setupSnapshot{OS: osName, Arch: arch, Directories: map[string]observedItem{}, Tools: map[string]observedItem{}, ServiceFiles: map[string]observedItem{}}
+	if distro, err := deps.Observer.Distribution(); err != nil {
+		s.DistributionState = "unknown"
+	} else {
+		s.Distribution, s.DistributionState = distro, "known"
+	}
+	directories := map[string]string{"directory.state": desired.StateRoot, "directory.hao": filepath.Join(desired.StateRoot, "hao"), "directory.bin": filepath.Join(desired.StateRoot, "bin"), "directory.data": filepath.Join(desired.StateRoot, "data")}
+	if desired.Mode == "pair" {
+		directories["directory.gateway"] = filepath.Join(desired.StateRoot, "vm-gateway")
+	}
+	for id, path := range directories {
+		s.Directories[id] = observeFile(deps.Observer, path)
+	}
+	artifactPath := filepath.Join(desired.StateRoot, "bin", "ao")
+	s.Artifact = observeFile(deps.Observer, artifactPath)
+	if s.Artifact.State == "present" && s.Artifact.Owner && !s.Artifact.IsDir && s.Artifact.Mode.Perm()&0o022 == 0 && s.Artifact.Mode.Perm()&0o111 != 0 {
+		s.Artifact.Version, s.Artifact.State, s.Artifact.Evidence = probeVersion(ctx, deps, artifactPath)
+		s.Artifact.Path = artifactPath
+	}
+	tools := map[string]string{"git": "git", "harness": harnessBinary(desired.Harness)}
+	if desired.Profile == "github" {
+		tools["gh"] = "gh"
+	}
+	for id, binary := range tools {
+		s.Tools[id] = observeTool(ctx, deps, binary)
+	}
+	s.PackageManager, s.ServiceManager = observePackageManager(ctx, deps, osName), observeServiceManager(ctx, deps, osName)
+	if osName == "linux" {
+		s.ServiceFiles["service.daemon"] = observeFile(deps.Observer, "/etc/systemd/system/hosted-ao.service")
+		if desired.Mode == "pair" {
+			s.ServiceFiles["service.gateway"] = observeFile(deps.Observer, "/etc/systemd/system/hosted-ao-gateway.service")
+		}
+	}
+	return s
+}
+
+func observeFile(obs Observer, path string) observedItem {
+	info, err := obs.Stat(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return observedItem{State: "absent", Evidence: "path is absent", Path: path}
+	}
+	if err != nil {
+		return observedItem{State: "unknown", Evidence: "path probe failed: " + safeDiagnostic(err), Path: path}
+	}
+	return observedItem{State: "present", Evidence: fmt.Sprintf("path exists with mode %04o and uid %d", info.Mode.Perm(), info.UID), Path: path, Mode: info.Mode, UID: info.UID, Owner: info.Owner, IsDir: info.IsDir}
+}
+
+func observeTool(ctx context.Context, deps Deps, binary string) observedItem {
+	path, err := deps.Observer.LookPath(binary)
+	if err != nil {
+		return observedItem{State: "absent", Evidence: binary + " was not found on PATH"}
+	}
+	version, state, evidence := probeVersion(ctx, deps, path)
+	return observedItem{State: state, Evidence: evidence, Version: version, Path: path, Owner: true}
+}
+func probeVersion(ctx context.Context, deps Deps, path string) (string, string, string) {
+	probeCtx, cancel := boundedContext(ctx, deps.Timeout)
+	defer cancel()
+	out, err := deps.Observer.Run(probeCtx, path, "--version")
+	if err != nil {
+		if probeCtx.Err() != nil || errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+			return "", "unknown", "version probe timed out or was canceled"
+		}
+		return "", "unknown", "version probe failed"
+	}
+	return safeVersion(out), "present", "version probe succeeded"
+}
+func observePackageManager(ctx context.Context, deps Deps, goos string) observedItem {
+	name := ""
+	if goos == "linux" {
+		name = "apt-get"
+	}
+	if goos == "darwin" {
+		name = "brew"
+	}
+	if name != "" {
+		item := observeTool(ctx, deps, name)
+		if item.State != "absent" {
+			return item
+		}
+	}
+	return observedItem{State: "absent", Evidence: "no supported package manager was found"}
+}
+func observeServiceManager(ctx context.Context, deps Deps, goos string) observedItem {
+	if goos != "linux" {
+		return observedItem{State: "unsupported", Evidence: "managed service definitions are not supported on " + goos}
+	}
+	path, err := deps.Observer.LookPath("systemctl")
+	if err != nil {
+		return observedItem{State: "absent", Evidence: "systemctl was not found"}
+	}
+	probeCtx, cancel := boundedContext(ctx, deps.Timeout)
+	defer cancel()
+	if _, err := deps.Observer.Run(probeCtx, path, "show-environment"); err != nil {
+		return observedItem{State: "unknown", Evidence: "systemd usability probe failed or timed out", Path: path}
+	}
+	return observedItem{State: "present", Evidence: "systemd is available and usable", Path: path}
+}
+
+func planSetup(d setupDesired, s setupSnapshot) SetupPlan {
+	p := SetupPlan{SchemaVersion: setupPlanSchemaVersion, DryRun: true, Machine: d.Machine, Mode: d.Mode, Platform: s.OS + "/" + s.Arch, InstallPolicy: d.Install}
+	add := func(step SetupStep) { p.Steps = append(p.Steps, step) }
+	platformBlocked := ""
+	if s.OS == "linux" && s.DistributionState == "unknown" {
+		platformBlocked = "Linux distribution could not be determined"
+	} else if s.OS == "linux" && s.Distribution != "ubuntu" {
+		platformBlocked = "managed setup is supported only on Ubuntu Linux"
+	} else if s.OS == "windows" && d.Mode == "pair" {
+		platformBlocked = "pair-mode service and gateway setup is not supported on Windows"
+	} else if s.OS != "linux" && s.OS != "darwin" && s.OS != "windows" {
+		platformBlocked = "platform is not supported for managed setup"
+	}
+	if platformBlocked == "" && ((s.OS == "windows" && s.Arch != "amd64") || (s.OS != "windows" && s.Arch != "amd64" && s.Arch != "arm64")) {
+		platformBlocked = "architecture is not supported for managed setup"
+	}
+	if platformBlocked == "" {
+		add(noopStep("host.platform", "host", "verify-platform", "platform is supported for this setup mode", s.OS+"/"+s.Arch+" "+s.Distribution))
+	} else {
+		add(blockedStep("host.platform", "host", "verify-platform", platformBlocked, s.OS+"/"+s.Arch+" "+s.Distribution, "use a supported platform or manage the host manually"))
+	}
+	for _, id := range []string{"directory.state", "directory.hao", "directory.bin", "directory.data", "directory.gateway"} {
+		item, ok := s.Directories[id]
+		if !ok {
+			continue
+		}
+		step := planDirectory(id, item)
+		if id == "directory.state" {
+			step.Dependencies = []string{"host.platform"}
+		} else {
+			step.Dependencies = []string{"directory.state"}
+		}
+		add(step)
+	}
+	artifact := planArtifact(d, s.Artifact)
+	artifact.Dependencies = []string{"directory.bin"}
+	add(artifact)
+	needsPackageManager := false
+	for id, item := range s.Tools {
+		if id != "harness" && item.State == "absent" && d.Install == "missing" {
+			needsPackageManager = true
+		}
+	}
+	managerStep := noopStep("host.package-manager", "package-manager", "verify-capability", "no package installation is required by the observed state", s.PackageManager.Evidence)
+	if s.PackageManager.State == "present" {
+		managerStep.Reason = "supported package manager is available"
+	} else if needsPackageManager {
+		managerStep = blockedStep("host.package-manager", "package-manager", "verify-capability", "required package installation cannot be planned safely", s.PackageManager.Evidence, "restore the supported package manager or install prerequisites manually")
+	}
+	managerStep.Dependencies = []string{"host.platform"}
+	add(managerStep)
+	for _, prereq := range []struct{ id, component string }{{"git", "git"}, {"gh", "github-cli"}, {"harness", d.Harness}} {
+		if item, ok := s.Tools[prereq.id]; ok {
+			step := planPrerequisite(d, s, prereq.id, prereq.component, item)
+			step.Dependencies = []string{"host.platform"}
+			if step.Operation == "install-package" {
+				step.Dependencies = append(step.Dependencies, "host.package-manager")
+			}
+			add(step)
+		}
+	}
+	add(noopStep("ao.runtime", "ao-artifact", "verify-ownership", "AO runtime and terminal implementation are owned by the AO artifact", "no separate runtime backend is machine-managed"))
+	if d.Mode == "pair" {
+		port := noopStep("pair.port-policy", "pair-gateway", "verify-port-policy", "configured pair port is valid; activation remains an init responsibility", fmt.Sprintf("configured port %d", d.PairPort))
+		if d.PairPort < 1024 {
+			port.Privilege = SetupPrivilege{Required: true, Scope: "privileged-port-preparation"}
+		}
+		port.Dependencies = []string{"host.platform"}
+		add(port)
+	}
+	for _, step := range planServices(d, s) {
+		add(step)
+	}
+	propagateBlocked(p.Steps)
+	for _, step := range p.Steps {
+		switch step.Disposition {
+		case "create":
+			p.Summary.Create++
+		case "update":
+			p.Summary.Update++
+		case "no-op":
+			p.Summary.NoOp++
+		case "blocked":
+			p.Summary.Blocked++
+		}
+	}
+	p.Summary.Ready = p.Summary.Blocked == 0
+	return p
+}
+
+func planDirectory(id string, item observedItem) SetupStep {
+	component := strings.TrimPrefix(id, "directory.")
+	if item.State == "unknown" {
+		return blockedStep(id, component, "reconcile-directory", "directory state is unknown", item.Evidence, "inspect the path and its parent permissions manually")
+	}
+	if item.State == "absent" {
+		return SetupStep{ID: id, Component: component, Operation: "create-directory", Disposition: "create", Reason: "required directory is absent", Evidence: item.Evidence, Action: &SetupAction{Kind: "directory", Path: item.Path, Mode: "0700"}}
+	}
+	if !item.IsDir {
+		return blockedStep(id, component, "reconcile-directory", "required directory path is occupied by a non-directory", item.Evidence, "move the conflicting path outside hao, then retry")
+	}
+	if !item.Owner {
+		return blockedStep(id, component, "reconcile-directory", "existing directory has unsafe ownership", item.Evidence, "correct ownership outside hao, then retry")
+	}
+	if item.Mode.Perm()&0o077 != 0 {
+		return SetupStep{ID: id, Component: component, Operation: "set-directory-mode", Disposition: "update", Reason: "directory permissions are broader than owner-only", Evidence: item.Evidence, Action: &SetupAction{Kind: "file-mode", Path: item.Path, Mode: "0700"}}
+	}
+	return noopStep(id, component, "verify-directory", "directory ownership and permissions already match", item.Evidence)
+}
+func planArtifact(d setupDesired, item observedItem) SetupStep {
+	if item.State == "unknown" {
+		return blockedStep("artifact.ao", "ao-gateway-artifact", "reconcile-artifact", "artifact state or version is unknown", item.Evidence, "inspect the hao-owned AO artifact manually")
+	}
+	action := &SetupAction{Kind: "artifact-install", Path: item.Path, Argv: []string{"ao", d.AOVersion}}
+	if item.State == "absent" {
+		return SetupStep{ID: "artifact.ao", Component: "ao-gateway-artifact", Operation: "install-artifact", Disposition: "create", Reason: "hao-owned AO/gateway artifact is absent", Evidence: item.Evidence, Action: action}
+	}
+	if item.IsDir {
+		return blockedStep("artifact.ao", "ao-gateway-artifact", "reconcile-artifact", "artifact path is occupied by a directory", item.Evidence, "move the conflicting directory outside hao")
+	}
+	if !item.Owner {
+		return blockedStep("artifact.ao", "ao-gateway-artifact", "reconcile-artifact", "existing artifact has unsafe ownership", item.Evidence, "correct or remove the conflicting artifact outside hao")
+	}
+	if item.Mode.Perm()&0o022 != 0 {
+		return blockedStep("artifact.ao", "ao-gateway-artifact", "reconcile-artifact", "existing artifact is writable by group or other users", item.Evidence, "secure or remove the conflicting artifact outside hao")
+	}
+	if item.Mode.Perm()&0o111 == 0 {
+		return SetupStep{ID: "artifact.ao", Component: "ao-gateway-artifact", Operation: "replace-artifact", Disposition: "update", Reason: "existing artifact is not executable", Evidence: item.Evidence, Action: action}
+	}
+	if !versionMatches(item.Version, d.AOVersion) {
+		return SetupStep{ID: "artifact.ao", Component: "ao-gateway-artifact", Operation: "replace-artifact", Disposition: "update", Reason: "installed artifact version differs from desired version", Evidence: "observed " + item.Version + "; desired " + d.AOVersion, Action: action}
+	}
+	return noopStep("artifact.ao", "ao-gateway-artifact", "verify-artifact", "hao-owned AO/gateway artifact version already matches", item.Version)
+}
+func planPrerequisite(d setupDesired, s setupSnapshot, id, component string, item observedItem) SetupStep {
+	stepID := "prerequisite." + id
+	if item.State == "present" {
+		return noopStep(stepID, component, "verify-prerequisite", "required prerequisite is available", item.Path+" "+item.Version)
+	}
+	if item.State == "unknown" {
+		return blockedStep(stepID, component, "verify-prerequisite", "prerequisite availability is unknown", item.Evidence, "inspect the prerequisite manually and retry")
+	}
+	if d.Install == "none" {
+		return blockedStep(stepID, component, "manual-install", "audit-only policy forbids planning installation", item.Evidence, "install "+component+" manually, then rerun setup")
+	}
+	if id == "harness" && d.Harness != "claude-code" {
+		return blockedStep(stepID, component, "manual-install", "selected harness has no allowlisted installer", item.Evidence, "install the selected harness using its vendor documentation")
+	}
+	if s.PackageManager.State != "present" {
+		return blockedStep(stepID, component, "install-prerequisite", "a supported package manager is not proven usable", s.PackageManager.Evidence, "install the prerequisite manually or restore the supported package manager")
+	}
+	if id == "harness" {
+		return SetupStep{ID: stepID, Component: component, Operation: "install-vendor-artifact", Disposition: "create", Reason: "required allowlisted harness is absent", Evidence: item.Evidence, Action: &SetupAction{Kind: "vendor-installer", Executable: "hao-installer", Argv: []string{"install", "harness", d.Harness}}}
+	}
+	return SetupStep{ID: stepID, Component: component, Operation: "install-package", Disposition: "create", Privilege: SetupPrivilege{Required: true, Scope: "package-install"}, Reason: "required prerequisite is absent", Evidence: item.Evidence, Action: &SetupAction{Kind: "package-manager", Executable: s.PackageManager.Path, Argv: []string{"install", id}}}
+}
+
+func planServices(d setupDesired, s setupSnapshot) []SetupStep {
+	if !d.ServiceEnabled {
+		steps := []SetupStep{noopStep("service.daemon", "ao-daemon-service", "leave-disabled", "service lifecycle is intentionally disabled", "configuration service.enabled=false")}
+		if d.Mode == "pair" {
+			step := noopStep("service.gateway", "pair-gateway-service", "leave-disabled", "gateway service lifecycle is intentionally disabled", "configuration service.enabled=false")
+			step.Dependencies = []string{"service.daemon"}
+			steps = append(steps, step)
+		}
+		return steps
+	}
+	if s.OS == "darwin" && d.Mode == "local" {
+		return []SetupStep{noopStep("service.daemon", "desktop-supervisor", "desktop-supervised", "macOS local daemon lifecycle is owned by Hosted AO desktop", "no launchd definition is planned")}
+	}
+	if s.OS != "linux" || s.Distribution != "ubuntu" || s.ServiceManager.State != "present" {
+		steps := []SetupStep{blockedStep("service.daemon", "ao-daemon-service", "reconcile-definition", "supported managed service lifecycle is unavailable", s.ServiceManager.Evidence, "use Ubuntu systemd or manage the daemon manually")}
+		if d.Mode == "pair" {
+			step := blockedStep("service.gateway", "pair-gateway-service", "reconcile-definition", "supported managed service lifecycle is unavailable", s.ServiceManager.Evidence, "use Ubuntu systemd for pair mode")
+			step.Dependencies = []string{"service.daemon"}
+			steps = append(steps, step)
+		}
+		return steps
+	}
+	ids := []string{"service.daemon"}
+	if d.Mode == "pair" {
+		ids = append(ids, "service.gateway")
+	}
+	steps := make([]SetupStep, 0, len(ids))
+	for _, id := range ids {
+		item, component, deps := s.ServiceFiles[id], "ao-daemon-service", []string{"artifact.ao", "directory.data"}
+		if id == "service.gateway" {
+			component, deps = "pair-gateway-service", []string{"service.daemon", "directory.gateway", "artifact.ao"}
+		}
+		var step SetupStep
+		switch item.State {
+		case "absent":
+			step = SetupStep{ID: id, Component: component, Operation: "install-definition", Disposition: "create", Privilege: SetupPrivilege{Required: true, Scope: "system-service-definition"}, Reason: "supported service definition is absent", Evidence: item.Evidence, Action: &SetupAction{Kind: "service-definition", Path: item.Path}}
+		case "present":
+			if item.IsDir || item.UID > 0 || item.Mode.Perm()&0o022 != 0 {
+				step = blockedStep(id, component, "reconcile-definition", "existing service definition has unsafe ownership", item.Evidence, "inspect and reconcile the conflicting definition manually")
+			} else {
+				step = noopStep(id, component, "verify-definition", "service definition is present; setup does not enable or start it", item.Evidence)
+			}
+		default:
+			step = blockedStep(id, component, "reconcile-definition", "service definition state is unknown", item.Evidence, "inspect the service definition manually")
+		}
+		step.Dependencies = deps
+		steps = append(steps, step)
+	}
+	return steps
+}
+
+func propagateBlocked(steps []SetupStep) {
+	byID := make(map[string]int, len(steps))
+	for i := range steps {
+		byID[steps[i].ID] = i
+	}
+	for i := range steps {
+		if steps[i].Disposition == "blocked" {
+			continue
+		}
+		for _, dependency := range steps[i].Dependencies {
+			if j, ok := byID[dependency]; ok && steps[j].Disposition == "blocked" {
+				steps[i].Disposition, steps[i].Reason, steps[i].Remediation, steps[i].Action = "blocked", "dependency "+dependency+" is blocked", "resolve the blocked dependency, then rerun setup", nil
+				break
+			}
+		}
+	}
+}
+func noopStep(id, component, operation, reason, evidence string) SetupStep {
+	return SetupStep{ID: id, Component: component, Operation: operation, Disposition: "no-op", Reason: reason, Evidence: evidence}
+}
+func blockedStep(id, component, operation, reason, evidence, remediation string) SetupStep {
+	return SetupStep{ID: id, Component: component, Operation: operation, Disposition: "blocked", Reason: reason, Evidence: evidence, Remediation: remediation}
+}
+func versionMatches(observed, desired string) bool {
+	for _, field := range strings.Fields(observed) {
+		if strings.TrimPrefix(field, "v") == desired {
+			return true
+		}
+	}
+	return false
+}
+
+func writeSetupPlan(cmd *cobra.Command, plan SetupPlan, yes bool) error {
+	out := cmd.OutOrStdout()
+	if _, err := fmt.Fprintf(out, "HAO setup plan (dry-run): %s (%s) on %s\nInstall policy: %s\n", redactedString(plan.Machine), redactedString(plan.Mode), redactedString(plan.Platform), plan.InstallPolicy); err != nil {
+		return err
+	}
+	for _, step := range plan.Steps {
+		privilege := ""
+		if step.Privilege.Required {
+			privilege = " [privileged:" + step.Privilege.Scope + "]"
+		}
+		if _, err := fmt.Fprintf(out, "%-24s %-8s %s%s — %s\n", step.ID+":", step.Disposition, step.Operation, privilege, redactedString(step.Reason)); err != nil {
+			return err
+		}
+		if _, err := fmt.Fprintf(out, "  evidence: %s\n", redactedString(step.Evidence)); err != nil {
+			return err
+		}
+		if step.Remediation != "" {
+			if _, err := fmt.Fprintf(out, "  remediation: %s\n", redactedString(step.Remediation)); err != nil {
+				return err
+			}
+		}
+	}
+	if _, err := fmt.Fprintf(out, "Summary: create=%d update=%d no-op=%d blocked=%d ready=%t\n", plan.Summary.Create, plan.Summary.Update, plan.Summary.NoOp, plan.Summary.Blocked, plan.Summary.Ready); err != nil {
+		return err
+	}
+	if yes {
+		_, err := fmt.Fprintln(out, "Note: --yes has no mutation effect in dry-run; it will approve the displayed plan only when setup execution exists.")
+		return err
+	}
+	return nil
 }

--- a/backend/internal/haocli/setup.go
+++ b/backend/internal/haocli/setup.go
@@ -1,7 +1,6 @@
 package haocli
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -26,6 +25,10 @@ type SetupAction struct {
 	Argv       []string `json:"argv,omitempty"`
 	Path       string   `json:"path,omitempty"`
 	Mode       string   `json:"mode,omitempty"`
+	Version    string   `json:"version,omitempty"`
+	Source     string   `json:"source,omitempty"`
+	VerifyWith string   `json:"verifyWith,omitempty"`
+	Content    string   `json:"content,omitempty"`
 }
 
 // SetupStep is one stable desired-versus-observed reconciliation decision.
@@ -68,6 +71,7 @@ type setupDesired struct {
 	ServiceEnabled                                      bool
 	PairPort                                            int
 	StateRoot, ConfigPath                               string
+	OS, Arch                                            string
 }
 
 type observedItem struct {
@@ -76,6 +80,7 @@ type observedItem struct {
 	UID                            int
 	Owner                          bool
 	IsDir                          bool
+	Link                           bool
 }
 
 type setupSnapshot struct {
@@ -85,6 +90,8 @@ type setupSnapshot struct {
 	Tools                                     map[string]observedItem
 	PackageManager, ServiceManager            observedItem
 	ServiceFiles                              map[string]observedItem
+	User                                      UserObservation
+	UserState                                 string
 }
 
 func newSetupCommand(deps Deps, opts *options) *cobra.Command {
@@ -106,7 +113,7 @@ func newSetupCommand(deps Deps, opts *options) *cobra.Command {
 		if err != nil {
 			return err
 		}
-		plan := planSetup(desired, observeSetup(cmd.Context(), deps, desired))
+		plan := planSetup(desired, observeSetup(deps, desired))
 		if opts.json {
 			err = writeJSON(cmd.OutOrStdout(), haocontractRedact(plan))
 		} else {
@@ -146,13 +153,18 @@ func resolveSetupDesired(deps Deps, path string, object map[string]any, install 
 	return d, nil
 }
 
-func observeSetup(ctx context.Context, deps Deps, desired setupDesired) setupSnapshot {
+func observeSetup(deps Deps, desired setupDesired) setupSnapshot {
 	osName, arch := deps.Observer.Platform()
 	s := setupSnapshot{OS: osName, Arch: arch, Directories: map[string]observedItem{}, Tools: map[string]observedItem{}, ServiceFiles: map[string]observedItem{}}
 	if distro, err := deps.Observer.Distribution(); err != nil {
 		s.DistributionState = "unknown"
 	} else {
 		s.Distribution, s.DistributionState = distro, "known"
+	}
+	if currentUser, err := deps.Observer.CurrentUser(); err != nil {
+		s.UserState = "unknown"
+	} else {
+		s.User, s.UserState = currentUser, "known"
 	}
 	directories := map[string]string{"directory.state": desired.StateRoot, "directory.hao": filepath.Join(desired.StateRoot, "hao"), "directory.bin": filepath.Join(desired.StateRoot, "bin"), "directory.data": filepath.Join(desired.StateRoot, "data")}
 	if desired.Mode == "pair" {
@@ -163,8 +175,13 @@ func observeSetup(ctx context.Context, deps Deps, desired setupDesired) setupSna
 	}
 	artifactPath := filepath.Join(desired.StateRoot, "bin", "ao")
 	s.Artifact = observeFile(deps.Observer, artifactPath)
-	if s.Artifact.State == "present" && s.Artifact.Owner && !s.Artifact.IsDir && s.Artifact.Mode.Perm()&0o022 == 0 && s.Artifact.Mode.Perm()&0o111 != 0 {
-		s.Artifact.Version, s.Artifact.State, s.Artifact.Evidence = probeVersion(ctx, deps, artifactPath)
+	if s.Artifact.State == "present" && s.Artifact.Owner && !s.Artifact.IsDir && !s.Artifact.Link && s.Artifact.Mode.Perm()&0o022 == 0 && s.Artifact.Mode.Perm()&0o111 != 0 {
+		metadata, err := deps.Observer.InspectArtifact(artifactPath)
+		if err != nil {
+			s.Artifact.State, s.Artifact.Evidence = "unknown", "artifact provenance probe failed: "+safeDiagnostic(err)
+		} else {
+			s.Artifact.Version, s.Artifact.Evidence = metadata.Version, "verified hao manifest from "+metadata.Source
+		}
 		s.Artifact.Path = artifactPath
 	}
 	tools := map[string]string{"git": "git", "harness": harnessBinary(desired.Harness)}
@@ -172,13 +189,13 @@ func observeSetup(ctx context.Context, deps Deps, desired setupDesired) setupSna
 		tools["gh"] = "gh"
 	}
 	for id, binary := range tools {
-		s.Tools[id] = observeTool(ctx, deps, binary)
+		s.Tools[id] = observeTool(deps, binary)
 	}
-	s.PackageManager, s.ServiceManager = observePackageManager(ctx, deps, osName), observeServiceManager(ctx, deps, osName)
+	s.PackageManager, s.ServiceManager = observePackageManager(deps, osName), observeServiceManager(deps, osName)
 	if osName == "linux" {
-		s.ServiceFiles["service.daemon"] = observeFile(deps.Observer, "/etc/systemd/system/hosted-ao.service")
+		s.ServiceFiles["service.daemon"] = observeServiceFile(deps.Observer, "/etc/systemd/system/ao-daemon.service")
 		if desired.Mode == "pair" {
-			s.ServiceFiles["service.gateway"] = observeFile(deps.Observer, "/etc/systemd/system/hosted-ao-gateway.service")
+			s.ServiceFiles["service.gateway"] = observeServiceFile(deps.Observer, "/etc/systemd/system/ao-gateway.service")
 		}
 	}
 	return s
@@ -192,30 +209,34 @@ func observeFile(obs Observer, path string) observedItem {
 	if err != nil {
 		return observedItem{State: "unknown", Evidence: "path probe failed: " + safeDiagnostic(err), Path: path}
 	}
-	return observedItem{State: "present", Evidence: fmt.Sprintf("path exists with mode %04o and uid %d", info.Mode.Perm(), info.UID), Path: path, Mode: info.Mode, UID: info.UID, Owner: info.Owner, IsDir: info.IsDir}
+	return observedItem{State: "present", Evidence: fmt.Sprintf("path exists with mode %04o and uid %d", info.Mode.Perm(), info.UID), Path: path, Mode: info.Mode, UID: info.UID, Owner: info.Owner, IsDir: info.IsDir, Link: info.Link}
 }
 
-func observeTool(ctx context.Context, deps Deps, binary string) observedItem {
+func observeServiceFile(obs Observer, path string) observedItem {
+	item := observeFile(obs, path)
+	if item.State != "present" || item.Link || item.IsDir {
+		return item
+	}
+	data, err := obs.ReadFile(path)
+	if err != nil {
+		item.State, item.Evidence = "unknown", "service definition read failed: "+safeDiagnostic(err)
+		return item
+	}
+	item.Version = string(data)
+	return item
+}
+
+func observeTool(deps Deps, binary string) observedItem {
 	path, err := deps.Observer.LookPath(binary)
 	if err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			return observedItem{State: "unknown", Evidence: binary + " path lookup failed: " + safeDiagnostic(err)}
+		}
 		return observedItem{State: "absent", Evidence: binary + " was not found on PATH"}
 	}
-	version, state, evidence := probeVersion(ctx, deps, path)
-	return observedItem{State: state, Evidence: evidence, Version: version, Path: path, Owner: true}
+	return observedItem{State: "present", Evidence: "executable path is present (not executed)", Path: path, Owner: true}
 }
-func probeVersion(ctx context.Context, deps Deps, path string) (string, string, string) {
-	probeCtx, cancel := boundedContext(ctx, deps.Timeout)
-	defer cancel()
-	out, err := deps.Observer.Run(probeCtx, path, "--version")
-	if err != nil {
-		if probeCtx.Err() != nil || errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
-			return "", "unknown", "version probe timed out or was canceled"
-		}
-		return "", "unknown", "version probe failed"
-	}
-	return safeVersion(out), "present", "version probe succeeded"
-}
-func observePackageManager(ctx context.Context, deps Deps, goos string) observedItem {
+func observePackageManager(deps Deps, goos string) observedItem {
 	name := ""
 	if goos == "linux" {
 		name = "apt-get"
@@ -224,30 +245,29 @@ func observePackageManager(ctx context.Context, deps Deps, goos string) observed
 		name = "brew"
 	}
 	if name != "" {
-		item := observeTool(ctx, deps, name)
+		item := observeTool(deps, name)
 		if item.State != "absent" {
 			return item
 		}
 	}
 	return observedItem{State: "absent", Evidence: "no supported package manager was found"}
 }
-func observeServiceManager(ctx context.Context, deps Deps, goos string) observedItem {
+func observeServiceManager(deps Deps, goos string) observedItem {
 	if goos != "linux" {
 		return observedItem{State: "unsupported", Evidence: "managed service definitions are not supported on " + goos}
 	}
 	path, err := deps.Observer.LookPath("systemctl")
 	if err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			return observedItem{State: "unknown", Evidence: "systemctl path lookup failed: " + safeDiagnostic(err)}
+		}
 		return observedItem{State: "absent", Evidence: "systemctl was not found"}
 	}
-	probeCtx, cancel := boundedContext(ctx, deps.Timeout)
-	defer cancel()
-	if _, err := deps.Observer.Run(probeCtx, path, "show-environment"); err != nil {
-		return observedItem{State: "unknown", Evidence: "systemd usability probe failed or timed out", Path: path}
-	}
-	return observedItem{State: "present", Evidence: "systemd is available and usable", Path: path}
+	return observedItem{State: "present", Evidence: "systemd executable is present (not executed)", Path: path}
 }
 
 func planSetup(d setupDesired, s setupSnapshot) SetupPlan {
+	d.OS, d.Arch = s.OS, s.Arch
 	p := SetupPlan{SchemaVersion: setupPlanSchemaVersion, DryRun: true, Machine: d.Machine, Mode: d.Mode, Platform: s.OS + "/" + s.Arch, InstallPolicy: d.Install}
 	add := func(step SetupStep) { p.Steps = append(p.Steps, step) }
 	platformBlocked := ""
@@ -348,6 +368,9 @@ func planDirectory(id string, item observedItem) SetupStep {
 	if !item.IsDir {
 		return blockedStep(id, component, "reconcile-directory", "required directory path is occupied by a non-directory", item.Evidence, "move the conflicting path outside hao, then retry")
 	}
+	if item.Link {
+		return blockedStep(id, component, "reconcile-directory", "managed directory path is a symbolic link", item.Evidence, "replace the link with a directory inside the HAO state root")
+	}
 	if !item.Owner {
 		return blockedStep(id, component, "reconcile-directory", "existing directory has unsafe ownership", item.Evidence, "correct ownership outside hao, then retry")
 	}
@@ -360,7 +383,7 @@ func planArtifact(d setupDesired, item observedItem) SetupStep {
 	if item.State == "unknown" {
 		return blockedStep("artifact.ao", "ao-gateway-artifact", "reconcile-artifact", "artifact state or version is unknown", item.Evidence, "inspect the hao-owned AO artifact manually")
 	}
-	action := &SetupAction{Kind: "artifact-install", Path: item.Path, Argv: []string{"ao", d.AOVersion}}
+	action := artifactReleaseAction(d, item.Path)
 	if item.State == "absent" {
 		if d.Install == "none" {
 			return blockedStep("artifact.ao", "ao-gateway-artifact", "manual-install", "audit-only policy forbids planning artifact installation", item.Evidence, "install the requested hao-owned AO artifact manually, then rerun setup")
@@ -369,6 +392,9 @@ func planArtifact(d setupDesired, item observedItem) SetupStep {
 	}
 	if item.IsDir {
 		return blockedStep("artifact.ao", "ao-gateway-artifact", "reconcile-artifact", "artifact path is occupied by a directory", item.Evidence, "move the conflicting directory outside hao")
+	}
+	if item.Link {
+		return blockedStep("artifact.ao", "ao-gateway-artifact", "reconcile-artifact", "managed artifact path is a symbolic link", item.Evidence, "replace the link with a regular hao-owned artifact")
 	}
 	if !item.Owner {
 		return blockedStep("artifact.ao", "ao-gateway-artifact", "reconcile-artifact", "existing artifact has unsafe ownership", item.Evidence, "correct or remove the conflicting artifact outside hao")
@@ -401,13 +427,17 @@ func planPrerequisite(d setupDesired, s setupSnapshot, id, component string, ite
 	if id == "harness" && d.Harness != "claude-code" {
 		return blockedStep(stepID, component, "manual-install", "selected harness has no allowlisted installer", item.Evidence, "install the selected harness using its vendor documentation")
 	}
+	if id == "harness" {
+		return SetupStep{ID: stepID, Component: component, Operation: "install-vendor-artifact", Disposition: "create", Reason: "required allowlisted harness is absent", Evidence: item.Evidence, Action: &SetupAction{Kind: "vendor-package", Source: "npm:@anthropic-ai/claude-code", Version: "latest"}}
+	}
 	if s.PackageManager.State != "present" {
 		return blockedStep(stepID, component, "install-prerequisite", "a supported package manager is not proven usable", s.PackageManager.Evidence, "install the prerequisite manually or restore the supported package manager")
 	}
-	if id == "harness" {
-		return SetupStep{ID: stepID, Component: component, Operation: "install-vendor-artifact", Disposition: "create", Reason: "required allowlisted harness is absent", Evidence: item.Evidence, Action: &SetupAction{Kind: "vendor-installer", Executable: "hao-installer", Argv: []string{"install", "harness", d.Harness}}}
+	privilege := SetupPrivilege{}
+	if filepath.Base(s.PackageManager.Path) == "apt-get" {
+		privilege = SetupPrivilege{Required: true, Scope: "package-install"}
 	}
-	return SetupStep{ID: stepID, Component: component, Operation: "install-package", Disposition: "create", Privilege: SetupPrivilege{Required: true, Scope: "package-install"}, Reason: "required prerequisite is absent", Evidence: item.Evidence, Action: &SetupAction{Kind: "package-manager", Executable: s.PackageManager.Path, Argv: []string{"install", id}}}
+	return SetupStep{ID: stepID, Component: component, Operation: "install-package", Disposition: "create", Privilege: privilege, Reason: "required prerequisite is absent", Evidence: item.Evidence, Action: &SetupAction{Kind: "package-manager", Executable: s.PackageManager.Path, Argv: []string{"install", id}}}
 }
 
 func planServices(d setupDesired, s setupSnapshot) []SetupStep {
@@ -432,6 +462,15 @@ func planServices(d setupDesired, s setupSnapshot) []SetupStep {
 		}
 		return steps
 	}
+	if s.UserState != "known" || s.User.Name == "" || s.User.UID == 0 || s.User.Home == "" {
+		steps := []SetupStep{blockedStep("service.daemon", "ao-daemon-service", "reconcile-definition", "target unprivileged user could not be determined", "user observation is "+s.UserState, "rerun as the target non-root user")}
+		if d.Mode == "pair" {
+			step := blockedStep("service.gateway", "pair-gateway-service", "reconcile-definition", "target unprivileged user could not be determined", "user observation is "+s.UserState, "rerun as the target non-root user")
+			step.Dependencies = []string{"service.daemon"}
+			steps = append(steps, step)
+		}
+		return steps
+	}
 	ids := []string{"service.daemon"}
 	if d.Mode == "pair" {
 		ids = append(ids, "service.gateway")
@@ -443,12 +482,16 @@ func planServices(d setupDesired, s setupSnapshot) []SetupStep {
 			component, deps = "pair-gateway-service", []string{"service.daemon", "directory.gateway", "artifact.ao"}
 		}
 		var step SetupStep
+		desiredContent := renderSystemdDefinition(id, d, s.User)
+		action := &SetupAction{Kind: "service-definition-v1", Path: item.Path, Mode: "0644", Content: desiredContent}
 		switch item.State {
 		case "absent":
-			step = SetupStep{ID: id, Component: component, Operation: "install-definition", Disposition: "create", Privilege: SetupPrivilege{Required: true, Scope: "system-service-definition"}, Reason: "supported service definition is absent", Evidence: item.Evidence, Action: &SetupAction{Kind: "service-definition", Path: item.Path}}
+			step = SetupStep{ID: id, Component: component, Operation: "install-definition", Disposition: "create", Privilege: SetupPrivilege{Required: true, Scope: "system-service-definition"}, Reason: "supported service definition is absent", Evidence: item.Evidence, Action: action}
 		case "present":
-			if item.IsDir || item.UID > 0 || item.Mode.Perm()&0o022 != 0 {
+			if item.Link || item.IsDir || item.UID > 0 || item.Mode.Perm()&0o022 != 0 {
 				step = blockedStep(id, component, "reconcile-definition", "existing service definition has unsafe ownership", item.Evidence, "inspect and reconcile the conflicting definition manually")
+			} else if item.Version != desiredContent {
+				step = SetupStep{ID: id, Component: component, Operation: "update-definition", Disposition: "update", Privilege: SetupPrivilege{Required: true, Scope: "system-service-definition"}, Reason: "service definition content differs from desired canonical v1 content", Evidence: "canonical content mismatch", Action: action}
 			} else {
 				step = noopStep(id, component, "verify-definition", "service definition is present; setup does not enable or start it", item.Evidence)
 			}
@@ -459,6 +502,25 @@ func planServices(d setupDesired, s setupSnapshot) []SetupStep {
 		steps = append(steps, step)
 	}
 	return steps
+}
+
+func renderSystemdDefinition(id string, d setupDesired, user UserObservation) string {
+	dataDir, runFile, binary := filepath.Join(d.StateRoot, "data"), filepath.Join(d.StateRoot, "running.json"), filepath.Join(d.StateRoot, "bin", "ao")
+	var b strings.Builder
+	b.WriteString("[Unit]\nDescription=Hosted AO ")
+	if id == "service.gateway" {
+		b.WriteString("pair gateway\nAfter=network-online.target ao-daemon.service\nRequires=ao-daemon.service\n")
+	} else {
+		b.WriteString("daemon\nAfter=network-online.target\n")
+	}
+	b.WriteString("\n[Service]\nType=simple\nUser=" + user.Name + "\nWorkingDirectory=" + dataDir + "\nEnvironment=\"HOME=" + user.Home + "\"\n")
+	if id == "service.gateway" {
+		b.WriteString("Environment=\"AO_VM_PAIR=on\"\nEnvironment=\"AO_VM_CERT_DIR=" + filepath.Join(d.StateRoot, "vm-gateway", "pair-cert") + "\"\nEnvironment=\"AO_VM_PASSCODE_DIR=" + filepath.Join(d.StateRoot, "vm-gateway", "pair-passcode") + "\"\nExecStart=" + binary + " vm serve\n")
+	} else {
+		b.WriteString("Environment=\"AO_DATA_DIR=" + dataDir + "\"\nEnvironment=\"AO_RUN_FILE=" + runFile + "\"\nExecStart=" + binary + " daemon\n")
+	}
+	b.WriteString("Restart=on-failure\n\n[Install]\nWantedBy=multi-user.target\n")
+	return b.String()
 }
 
 func propagateBlocked(steps []SetupStep) {
@@ -491,6 +553,13 @@ func versionMatches(observed, desired string) bool {
 		}
 	}
 	return false
+}
+
+func artifactReleaseAction(d setupDesired, path string) *SetupAction {
+	arch := map[string]string{"amd64": "x64", "arm64": "arm64"}[d.Arch]
+	asset := "ao-" + d.OS + "-" + arch
+	source := "https://github.com/agentlab-in/hosted-ao/releases/download/v" + d.AOVersion + "/" + asset
+	return &SetupAction{Kind: "verified-release-artifact", Path: path, Version: d.AOVersion, Source: source, VerifyWith: source + ".sha256"}
 }
 
 func writeSetupPlan(cmd *cobra.Command, plan SetupPlan, yes bool) error {

--- a/backend/internal/haocli/setup.go
+++ b/backend/internal/haocli/setup.go
@@ -668,20 +668,6 @@ func consumeSystemdDefinition(content string) (systemdDefinitionConsumer, error)
 	return parsed, nil
 }
 
-func lookPathInService(name, pathValue string) (string, error) {
-	if name == "" || filepath.Base(name) != name {
-		return "", errors.New("service executable name must be a base name")
-	}
-	for _, directory := range filepath.SplitList(pathValue) {
-		candidate := filepath.Join(directory, name)
-		info, err := os.Stat(candidate)
-		if err == nil && info.Mode().IsRegular() && info.Mode().Perm()&0o111 != 0 {
-			return candidate, nil
-		}
-	}
-	return "", os.ErrNotExist
-}
-
 var systemdUserPattern = regexp.MustCompile(`^[A-Za-z0-9_.-]+$`)
 
 func systemdInputsSafe(d setupDesired, user UserObservation) bool {

--- a/backend/internal/haocli/setup.go
+++ b/backend/internal/haocli/setup.go
@@ -1,0 +1,28 @@
+package haocli
+
+import (
+	"github.com/spf13/cobra"
+)
+
+func newSetupCommand(_ Deps, _ *options) *cobra.Command {
+	var dryRun bool
+	var nonInteractive bool
+	var install string
+	var yes bool
+	cmd := &cobra.Command{
+		Use:   "setup",
+		Short: "Plan machine preparation",
+		Args:  noArgs,
+		RunE: func(*cobra.Command, []string) error {
+			if !dryRun {
+				return commandError{Code: "feature_deferred", Message: "hao setup mutation is not yet supported", Remediation: "rerun with --dry-run to inspect the setup plan", ExitStatus: 2}
+			}
+			return commandError{Code: "operation_failed", Message: "setup planning is being implemented", Remediation: "retry with a completed Batch 4 build", ExitStatus: 1}
+		},
+	}
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "display the setup plan without changing the machine")
+	cmd.Flags().BoolVar(&nonInteractive, "non-interactive", false, "never prompt for input")
+	cmd.Flags().StringVar(&install, "install", "", "dependency policy: missing or none")
+	cmd.Flags().BoolVar(&yes, "yes", false, "approve the displayed plan for future setup execution")
+	return cmd
+}

--- a/backend/internal/haocli/setup.go
+++ b/backend/internal/haocli/setup.go
@@ -1,6 +1,7 @@
 package haocli
 
 import (
+	"crypto/sha256"
 	"errors"
 	"fmt"
 	"os"
@@ -22,15 +23,17 @@ type SetupPrivilege struct {
 
 // SetupAction is a structured, shell-free future execution description.
 type SetupAction struct {
-	Kind       string   `json:"kind"`
-	Executable string   `json:"executable,omitempty"`
-	Argv       []string `json:"argv,omitempty"`
-	Path       string   `json:"path,omitempty"`
-	Mode       string   `json:"mode,omitempty"`
-	Version    string   `json:"version,omitempty"`
-	Source     string   `json:"source,omitempty"`
-	VerifyWith string   `json:"verifyWith,omitempty"`
-	Content    string   `json:"content,omitempty"`
+	SchemaVersion int      `json:"schemaVersion"`
+	Kind          string   `json:"kind"`
+	Executable    string   `json:"executable,omitempty"`
+	Argv          []string `json:"argv,omitempty"`
+	Path          string   `json:"path,omitempty"`
+	Mode          string   `json:"mode,omitempty"`
+	Version       string   `json:"version,omitempty"`
+	Source        string   `json:"source,omitempty"`
+	VerifyWith    string   `json:"verifyWith,omitempty"`
+	Content       string   `json:"content,omitempty"`
+	SHA256        string   `json:"sha256,omitempty"`
 }
 
 // SetupStep is one stable desired-versus-observed reconciliation decision.
@@ -102,7 +105,7 @@ func newSetupCommand(deps Deps, opts *options) *cobra.Command {
 	cmd := &cobra.Command{Use: "setup", Short: "Plan machine preparation", Args: noArgs, RunE: func(cmd *cobra.Command, _ []string) error {
 		// This guard intentionally precedes config loading and every observation.
 		if !dryRun {
-			return commandError{Code: "feature_deferred", Message: "hao setup mutation is not yet supported", Remediation: "rerun with --dry-run to inspect the setup plan", ExitStatus: 2}
+			return commandError{Code: "feature_deferred", Message: "hao setup mutation is not yet supported", Remediation: "rerun with --dry-run to inspect the setup plan", ExitStatus: 4}
 		}
 		if install != "" && install != "missing" && install != "none" {
 			return commandError{Code: "invalid_usage", Message: "--install must be missing or none", Remediation: "pass --install missing or --install none", ExitStatus: 2}
@@ -116,6 +119,9 @@ func newSetupCommand(deps Deps, opts *options) *cobra.Command {
 			return err
 		}
 		plan := planSetup(desired, observeSetup(deps, desired))
+		if err := validateSetupPlan(plan); err != nil {
+			return operationalError("validate setup plan", err)
+		}
 		if opts.json {
 			err = writeJSON(cmd.OutOrStdout(), haocontractRedact(plan))
 		} else {
@@ -177,6 +183,14 @@ func observeSetup(deps Deps, desired setupDesired) setupSnapshot {
 	}
 	artifactPath := filepath.Join(desired.StateRoot, "bin", "ao")
 	s.Artifact = observeFile(deps.Observer, artifactPath)
+	parentsSafe := true
+	for _, id := range []string{"directory.state", "directory.bin"} {
+		item := s.Directories[id]
+		parentsSafe = parentsSafe && item.State == "present" && item.IsDir && !item.Link && item.Owner
+	}
+	if !parentsSafe && s.Artifact.State == "present" {
+		s.Artifact.State, s.Artifact.Evidence = "unknown", "managed artifact ancestry is not a proven owned non-link directory chain"
+	}
 	if s.Artifact.State == "present" && s.Artifact.Owner && !s.Artifact.IsDir && !s.Artifact.Link && s.Artifact.Mode.Perm()&0o022 == 0 && s.Artifact.Mode.Perm()&0o111 != 0 {
 		metadata, err := deps.Observer.InspectArtifact(artifactPath)
 		if err != nil {
@@ -365,7 +379,7 @@ func planDirectory(id string, item observedItem) SetupStep {
 		return blockedStep(id, component, "reconcile-directory", "directory state is unknown", item.Evidence, "inspect the path and its parent permissions manually")
 	}
 	if item.State == "absent" {
-		return SetupStep{ID: id, Component: component, Operation: "create-directory", Disposition: "create", Reason: "required directory is absent", Evidence: item.Evidence, Action: &SetupAction{Kind: "directory", Path: item.Path, Mode: "0700"}}
+		return SetupStep{ID: id, Component: component, Operation: "create-directory", Disposition: "create", Reason: "required directory is absent", Evidence: item.Evidence, Action: &SetupAction{SchemaVersion: 1, Kind: "directory", Path: item.Path, Mode: "0700"}}
 	}
 	if !item.IsDir {
 		return blockedStep(id, component, "reconcile-directory", "required directory path is occupied by a non-directory", item.Evidence, "move the conflicting path outside hao, then retry")
@@ -377,7 +391,7 @@ func planDirectory(id string, item observedItem) SetupStep {
 		return blockedStep(id, component, "reconcile-directory", "existing directory has unsafe ownership", item.Evidence, "correct ownership outside hao, then retry")
 	}
 	if item.Mode.Perm()&0o077 != 0 {
-		return SetupStep{ID: id, Component: component, Operation: "set-directory-mode", Disposition: "update", Reason: "directory permissions are broader than owner-only", Evidence: item.Evidence, Action: &SetupAction{Kind: "file-mode", Path: item.Path, Mode: "0700"}}
+		return SetupStep{ID: id, Component: component, Operation: "set-directory-mode", Disposition: "update", Reason: "directory permissions are broader than owner-only", Evidence: item.Evidence, Action: &SetupAction{SchemaVersion: 1, Kind: "file-mode", Path: item.Path, Mode: "0700"}}
 	}
 	return noopStep(id, component, "verify-directory", "directory ownership and permissions already match", item.Evidence)
 }
@@ -430,7 +444,7 @@ func planPrerequisite(d setupDesired, s setupSnapshot, id, component string, ite
 		return blockedStep(stepID, component, "manual-install", "selected harness has no allowlisted installer", item.Evidence, "install the selected harness using its vendor documentation")
 	}
 	if id == "harness" {
-		return SetupStep{ID: stepID, Component: component, Operation: "install-vendor-artifact", Disposition: "create", Reason: "required allowlisted harness is absent", Evidence: item.Evidence, Action: &SetupAction{Kind: "vendor-package", Source: "npm:@anthropic-ai/claude-code", Version: "latest"}}
+		return SetupStep{ID: stepID, Component: component, Operation: "install-vendor-artifact", Disposition: "create", Reason: "required allowlisted harness is absent", Evidence: item.Evidence, Action: &SetupAction{SchemaVersion: 1, Kind: "vendor-package", Executable: "npm", Argv: []string{"install", "--global", "@anthropic-ai/claude-code@latest"}, Source: "https://registry.npmjs.org/@anthropic-ai/claude-code", Version: "latest"}}
 	}
 	if s.PackageManager.State != "present" {
 		return blockedStep(stepID, component, "install-prerequisite", "a supported package manager is not proven usable", s.PackageManager.Evidence, "install the prerequisite manually or restore the supported package manager")
@@ -439,7 +453,7 @@ func planPrerequisite(d setupDesired, s setupSnapshot, id, component string, ite
 	if filepath.Base(s.PackageManager.Path) == "apt-get" {
 		privilege = SetupPrivilege{Required: true, Scope: "package-install"}
 	}
-	return SetupStep{ID: stepID, Component: component, Operation: "install-package", Disposition: "create", Privilege: privilege, Reason: "required prerequisite is absent", Evidence: item.Evidence, Action: &SetupAction{Kind: "package-manager", Executable: s.PackageManager.Path, Argv: []string{"install", id}}}
+	return SetupStep{ID: stepID, Component: component, Operation: "install-package", Disposition: "create", Privilege: privilege, Reason: "required prerequisite is absent", Evidence: item.Evidence, Action: &SetupAction{SchemaVersion: 1, Kind: "package-manager", Executable: s.PackageManager.Path, Argv: []string{"install", id}}}
 }
 
 func planServices(d setupDesired, s setupSnapshot) []SetupStep {
@@ -494,7 +508,8 @@ func planServices(d setupDesired, s setupSnapshot) []SetupStep {
 		}
 		var step SetupStep
 		desiredContent := renderSystemdDefinition(id, d, s.User)
-		action := &SetupAction{Kind: "service-definition-v1", Path: item.Path, Mode: "0644", Content: desiredContent}
+		digest := sha256.Sum256([]byte(desiredContent))
+		action := &SetupAction{SchemaVersion: 1, Kind: "service-definition-v1", Path: item.Path, Mode: "0644", Version: "1", Content: desiredContent, SHA256: fmt.Sprintf("%x", digest[:])}
 		switch item.State {
 		case "absent":
 			step = SetupStep{ID: id, Component: component, Operation: "install-definition", Disposition: "create", Privilege: SetupPrivilege{Required: true, Scope: "system-service-definition"}, Reason: "supported service definition is absent", Evidence: item.Evidence, Action: action}
@@ -524,9 +539,14 @@ func renderSystemdDefinition(id string, d setupDesired, user UserObservation) st
 	} else {
 		b.WriteString("daemon\nAfter=network-online.target\n")
 	}
-	b.WriteString("\n[Service]\nType=simple\nUser=" + user.Name + "\nWorkingDirectory=" + systemdQuote(dataDir) + "\nEnvironment=" + systemdQuote("HOME="+user.Home) + "\n")
+	path := filepath.Join(user.Home, ".local", "bin") + ":" + filepath.Join(user.Home, "bin") + ":/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+	b.WriteString("\n[Service]\nType=simple\nUser=" + user.Name + "\nWorkingDirectory=" + systemdQuote(dataDir) + "\nEnvironment=" + systemdQuote("HOME="+user.Home) + "\nEnvironment=" + systemdQuote("PATH="+path) + "\n")
 	if id == "service.gateway" {
-		b.WriteString("Environment=" + systemdQuote("AO_VM_PAIR=on") + "\nEnvironment=" + systemdQuote("AO_VM_CERT_DIR="+filepath.Join(d.StateRoot, "vm-gateway", "pair-cert")) + "\nEnvironment=" + systemdQuote("AO_VM_PASSCODE_DIR="+filepath.Join(d.StateRoot, "vm-gateway", "pair-passcode")) + "\nExecStart=" + systemdQuote(binary) + " vm serve\n")
+		b.WriteString("Environment=" + systemdQuote("AO_VM_PAIR=on") + "\nEnvironment=" + systemdQuote("AO_VM_HTTPS_ADDR=:"+strconv.Itoa(d.PairPort)) + "\nEnvironment=" + systemdQuote("AO_VM_CERT_DIR="+filepath.Join(d.StateRoot, "vm-gateway", "pair-cert")) + "\nEnvironment=" + systemdQuote("AO_VM_PASSCODE_DIR="+filepath.Join(d.StateRoot, "vm-gateway", "pair-passcode")) + "\n")
+		if d.PairPort < 1024 {
+			b.WriteString("AmbientCapabilities=CAP_NET_BIND_SERVICE\nCapabilityBoundingSet=CAP_NET_BIND_SERVICE\n")
+		}
+		b.WriteString("ExecStart=" + systemdQuote(binary) + " vm serve\n")
 	} else {
 		b.WriteString("Environment=" + systemdQuote("AO_DATA_DIR="+dataDir) + "\nEnvironment=" + systemdQuote("AO_RUN_FILE="+runFile) + "\nExecStart=" + systemdQuote(binary) + " daemon\n")
 	}
@@ -588,7 +608,44 @@ func artifactReleaseAction(d setupDesired, path string) *SetupAction {
 	arch := map[string]string{"amd64": "x64", "arm64": "arm64"}[d.Arch]
 	asset := "ao-" + d.OS + "-" + arch
 	source := "https://github.com/agentlab-in/hosted-ao/releases/download/v" + d.AOVersion + "/" + asset
-	return &SetupAction{Kind: "verified-release-artifact", Path: path, Version: d.AOVersion, Source: source, VerifyWith: source + ".sha256"}
+	return &SetupAction{SchemaVersion: 1, Kind: "verified-release-artifact", Path: path, Version: d.AOVersion, Source: source, VerifyWith: source + ".sha256"}
+}
+
+// validateSetupPlan is the non-mutating consumer boundary for the future executor.
+// It rejects ambiguous action variants without opening files, executing programs,
+// contacting networks, or changing machine state.
+func validateSetupPlan(plan SetupPlan) error {
+	for _, step := range plan.Steps {
+		a := step.Action
+		if a == nil {
+			continue
+		}
+		if a.SchemaVersion != 1 {
+			return fmt.Errorf("step %s has unsupported action schema", step.ID)
+		}
+		switch a.Kind {
+		case "directory", "file-mode":
+			if a.Path == "" || a.Mode == "" {
+				return fmt.Errorf("step %s has incomplete file action", step.ID)
+			}
+		case "package-manager", "vendor-package":
+			if a.Executable == "" || len(a.Argv) == 0 || a.Source == "" && a.Kind == "vendor-package" {
+				return fmt.Errorf("step %s has incomplete installer action", step.ID)
+			}
+		case "verified-release-artifact":
+			if a.Path == "" || a.Version == "" || a.Source == "" || a.VerifyWith == "" {
+				return fmt.Errorf("step %s has incomplete artifact provenance", step.ID)
+			}
+		case "service-definition-v1":
+			digest := sha256.Sum256([]byte(a.Content))
+			if a.Path == "" || a.Mode == "" || a.Version != "1" || a.Content == "" || a.SHA256 != fmt.Sprintf("%x", digest[:]) {
+				return fmt.Errorf("step %s has invalid service definition contract", step.ID)
+			}
+		default:
+			return fmt.Errorf("step %s has unsupported action kind %q", step.ID, a.Kind)
+		}
+	}
+	return nil
 }
 
 func writeSetupPlan(cmd *cobra.Command, plan SetupPlan, yes bool) error {

--- a/backend/internal/haocli/setup.go
+++ b/backend/internal/haocli/setup.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -471,6 +473,15 @@ func planServices(d setupDesired, s setupSnapshot) []SetupStep {
 		}
 		return steps
 	}
+	if !systemdInputsSafe(d, s.User) {
+		steps := []SetupStep{blockedStep("service.daemon", "ao-daemon-service", "reconcile-definition", "service definition inputs contain unsupported control characters or user syntax", "canonical systemd rendering refused unsafe input", "use conventional target-user and state paths without control characters")}
+		if d.Mode == "pair" {
+			step := blockedStep("service.gateway", "pair-gateway-service", "reconcile-definition", "service definition inputs contain unsupported control characters or user syntax", "canonical systemd rendering refused unsafe input", "use conventional target-user and state paths without control characters")
+			step.Dependencies = []string{"service.daemon"}
+			steps = append(steps, step)
+		}
+		return steps
+	}
 	ids := []string{"service.daemon"}
 	if d.Mode == "pair" {
 		ids = append(ids, "service.gateway")
@@ -513,15 +524,33 @@ func renderSystemdDefinition(id string, d setupDesired, user UserObservation) st
 	} else {
 		b.WriteString("daemon\nAfter=network-online.target\n")
 	}
-	b.WriteString("\n[Service]\nType=simple\nUser=" + user.Name + "\nWorkingDirectory=" + dataDir + "\nEnvironment=\"HOME=" + user.Home + "\"\n")
+	b.WriteString("\n[Service]\nType=simple\nUser=" + user.Name + "\nWorkingDirectory=" + systemdQuote(dataDir) + "\nEnvironment=" + systemdQuote("HOME="+user.Home) + "\n")
 	if id == "service.gateway" {
-		b.WriteString("Environment=\"AO_VM_PAIR=on\"\nEnvironment=\"AO_VM_CERT_DIR=" + filepath.Join(d.StateRoot, "vm-gateway", "pair-cert") + "\"\nEnvironment=\"AO_VM_PASSCODE_DIR=" + filepath.Join(d.StateRoot, "vm-gateway", "pair-passcode") + "\"\nExecStart=" + binary + " vm serve\n")
+		b.WriteString("Environment=" + systemdQuote("AO_VM_PAIR=on") + "\nEnvironment=" + systemdQuote("AO_VM_CERT_DIR="+filepath.Join(d.StateRoot, "vm-gateway", "pair-cert")) + "\nEnvironment=" + systemdQuote("AO_VM_PASSCODE_DIR="+filepath.Join(d.StateRoot, "vm-gateway", "pair-passcode")) + "\nExecStart=" + systemdQuote(binary) + " vm serve\n")
 	} else {
-		b.WriteString("Environment=\"AO_DATA_DIR=" + dataDir + "\"\nEnvironment=\"AO_RUN_FILE=" + runFile + "\"\nExecStart=" + binary + " daemon\n")
+		b.WriteString("Environment=" + systemdQuote("AO_DATA_DIR="+dataDir) + "\nEnvironment=" + systemdQuote("AO_RUN_FILE="+runFile) + "\nExecStart=" + systemdQuote(binary) + " daemon\n")
 	}
 	b.WriteString("Restart=on-failure\n\n[Install]\nWantedBy=multi-user.target\n")
 	return b.String()
 }
+
+var systemdUserPattern = regexp.MustCompile(`^[A-Za-z0-9_.-]+$`)
+
+func systemdInputsSafe(d setupDesired, user UserObservation) bool {
+	if !systemdUserPattern.MatchString(user.Name) {
+		return false
+	}
+	for _, value := range []string{user.Home, d.StateRoot} {
+		for _, r := range value {
+			if r < 0x20 || r == 0x7f {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func systemdQuote(value string) string { return strconv.Quote(strings.ReplaceAll(value, "%", "%%")) }
 
 func propagateBlocked(steps []SetupStep) {
 	byID := make(map[string]int, len(steps))

--- a/backend/internal/haocli/setup_test.go
+++ b/backend/internal/haocli/setup_test.go
@@ -2,8 +2,10 @@ package haocli
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -21,9 +23,12 @@ func setupDeps(t *testing.T, fixture string, obs *fakeObserver) (Deps, string) {
 		t.Fatal(err)
 	}
 	obs.files[filepath.Join(root, "bin", "ao")] = FileObservation{Mode: 0o755, Owner: true}
-	obs.files["/etc/systemd/system/hosted-ao.service"] = FileObservation{Mode: 0o644, UID: 0}
-	obs.files["/etc/systemd/system/hosted-ao-gateway.service"] = FileObservation{Mode: 0o644, UID: 0}
-	obs.runs[filepath.Join(root, "bin", "ao")+" --version"] = "ao 0.14.0"
+	obs.artifacts[filepath.Join(root, "bin", "ao")] = ArtifactMetadata{Version: "0.14.0", SHA256: strings.Repeat("a", 64), Source: "test-release"}
+	obs.files["/etc/systemd/system/ao-daemon.service"] = FileObservation{Mode: 0o644, UID: 0}
+	obs.files["/etc/systemd/system/ao-gateway.service"] = FileObservation{Mode: 0o644, UID: 0}
+	desired := setupDesired{StateRoot: root}
+	obs.readFiles["/etc/systemd/system/ao-daemon.service"] = []byte(renderSystemdDefinition("service.daemon", desired, obs.user))
+	obs.readFiles["/etc/systemd/system/ao-gateway.service"] = []byte(renderSystemdDefinition("service.gateway", desired, obs.user))
 	return deps, root
 }
 
@@ -117,8 +122,8 @@ func TestSetupInstallPoliciesAndStructuredPrivilege(t *testing.T) {
 		}
 		deps, root := setupDeps(t, "pair", obs)
 		obs.statErr[filepath.Join(root, "bin", "ao")] = os.ErrNotExist
-		obs.statErr["/etc/systemd/system/hosted-ao.service"] = os.ErrNotExist
-		obs.statErr["/etc/systemd/system/hosted-ao-gateway.service"] = os.ErrNotExist
+		obs.statErr["/etc/systemd/system/ao-daemon.service"] = os.ErrNotExist
+		obs.statErr["/etc/systemd/system/ao-gateway.service"] = os.ErrNotExist
 		out, stderr, code := runCLI(t, deps, "--json", "--config", fixturePath("valid", "pair.yaml"), "setup", "--dry-run", "--install", "missing")
 		if code != 0 || stderr != "" {
 			t.Fatalf("code=%d stderr=%q out=%s", code, stderr, out)
@@ -144,7 +149,7 @@ func TestSetupUnknownConflictAndBlockedPropagation(t *testing.T) {
 	obs := healthyObserver()
 	deps, root := setupDeps(t, "pair", obs)
 	artifact := filepath.Join(root, "bin", "ao")
-	obs.runErr[artifact+" --version"] = context.DeadlineExceeded
+	obs.artifactErr[artifact] = context.DeadlineExceeded
 	obs.files[root] = FileObservation{Mode: 0o700, Owner: false}
 	obs.runErr["/usr/bin/apt-get --version"] = errors.New("probe failure")
 	out, _, code := runCLI(t, deps, "--json", "--config", fixturePath("valid", "pair.yaml"), "setup", "--dry-run")
@@ -195,7 +200,7 @@ func TestSetupPlatformsAndServiceManagers(t *testing.T) {
 			if state == "absent" {
 				delete(obs.paths, "systemctl")
 			} else {
-				obs.runErr["/usr/bin/systemctl show-environment"] = context.DeadlineExceeded
+				obs.pathErr["systemctl"] = context.DeadlineExceeded
 			}
 			deps, _ := setupDeps(t, "pair", obs)
 			out, _, code := runCLI(t, deps, "--json", "--config", fixturePath("valid", "pair.yaml"), "setup", "--dry-run")
@@ -210,7 +215,7 @@ func TestSetupWrongVersionsPermissionsAndManagerUnknown(t *testing.T) {
 	obs := healthyObserver()
 	deps, root := setupDeps(t, "pair", obs)
 	artifact := filepath.Join(root, "bin", "ao")
-	obs.runs[artifact+" --version"] = "ao 0.13.9"
+	obs.artifacts[artifact] = ArtifactMetadata{Version: "0.13.9", SHA256: strings.Repeat("b", 64), Source: "old-release"}
 	obs.files[filepath.Join(root, "data")] = FileObservation{Mode: 0o755, Owner: true, IsDir: true}
 	out, _, code := runCLI(t, deps, "--json", "--config", fixturePath("valid", "pair.yaml"), "setup", "--dry-run")
 	if code != 0 {
@@ -223,7 +228,7 @@ func TestSetupWrongVersionsPermissionsAndManagerUnknown(t *testing.T) {
 
 	obs = healthyObserver()
 	delete(obs.paths, "git")
-	obs.runErr["/usr/bin/apt-get --version"] = context.DeadlineExceeded
+	obs.pathErr["apt-get"] = context.DeadlineExceeded
 	deps, _ = setupDeps(t, "pair", obs)
 	out, _, code = runCLI(t, deps, "--json", "--config", fixturePath("valid", "pair.yaml"), "setup", "--dry-run")
 	if code != 1 {
@@ -240,7 +245,6 @@ func TestSetupLocalNeverPlansGatewayAndUnsafeArtifactIsNotExecuted(t *testing.T)
 	deps, root := setupDeps(t, "local", obs)
 	artifact := filepath.Join(root, "bin", "ao")
 	obs.files[artifact] = FileObservation{Mode: 0o777, Owner: true}
-	before := obs.runCalls
 	out, _, code := runCLI(t, deps, "--json", "--config", fixturePath("valid", "local.yaml"), "setup", "--dry-run")
 	if code != 1 {
 		t.Fatalf("code=%d out=%s", code, out)
@@ -249,14 +253,77 @@ func TestSetupLocalNeverPlansGatewayAndUnsafeArtifactIsNotExecuted(t *testing.T)
 	if stepByID(t, plan, "artifact.ao").Disposition != "blocked" {
 		t.Fatalf("plan=%+v", plan)
 	}
-	// git, harness, package manager, and systemd probes run; the unsafe artifact must not.
-	if obs.runCalls-before != 4 {
-		t.Fatalf("runCalls=%d want 4 safe probes", obs.runCalls-before)
+	if obs.runCalls != 0 {
+		t.Fatalf("setup executed %d subprocess probes", obs.runCalls)
 	}
 	for _, step := range plan.Steps {
 		if strings.Contains(step.ID, "gateway") || strings.HasPrefix(step.ID, "pair.") {
 			t.Fatalf("local plan contains gateway step: %+v", step)
 		}
+	}
+}
+
+func TestSetupHarnessDoesNotDependOnPackageManager(t *testing.T) {
+	obs := healthyObserver()
+	delete(obs.paths, "claude")
+	delete(obs.paths, "apt-get")
+	deps, _ := setupDeps(t, "pair", obs)
+	out, _, code := runCLI(t, deps, "--json", "--config", fixturePath("valid", "pair.yaml"), "setup", "--dry-run")
+	if code != 0 {
+		t.Fatalf("code=%d out=%s", code, out)
+	}
+	step := stepByID(t, decodeSetupPlan(t, out), "prerequisite.harness")
+	if step.Disposition != "create" || step.Action == nil || step.Action.Kind != "vendor-package" || len(step.Dependencies) != 1 {
+		t.Fatalf("step=%+v", step)
+	}
+}
+
+func TestSetupServiceDefinitionDriftCarriesCanonicalContent(t *testing.T) {
+	obs := healthyObserver()
+	deps, _ := setupDeps(t, "pair", obs)
+	obs.readFiles["/etc/systemd/system/ao-daemon.service"] = []byte("[Service]\nExecStart=/wrong\n")
+	out, _, code := runCLI(t, deps, "--json", "--config", fixturePath("valid", "pair.yaml"), "setup", "--dry-run")
+	if code != 0 {
+		t.Fatalf("code=%d out=%s", code, out)
+	}
+	step := stepByID(t, decodeSetupPlan(t, out), "service.daemon")
+	if step.Disposition != "update" || step.Action == nil || !strings.Contains(step.Action.Content, "ExecStart=") || !strings.Contains(step.Action.Content, "AO_DATA_DIR") {
+		t.Fatalf("step=%+v", step)
+	}
+}
+
+func TestSystemObserverBlocksManagedSymlinkAndVerifiesArtifactManifest(t *testing.T) {
+	root := t.TempDir()
+	target := filepath.Join(root, "target")
+	if err := os.Mkdir(target, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(root, "link")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatal(err)
+	}
+	item := observeFile(systemObserver{}, link)
+	if !item.Link || planDirectory("directory.state", item).Disposition != "blocked" {
+		t.Fatalf("item=%+v", item)
+	}
+
+	artifact := filepath.Join(root, "ao")
+	payload := []byte("non-executable-test-artifact")
+	if err := os.WriteFile(artifact, payload, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	sum := sha256.Sum256(payload)
+	metadata := ArtifactMetadata{Version: "0.14.0", SHA256: fmt.Sprintf("%x", sum[:]), Source: "test-release"}
+	manifest, err := json.Marshal(metadata)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(artifact+".hao-manifest.json", manifest, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got, err := (systemObserver{}).InspectArtifact(artifact)
+	if err != nil || !reflect.DeepEqual(got, metadata) {
+		t.Fatalf("got=%+v err=%v", got, err)
 	}
 }
 
@@ -297,11 +364,14 @@ func TestSetupWithoutDryRunFailsBeforeEveryBoundary(t *testing.T) {
 
 type panicObserver struct{}
 
-func (panicObserver) Platform() (string, string)           { panic("platform probe") }
-func (panicObserver) Distribution() (string, error)        { panic("distribution probe") }
-func (panicObserver) Stat(string) (FileObservation, error) { panic("filesystem probe") }
-func (panicObserver) Disk(string) (uint64, error)          { panic("disk probe") }
-func (panicObserver) LookPath(string) (string, error)      { panic("path probe") }
+func (panicObserver) Platform() (string, string)                       { panic("platform probe") }
+func (panicObserver) Distribution() (string, error)                    { panic("distribution probe") }
+func (panicObserver) CurrentUser() (UserObservation, error)            { panic("user probe") }
+func (panicObserver) Stat(string) (FileObservation, error)             { panic("filesystem probe") }
+func (panicObserver) ReadFile(string) ([]byte, error)                  { panic("file read") }
+func (panicObserver) InspectArtifact(string) (ArtifactMetadata, error) { panic("artifact probe") }
+func (panicObserver) Disk(string) (uint64, error)                      { panic("disk probe") }
+func (panicObserver) LookPath(string) (string, error)                  { panic("path probe") }
 func (panicObserver) Run(context.Context, string, ...string) (string, error) {
 	panic("subprocess probe")
 }
@@ -314,8 +384,8 @@ func (panicObserver) PortAvailable(context.Context, string, int) (bool, error) {
 
 func TestSetupHumanJSONRedactionAndYesSemantics(t *testing.T) {
 	obs := healthyObserver()
-	obs.runs["/usr/bin/git --version"] = `token=setup-secret`
 	deps, _ := setupDeps(t, "local", obs)
+	obs.paths["git"] = `/tmp/token=setup-secret/git`
 	for _, args := range [][]string{{"--config", fixturePath("valid", "local.yaml"), "setup", "--dry-run", "--yes"}, {"--json", "--config", fixturePath("valid", "local.yaml"), "setup", "--dry-run", "--yes"}} {
 		out, stderr, code := runCLI(t, deps, args...)
 		if code != 0 || stderr != "" || strings.Contains(out, "setup-secret") || !strings.Contains(out, "[REDACTED]") {

--- a/backend/internal/haocli/setup_test.go
+++ b/backend/internal/haocli/setup_test.go
@@ -660,6 +660,32 @@ func TestControlledServicePathFindsUserHarness(t *testing.T) {
 	}
 }
 
+func TestSystemdInputsRejectPathsThatCannotRoundTripLiterally(t *testing.T) {
+	user := UserObservation{Name: "agent", UID: 1000, Home: "/home/agent"}
+	for _, stateRoot := range []string{
+		"relative/state",
+		"/srv/%n/state",
+		`/srv/hao\state`,
+		"/srv/hao state",
+		"/srv/hao\tstate",
+		"/srv/hao\nstate",
+	} {
+		if systemdInputsSafe(setupDesired{StateRoot: stateRoot}, user) {
+			t.Fatalf("unsafe systemd state root accepted: %q", stateRoot)
+		}
+	}
+	for _, home := range []string{"relative/home", "/home/%u", `/home/agent\escape`, "/home/agent name"} {
+		unsafeUser := user
+		unsafeUser.Home = home
+		if systemdInputsSafe(setupDesired{StateRoot: "/srv/hao"}, unsafeUser) {
+			t.Fatalf("unsafe systemd home accepted: %q", home)
+		}
+	}
+	if !systemdInputsSafe(setupDesired{StateRoot: "/srv/hao"}, user) {
+		t.Fatal("conventional absolute systemd paths were rejected")
+	}
+}
+
 func TestSetupPairOrderingAndSetupInitSeparation(t *testing.T) {
 	obs := healthyObserver()
 	deps, _ := setupDeps(t, "pair", obs)

--- a/backend/internal/haocli/setup_test.go
+++ b/backend/internal/haocli/setup_test.go
@@ -104,8 +104,9 @@ func TestSetupInstallPoliciesAndStructuredPrivilege(t *testing.T) {
 				t.Fatalf("%s=%+v", id, step)
 			}
 		}
-		if stepByID(t, plan, "artifact.ao").Disposition != "create" {
-			t.Fatal("AO artifact ownership must remain independent from dependency install policy")
+		artifact := stepByID(t, plan, "artifact.ao")
+		if artifact.Disposition != "blocked" || artifact.Action != nil {
+			t.Fatalf("audit-only artifact=%+v", artifact)
 		}
 	})
 

--- a/backend/internal/haocli/setup_test.go
+++ b/backend/internal/haocli/setup_test.go
@@ -7,12 +7,14 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/runfile"
+	"github.com/aoagents/agent-orchestrator/backend/internal/vmgateway"
 )
 
 func setupDeps(t *testing.T, fixture string, obs *fakeObserver) (Deps, string) {
@@ -23,7 +25,9 @@ func setupDeps(t *testing.T, fixture string, obs *fakeObserver) (Deps, string) {
 		t.Fatal(err)
 	}
 	obs.files[filepath.Join(root, "bin", "ao")] = FileObservation{Mode: 0o755, Owner: true}
-	obs.artifacts[filepath.Join(root, "bin", "ao")] = ArtifactMetadata{Version: "0.14.0", SHA256: strings.Repeat("a", 64), Source: "test-release"}
+	trusted := ArtifactMetadata{Version: "0.14.0", SHA256: strings.Repeat("a", 64), Source: "https://github.com/agentlab-in/hosted-ao/releases/download/v0.14.0/ao-linux-x64"}
+	obs.artifacts[filepath.Join(root, "bin", "ao")] = trusted
+	deps.TrustedArtifact = func(_, _, _ string) (ArtifactMetadata, bool) { return trusted, true }
 	obs.files["/etc/systemd/system/ao-daemon.service"] = FileObservation{Mode: 0o644, UID: 0}
 	obs.files["/etc/systemd/system/ao-gateway.service"] = FileObservation{Mode: 0o644, UID: 0}
 	desired := setupDesired{StateRoot: root, PairPort: 443}
@@ -97,6 +101,7 @@ func TestSetupInstallPoliciesAndStructuredPrivilege(t *testing.T) {
 		delete(obs.paths, "git")
 		delete(obs.paths, "claude")
 		deps, root := setupDeps(t, "local", obs)
+		deps.TrustedArtifact = nil
 		obs.statErr[filepath.Join(root, "bin", "ao")] = os.ErrNotExist
 		out, stderr, code := runCLI(t, deps, "--json", "--config", fixturePath("valid", "local.yaml"), "setup", "--dry-run", "--install", "none")
 		if code != 1 || stderr != "" {
@@ -115,7 +120,7 @@ func TestSetupInstallPoliciesAndStructuredPrivilege(t *testing.T) {
 		}
 	})
 
-	t.Run("missing plans package and allowlisted vendor actions", func(t *testing.T) {
+	t.Run("missing blocks package and vendor work without immutable metadata", func(t *testing.T) {
 		obs := healthyObserver()
 		for _, name := range []string{"git", "gh", "claude"} {
 			delete(obs.paths, name)
@@ -125,22 +130,22 @@ func TestSetupInstallPoliciesAndStructuredPrivilege(t *testing.T) {
 		obs.statErr["/etc/systemd/system/ao-daemon.service"] = os.ErrNotExist
 		obs.statErr["/etc/systemd/system/ao-gateway.service"] = os.ErrNotExist
 		out, stderr, code := runCLI(t, deps, "--json", "--config", fixturePath("valid", "pair.yaml"), "setup", "--dry-run", "--install", "missing")
-		if code != 0 || stderr != "" {
+		if code != 1 || stderr != "" {
 			t.Fatalf("code=%d stderr=%q out=%s", code, stderr, out)
 		}
 		plan := decodeSetupPlan(t, out)
 		for _, id := range []string{"prerequisite.git", "prerequisite.gh"} {
 			step := stepByID(t, plan, id)
-			if step.Disposition != "create" || !step.Privilege.Required || step.Privilege.Scope != "package-install" || step.Action == nil || len(step.Action.Argv) != 2 {
+			if step.Disposition != "blocked" || step.Privilege.Required || step.Action != nil || !strings.Contains(step.Reason, "immutable package metadata") {
 				t.Fatalf("%s=%+v", id, step)
-			}
-			if strings.Contains(strings.Join(step.Action.Argv, " "), "sudo") {
-				t.Fatalf("sudo embedded in argv: %+v", step.Action)
 			}
 		}
 		harness := stepByID(t, plan, "prerequisite.harness")
-		if harness.Disposition != "create" || harness.Privilege.Required || harness.Action == nil {
+		if harness.Disposition != "blocked" || harness.Privilege.Required || harness.Action != nil {
 			t.Fatalf("harness=%+v", harness)
+		}
+		if artifact := stepByID(t, plan, "artifact.ao"); artifact.Disposition != "blocked" || artifact.Action != nil {
+			t.Fatalf("artifact=%+v", artifact)
 		}
 	})
 }
@@ -218,11 +223,11 @@ func TestSetupWrongVersionsPermissionsAndManagerUnknown(t *testing.T) {
 	obs.artifacts[artifact] = ArtifactMetadata{Version: "0.13.9", SHA256: strings.Repeat("b", 64), Source: "old-release"}
 	obs.files[filepath.Join(root, "data")] = FileObservation{Mode: 0o755, Owner: true, IsDir: true}
 	out, _, code := runCLI(t, deps, "--json", "--config", fixturePath("valid", "pair.yaml"), "setup", "--dry-run")
-	if code != 0 {
+	if code != 1 {
 		t.Fatalf("code=%d out=%s", code, out)
 	}
 	plan := decodeSetupPlan(t, out)
-	if stepByID(t, plan, "artifact.ao").Disposition != "update" || stepByID(t, plan, "directory.data").Disposition != "update" {
+	if stepByID(t, plan, "artifact.ao").Disposition != "blocked" || stepByID(t, plan, "directory.data").Disposition != "update" {
 		t.Fatalf("plan=%+v", plan)
 	}
 
@@ -238,6 +243,42 @@ func TestSetupWrongVersionsPermissionsAndManagerUnknown(t *testing.T) {
 	if stepByID(t, plan, "host.package-manager").Disposition != "blocked" || stepByID(t, plan, "prerequisite.git").Disposition != "blocked" {
 		t.Fatalf("plan=%+v", plan)
 	}
+}
+
+func TestSetupUntrustedArtifactProvenanceNeverBecomesExecutableOrNoOp(t *testing.T) {
+	t.Run("self-attested existing artifact is blocked", func(t *testing.T) {
+		obs := healthyObserver()
+		deps, root := setupDeps(t, "local", obs)
+		deps.TrustedArtifact = nil
+		artifact := filepath.Join(root, "bin", "ao")
+		obs.artifacts[artifact] = ArtifactMetadata{Version: "0.14.0", SHA256: strings.Repeat("a", 64), Source: "https://github.com/agentlab-in/hosted-ao/releases/download/v0.14.0/ao-linux-x64"}
+		out, _, code := runCLI(t, deps, "--json", "--config", fixturePath("valid", "local.yaml"), "setup", "--dry-run")
+		if code != 1 {
+			t.Fatalf("code=%d out=%s", code, out)
+		}
+		step := stepByID(t, decodeSetupPlan(t, out), "artifact.ao")
+		if step.Disposition != "blocked" || step.Action != nil || !strings.Contains(step.Reason, "immutable release metadata") {
+			t.Fatalf("artifact step=%+v", step)
+		}
+	})
+
+	t.Run("absent artifact and harness are manual without immutable metadata", func(t *testing.T) {
+		obs := healthyObserver()
+		delete(obs.paths, "claude")
+		deps, root := setupDeps(t, "local", obs)
+		obs.statErr[filepath.Join(root, "bin", "ao")] = os.ErrNotExist
+		out, _, code := runCLI(t, deps, "--json", "--config", fixturePath("valid", "local.yaml"), "setup", "--dry-run", "--install", "missing")
+		if code != 1 {
+			t.Fatalf("code=%d out=%s", code, out)
+		}
+		plan := decodeSetupPlan(t, out)
+		for _, id := range []string{"artifact.ao", "prerequisite.harness"} {
+			step := stepByID(t, plan, id)
+			if step.Disposition != "blocked" || step.Action != nil || !strings.Contains(step.Reason, "immutable") {
+				t.Fatalf("%s=%+v", id, step)
+			}
+		}
+	})
 }
 
 func TestSetupLocalNeverPlansGatewayAndUnsafeArtifactIsNotExecuted(t *testing.T) {
@@ -269,11 +310,11 @@ func TestSetupHarnessDoesNotDependOnPackageManager(t *testing.T) {
 	delete(obs.paths, "apt-get")
 	deps, _ := setupDeps(t, "pair", obs)
 	out, _, code := runCLI(t, deps, "--json", "--config", fixturePath("valid", "pair.yaml"), "setup", "--dry-run")
-	if code != 0 {
+	if code != 1 {
 		t.Fatalf("code=%d out=%s", code, out)
 	}
 	step := stepByID(t, decodeSetupPlan(t, out), "prerequisite.harness")
-	if step.Disposition != "create" || step.Action == nil || step.Action.Kind != "vendor-package" || len(step.Dependencies) != 1 {
+	if step.Disposition != "blocked" || step.Action != nil || len(step.Dependencies) != 1 {
 		t.Fatalf("step=%+v", step)
 	}
 }
@@ -287,13 +328,16 @@ func TestSetupServiceDefinitionDriftCarriesCanonicalContent(t *testing.T) {
 		t.Fatalf("code=%d out=%s", code, out)
 	}
 	step := stepByID(t, decodeSetupPlan(t, out), "service.daemon")
-	if step.Disposition != "update" || step.Action == nil || !strings.Contains(step.Action.Content, "ExecStart=") || !strings.Contains(step.Action.Content, "AO_DATA_DIR") {
+	if step.Disposition != "update" || step.Action == nil || step.Action.Service == nil || !strings.Contains(step.Action.Service.Content, "ExecStart=") || !strings.Contains(step.Action.Service.Content, "AO_DATA_DIR") {
 		t.Fatalf("step=%+v", step)
 	}
 }
 
 func TestSystemObserverBlocksManagedSymlinkAndVerifiesArtifactManifest(t *testing.T) {
-	root := t.TempDir()
+	root, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
 	target := filepath.Join(root, "target")
 	if err := os.Mkdir(target, 0o700); err != nil {
 		t.Fatal(err)
@@ -321,9 +365,42 @@ func TestSystemObserverBlocksManagedSymlinkAndVerifiesArtifactManifest(t *testin
 	if err := os.WriteFile(artifact+".hao-manifest.json", manifest, 0o600); err != nil {
 		t.Fatal(err)
 	}
-	got, err := (systemObserver{}).InspectArtifact(artifact)
+	got, err := (systemObserver{}).InspectArtifact(context.Background(), artifact)
 	if err != nil || !reflect.DeepEqual(got, metadata) {
 		t.Fatalf("got=%+v err=%v", got, err)
+	}
+}
+
+func TestTrustedReleaseMetadataMatchesInspectedArtifactExactly(t *testing.T) {
+	root, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	artifact := filepath.Join(root, "ao")
+	payload := []byte("release-artifact")
+	if err := os.WriteFile(artifact, payload, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	sum := sha256.Sum256(payload)
+	trusted := ArtifactMetadata{Version: "0.14.0", Source: "https://github.com/agentlab-in/hosted-ao/releases/download/v0.14.0/ao-linux-x64", SHA256: fmt.Sprintf("%x", sum[:])}
+	manifest, err := json.Marshal(trusted)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(artifact+".hao-manifest.json", manifest, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	observed, err := (systemObserver{}).InspectArtifact(context.Background(), artifact)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !matchesTrustedArtifact(observed, trusted) {
+		t.Fatalf("exact immutable provenance did not match: observed=%+v trusted=%+v", observed, trusted)
+	}
+	mutated := trusted
+	mutated.SHA256 = strings.Repeat("b", 64)
+	if matchesTrustedArtifact(observed, mutated) {
+		t.Fatal("mismatched trusted digest was accepted")
 	}
 }
 
@@ -351,8 +428,76 @@ func TestSystemObserverRejectsLinkedAndOversizedManagedReads(t *testing.T) {
 	if err := file.Close(); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := (systemObserver{}).InspectArtifact(oversized); err == nil {
+	if _, err := (systemObserver{}).InspectArtifact(context.Background(), oversized); err == nil {
 		t.Fatal("oversized artifact inspection unexpectedly succeeded")
+	}
+}
+
+func TestSystemObserverRejectsArtifactThroughLinkedAncestor(t *testing.T) {
+	root, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(root, "target")
+	if err := os.Mkdir(target, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	payload := []byte("artifact")
+	artifact := filepath.Join(target, "ao")
+	if err := os.WriteFile(artifact, payload, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	sum := sha256.Sum256(payload)
+	metadata := ArtifactMetadata{Version: "0.14.0", Source: "release", SHA256: fmt.Sprintf("%x", sum[:])}
+	manifest, err := json.Marshal(metadata)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(artifact+".hao-manifest.json", manifest, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	ancestor := filepath.Join(root, "linked-parent")
+	if err := os.Symlink(target, ancestor); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := (systemObserver{}).InspectArtifact(context.Background(), filepath.Join(ancestor, "ao")); err == nil {
+		t.Fatal("artifact inspection followed a linked ancestor")
+	}
+}
+
+func TestSystemObserverArtifactHashHonorsCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := inspectArtifact(ctx, filepath.Join(t.TempDir(), "ao")); !errors.Is(err, context.Canceled) {
+		t.Fatalf("inspect canceled artifact error=%v, want context.Canceled", err)
+	}
+}
+
+func TestManagedReadNeverReturnsLinkSwapTarget(t *testing.T) {
+	root, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	managed := filepath.Join(root, "managed")
+	outside := filepath.Join(root, "outside")
+	if err := os.WriteFile(outside, []byte("outside"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(managed, []byte("safe"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 500; i++ {
+		_ = os.Remove(managed)
+		if err := os.Symlink(outside, managed); err != nil {
+			t.Fatal(err)
+		}
+		if data, readErr := (systemObserver{}).ReadFile(managed); readErr == nil && string(data) != "safe" {
+			t.Fatalf("managed read escaped through swap: %q", data)
+		}
+		_ = os.Remove(managed)
+		if err := os.WriteFile(managed, []byte("safe"), 0o600); err != nil {
+			t.Fatal(err)
+		}
 	}
 }
 
@@ -382,25 +527,135 @@ func TestSetupActionValidatorAndPairServiceConsumerContract(t *testing.T) {
 		t.Fatalf("validate action contract: %v", err)
 	}
 	action := stepByID(t, plan, "service.gateway").Action
-	if action == nil || action.SchemaVersion != 1 || action.Version != "1" || action.SHA256 == "" {
+	if action == nil || action.SchemaVersion != 1 || action.Service == nil || action.Service.Version != "1" || action.Service.SHA256 == "" {
 		t.Fatalf("gateway action=%+v", action)
 	}
 	for _, fragment := range []string{"AO_VM_HTTPS_ADDR=:443", "PATH=/home/ubuntu/.local/bin", "AmbientCapabilities=CAP_NET_BIND_SERVICE", "CapabilityBoundingSet=CAP_NET_BIND_SERVICE"} {
-		if !strings.Contains(action.Content, fragment) {
-			t.Fatalf("gateway content missing %q: %s", fragment, action.Content)
+		if !strings.Contains(action.Service.Content, fragment) {
+			t.Fatalf("gateway content missing %q: %s", fragment, action.Service.Content)
 		}
 	}
 	tampered := plan
 	for i := range tampered.Steps {
 		if tampered.Steps[i].Action != nil && tampered.Steps[i].Action.Kind == "service-definition-v1" {
 			copyAction := *tampered.Steps[i].Action
-			copyAction.Content += "# tampered\n"
+			copyService := *copyAction.Service
+			copyService.Content += "# tampered\n"
+			copyAction.Service = &copyService
 			tampered.Steps[i].Action = &copyAction
 			break
 		}
 	}
 	if err := validateSetupPlan(tampered); err == nil {
 		t.Fatal("tampered action contract unexpectedly validated")
+	}
+}
+
+func TestSetupActionValidatorRejectsMutableOrIncompleteProvenance(t *testing.T) {
+	for _, action := range []*SetupAction{
+		{SchemaVersion: 1, Kind: "verified-release-artifact", Artifact: &SetupArtifactAction{Path: "/managed/ao", Version: "0.14.0", Source: "https://example.invalid/ao"}},
+		{SchemaVersion: 1, Kind: "verified-release-artifact", Artifact: &SetupArtifactAction{Path: "/managed/ao", Version: "0.14.0", Source: "https://example.invalid/latest/ao", SHA256: strings.Repeat("a", 64)}},
+		{SchemaVersion: 1, Kind: "vendor-package", Vendor: &SetupVendorAction{Executable: "/usr/bin/npm", Argv: []string{"install", "pkg@latest"}, Version: "latest", Source: "https://registry.invalid/pkg"}},
+		{SchemaVersion: 1, Kind: "vendor-package", Vendor: &SetupVendorAction{Executable: "/usr/bin/npm", Argv: []string{"install", "pkg@latest"}, Version: "1.2.3", Source: "https://registry.invalid/pkg-1.2.3.tgz", SHA256: strings.Repeat("a", 64)}},
+		{SchemaVersion: 1, Kind: "package-manager", Package: &SetupPackageAction{Executable: "/usr/bin/apt-get", Argv: []string{"install", "git"}, Version: "latest", Source: "https://packages.invalid/git", SHA256: strings.Repeat("a", 64)}},
+		{SchemaVersion: 1, Kind: "package-manager", Package: &SetupPackageAction{Executable: "/usr/bin/apt-get", Argv: []string{"install", "git"}, Version: "1.2.3", Source: "https://packages.invalid/git-1.2.3.deb", SHA256: strings.Repeat("a", 64)}},
+	} {
+		plan := SetupPlan{SchemaVersion: 1, DryRun: true, Steps: []SetupStep{{ID: "test", Disposition: "create", Action: action}}}
+		if err := validateSetupPlan(plan); err == nil {
+			t.Fatalf("mutable/incomplete action unexpectedly validated: %+v", action)
+		}
+	}
+}
+
+func TestImmutableActionJSONRoundTripsThroughNonMutatingConsumer(t *testing.T) {
+	digest := strings.Repeat("a", 64)
+	plan := SetupPlan{SchemaVersion: 1, DryRun: true, Steps: []SetupStep{{
+		ID: "artifact.ao", Disposition: "create", Action: &SetupAction{
+			SchemaVersion: 1, Kind: "verified-release-artifact", Artifact: &SetupArtifactAction{Path: "/managed/ao",
+				Version: "0.14.0", Source: "https://releases.example.invalid/v0.14.0/ao-linux-x64", SHA256: digest},
+		},
+	}, {
+		ID: "prerequisite.git", Disposition: "create", Action: &SetupAction{
+			SchemaVersion: 1, Kind: "package-manager", Package: &SetupPackageAction{
+				Executable: "/usr/bin/apt-get", Argv: []string{"install", "git=1.2.3"}, Version: "1.2.3",
+				Source: "https://packages.example.invalid/git-1.2.3.deb", SHA256: digest,
+			},
+		},
+	}, {
+		ID: "prerequisite.harness", Disposition: "create", Action: &SetupAction{
+			SchemaVersion: 1, Kind: "vendor-package", Vendor: &SetupVendorAction{
+				Executable: "/usr/bin/npm", Argv: []string{"install", "--global", "pkg@1.2.3"}, Version: "1.2.3",
+				Source: "https://registry.example.invalid/pkg/-/pkg-1.2.3.tgz", SHA256: digest,
+			},
+		},
+	}}}
+	data, err := json.Marshal(plan)
+	if err != nil {
+		t.Fatal(err)
+	}
+	operations, err := consumeSetupPlanJSON(data)
+	if err != nil {
+		t.Fatalf("consume serialized plan: %v", err)
+	}
+	want := []string{
+		"artifact source=https://releases.example.invalid/v0.14.0/ao-linux-x64 version=0.14.0 sha256=" + digest + " path=/managed/ao",
+		"package executable=/usr/bin/apt-get source=https://packages.example.invalid/git-1.2.3.deb version=1.2.3 sha256=" + digest + ` argv=["install" "git=1.2.3"]`,
+		"vendor source=https://registry.example.invalid/pkg/-/pkg-1.2.3.tgz version=1.2.3 sha256=" + digest,
+	}
+	if !reflect.DeepEqual(operations, want) {
+		t.Fatalf("operations=%q want=%q", operations, want)
+	}
+}
+
+func TestPairSystemdConsumerCarriesPortCapabilitiesAndHarnessPath(t *testing.T) {
+	desired := setupDesired{StateRoot: "/home/ubuntu/.ao/hosted", PairPort: 8443}
+	user := UserObservation{Name: "ubuntu", UID: 1000, Home: "/home/ubuntu"}
+	parsed, err := consumeSystemdDefinition(renderSystemdDefinition("service.gateway", desired, user))
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := vmgateway.Resolve(vmgateway.Options{
+		Pair: true, HTTPSAddr: parsed.Environment["AO_VM_HTTPS_ADDR"],
+		CertDir: parsed.Environment["AO_VM_CERT_DIR"], PasscodeDir: parsed.Environment["AO_VM_PASSCODE_DIR"],
+		MachineFile: filepath.Join(t.TempDir(), "absent-machine.json"),
+	}, "/home/ubuntu/.ao/hosted/data")
+	if err != nil {
+		t.Fatalf("resolve gateway from parsed unit: %v", err)
+	}
+	if cfg.HTTPSAddr != ":8443" || parsed.HasNetBindCapability {
+		t.Fatalf("https=%q capability=%v", cfg.HTTPSAddr, parsed.HasNetBindCapability)
+	}
+	if parsed.Environment["PATH"] != "/home/ubuntu/.local/bin:/home/ubuntu/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" {
+		t.Fatalf("service PATH=%q", parsed.Environment["PATH"])
+	}
+
+	desired.PairPort = 443
+	parsed, err = consumeSystemdDefinition(renderSystemdDefinition("service.gateway", desired, user))
+	if err != nil || !parsed.HasNetBindCapability {
+		t.Fatalf("privileged port consumer capability=%v err=%v", parsed.HasNetBindCapability, err)
+	}
+}
+
+func TestControlledServicePathFindsUserHarness(t *testing.T) {
+	home, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	bin := filepath.Join(home, ".local", "bin")
+	if err := os.MkdirAll(bin, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	harness := filepath.Join(bin, "claude")
+	if err := os.WriteFile(harness, []byte("fixture"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	parsed, err := consumeSystemdDefinition(renderSystemdDefinition("service.daemon", setupDesired{StateRoot: filepath.Join(home, ".ao", "hosted")}, UserObservation{Name: "agent", UID: 1000, Home: home}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := lookPathInService("claude", parsed.Environment["PATH"])
+	if err != nil || got != harness {
+		t.Fatalf("harness path=%q err=%v want=%q", got, err, harness)
 	}
 }
 
@@ -439,16 +694,44 @@ func TestSetupWithoutDryRunFailsBeforeEveryBoundary(t *testing.T) {
 	assertEnvelope(t, stderr, code, 4, "feature_deferred", "setup")
 }
 
+func TestSetupWithoutDryRunProcessExitFourHumanAndJSON(t *testing.T) {
+	binary := filepath.Join(t.TempDir(), "hao")
+	build := exec.Command("go", "build", "-o", binary, "./cmd/hao")
+	build.Dir = filepath.Join("..", "..")
+	if output, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("build hao: %v\n%s", err, output)
+	}
+	for _, tc := range []struct {
+		name string
+		args []string
+		want string
+	}{
+		{name: "human", args: []string{"setup"}, want: "hao setup mutation is not yet supported"},
+		{name: "json", args: []string{"--json", "setup"}, want: `"code":"feature_deferred"`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := exec.Command(binary, tc.args...)
+			output, err := cmd.CombinedOutput()
+			var exitErr *exec.ExitError
+			if !errors.As(err, &exitErr) || exitErr.ExitCode() != 4 || !strings.Contains(string(output), tc.want) {
+				t.Fatalf("exit=%v output=%s", err, output)
+			}
+		})
+	}
+}
+
 type panicObserver struct{}
 
-func (panicObserver) Platform() (string, string)                       { panic("platform probe") }
-func (panicObserver) Distribution() (string, error)                    { panic("distribution probe") }
-func (panicObserver) CurrentUser() (UserObservation, error)            { panic("user probe") }
-func (panicObserver) Stat(string) (FileObservation, error)             { panic("filesystem probe") }
-func (panicObserver) ReadFile(string) ([]byte, error)                  { panic("file read") }
-func (panicObserver) InspectArtifact(string) (ArtifactMetadata, error) { panic("artifact probe") }
-func (panicObserver) Disk(string) (uint64, error)                      { panic("disk probe") }
-func (panicObserver) LookPath(string) (string, error)                  { panic("path probe") }
+func (panicObserver) Platform() (string, string)            { panic("platform probe") }
+func (panicObserver) Distribution() (string, error)         { panic("distribution probe") }
+func (panicObserver) CurrentUser() (UserObservation, error) { panic("user probe") }
+func (panicObserver) Stat(string) (FileObservation, error)  { panic("filesystem probe") }
+func (panicObserver) ReadFile(string) ([]byte, error)       { panic("file read") }
+func (panicObserver) InspectArtifact(context.Context, string) (ArtifactMetadata, error) {
+	panic("artifact probe")
+}
+func (panicObserver) Disk(string) (uint64, error)     { panic("disk probe") }
+func (panicObserver) LookPath(string) (string, error) { panic("path probe") }
 func (panicObserver) Run(context.Context, string, ...string) (string, error) {
 	panic("subprocess probe")
 }

--- a/backend/internal/haocli/setup_test.go
+++ b/backend/internal/haocli/setup_test.go
@@ -26,7 +26,7 @@ func setupDeps(t *testing.T, fixture string, obs *fakeObserver) (Deps, string) {
 	obs.artifacts[filepath.Join(root, "bin", "ao")] = ArtifactMetadata{Version: "0.14.0", SHA256: strings.Repeat("a", 64), Source: "test-release"}
 	obs.files["/etc/systemd/system/ao-daemon.service"] = FileObservation{Mode: 0o644, UID: 0}
 	obs.files["/etc/systemd/system/ao-gateway.service"] = FileObservation{Mode: 0o644, UID: 0}
-	desired := setupDesired{StateRoot: root}
+	desired := setupDesired{StateRoot: root, PairPort: 443}
 	obs.readFiles["/etc/systemd/system/ao-daemon.service"] = []byte(renderSystemdDefinition("service.daemon", desired, obs.user))
 	obs.readFiles["/etc/systemd/system/ao-gateway.service"] = []byte(renderSystemdDefinition("service.gateway", desired, obs.user))
 	return deps, root
@@ -327,6 +327,83 @@ func TestSystemObserverBlocksManagedSymlinkAndVerifiesArtifactManifest(t *testin
 	}
 }
 
+func TestSystemObserverRejectsLinkedAndOversizedManagedReads(t *testing.T) {
+	root := t.TempDir()
+	outside := filepath.Join(root, "outside")
+	if err := os.WriteFile(outside, []byte("outside"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	linked := filepath.Join(root, "linked")
+	if err := os.Symlink(outside, linked); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := (systemObserver{}).ReadFile(linked); err == nil {
+		t.Fatal("linked managed read unexpectedly succeeded")
+	}
+	oversized := filepath.Join(root, "oversized")
+	file, err := os.Create(oversized)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := file.Truncate(maxArtifactSize + 1); err != nil {
+		t.Fatal(err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := (systemObserver{}).InspectArtifact(oversized); err == nil {
+		t.Fatal("oversized artifact inspection unexpectedly succeeded")
+	}
+}
+
+func TestSetupBlocksArtifactInspectionThroughManagedAncestorLink(t *testing.T) {
+	obs := healthyObserver()
+	deps, root := setupDeps(t, "local", obs)
+	obs.files[root] = FileObservation{Mode: os.ModeSymlink | 0o777, Owner: true, Link: true}
+	out, _, code := runCLI(t, deps, "--json", "--config", fixturePath("valid", "local.yaml"), "setup", "--dry-run")
+	if code != 1 {
+		t.Fatalf("code=%d out=%s", code, out)
+	}
+	if stepByID(t, decodeSetupPlan(t, out), "artifact.ao").Disposition != "blocked" {
+		t.Fatalf("artifact ancestry did not block: %s", out)
+	}
+}
+
+func TestSetupActionValidatorAndPairServiceConsumerContract(t *testing.T) {
+	obs := healthyObserver()
+	deps, _ := setupDeps(t, "pair", obs)
+	obs.statErr["/etc/systemd/system/ao-gateway.service"] = os.ErrNotExist
+	out, _, code := runCLI(t, deps, "--json", "--config", fixturePath("valid", "pair.yaml"), "setup", "--dry-run")
+	if code != 0 {
+		t.Fatalf("code=%d out=%s", code, out)
+	}
+	plan := decodeSetupPlan(t, out)
+	if err := validateSetupPlan(plan); err != nil {
+		t.Fatalf("validate action contract: %v", err)
+	}
+	action := stepByID(t, plan, "service.gateway").Action
+	if action == nil || action.SchemaVersion != 1 || action.Version != "1" || action.SHA256 == "" {
+		t.Fatalf("gateway action=%+v", action)
+	}
+	for _, fragment := range []string{"AO_VM_HTTPS_ADDR=:443", "PATH=/home/ubuntu/.local/bin", "AmbientCapabilities=CAP_NET_BIND_SERVICE", "CapabilityBoundingSet=CAP_NET_BIND_SERVICE"} {
+		if !strings.Contains(action.Content, fragment) {
+			t.Fatalf("gateway content missing %q: %s", fragment, action.Content)
+		}
+	}
+	tampered := plan
+	for i := range tampered.Steps {
+		if tampered.Steps[i].Action != nil && tampered.Steps[i].Action.Kind == "service-definition-v1" {
+			copyAction := *tampered.Steps[i].Action
+			copyAction.Content += "# tampered\n"
+			tampered.Steps[i].Action = &copyAction
+			break
+		}
+	}
+	if err := validateSetupPlan(tampered); err == nil {
+		t.Fatal("tampered action contract unexpectedly validated")
+	}
+}
+
 func TestSetupPairOrderingAndSetupInitSeparation(t *testing.T) {
 	obs := healthyObserver()
 	deps, _ := setupDeps(t, "pair", obs)
@@ -356,10 +433,10 @@ func TestSetupWithoutDryRunFailsBeforeEveryBoundary(t *testing.T) {
 	panicRead := func(string) ([]byte, error) { panic("config read invoked") }
 	panicPath := func() (string, error) { panic("path resolution invoked") }
 	out, stderr, code := runCLI(t, Deps{ReadFile: panicRead, StateDir: panicPath, RunFile: panicPath, Observer: panicObserver{}}, "--json", "setup", "--non-interactive", "--install", "missing", "--yes")
-	if code != 2 || out != "" {
+	if code != 4 || out != "" {
 		t.Fatalf("code=%d out=%q stderr=%q", code, out, stderr)
 	}
-	assertEnvelope(t, stderr, code, 2, "feature_deferred", "setup")
+	assertEnvelope(t, stderr, code, 4, "feature_deferred", "setup")
 }
 
 type panicObserver struct{}

--- a/backend/internal/haocli/setup_test.go
+++ b/backend/internal/haocli/setup_test.go
@@ -1,0 +1,327 @@
+package haocli
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/runfile"
+)
+
+func setupDeps(t *testing.T, fixture string, obs *fakeObserver) (Deps, string) {
+	t.Helper()
+	deps := observationDeps(t, fixture, obs)
+	root, err := deps.StateDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	obs.files[filepath.Join(root, "bin", "ao")] = FileObservation{Mode: 0o755, Owner: true}
+	obs.files["/etc/systemd/system/hosted-ao.service"] = FileObservation{Mode: 0o644, UID: 0}
+	obs.files["/etc/systemd/system/hosted-ao-gateway.service"] = FileObservation{Mode: 0o644, UID: 0}
+	obs.runs[filepath.Join(root, "bin", "ao")+" --version"] = "ao 0.14.0"
+	return deps, root
+}
+
+func decodeSetupPlan(t *testing.T, out string) SetupPlan {
+	t.Helper()
+	var plan SetupPlan
+	if err := json.Unmarshal([]byte(out), &plan); err != nil {
+		t.Fatalf("decode plan: %v\n%s", err, out)
+	}
+	return plan
+}
+
+func stepByID(t *testing.T, plan SetupPlan, id string) SetupStep {
+	t.Helper()
+	for _, step := range plan.Steps {
+		if step.ID == id {
+			return step
+		}
+	}
+	t.Fatalf("missing step %q in %+v", id, plan.Steps)
+	return SetupStep{}
+}
+
+func TestSetupValidLocalAndPairPlansAreDeterministic(t *testing.T) {
+	for _, fixture := range []string{"local", "pair"} {
+		t.Run(fixture, func(t *testing.T) {
+			obs := healthyObserver()
+			deps, _ := setupDeps(t, fixture, obs)
+			args := []string{"--json", "--config", fixturePath("valid", fixture+".yaml"), "setup", "--dry-run", "--non-interactive"}
+			out1, stderr1, code1 := runCLI(t, deps, args...)
+			out2, stderr2, code2 := runCLI(t, deps, args...)
+			if code1 != 0 || code2 != 0 || stderr1 != "" || stderr2 != "" || out1 != out2 {
+				t.Fatalf("code=%d/%d stderr=%q/%q deterministic=%v\n%s\n%s", code1, code2, stderr1, stderr2, out1 == out2, out1, out2)
+			}
+			plan := decodeSetupPlan(t, out1)
+			if plan.SchemaVersion != 1 || !plan.DryRun || !plan.Summary.Ready || plan.Summary.Blocked != 0 {
+				t.Fatalf("plan=%+v", plan)
+			}
+			for _, step := range plan.Steps {
+				if step.Disposition != "no-op" {
+					t.Fatalf("satisfied step is not no-op: %+v", step)
+				}
+			}
+			joined := strings.ToLower(out1)
+			if strings.Contains(joined, "tmux") || strings.Contains(joined, "runtimebackend") {
+				t.Fatalf("AO-internal runtime policy leaked into plan: %s", out1)
+			}
+			_, hasGH := func() (SetupStep, bool) {
+				for _, step := range plan.Steps {
+					if step.ID == "prerequisite.gh" {
+						return step, true
+					}
+				}
+				return SetupStep{}, false
+			}()
+			if hasGH != (fixture == "pair") {
+				t.Fatalf("profile-conditional gh presence=%v fixture=%s", hasGH, fixture)
+			}
+		})
+	}
+}
+
+func TestSetupInstallPoliciesAndStructuredPrivilege(t *testing.T) {
+	t.Run("none blocks missing prerequisites without actions", func(t *testing.T) {
+		obs := healthyObserver()
+		delete(obs.paths, "git")
+		delete(obs.paths, "claude")
+		deps, root := setupDeps(t, "local", obs)
+		obs.statErr[filepath.Join(root, "bin", "ao")] = os.ErrNotExist
+		out, stderr, code := runCLI(t, deps, "--json", "--config", fixturePath("valid", "local.yaml"), "setup", "--dry-run", "--install", "none")
+		if code != 1 || stderr != "" {
+			t.Fatalf("code=%d stderr=%q out=%s", code, stderr, out)
+		}
+		plan := decodeSetupPlan(t, out)
+		for _, id := range []string{"prerequisite.git", "prerequisite.harness"} {
+			step := stepByID(t, plan, id)
+			if step.Disposition != "blocked" || step.Operation != "manual-install" || step.Action != nil {
+				t.Fatalf("%s=%+v", id, step)
+			}
+		}
+		if stepByID(t, plan, "artifact.ao").Disposition != "create" {
+			t.Fatal("AO artifact ownership must remain independent from dependency install policy")
+		}
+	})
+
+	t.Run("missing plans package and allowlisted vendor actions", func(t *testing.T) {
+		obs := healthyObserver()
+		for _, name := range []string{"git", "gh", "claude"} {
+			delete(obs.paths, name)
+		}
+		deps, root := setupDeps(t, "pair", obs)
+		obs.statErr[filepath.Join(root, "bin", "ao")] = os.ErrNotExist
+		obs.statErr["/etc/systemd/system/hosted-ao.service"] = os.ErrNotExist
+		obs.statErr["/etc/systemd/system/hosted-ao-gateway.service"] = os.ErrNotExist
+		out, stderr, code := runCLI(t, deps, "--json", "--config", fixturePath("valid", "pair.yaml"), "setup", "--dry-run", "--install", "missing")
+		if code != 0 || stderr != "" {
+			t.Fatalf("code=%d stderr=%q out=%s", code, stderr, out)
+		}
+		plan := decodeSetupPlan(t, out)
+		for _, id := range []string{"prerequisite.git", "prerequisite.gh"} {
+			step := stepByID(t, plan, id)
+			if step.Disposition != "create" || !step.Privilege.Required || step.Privilege.Scope != "package-install" || step.Action == nil || len(step.Action.Argv) != 2 {
+				t.Fatalf("%s=%+v", id, step)
+			}
+			if strings.Contains(strings.Join(step.Action.Argv, " "), "sudo") {
+				t.Fatalf("sudo embedded in argv: %+v", step.Action)
+			}
+		}
+		harness := stepByID(t, plan, "prerequisite.harness")
+		if harness.Disposition != "create" || harness.Privilege.Required || harness.Action == nil {
+			t.Fatalf("harness=%+v", harness)
+		}
+	})
+}
+
+func TestSetupUnknownConflictAndBlockedPropagation(t *testing.T) {
+	obs := healthyObserver()
+	deps, root := setupDeps(t, "pair", obs)
+	artifact := filepath.Join(root, "bin", "ao")
+	obs.runErr[artifact+" --version"] = context.DeadlineExceeded
+	obs.files[root] = FileObservation{Mode: 0o700, Owner: false}
+	obs.runErr["/usr/bin/apt-get --version"] = errors.New("probe failure")
+	out, _, code := runCLI(t, deps, "--json", "--config", fixturePath("valid", "pair.yaml"), "setup", "--dry-run")
+	if code != 1 {
+		t.Fatalf("code=%d out=%s", code, out)
+	}
+	plan := decodeSetupPlan(t, out)
+	if stepByID(t, plan, "directory.state").Disposition != "blocked" || stepByID(t, plan, "artifact.ao").Disposition != "blocked" {
+		t.Fatalf("plan=%+v", plan)
+	}
+	if stepByID(t, plan, "service.daemon").Disposition != "blocked" || stepByID(t, plan, "service.gateway").Disposition != "blocked" {
+		t.Fatalf("blocked dependencies did not propagate: %+v", plan.Steps)
+	}
+}
+
+func TestSetupPlatformsAndServiceManagers(t *testing.T) {
+	tests := []struct {
+		name, fixture, goos, distro string
+		serviceEnabled              bool
+		wantCode                    int
+		wantPlatform, wantService   string
+	}{
+		{"ubuntu systemd", "pair", "linux", "ubuntu", true, 0, "no-op", "no-op"},
+		{"mac local desktop", "local", "darwin", "darwin", false, 0, "no-op", "no-op"},
+		{"mac pair unsupported lifecycle", "pair", "darwin", "darwin", true, 1, "no-op", "blocked"},
+		{"windows pair unsupported", "pair", "windows", "windows", true, 1, "blocked", "blocked"},
+		{"other linux unsupported", "pair", "linux", "fedora", true, 1, "blocked", "blocked"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			obs := healthyObserver()
+			obs.platform, obs.distribution = tc.goos, tc.distro
+			deps, _ := setupDeps(t, tc.fixture, obs)
+			out, _, code := runCLI(t, deps, "--json", "--config", fixturePath("valid", tc.fixture+".yaml"), "setup", "--dry-run")
+			if code != tc.wantCode {
+				t.Fatalf("code=%d want=%d out=%s", code, tc.wantCode, out)
+			}
+			plan := decodeSetupPlan(t, out)
+			if stepByID(t, plan, "host.platform").Disposition != tc.wantPlatform || stepByID(t, plan, "service.daemon").Disposition != tc.wantService {
+				t.Fatalf("plan=%+v", plan)
+			}
+		})
+	}
+
+	for _, state := range []string{"absent", "unknown"} {
+		t.Run("systemd "+state, func(t *testing.T) {
+			obs := healthyObserver()
+			if state == "absent" {
+				delete(obs.paths, "systemctl")
+			} else {
+				obs.runErr["/usr/bin/systemctl show-environment"] = context.DeadlineExceeded
+			}
+			deps, _ := setupDeps(t, "pair", obs)
+			out, _, code := runCLI(t, deps, "--json", "--config", fixturePath("valid", "pair.yaml"), "setup", "--dry-run")
+			if code != 1 || stepByID(t, decodeSetupPlan(t, out), "service.daemon").Disposition != "blocked" {
+				t.Fatalf("code=%d out=%s", code, out)
+			}
+		})
+	}
+}
+
+func TestSetupWrongVersionsPermissionsAndManagerUnknown(t *testing.T) {
+	obs := healthyObserver()
+	deps, root := setupDeps(t, "pair", obs)
+	artifact := filepath.Join(root, "bin", "ao")
+	obs.runs[artifact+" --version"] = "ao 0.13.9"
+	obs.files[filepath.Join(root, "data")] = FileObservation{Mode: 0o755, Owner: true, IsDir: true}
+	out, _, code := runCLI(t, deps, "--json", "--config", fixturePath("valid", "pair.yaml"), "setup", "--dry-run")
+	if code != 0 {
+		t.Fatalf("code=%d out=%s", code, out)
+	}
+	plan := decodeSetupPlan(t, out)
+	if stepByID(t, plan, "artifact.ao").Disposition != "update" || stepByID(t, plan, "directory.data").Disposition != "update" {
+		t.Fatalf("plan=%+v", plan)
+	}
+
+	obs = healthyObserver()
+	delete(obs.paths, "git")
+	obs.runErr["/usr/bin/apt-get --version"] = context.DeadlineExceeded
+	deps, _ = setupDeps(t, "pair", obs)
+	out, _, code = runCLI(t, deps, "--json", "--config", fixturePath("valid", "pair.yaml"), "setup", "--dry-run")
+	if code != 1 {
+		t.Fatalf("code=%d out=%s", code, out)
+	}
+	plan = decodeSetupPlan(t, out)
+	if stepByID(t, plan, "host.package-manager").Disposition != "blocked" || stepByID(t, plan, "prerequisite.git").Disposition != "blocked" {
+		t.Fatalf("plan=%+v", plan)
+	}
+}
+
+func TestSetupLocalNeverPlansGatewayAndUnsafeArtifactIsNotExecuted(t *testing.T) {
+	obs := healthyObserver()
+	deps, root := setupDeps(t, "local", obs)
+	artifact := filepath.Join(root, "bin", "ao")
+	obs.files[artifact] = FileObservation{Mode: 0o777, Owner: true}
+	before := obs.runCalls
+	out, _, code := runCLI(t, deps, "--json", "--config", fixturePath("valid", "local.yaml"), "setup", "--dry-run")
+	if code != 1 {
+		t.Fatalf("code=%d out=%s", code, out)
+	}
+	plan := decodeSetupPlan(t, out)
+	if stepByID(t, plan, "artifact.ao").Disposition != "blocked" {
+		t.Fatalf("plan=%+v", plan)
+	}
+	// git, harness, package manager, and systemd probes run; the unsafe artifact must not.
+	if obs.runCalls-before != 4 {
+		t.Fatalf("runCalls=%d want 4 safe probes", obs.runCalls-before)
+	}
+	for _, step := range plan.Steps {
+		if strings.Contains(step.ID, "gateway") || strings.HasPrefix(step.ID, "pair.") {
+			t.Fatalf("local plan contains gateway step: %+v", step)
+		}
+	}
+}
+
+func TestSetupPairOrderingAndSetupInitSeparation(t *testing.T) {
+	obs := healthyObserver()
+	deps, _ := setupDeps(t, "pair", obs)
+	out, _, code := runCLI(t, deps, "--json", "--config", fixturePath("valid", "pair.yaml"), "setup", "--dry-run", "--yes")
+	if code != 0 {
+		t.Fatalf("code=%d out=%s", code, out)
+	}
+	plan := decodeSetupPlan(t, out)
+	positions := map[string]int{}
+	for i, step := range plan.Steps {
+		positions[step.ID] = i
+	}
+	if positions["directory.data"] > positions["artifact.ao"] || positions["artifact.ao"] > positions["service.daemon"] || positions["service.daemon"] > positions["service.gateway"] {
+		t.Fatalf("ordering=%v", positions)
+	}
+	if !reflect.DeepEqual(stepByID(t, plan, "service.gateway").Dependencies, []string{"service.daemon", "directory.gateway", "artifact.ao"}) {
+		t.Fatalf("gateway deps=%v", stepByID(t, plan, "service.gateway").Dependencies)
+	}
+	for _, forbidden := range []string{"certificate", "passcode", "pair string", "ao-pair://", "listener", "authenticate", "start-service", "enable-service"} {
+		if strings.Contains(strings.ToLower(out), forbidden) {
+			t.Fatalf("setup planned init concern %q: %s", forbidden, out)
+		}
+	}
+}
+
+func TestSetupWithoutDryRunFailsBeforeEveryBoundary(t *testing.T) {
+	panicRead := func(string) ([]byte, error) { panic("config read invoked") }
+	panicPath := func() (string, error) { panic("path resolution invoked") }
+	out, stderr, code := runCLI(t, Deps{ReadFile: panicRead, StateDir: panicPath, RunFile: panicPath, Observer: panicObserver{}}, "--json", "setup", "--non-interactive", "--install", "missing", "--yes")
+	if code != 2 || out != "" {
+		t.Fatalf("code=%d out=%q stderr=%q", code, out, stderr)
+	}
+	assertEnvelope(t, stderr, code, 2, "feature_deferred", "setup")
+}
+
+type panicObserver struct{}
+
+func (panicObserver) Platform() (string, string)           { panic("platform probe") }
+func (panicObserver) Distribution() (string, error)        { panic("distribution probe") }
+func (panicObserver) Stat(string) (FileObservation, error) { panic("filesystem probe") }
+func (panicObserver) Disk(string) (uint64, error)          { panic("disk probe") }
+func (panicObserver) LookPath(string) (string, error)      { panic("path probe") }
+func (panicObserver) Run(context.Context, string, ...string) (string, error) {
+	panic("subprocess probe")
+}
+func (panicObserver) ReadRunFile(string) (*runfile.Info, error)   { panic("runfile probe") }
+func (panicObserver) ProcessAlive(int) bool                       { panic("process probe") }
+func (panicObserver) GET(context.Context, string) ([]byte, error) { panic("network probe") }
+func (panicObserver) PortAvailable(context.Context, string, int) (bool, error) {
+	panic("listener probe")
+}
+
+func TestSetupHumanJSONRedactionAndYesSemantics(t *testing.T) {
+	obs := healthyObserver()
+	obs.runs["/usr/bin/git --version"] = `token=setup-secret`
+	deps, _ := setupDeps(t, "local", obs)
+	for _, args := range [][]string{{"--config", fixturePath("valid", "local.yaml"), "setup", "--dry-run", "--yes"}, {"--json", "--config", fixturePath("valid", "local.yaml"), "setup", "--dry-run", "--yes"}} {
+		out, stderr, code := runCLI(t, deps, args...)
+		if code != 0 || stderr != "" || strings.Contains(out, "setup-secret") || !strings.Contains(out, "[REDACTED]") {
+			t.Fatalf("args=%v code=%d out=%s err=%s", args, code, out, stderr)
+		}
+		if args[0] != "--json" && !strings.Contains(out, "--yes has no mutation effect") {
+			t.Fatalf("missing --yes note: %s", out)
+		}
+	}
+}

--- a/backend/internal/haocli/setup_test.go
+++ b/backend/internal/haocli/setup_test.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/aoagents/agent-orchestrator/backend/internal/agentlaunch"
 	"github.com/aoagents/agent-orchestrator/backend/internal/runfile"
 	"github.com/aoagents/agent-orchestrator/backend/internal/vmgateway"
 )
@@ -653,7 +654,7 @@ func TestControlledServicePathFindsUserHarness(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	got, err := lookPathInService("claude", parsed.Environment["PATH"])
+	got, err := agentlaunch.LookPath("claude", parsed.Environment["PATH"])
 	if err != nil || got != harness {
 		t.Fatalf("harness path=%q err=%v want=%q", got, err, harness)
 	}

--- a/backend/internal/haocli/systemd_linux_test.go
+++ b/backend/internal/haocli/systemd_linux_test.go
@@ -1,0 +1,47 @@
+//go:build linux
+
+package haocli
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRenderedPrivilegedGatewayPassesSystemdVerify(t *testing.T) {
+	if _, err := exec.LookPath("systemd-analyze"); err != nil {
+		t.Skip("systemd-analyze is unavailable")
+	}
+	root := t.TempDir()
+	stateRoot := filepath.Join(root, "state")
+	for _, dir := range []string{filepath.Join(stateRoot, "bin"), filepath.Join(stateRoot, "data")} {
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(stateRoot, "bin", "ao"), []byte("fixture"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	desired := setupDesired{StateRoot: stateRoot, PairPort: 443}
+	user := UserObservation{Name: "nobody", UID: 65534, Home: root}
+	daemonPath := filepath.Join(root, "ao-daemon.service")
+	gatewayPath := filepath.Join(root, "ao-gateway.service")
+	if err := os.WriteFile(daemonPath, []byte(renderSystemdDefinition("service.daemon", desired, user)), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	gateway := renderSystemdDefinition("service.gateway", desired, user)
+	if err := os.WriteFile(gatewayPath, []byte(gateway), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	output, err := exec.Command("systemd-analyze", "verify", daemonPath, gatewayPath).CombinedOutput()
+	if err != nil {
+		t.Fatalf("systemd rejected rendered units: %v\n%s", err, output)
+	}
+	for _, directive := range []string{"AmbientCapabilities=CAP_NET_BIND_SERVICE", "CapabilityBoundingSet=CAP_NET_BIND_SERVICE", "User=nobody", "AO_VM_HTTPS_ADDR=:443"} {
+		if !strings.Contains(gateway, directive) {
+			t.Fatalf("verified gateway lacks effective privileged-port directive %q", directive)
+		}
+	}
+}

--- a/backend/internal/haocli/systemd_linux_test.go
+++ b/backend/internal/haocli/systemd_linux_test.go
@@ -25,7 +25,7 @@ func TestRenderedPrivilegedGatewayPassesSystemdVerify(t *testing.T) {
 		t.Fatal(err)
 	}
 	desired := setupDesired{StateRoot: stateRoot, PairPort: 443}
-	user := UserObservation{Name: "nobody", UID: 65534, Home: root}
+	user := UserObservation{Name: "hao-test", UID: 65534, Home: root}
 	daemonPath := filepath.Join(root, "ao-daemon.service")
 	gatewayPath := filepath.Join(root, "ao-gateway.service")
 	if err := os.WriteFile(daemonPath, []byte(renderSystemdDefinition("service.daemon", desired, user)), 0o600); err != nil {
@@ -39,7 +39,7 @@ func TestRenderedPrivilegedGatewayPassesSystemdVerify(t *testing.T) {
 	if err != nil {
 		t.Fatalf("systemd rejected rendered units: %v\n%s", err, output)
 	}
-	for _, directive := range []string{"AmbientCapabilities=CAP_NET_BIND_SERVICE", "CapabilityBoundingSet=CAP_NET_BIND_SERVICE", "User=nobody", "AO_VM_HTTPS_ADDR=:443"} {
+	for _, directive := range []string{"AmbientCapabilities=CAP_NET_BIND_SERVICE", "CapabilityBoundingSet=CAP_NET_BIND_SERVICE", "User=hao-test", "AO_VM_HTTPS_ADDR=:443"} {
 		if !strings.Contains(gateway, directive) {
 			t.Fatalf("verified gateway lacks effective privileged-port directive %q", directive)
 		}

--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -721,7 +721,7 @@ func New(d Deps) *Manager {
 		m.backgroundContext = context.Background()
 	}
 	if m.lookPath == nil {
-		m.lookPath = exec.LookPath
+		m.lookPath = func(name string) (string, error) { return agentlaunch.LookPath(name, os.Getenv("PATH")) }
 	}
 	if m.executable == nil {
 		m.executable = os.Executable

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -49,9 +49,12 @@ surface (`npm run sqlc`, `npm run api`).
   read-only host snapshot, and emits a deterministic ordered preparation plan.
   Steps are classified as create, update, no-op, or blocked with stable IDs,
   structured privilege/action metadata, dependencies, evidence, and safe
-  remediation. Managed paths are inspected without following links; installed
-  AO artifacts are verified through an adjacent provenance/checksum manifest;
-  canonical systemd definition content is compared byte-for-byte. Dependency
+  remediation. Managed paths are inspected through bounded no-follow handles.
+  Adjacent AO manifests are observed but are not trusted release authority, so
+  artifact or vendor install/no-op steps remain blocked unless immutable trusted
+  version/source/digest provenance is supplied by an injected resolver. The
+  release-metadata resolver and mutation executor are deferred. Canonical
+  systemd definition content is compared byte-for-byte. Dependency
   installation policy, Ubuntu systemd support, macOS
   desktop supervision, pair prerequisites, and profile-conditional `gh` are
   planned without executing anything. `--yes` is forward-compatible and has no

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -49,7 +49,10 @@ surface (`npm run sqlc`, `npm run api`).
   read-only host snapshot, and emits a deterministic ordered preparation plan.
   Steps are classified as create, update, no-op, or blocked with stable IDs,
   structured privilege/action metadata, dependencies, evidence, and safe
-  remediation. Dependency installation policy, Ubuntu systemd support, macOS
+  remediation. Managed paths are inspected without following links; installed
+  AO artifacts are verified through an adjacent provenance/checksum manifest;
+  canonical systemd definition content is compared byte-for-byte. Dependency
+  installation policy, Ubuntu systemd support, macOS
   desktop supervision, pair prerequisites, and profile-conditional `gh` are
   planned without executing anything. `--yes` is forward-compatible and has no
   mutation effect. Setup without `--dry-run` fails closed.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -45,9 +45,17 @@ surface (`npm run sqlc`, `npm run api`).
   time-bounded tool authentication probes. When the daemon is reachable it
   aggregates the daemon's shared doctor report instead of redefining AO runtime
   or terminal readiness.
-- Configuration mutation, setup, initialization, service lifecycle changes,
-  pairing, gateway changes, authentication flows, and other host mutation are
-  not performed by these observation commands.
+- `hao setup --dry-run` loads the same validated v1 configuration, captures a
+  read-only host snapshot, and emits a deterministic ordered preparation plan.
+  Steps are classified as create, update, no-op, or blocked with stable IDs,
+  structured privilege/action metadata, dependencies, evidence, and safe
+  remediation. Dependency installation policy, Ubuntu systemd support, macOS
+  desktop supervision, pair prerequisites, and profile-conditional `gh` are
+  planned without executing anything. `--yes` is forward-compatible and has no
+  mutation effect. Setup without `--dry-run` fails closed.
+- Configuration mutation, setup execution, initialization, service lifecycle
+  changes, pairing activation, gateway exposure, authentication flows, and
+  other host mutation are not performed by these commands.
 
 ### Backend (Go daemon)
 

--- a/docs/hao-machine-management-boundary.md
+++ b/docs/hao-machine-management-boundary.md
@@ -224,12 +224,15 @@ V1 should keep this root to avoid breaking installations. Proposed additions are
 
 `hao` must use the shared state-root helper rather than respell `.ao/hosted`. A system service must receive absolute `AO_DATA_DIR` and `AO_RUN_FILE` paths and run as the target unprivileged user.
 
-Setup observation never executes a discovered binary. A `hao`-owned AO artifact
-is considered version-known only when `bin/ao.hao-manifest.json` names its
-version, release source, and SHA-256 and the digest matches the adjacent binary.
-Managed directories, artifacts, and service definitions are inspected without
-following symbolic links; links at those paths are conflicts rather than
-shortcuts to state outside the Hosted AO root.
+Setup observation never executes a discovered binary. An adjacent
+`bin/ao.hao-manifest.json` can prove that its digest matches the adjacent binary,
+but it is self-attested and is not trusted release authority. Artifact no-op or
+install actions require immutable version, source, and digest provenance from a
+trusted injected resolver; without it the dry-run plan blocks with manual
+remediation. The resolver and mutation executor belong to the later execution
+batch. Managed directories, artifacts, and service definitions are inspected
+through bounded no-follow handles; links/reparse points at the path or in its
+ancestor chain are conflicts rather than shortcuts outside the Hosted AO root.
 
 ## 6. Idempotency, privileges, installation, and errors
 

--- a/docs/hao-machine-management-boundary.md
+++ b/docs/hao-machine-management-boundary.md
@@ -213,6 +213,7 @@ V1 should keep this root to avoid breaking installations. Proposed additions are
   hao/config.yaml
   hao/backups/
   bin/                         # only if using a per-user install
+    ao.hao-manifest.json       # hao-owned version/source/SHA-256 provenance
   data/                        # existing daemon durable data
   running.json                 # existing daemon discovery file
   machine.json                 # legacy hosted gateway config, compatibility only
@@ -222,6 +223,13 @@ V1 should keep this root to avoid breaking installations. Proposed additions are
 ```
 
 `hao` must use the shared state-root helper rather than respell `.ao/hosted`. A system service must receive absolute `AO_DATA_DIR` and `AO_RUN_FILE` paths and run as the target unprivileged user.
+
+Setup observation never executes a discovered binary. A `hao`-owned AO artifact
+is considered version-known only when `bin/ao.hao-manifest.json` names its
+version, release source, and SHA-256 and the digest matches the adjacent binary.
+Managed directories, artifacts, and service definitions are inspected without
+following symbolic links; links at those paths are conflicts rather than
+shortcuts to state outside the Hosted AO root.
 
 ## 6. Idempotency, privileges, installation, and errors
 


### PR DESCRIPTION
Closes #147

## Summary
- add mandatory planning-only `hao setup --dry-run` with stable human and versioned JSON output
- observe through injected read-only boundaries and generate deterministic create/update/no-op/blocked steps
- model dependency, artifact, directory, prerequisite, service, privilege, pair-mode, and platform policy without an execution boundary
- fail closed without `--dry-run`, preserve setup/init separation, and recursively redact output
- verify packaged Linux `hao` artifacts expose the command

## Tests
- `cd backend && go test ./internal/haocli`
- `cd backend && go test -race ./internal/haocli`
- `cd backend && go vet ./...`
- focused golangci-lint for `./internal/haocli/...` (clean cache): 0 issues
- host `hao setup --help` and linux/amd64 cross-build artifact check
- Windows amd64 and Linux arm64 haocli cross-compilation

The unscoped local `npm run lint` / `go test ./...` run was contaminated by the active AO desktop environment (`AO_SESSION_ID`, daemon discovery, and runtime overrides), causing unrelated existing CLI/tmux/systemcheck/session-manager tests to bind to the live session. Focused tests are green; GitHub CI provides the required clean environment for the full suite.

## Risks / follow-ups
- no setup execution, authentication, certificate/passcode generation, listener exposure, service activation, or rollback journal exists in this batch
- `--yes` is accepted only for forward compatibility and has no dry-run mutation effect