### PR TITLE
feat: execute verified hao setup plans

### DIFF
--- a/.github/workflows/frontend-release.yml
+++ b/.github/workflows/frontend-release.yml
@@ -249,11 +249,15 @@ jobs:
           CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -trimpath \
             -ldflags "-X ${ao_pkg}.Version=${VERSION} -X ${ao_pkg}.Commit=${COMMIT} -X ${ao_pkg}.Date=${DATE}" \
             -o "$GITHUB_WORKSPACE/dist-cli/ao-linux-arm64" ./cmd/ao
+          ao_x64_hash="$(sha256sum "$GITHUB_WORKSPACE/dist-cli/ao-linux-x64" | awk '{print $1}')"
+          ao_arm64_hash="$(sha256sum "$GITHUB_WORKSPACE/dist-cli/ao-linux-arm64" | awk '{print $1}')"
+          ao_x64_source="https://github.com/agentlab-in/hosted-ao/releases/download/v${VERSION}/ao-linux-x64"
+          ao_arm64_source="https://github.com/agentlab-in/hosted-ao/releases/download/v${VERSION}/ao-linux-arm64"
           CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath \
-            -ldflags "-X ${hao_pkg}.Version=${VERSION} -X ${hao_pkg}.Commit=${COMMIT} -X ${hao_pkg}.Date=${DATE}" \
+            -ldflags "-X ${hao_pkg}.Version=${VERSION} -X ${hao_pkg}.Commit=${COMMIT} -X ${hao_pkg}.Date=${DATE} -X ${hao_pkg}.AOArtifactVersion=${VERSION} -X ${hao_pkg}.AOArtifactSource=${ao_x64_source} -X ${hao_pkg}.AOArtifactSHA256=${ao_x64_hash}" \
             -o "$GITHUB_WORKSPACE/dist-cli/hao-linux-x64" ./cmd/hao
           CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -trimpath \
-            -ldflags "-X ${hao_pkg}.Version=${VERSION} -X ${hao_pkg}.Commit=${COMMIT} -X ${hao_pkg}.Date=${DATE}" \
+            -ldflags "-X ${hao_pkg}.Version=${VERSION} -X ${hao_pkg}.Commit=${COMMIT} -X ${hao_pkg}.Date=${DATE} -X ${hao_pkg}.AOArtifactVersion=${VERSION} -X ${hao_pkg}.AOArtifactSource=${ao_arm64_source} -X ${hao_pkg}.AOArtifactSHA256=${ao_arm64_hash}" \
             -o "$GITHUB_WORKSPACE/dist-cli/hao-linux-arm64" ./cmd/hao
 
       # A green build is not proof: a bad GOARCH would still exit 0 having

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -128,6 +128,9 @@ jobs:
       - name: Test workspace teardown and session kill
         run: go test -race -v -run 'Destroy|Discard|Sweep|Kill' ./internal/adapters/workspace/... ./internal/session_manager/
 
+      - name: Test HAO managed path safety
+        run: go test -race -v -run 'Test(OpenManagedRegularRejectsWindows|ManagedWindowsMutationsUseStableParentHandles)' ./internal/haocli
+
   lint:
     needs: changes
     runs-on: ubuntu-latest

--- a/.github/workflows/linux-cli-binaries.yml
+++ b/.github/workflows/linux-cli-binaries.yml
@@ -106,8 +106,15 @@ jobs:
           CGO_ENABLED=0 GOOS=linux go build -trimpath \
             -ldflags "-X ${ao_pkg}.Version=${VERSION} -X ${ao_pkg}.Commit=${COMMIT} -X ${ao_pkg}.Date=${DATE}" \
             -o ../dist/ao ./cmd/ao
+          ao_hash="$(sha256sum ../dist/ao | awk '{print $1}')"
+          case "$GOARCH" in
+            amd64) ao_asset="ao-linux-x64" ;;
+            arm64) ao_asset="ao-linux-arm64" ;;
+            *) echo "unsupported GOARCH: $GOARCH"; exit 1 ;;
+          esac
+          ao_source="https://github.com/agentlab-in/hosted-ao/releases/download/v${VERSION}/${ao_asset}"
           CGO_ENABLED=0 GOOS=linux go build -trimpath \
-            -ldflags "-X ${hao_pkg}.Version=${VERSION} -X ${hao_pkg}.Commit=${COMMIT} -X ${hao_pkg}.Date=${DATE}" \
+            -ldflags "-X ${hao_pkg}.Version=${VERSION} -X ${hao_pkg}.Commit=${COMMIT} -X ${hao_pkg}.Date=${DATE} -X ${hao_pkg}.AOArtifactVersion=${VERSION} -X ${hao_pkg}.AOArtifactSource=${ao_source} -X ${hao_pkg}.AOArtifactSHA256=${ao_hash}" \
             -o ../dist/hao ./cmd/hao
       # A green build is not proof: `go build` with a bad GOARCH would still
       # exit 0 having produced a host binary. Assert the ELF machine, and on

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -536,6 +536,10 @@ func resolveDataDir() (string, error) {
 	return filepath.Join(stateDir, "data"), nil
 }
 
+// ResolveDataDir returns the durable daemon data path without loading unrelated
+// daemon settings or secrets.
+func ResolveDataDir() (string, error) { return resolveDataDir() }
+
 // StateRootSubdir is hosted-ao's own subdirectory of ~/.ao.
 //
 // The upstream agent-orchestrator desktop app writes its running.json, its

--- a/backend/internal/haocli/managed_open_unix.go
+++ b/backend/internal/haocli/managed_open_unix.go
@@ -56,3 +56,120 @@ func openManagedRegular(path string, maxSize int64) (*os.File, error) {
 	}
 	return os.NewFile(uintptr(fileFD), abs), nil
 }
+
+func openManagedParent(path string) (int, string, error) {
+	abs, err := filepath.Abs(filepath.Clean(path))
+	if err != nil {
+		return -1, "", err
+	}
+	parts := strings.FieldsFunc(abs, func(r rune) bool { return r == filepath.Separator })
+	if len(parts) == 0 {
+		return -1, "", errors.New("managed path has no file component")
+	}
+	fd, err := unix.Open(string(filepath.Separator), unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC, 0)
+	if err != nil {
+		return -1, "", err
+	}
+	for _, part := range parts[:len(parts)-1] {
+		next, openErr := unix.Openat(fd, part, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_NOFOLLOW|unix.O_CLOEXEC, 0)
+		_ = unix.Close(fd)
+		if openErr != nil {
+			if errors.Is(openErr, os.ErrNotExist) {
+				return -1, "", openErr
+			}
+			return -1, "", errors.New("managed path contains an inaccessible or linked ancestor")
+		}
+		fd = next
+	}
+	return fd, parts[len(parts)-1], nil
+}
+
+func managedLstat(path string) (os.FileInfo, error) {
+	fd, name, err := openManagedParent(path)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = unix.Close(fd) }()
+	child, err := unix.Openat(fd, name, unix.O_RDONLY|unix.O_NONBLOCK|unix.O_NOFOLLOW|unix.O_CLOEXEC, 0)
+	if err != nil {
+		return nil, err
+	}
+	file := os.NewFile(uintptr(child), path)
+	defer func() { _ = file.Close() }()
+	return file.Stat()
+}
+
+func managedChmod(path string, mode os.FileMode) error {
+	fd, name, err := openManagedParent(path)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = unix.Close(fd) }()
+	child, err := unix.Openat(fd, name, unix.O_RDONLY|unix.O_NONBLOCK|unix.O_NOFOLLOW|unix.O_CLOEXEC, 0)
+	if err != nil {
+		return err
+	}
+	file := os.NewFile(uintptr(child), path)
+	defer func() { _ = file.Close() }()
+	return file.Chmod(mode)
+}
+
+func managedMkdir(path string, mode os.FileMode) error {
+	fd, name, err := openManagedParent(path)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = unix.Close(fd) }()
+	if err := unix.Mkdirat(fd, name, uint32(mode.Perm())); err != nil {
+		return err
+	}
+	return unix.Fsync(fd)
+}
+
+func managedCreateExclusive(path string, mode os.FileMode) (*os.File, error) {
+	fd, name, err := openManagedParent(path)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = unix.Close(fd) }()
+	child, err := unix.Openat(fd, name, unix.O_CREAT|unix.O_EXCL|unix.O_WRONLY|unix.O_NOFOLLOW|unix.O_CLOEXEC, uint32(mode.Perm()))
+	if err != nil {
+		return nil, err
+	}
+	return os.NewFile(uintptr(child), path), nil
+}
+
+func managedRename(source, destination string) error {
+	sourceFD, sourceName, err := openManagedParent(source)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = unix.Close(sourceFD) }()
+	destinationFD, destinationName, err := openManagedParent(destination)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = unix.Close(destinationFD) }()
+	if err := unix.Renameat(sourceFD, sourceName, destinationFD, destinationName); err != nil {
+		return err
+	}
+	if err := unix.Fsync(destinationFD); err != nil {
+		return err
+	}
+	if sourceFD != destinationFD {
+		return unix.Fsync(sourceFD)
+	}
+	return nil
+}
+
+func managedRemove(path string) error {
+	fd, name, err := openManagedParent(path)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = unix.Close(fd) }()
+	if err := unix.Unlinkat(fd, name, 0); err != nil {
+		return err
+	}
+	return unix.Fsync(fd)
+}

--- a/backend/internal/haocli/managed_open_windows.go
+++ b/backend/internal/haocli/managed_open_windows.go
@@ -169,7 +169,7 @@ func managedCreateExclusive(path string, mode os.FileMode) (*os.File, error) {
 }
 
 func managedCreateExclusiveAt(parent windows.Handle, name, path string, mode os.FileMode) (*os.File, error) {
-	handle, err := openManagedRelative(parent, name, windows.FILE_GENERIC_WRITE|windows.SYNCHRONIZE, windows.FILE_CREATE, windows.FILE_NON_DIRECTORY_FILE|windows.FILE_SYNCHRONOUS_IO_NONALERT)
+	handle, err := openManagedRelative(parent, name, windows.FILE_GENERIC_WRITE|windows.FILE_READ_ATTRIBUTES|windows.SYNCHRONIZE, windows.FILE_CREATE, windows.FILE_NON_DIRECTORY_FILE|windows.FILE_SYNCHRONOUS_IO_NONALERT)
 	if err != nil {
 		return nil, normalizeManagedWindowsError(err)
 	}

--- a/backend/internal/haocli/managed_open_windows.go
+++ b/backend/internal/haocli/managed_open_windows.go
@@ -12,29 +12,26 @@ import (
 	"golang.org/x/sys/windows"
 )
 
+const managedWindowsShareMode = windows.FILE_SHARE_READ | windows.FILE_SHARE_WRITE | windows.FILE_SHARE_DELETE
+
+type managedWindowsRenameInformation struct {
+	ReplaceIfExists uint32
+	RootDirectory   windows.Handle
+	FileNameLength  uint32
+	FileName        [1]uint16
+}
+
 func openManagedRegular(path string, maxSize int64) (*os.File, error) {
-	abs, err := filepath.Abs(filepath.Clean(path))
+	parent, name, err := openManagedParent(path)
 	if err != nil {
 		return nil, err
 	}
-	ntPath := `\??\` + abs
-	if strings.HasPrefix(abs, `\\`) {
-		ntPath = `\??\UNC\` + strings.TrimPrefix(abs, `\\`)
-	}
-	name, err := windows.NewNTUnicodeString(ntPath)
+	defer windows.CloseHandle(parent)
+	handle, err := openManagedRelative(parent, name, windows.FILE_GENERIC_READ|windows.SYNCHRONIZE, windows.FILE_OPEN, windows.FILE_NON_DIRECTORY_FILE|windows.FILE_SYNCHRONOUS_IO_NONALERT)
 	if err != nil {
-		return nil, err
-	}
-	attributes := &windows.OBJECT_ATTRIBUTES{ObjectName: name, Attributes: windows.OBJ_CASE_INSENSITIVE | windows.OBJ_DONT_REPARSE}
-	attributes.Length = uint32(unsafe.Sizeof(*attributes))
-	var handle windows.Handle
-	var status windows.IO_STATUS_BLOCK
-	if err := windows.NtCreateFile(&handle, windows.FILE_GENERIC_READ|windows.SYNCHRONIZE, attributes, &status, nil, 0,
-		windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE|windows.FILE_SHARE_DELETE, windows.FILE_OPEN,
-		windows.FILE_NON_DIRECTORY_FILE|windows.FILE_SYNCHRONOUS_IO_NONALERT, 0, 0); err != nil {
 		return nil, errors.New("managed file could not be opened without traversing a reparse point")
 	}
-	file := os.NewFile(uintptr(handle), abs)
+	file := os.NewFile(uintptr(handle), path)
 	info, err := file.Stat()
 	if err != nil || !info.Mode().IsRegular() || info.Size() > maxSize {
 		_ = file.Close()
@@ -43,47 +40,214 @@ func openManagedRegular(path string, maxSize int64) (*os.File, error) {
 	return file, nil
 }
 
+func openManagedParent(path string) (windows.Handle, string, error) {
+	abs, err := filepath.Abs(filepath.Clean(path))
+	if err != nil {
+		return 0, "", err
+	}
+	name := filepath.Base(abs)
+	parentPath := filepath.Dir(abs)
+	if name == "." || name == string(filepath.Separator) || parentPath == abs {
+		return 0, "", errors.New("managed path has no file component")
+	}
+	handle, err := openManagedAbsolute(parentPath, windows.FILE_LIST_DIRECTORY|windows.FILE_TRAVERSE|windows.FILE_READ_ATTRIBUTES|windows.SYNCHRONIZE, windows.FILE_DIRECTORY_FILE|windows.FILE_SYNCHRONOUS_IO_NONALERT)
+	if err != nil {
+		if isManagedWindowsNotExist(err) {
+			return 0, "", os.ErrNotExist
+		}
+		return 0, "", errors.New("managed path contains an inaccessible or reparse ancestor")
+	}
+	return handle, name, nil
+}
+
+func openManagedAbsolute(path string, access uint32, options uint32) (windows.Handle, error) {
+	ntPath := `\??\` + path
+	if strings.HasPrefix(path, `\\`) {
+		ntPath = `\??\UNC\` + strings.TrimPrefix(path, `\\`)
+	}
+	name, err := windows.NewNTUnicodeString(ntPath)
+	if err != nil {
+		return 0, err
+	}
+	attributes := managedWindowsObjectAttributes(0, name)
+	return ntCreateManagedWindowsFile(attributes, access, windows.FILE_OPEN, options)
+}
+
+func openManagedRelative(parent windows.Handle, name string, access uint32, disposition uint32, options uint32) (windows.Handle, error) {
+	if name == "" || name == "." || name == ".." || strings.ContainsAny(name, `/\`) {
+		return 0, errors.New("managed path has invalid file component")
+	}
+	objectName, err := windows.NewNTUnicodeString(name)
+	if err != nil {
+		return 0, err
+	}
+	attributes := managedWindowsObjectAttributes(parent, objectName)
+	return ntCreateManagedWindowsFile(attributes, access, disposition, options)
+}
+
+func managedWindowsObjectAttributes(parent windows.Handle, name *windows.NTUnicodeString) *windows.OBJECT_ATTRIBUTES {
+	attributes := &windows.OBJECT_ATTRIBUTES{
+		RootDirectory: parent,
+		ObjectName:    name,
+		Attributes:    windows.OBJ_CASE_INSENSITIVE | windows.OBJ_DONT_REPARSE,
+	}
+	attributes.Length = uint32(unsafe.Sizeof(*attributes))
+	return attributes
+}
+
+func ntCreateManagedWindowsFile(attributes *windows.OBJECT_ATTRIBUTES, access uint32, disposition uint32, options uint32) (windows.Handle, error) {
+	var handle windows.Handle
+	var status windows.IO_STATUS_BLOCK
+	err := windows.NtCreateFile(&handle, access, attributes, &status, nil, windows.FILE_ATTRIBUTE_NORMAL,
+		managedWindowsShareMode, disposition, options, 0, 0)
+	return handle, err
+}
+
 func managedLstat(path string) (os.FileInfo, error) {
-	if err := ensureNoSymlinkAncestors(path); err != nil {
+	parent, name, err := openManagedParent(path)
+	if err != nil {
 		return nil, err
 	}
-	return os.Lstat(path)
+	defer windows.CloseHandle(parent)
+	handle, err := openManagedRelative(parent, name, windows.FILE_READ_ATTRIBUTES|windows.SYNCHRONIZE, windows.FILE_OPEN, windows.FILE_SYNCHRONOUS_IO_NONALERT)
+	if err != nil {
+		if isManagedWindowsNotExist(err) {
+			return nil, os.ErrNotExist
+		}
+		return nil, errors.New("managed target is inaccessible or a reparse point")
+	}
+	file := os.NewFile(uintptr(handle), path)
+	defer file.Close()
+	return file.Stat()
 }
 
 func managedChmod(path string, mode os.FileMode) error {
-	if _, err := managedLstat(path); err != nil {
+	parent, name, err := openManagedParent(path)
+	if err != nil {
 		return err
 	}
-	return os.Chmod(path, mode)
+	defer windows.CloseHandle(parent)
+	return managedChmodAt(parent, name, path, mode)
+}
+
+func managedChmodAt(parent windows.Handle, name, path string, mode os.FileMode) error {
+	handle, err := openManagedRelative(parent, name, windows.FILE_READ_ATTRIBUTES|windows.FILE_WRITE_ATTRIBUTES|windows.SYNCHRONIZE, windows.FILE_OPEN, windows.FILE_SYNCHRONOUS_IO_NONALERT)
+	if err != nil {
+		return normalizeManagedWindowsError(err)
+	}
+	file := os.NewFile(uintptr(handle), path)
+	defer file.Close()
+	return file.Chmod(mode)
 }
 
 func managedMkdir(path string, mode os.FileMode) error {
-	if err := ensureNoSymlinkAncestors(filepath.Dir(path)); err != nil {
+	parent, name, err := openManagedParent(path)
+	if err != nil {
 		return err
 	}
-	return os.Mkdir(path, mode)
+	defer windows.CloseHandle(parent)
+	return managedMkdirAt(parent, name, path, mode)
+}
+
+func managedMkdirAt(parent windows.Handle, name, path string, mode os.FileMode) error {
+	handle, err := openManagedRelative(parent, name, windows.FILE_LIST_DIRECTORY|windows.FILE_TRAVERSE|windows.FILE_READ_ATTRIBUTES|windows.FILE_WRITE_ATTRIBUTES|windows.SYNCHRONIZE, windows.FILE_CREATE, windows.FILE_DIRECTORY_FILE|windows.FILE_SYNCHRONOUS_IO_NONALERT)
+	if err != nil {
+		return normalizeManagedWindowsError(err)
+	}
+	file := os.NewFile(uintptr(handle), path)
+	defer file.Close()
+	return file.Chmod(mode)
 }
 
 func managedCreateExclusive(path string, mode os.FileMode) (*os.File, error) {
-	if err := ensureNoSymlinkAncestors(filepath.Dir(path)); err != nil {
+	parent, name, err := openManagedParent(path)
+	if err != nil {
 		return nil, err
 	}
-	return os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, mode)
+	defer windows.CloseHandle(parent)
+	return managedCreateExclusiveAt(parent, name, path, mode)
+}
+
+func managedCreateExclusiveAt(parent windows.Handle, name, path string, mode os.FileMode) (*os.File, error) {
+	handle, err := openManagedRelative(parent, name, windows.FILE_GENERIC_WRITE|windows.SYNCHRONIZE, windows.FILE_CREATE, windows.FILE_NON_DIRECTORY_FILE|windows.FILE_SYNCHRONOUS_IO_NONALERT)
+	if err != nil {
+		return nil, normalizeManagedWindowsError(err)
+	}
+	file := os.NewFile(uintptr(handle), path)
+	if err := file.Chmod(mode); err != nil {
+		_ = file.Close()
+		return nil, err
+	}
+	return file, nil
 }
 
 func managedRename(source, destination string) error {
-	if err := ensureNoSymlinkAncestors(filepath.Dir(source)); err != nil {
+	sourceParent, sourceName, err := openManagedParent(source)
+	if err != nil {
 		return err
 	}
-	if err := ensureNoSymlinkAncestors(filepath.Dir(destination)); err != nil {
+	defer windows.CloseHandle(sourceParent)
+	destinationParent, destinationName, err := openManagedParent(destination)
+	if err != nil {
 		return err
 	}
-	return os.Rename(source, destination)
+	defer windows.CloseHandle(destinationParent)
+	sourceHandle, err := openManagedRelative(sourceParent, sourceName, windows.DELETE|windows.SYNCHRONIZE, windows.FILE_OPEN, windows.FILE_SYNCHRONOUS_IO_NONALERT)
+	if err != nil {
+		return normalizeManagedWindowsError(err)
+	}
+	defer windows.CloseHandle(sourceHandle)
+	return renameManagedWindowsHandle(sourceHandle, destinationParent, destinationName)
+}
+
+func renameManagedWindowsHandle(source, destinationParent windows.Handle, destinationName string) error {
+	name, err := windows.UTF16FromString(destinationName)
+	if err != nil {
+		return err
+	}
+	nameLength := (len(name) - 1) * 2
+	var layout managedWindowsRenameInformation
+	bufferSize := int(unsafe.Offsetof(layout.FileName)) + nameLength
+	buffer := make([]byte, bufferSize)
+	info := (*managedWindowsRenameInformation)(unsafe.Pointer(&buffer[0]))
+	info.ReplaceIfExists = windows.FILE_RENAME_REPLACE_IF_EXISTS
+	info.RootDirectory = destinationParent
+	info.FileNameLength = uint32(nameLength)
+	copy((*[windows.MAX_LONG_PATH]uint16)(unsafe.Pointer(&info.FileName[0]))[:nameLength/2:nameLength/2], name)
+	var status windows.IO_STATUS_BLOCK
+	return windows.NtSetInformationFile(source, &status, &buffer[0], uint32(bufferSize), windows.FileRenameInformation)
 }
 
 func managedRemove(path string) error {
-	if err := ensureNoSymlinkAncestors(filepath.Dir(path)); err != nil {
+	parent, name, err := openManagedParent(path)
+	if err != nil {
 		return err
 	}
-	return os.Remove(path)
+	defer windows.CloseHandle(parent)
+	return managedRemoveAt(parent, name)
+}
+
+func managedRemoveAt(parent windows.Handle, name string) error {
+	handle, err := openManagedRelative(parent, name, windows.DELETE|windows.SYNCHRONIZE, windows.FILE_OPEN, windows.FILE_SYNCHRONOUS_IO_NONALERT)
+	if err != nil {
+		return normalizeManagedWindowsError(err)
+	}
+	defer windows.CloseHandle(handle)
+	deleteFile := byte(1)
+	var status windows.IO_STATUS_BLOCK
+	return windows.NtSetInformationFile(handle, &status, &deleteFile, 1, windows.FileDispositionInformation)
+}
+
+func isManagedWindowsNotExist(err error) bool {
+	return errors.Is(err, windows.STATUS_OBJECT_NAME_NOT_FOUND) || errors.Is(err, windows.STATUS_OBJECT_PATH_NOT_FOUND)
+}
+
+func normalizeManagedWindowsError(err error) error {
+	if isManagedWindowsNotExist(err) {
+		return os.ErrNotExist
+	}
+	if errors.Is(err, windows.STATUS_OBJECT_NAME_COLLISION) {
+		return os.ErrExist
+	}
+	return err
 }

--- a/backend/internal/haocli/managed_open_windows.go
+++ b/backend/internal/haocli/managed_open_windows.go
@@ -42,3 +42,48 @@ func openManagedRegular(path string, maxSize int64) (*os.File, error) {
 	}
 	return file, nil
 }
+
+func managedLstat(path string) (os.FileInfo, error) {
+	if err := ensureNoSymlinkAncestors(path); err != nil {
+		return nil, err
+	}
+	return os.Lstat(path)
+}
+
+func managedChmod(path string, mode os.FileMode) error {
+	if _, err := managedLstat(path); err != nil {
+		return err
+	}
+	return os.Chmod(path, mode)
+}
+
+func managedMkdir(path string, mode os.FileMode) error {
+	if err := ensureNoSymlinkAncestors(filepath.Dir(path)); err != nil {
+		return err
+	}
+	return os.Mkdir(path, mode)
+}
+
+func managedCreateExclusive(path string, mode os.FileMode) (*os.File, error) {
+	if err := ensureNoSymlinkAncestors(filepath.Dir(path)); err != nil {
+		return nil, err
+	}
+	return os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, mode)
+}
+
+func managedRename(source, destination string) error {
+	if err := ensureNoSymlinkAncestors(filepath.Dir(source)); err != nil {
+		return err
+	}
+	if err := ensureNoSymlinkAncestors(filepath.Dir(destination)); err != nil {
+		return err
+	}
+	return os.Rename(source, destination)
+}
+
+func managedRemove(path string) error {
+	if err := ensureNoSymlinkAncestors(filepath.Dir(path)); err != nil {
+		return err
+	}
+	return os.Remove(path)
+}

--- a/backend/internal/haocli/managed_open_windows_test.go
+++ b/backend/internal/haocli/managed_open_windows_test.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"golang.org/x/sys/windows"
 )
 
 func TestOpenManagedRegularRejectsWindowsReparsePoint(t *testing.T) {
@@ -96,5 +98,164 @@ func TestOpenManagedRegularRejectsWindowsAncestorSwap(t *testing.T) {
 		if readErr != nil || string(data[:n]) != "safe" {
 			t.Fatalf("managed open escaped during ancestor swap: data=%q err=%v", data[:n], readErr)
 		}
+	}
+}
+
+func TestManagedWindowsMutationsUseStableParentHandles(t *testing.T) {
+	t.Run("create file", func(t *testing.T) {
+		parent, name, moved, outside := openManagedParentThenSwap(t, "artifact")
+		file, err := managedCreateExclusiveAt(parent, name, filepath.Join(moved, name), 0o600)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := file.Write([]byte("managed")); err != nil {
+			t.Fatal(err)
+		}
+		if err := file.Close(); err != nil {
+			t.Fatal(err)
+		}
+		assertWindowsMutationStayedInMovedParent(t, moved, outside, name)
+	})
+
+	t.Run("create directory", func(t *testing.T) {
+		parent, name, moved, outside := openManagedParentThenSwap(t, "data")
+		if err := managedMkdirAt(parent, name, filepath.Join(moved, name), 0o700); err != nil {
+			t.Fatal(err)
+		}
+		info, err := os.Stat(filepath.Join(moved, name))
+		if err != nil || !info.IsDir() {
+			t.Fatalf("directory was not created in held parent: info=%v err=%v", info, err)
+		}
+		if _, err := os.Stat(filepath.Join(outside, name)); !os.IsNotExist(err) {
+			t.Fatalf("directory escaped through replacement junction: %v", err)
+		}
+	})
+
+	t.Run("chmod", func(t *testing.T) {
+		parent, name, moved, outside := openManagedParentThenSwap(t, "artifact")
+		if err := os.WriteFile(filepath.Join(moved, name), []byte("managed"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		outsidePath := filepath.Join(outside, name)
+		if err := os.WriteFile(outsidePath, []byte("outside"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := managedChmodAt(parent, name, filepath.Join(moved, name), 0o400); err != nil {
+			t.Fatal(err)
+		}
+		if attributes, err := windows.GetFileAttributes(windows.StringToUTF16Ptr(filepath.Join(moved, name))); err != nil || attributes&windows.FILE_ATTRIBUTE_READONLY == 0 {
+			t.Fatalf("held-parent file was not made read-only: attributes=%#x err=%v", attributes, err)
+		}
+		if attributes, err := windows.GetFileAttributes(windows.StringToUTF16Ptr(outsidePath)); err != nil || attributes&windows.FILE_ATTRIBUTE_READONLY != 0 {
+			t.Fatalf("replacement-junction file was modified: attributes=%#x err=%v", attributes, err)
+		}
+	})
+
+	t.Run("remove", func(t *testing.T) {
+		parent, name, moved, outside := openManagedParentThenSwap(t, "artifact")
+		if err := os.WriteFile(filepath.Join(moved, name), []byte("managed"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		outsidePath := filepath.Join(outside, name)
+		if err := os.WriteFile(outsidePath, []byte("outside"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := managedRemoveAt(parent, name); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := os.Stat(filepath.Join(moved, name)); !os.IsNotExist(err) {
+			t.Fatalf("held-parent file still exists after removal: %v", err)
+		}
+		if data, err := os.ReadFile(outsidePath); err != nil || string(data) != "outside" {
+			t.Fatalf("replacement-junction file was removed or changed: data=%q err=%v", data, err)
+		}
+	})
+
+	t.Run("rename", func(t *testing.T) {
+		root := t.TempDir()
+		managed := filepath.Join(root, "managed")
+		moved := filepath.Join(root, "moved")
+		outside := filepath.Join(root, "outside")
+		if err := os.Mkdir(managed, 0o700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Mkdir(outside, 0o700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(managed, "source"), []byte("managed"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(outside, "source"), []byte("outside"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		sourceParent, sourceName, err := openManagedParent(filepath.Join(managed, "source"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer windows.CloseHandle(sourceParent)
+		destinationParent, destinationName, err := openManagedParent(filepath.Join(managed, "destination"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer windows.CloseHandle(destinationParent)
+		if err := os.Rename(managed, moved); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink(outside, managed); err != nil {
+			t.Skipf("Windows symlink creation unavailable: %v", err)
+		}
+		source, err := openManagedRelative(sourceParent, sourceName, windows.DELETE|windows.SYNCHRONIZE, windows.FILE_OPEN, windows.FILE_SYNCHRONOUS_IO_NONALERT)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer windows.CloseHandle(source)
+		if err := renameManagedWindowsHandle(source, destinationParent, destinationName); err != nil {
+			t.Fatal(err)
+		}
+		if data, err := os.ReadFile(filepath.Join(moved, "destination")); err != nil || string(data) != "managed" {
+			t.Fatalf("held-parent file was not renamed: data=%q err=%v", data, err)
+		}
+		if data, err := os.ReadFile(filepath.Join(outside, "source")); err != nil || string(data) != "outside" {
+			t.Fatalf("replacement-junction source changed: data=%q err=%v", data, err)
+		}
+		if _, err := os.Stat(filepath.Join(outside, "destination")); !os.IsNotExist(err) {
+			t.Fatalf("rename escaped through replacement junction: %v", err)
+		}
+	})
+}
+
+func openManagedParentThenSwap(t *testing.T, name string) (windows.Handle, string, string, string) {
+	t.Helper()
+	root := t.TempDir()
+	managed := filepath.Join(root, "managed")
+	moved := filepath.Join(root, "moved")
+	outside := filepath.Join(root, "outside")
+	if err := os.Mkdir(managed, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(outside, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	parent, component, err := openManagedParent(filepath.Join(managed, name))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = windows.CloseHandle(parent) })
+	if err := os.Rename(managed, moved); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, managed); err != nil {
+		t.Skipf("Windows symlink creation unavailable: %v", err)
+	}
+	return parent, component, moved, outside
+}
+
+func assertWindowsMutationStayedInMovedParent(t *testing.T, moved, outside, name string) {
+	t.Helper()
+	if data, err := os.ReadFile(filepath.Join(moved, name)); err != nil || string(data) != "managed" {
+		t.Fatalf("held-parent file mismatch: data=%q err=%v", data, err)
+	}
+	if _, err := os.Stat(filepath.Join(outside, name)); !os.IsNotExist(err) {
+		t.Fatalf("mutation escaped through replacement junction: %v", err)
 	}
 }

--- a/backend/internal/haocli/managed_open_windows_test.go
+++ b/backend/internal/haocli/managed_open_windows_test.go
@@ -3,6 +3,8 @@
 package haocli
 
 import (
+	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
@@ -95,7 +97,10 @@ func TestOpenManagedRegularRejectsWindowsAncestorSwap(t *testing.T) {
 		data := make([]byte, 16)
 		n, readErr := file.Read(data)
 		_ = file.Close()
-		if readErr != nil || string(data[:n]) != "safe" {
+		if readErr != nil && !errors.Is(readErr, io.EOF) {
+			t.Fatalf("managed open failed during ancestor swap: data=%q err=%v", data[:n], readErr)
+		}
+		if string(data[:n]) == "outside" {
 			t.Fatalf("managed open escaped during ancestor swap: data=%q err=%v", data[:n], readErr)
 		}
 	}
@@ -208,8 +213,11 @@ func TestManagedWindowsMutationsUseStableParentHandles(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer windows.CloseHandle(source)
 		if err := renameManagedWindowsHandle(source, destinationParent, destinationName); err != nil {
+			_ = windows.CloseHandle(source)
+			t.Fatal(err)
+		}
+		if err := windows.CloseHandle(source); err != nil {
 			t.Fatal(err)
 		}
 		if data, err := os.ReadFile(filepath.Join(moved, "destination")); err != nil || string(data) != "managed" {

--- a/backend/internal/haocli/observation_test.go
+++ b/backend/internal/haocli/observation_test.go
@@ -2,8 +2,10 @@ package haocli
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -69,6 +71,16 @@ func (f *fakeObserver) InspectArtifact(_ context.Context, path string) (Artifact
 	}
 	return metadata, nil
 }
+func (f *fakeObserver) FileSHA256(_ context.Context, path string, _ int64) (string, error) {
+	if data, ok := f.readFiles[path]; ok {
+		digest := sha256.Sum256(data)
+		return fmt.Sprintf("%x", digest[:]), nil
+	}
+	if metadata, ok := f.artifacts[path]; ok {
+		return metadata.SHA256, nil
+	}
+	return "", os.ErrNotExist
+}
 func (f *fakeObserver) Stat(path string) (FileObservation, error) {
 	if err := f.statErr[path]; err != nil {
 		return FileObservation{}, err
@@ -125,7 +137,10 @@ func healthyObserver() *fakeObserver {
 
 func observationDeps(t *testing.T, fixture string, obs *fakeObserver) Deps {
 	t.Helper()
-	root := t.TempDir()
+	root, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
 	runPath := filepath.Join(root, "custom-discovery.json")
 	path := fixturePath("valid", fixture+".yaml")
 	absPath, err := filepath.Abs(path)

--- a/backend/internal/haocli/observe.go
+++ b/backend/internal/haocli/observe.go
@@ -37,6 +37,7 @@ type Observer interface {
 	CurrentUser() (UserObservation, error)
 	Stat(path string) (FileObservation, error)
 	ReadFile(path string) ([]byte, error)
+	FileSHA256(ctx context.Context, path string, limit int64) (string, error)
 	InspectArtifact(ctx context.Context, path string) (ArtifactMetadata, error)
 	Disk(path string) (uint64, error)
 	LookPath(name string) (string, error)
@@ -120,6 +121,12 @@ func (systemObserver) ReadFile(path string) ([]byte, error) {
 }
 func (systemObserver) InspectArtifact(ctx context.Context, path string) (ArtifactMetadata, error) {
 	return inspectArtifact(ctx, path)
+}
+func (systemObserver) FileSHA256(ctx context.Context, path string, limit int64) (string, error) {
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+	return fileDigest(path, limit)
 }
 
 func inspectArtifact(ctx context.Context, path string) (ArtifactMetadata, error) {

--- a/backend/internal/haocli/root.go
+++ b/backend/internal/haocli/root.go
@@ -40,7 +40,7 @@ type Deps struct {
 	RunFile  func() (string, error)
 	Observer Observer
 	// TrustedArtifact supplies immutable release metadata from an injected
-	// authority. Production leaves it nil until the Batch 5 resolver exists.
+	// authority. Production release builds supply their embedded AO tuple.
 	TrustedArtifact func(goos, arch, version string) (ArtifactMetadata, bool)
 	ExecuteSetup    func(context.Context, SetupPlan, string, SetupExecutionOptions) (SetupExecutionResult, error)
 	Timeout         time.Duration

--- a/backend/internal/haocli/root.go
+++ b/backend/internal/haocli/root.go
@@ -37,6 +37,7 @@ type Deps struct {
 	Err      io.Writer
 	ReadFile func(string) ([]byte, error)
 	StateDir func() (string, error)
+	DataDir  func() (string, error)
 	RunFile  func() (string, error)
 	Observer Observer
 	// TrustedArtifact supplies immutable release metadata from an injected
@@ -49,7 +50,7 @@ type Deps struct {
 
 // DefaultDeps returns the production CLI dependencies.
 func DefaultDeps() Deps {
-	return Deps{In: os.Stdin, Out: os.Stdout, Err: os.Stderr, ReadFile: os.ReadFile, StateDir: stateDir, RunFile: config.ResolveRunFilePath, Observer: systemObserver{}, TrustedArtifact: trustedBuildArtifact, ExecuteSetup: executeSetupPlan, Timeout: 2 * time.Second, Now: time.Now}
+	return Deps{In: os.Stdin, Out: os.Stdout, Err: os.Stderr, ReadFile: os.ReadFile, StateDir: stateDir, DataDir: config.ResolveDataDir, RunFile: config.ResolveRunFilePath, Observer: systemObserver{}, TrustedArtifact: trustedBuildArtifact, ExecuteSetup: executeSetupPlan, Timeout: 2 * time.Second, Now: time.Now}
 }
 
 func trustedBuildArtifact(goos, arch, version string) (ArtifactMetadata, bool) {
@@ -78,6 +79,9 @@ func (d Deps) withDefaults() Deps {
 	}
 	if d.StateDir == nil {
 		d.StateDir = defaults.StateDir
+	}
+	if d.DataDir == nil {
+		d.DataDir = defaults.DataDir
 	}
 	if d.RunFile == nil {
 		d.RunFile = defaults.RunFile

--- a/backend/internal/haocli/root.go
+++ b/backend/internal/haocli/root.go
@@ -22,12 +22,15 @@ import (
 
 // Build metadata. Release tooling overrides these with -ldflags.
 var (
-	Version = "dev"
-	Commit  = ""
-	Date    = ""
+	Version           = "dev"
+	Commit            = ""
+	Date              = ""
+	AOArtifactVersion = ""
+	AOArtifactSource  = ""
+	AOArtifactSHA256  = ""
 )
 
-// Deps is the testable side-effect boundary for the read-only CLI.
+// Deps is the testable observation and mutation boundary for the CLI.
 type Deps struct {
 	In       io.Reader
 	Out      io.Writer
@@ -44,9 +47,19 @@ type Deps struct {
 	Now             func() time.Time
 }
 
-// DefaultDeps returns the production read-only CLI dependencies.
+// DefaultDeps returns the production CLI dependencies.
 func DefaultDeps() Deps {
-	return Deps{In: os.Stdin, Out: os.Stdout, Err: os.Stderr, ReadFile: os.ReadFile, StateDir: stateDir, RunFile: config.ResolveRunFilePath, Observer: systemObserver{}, ExecuteSetup: executeSetupPlan, Timeout: 2 * time.Second, Now: time.Now}
+	return Deps{In: os.Stdin, Out: os.Stdout, Err: os.Stderr, ReadFile: os.ReadFile, StateDir: stateDir, RunFile: config.ResolveRunFilePath, Observer: systemObserver{}, TrustedArtifact: trustedBuildArtifact, ExecuteSetup: executeSetupPlan, Timeout: 2 * time.Second, Now: time.Now}
+}
+
+func trustedBuildArtifact(goos, arch, version string) (ArtifactMetadata, bool) {
+	metadata := ArtifactMetadata{Version: AOArtifactVersion, Source: AOArtifactSource, SHA256: strings.ToLower(AOArtifactSHA256)}
+	wantedAsset := map[string]string{"amd64": "ao-linux-x64", "arm64": "ao-linux-arm64"}[arch]
+	wantedSource := "https://github.com/agentlab-in/hosted-ao/releases/download/v" + version + "/" + wantedAsset
+	if goos != "linux" || wantedAsset == "" || version == "" || version == "latest" || metadata.Version != version || metadata.Source != wantedSource || !validSHA256(metadata.SHA256) {
+		return ArtifactMetadata{}, false
+	}
+	return metadata, true
 }
 
 func (d Deps) withDefaults() Deps {

--- a/backend/internal/haocli/root.go
+++ b/backend/internal/haocli/root.go
@@ -39,13 +39,14 @@ type Deps struct {
 	// TrustedArtifact supplies immutable release metadata from an injected
 	// authority. Production leaves it nil until the Batch 5 resolver exists.
 	TrustedArtifact func(goos, arch, version string) (ArtifactMetadata, bool)
+	ExecuteSetup    func(context.Context, SetupPlan, string, SetupExecutionOptions) (SetupExecutionResult, error)
 	Timeout         time.Duration
 	Now             func() time.Time
 }
 
 // DefaultDeps returns the production read-only CLI dependencies.
 func DefaultDeps() Deps {
-	return Deps{In: os.Stdin, Out: os.Stdout, Err: os.Stderr, ReadFile: os.ReadFile, StateDir: stateDir, RunFile: config.ResolveRunFilePath, Observer: systemObserver{}, Timeout: 2 * time.Second, Now: time.Now}
+	return Deps{In: os.Stdin, Out: os.Stdout, Err: os.Stderr, ReadFile: os.ReadFile, StateDir: stateDir, RunFile: config.ResolveRunFilePath, Observer: systemObserver{}, ExecuteSetup: executeSetupPlan, Timeout: 2 * time.Second, Now: time.Now}
 }
 
 func (d Deps) withDefaults() Deps {
@@ -70,6 +71,9 @@ func (d Deps) withDefaults() Deps {
 	}
 	if d.Observer == nil {
 		d.Observer = defaults.Observer
+	}
+	if d.ExecuteSetup == nil {
+		d.ExecuteSetup = defaults.ExecuteSetup
 	}
 	if d.Timeout <= 0 {
 		d.Timeout = defaults.Timeout

--- a/backend/internal/haocli/root_test.go
+++ b/backend/internal/haocli/root_test.go
@@ -18,7 +18,9 @@ func runCLI(t *testing.T, deps Deps, args ...string) (string, string, int) {
 	var out, stderr bytes.Buffer
 	deps.Out = &out
 	deps.Err = &stderr
-	deps.In = strings.NewReader("")
+	if deps.In == nil {
+		deps.In = strings.NewReader("")
+	}
 	returnOutput := ExecuteArgs(deps, args)
 	return out.String(), stderr.String(), returnOutput
 }

--- a/backend/internal/haocli/setup.go
+++ b/backend/internal/haocli/setup.go
@@ -37,6 +37,12 @@ type SetupAction struct {
 	Artifact      *SetupArtifactAction `json:"artifact,omitempty"`
 	Vendor        *SetupVendorAction   `json:"vendor,omitempty"`
 	Service       *SetupServiceAction  `json:"service,omitempty"`
+	Recovery      *SetupRecoveryAction `json:"recovery,omitempty"`
+}
+
+// SetupRecoveryAction binds consent to one durable interrupted transaction.
+type SetupRecoveryAction struct {
+	JournalSHA256 string `json:"journalSha256"`
 }
 
 // SetupFileAction is the payload for one managed file operation.
@@ -56,10 +62,12 @@ type SetupPackageAction struct {
 
 // SetupArtifactAction identifies one immutable release artifact.
 type SetupArtifactAction struct {
-	Path    string `json:"path"`
-	Version string `json:"version"`
-	Source  string `json:"source"`
-	SHA256  string `json:"sha256"`
+	Path           string `json:"path"`
+	Version        string `json:"version"`
+	Source         string `json:"source"`
+	SHA256         string `json:"sha256"`
+	ExpectedSHA256 string `json:"expectedSha256,omitempty"`
+	ExpectedMode   uint32 `json:"expectedMode,omitempty"`
 }
 
 // SetupVendorAction identifies one immutable vendor package.
@@ -73,11 +81,12 @@ type SetupVendorAction struct {
 
 // SetupServiceAction contains a complete canonical service definition.
 type SetupServiceAction struct {
-	Path    string `json:"path"`
-	Mode    string `json:"mode"`
-	Version string `json:"version"`
-	Content string `json:"content"`
-	SHA256  string `json:"sha256"`
+	Path           string `json:"path"`
+	Mode           string `json:"mode"`
+	Version        string `json:"version"`
+	Content        string `json:"content"`
+	SHA256         string `json:"sha256"`
+	ExpectedSHA256 string `json:"expectedSha256,omitempty"`
 }
 
 // SetupStep is one stable desired-versus-observed reconciliation decision.
@@ -115,22 +124,29 @@ type SetupPlan struct {
 	Summary       SetupSummary `json:"summary"`
 }
 
+// SetupExecutionReport is the single JSON document emitted by an execution.
+type SetupExecutionReport struct {
+	SchemaVersion int                  `json:"schemaVersion"`
+	Plan          SetupPlan            `json:"plan"`
+	Result        SetupExecutionResult `json:"result"`
+}
+
 type setupDesired struct {
 	Machine, Mode, AOVersion, Harness, Profile, Install string
 	ServiceEnabled                                      bool
 	PairPort                                            int
-	StateRoot, ConfigPath                               string
+	StateRoot, DataDir, RunFile, ConfigPath             string
 	OS, Arch                                            string
 }
 
 type observedItem struct {
-	State, Evidence, Version, Path, Source, SHA256 string
-	Mode                                           os.FileMode
-	UID                                            int
-	Owner                                          bool
-	IsDir                                          bool
-	Link                                           bool
-	Trusted                                        bool
+	State, Evidence, Version, Path, Source, SHA256, ActualSHA256 string
+	Mode                                                         os.FileMode
+	UID                                                          int
+	Owner                                                        bool
+	IsDir                                                        bool
+	Link                                                         bool
+	Trusted                                                      bool
 }
 
 type setupSnapshot struct {
@@ -162,6 +178,13 @@ func newSetupCommand(deps Deps, opts *options) *cobra.Command {
 			return err
 		}
 		plan := planSetup(desired, observeSetup(cmd.Context(), deps, desired))
+		if recoveryStep, found, recoveryErr := planSetupRecovery(desired.StateRoot); recoveryErr != nil {
+			plan.Steps = append([]SetupStep{blockedStep("transaction.recovery", "setup-transaction", "inspect-recovery", "an interrupted setup journal could not be validated safely", safeDiagnostic(recoveryErr), "inspect the transaction journal manually before retrying")}, plan.Steps...)
+			recountSetupPlan(&plan)
+		} else if found {
+			plan.Steps = append([]SetupStep{recoveryStep}, plan.Steps...)
+			recountSetupPlan(&plan)
+		}
 		plan.DryRun = dryRun
 		serializedPlan, err := json.Marshal(plan)
 		if err != nil {
@@ -170,7 +193,10 @@ func newSetupCommand(deps Deps, opts *options) *cobra.Command {
 		if _, err := consumeSetupPlanJSON(serializedPlan); err != nil {
 			return operationalError("validate setup plan", err)
 		}
-		if opts.json {
+		jsonExecution := opts.json && !dryRun && plan.Summary.Blocked == 0
+		if jsonExecution {
+			err = beginSetupExecutionJSON(cmd.OutOrStdout(), plan)
+		} else if opts.json {
 			err = writeJSON(cmd.OutOrStdout(), haocontractRedact(plan))
 		} else {
 			err = writeSetupPlan(cmd, plan, yes)
@@ -185,9 +211,16 @@ func newSetupCommand(deps Deps, opts *options) *cobra.Command {
 			return nil
 		}
 		if nonInteractive && !yes {
+			if jsonExecution {
+				_ = endSetupExecutionJSON(cmd.OutOrStdout(), SetupExecutionResult{Status: "not_executed", Completed: []string{}, Rollback: []string{}, Recovery: []string{}, Retry: "hao setup --dry-run"})
+			}
 			return commandError{Code: "invalid_usage", Message: "non-interactive setup requires explicit consent", Remediation: "review the dry-run plan, then rerun with --non-interactive --yes", ExitStatus: 2}
 		}
 		if !yes {
+			if opts.json {
+				_ = endSetupExecutionJSON(cmd.OutOrStdout(), SetupExecutionResult{Status: "not_executed", Completed: []string{}, Rollback: []string{}, Recovery: []string{}, Retry: "rerun with --yes after reviewing the plan"})
+				return commandError{Code: "invalid_usage", Message: "JSON setup execution requires explicit consent", Remediation: "review the plan, then rerun with --yes", ExitStatus: 2}
+			}
 			confirmed, confirmErr := confirmSetup(cmd)
 			if confirmErr != nil {
 				return operationalError("read setup confirmation", confirmErr)
@@ -201,13 +234,15 @@ func newSetupCommand(deps Deps, opts *options) *cobra.Command {
 		}
 		result, executeErr := deps.ExecuteSetup(cmd.Context(), plan, desired.StateRoot, SetupExecutionOptions{NonInteractive: nonInteractive, Input: cmd.InOrStdin()})
 		if executeErr != nil {
-			if !opts.json {
+			if jsonExecution {
+				_ = endSetupExecutionJSON(cmd.OutOrStdout(), result)
+			} else {
 				writeSetupFailure(cmd.OutOrStdout(), result)
 			}
 			return executeErr
 		}
-		if opts.json {
-			return writeJSON(cmd.OutOrStdout(), haocontractRedact(result))
+		if jsonExecution {
+			return endSetupExecutionJSON(cmd.OutOrStdout(), result)
 		}
 		_, err = fmt.Fprintf(cmd.OutOrStdout(), "Setup %s. Completed %d action(s).\n", result.Status, len(result.Completed))
 		return err
@@ -217,6 +252,29 @@ func newSetupCommand(deps Deps, opts *options) *cobra.Command {
 	cmd.Flags().StringVar(&install, "install", "", "dependency policy: missing or none")
 	cmd.Flags().BoolVar(&yes, "yes", false, "approve and execute the displayed setup plan")
 	return cmd
+}
+
+func beginSetupExecutionJSON(out io.Writer, plan SetupPlan) error {
+	data, err := json.Marshal(haocontractRedact(plan))
+	if err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(out, "{\"schemaVersion\":1,\"plan\":%s,\"result\":", data); err != nil {
+		return err
+	}
+	if flusher, ok := out.(interface{ Flush() error }); ok {
+		return flusher.Flush()
+	}
+	return nil
+}
+
+func endSetupExecutionJSON(out io.Writer, result SetupExecutionResult) error {
+	data, err := json.Marshal(haocontractRedact(result))
+	if err != nil {
+		return err
+	}
+	_, err = fmt.Fprintf(out, "%s}\n", data)
+	return err
 }
 
 func writeSetupFailure(out io.Writer, result SetupExecutionResult) {
@@ -269,6 +327,14 @@ func resolveSetupDesired(deps Deps, path string, object map[string]any, install 
 		return setupDesired{}, operationalError("resolve state root", err)
 	}
 	d.StateRoot = root
+	d.DataDir, err = deps.DataDir()
+	if err != nil {
+		return setupDesired{}, operationalError("resolve data directory", err)
+	}
+	d.RunFile, err = deps.RunFile()
+	if err != nil {
+		return setupDesired{}, operationalError("resolve run file", err)
+	}
 	return d, nil
 }
 
@@ -297,6 +363,9 @@ func observeSetup(ctx context.Context, deps Deps, desired setupDesired) setupSna
 	}
 	artifactPath := filepath.Join(desired.StateRoot, "bin", "ao")
 	s.Artifact = observeFile(deps.Observer, artifactPath)
+	if s.Artifact.State == "present" && !s.Artifact.IsDir && !s.Artifact.Link {
+		s.Artifact.ActualSHA256, _ = deps.Observer.FileSHA256(ctx, artifactPath, maxArtifactSize)
+	}
 	parentsSafe := true
 	for _, id := range []string{"directory.state", "directory.bin"} {
 		item := s.Directories[id]
@@ -359,6 +428,8 @@ func observeServiceFile(obs Observer, path string) observedItem {
 		return item
 	}
 	item.Version = string(data)
+	digest := sha256.Sum256(data)
+	item.ActualSHA256 = fmt.Sprintf("%x", digest[:])
 	return item
 }
 
@@ -480,20 +551,25 @@ func planSetup(d setupDesired, s setupSnapshot) SetupPlan {
 		add(step)
 	}
 	propagateBlocked(p.Steps)
-	for _, step := range p.Steps {
+	recountSetupPlan(&p)
+	return p
+}
+
+func recountSetupPlan(plan *SetupPlan) {
+	plan.Summary = SetupSummary{}
+	for _, step := range plan.Steps {
 		switch step.Disposition {
 		case "create":
-			p.Summary.Create++
+			plan.Summary.Create++
 		case "update":
-			p.Summary.Update++
+			plan.Summary.Update++
 		case "no-op":
-			p.Summary.NoOp++
+			plan.Summary.NoOp++
 		case "blocked":
-			p.Summary.Blocked++
+			plan.Summary.Blocked++
 		}
 	}
-	p.Summary.Ready = p.Summary.Blocked == 0
-	return p
+	plan.Summary.Ready = plan.Summary.Blocked == 0
 }
 
 func planDirectory(id string, item observedItem) SetupStep {
@@ -544,9 +620,14 @@ func planArtifact(d setupDesired, item observedItem, trusted ArtifactMetadata, a
 	if action == nil {
 		return blockedStep("artifact.ao", "ao-gateway-artifact", "manual-update", "trusted immutable release metadata is unavailable for replacement", item.Evidence, "replace the artifact manually from a trusted release")
 	}
+	if !validSHA256(item.ActualSHA256) {
+		return blockedStep("artifact.ao", "ao-gateway-artifact", "reconcile-artifact", "current artifact digest could not be observed safely", item.Evidence, "inspect the artifact manually, then rerun setup")
+	}
 	if item.Trusted && versionMatches(item.Version, d.AOVersion) {
 		return noopStep("artifact.ao", "ao-gateway-artifact", "verify-artifact", "hao-owned AO/gateway artifact version already matches", item.Version)
 	}
+	action.Artifact.ExpectedSHA256 = item.ActualSHA256
+	action.Artifact.ExpectedMode = uint32(item.Mode.Perm())
 	return SetupStep{ID: "artifact.ao", Component: "ao-gateway-artifact", Operation: "update-artifact", Disposition: "update", Reason: "installed artifact does not match trusted immutable metadata", Evidence: item.Evidence, Action: action}
 }
 
@@ -640,6 +721,7 @@ func planServices(d setupDesired, s setupSnapshot) []SetupStep {
 			if item.Link || item.IsDir || item.UID > 0 || item.Mode.Perm()&0o022 != 0 {
 				step = blockedStep(id, component, "reconcile-definition", "existing service definition has unsafe ownership", item.Evidence, "inspect and reconcile the conflicting definition manually")
 			} else if item.Version != desiredContent {
+				action.Service.ExpectedSHA256 = item.ActualSHA256
 				step = SetupStep{ID: id, Component: component, Operation: "update-definition", Disposition: "update", Privilege: SetupPrivilege{Required: true, Scope: "system-service-definition"}, Reason: "service definition content differs from desired canonical v1 content", Evidence: "canonical content mismatch", Action: action}
 			} else {
 				step = noopStep(id, component, "verify-definition", "service definition is present; setup does not enable or start it", item.Evidence)
@@ -654,7 +736,13 @@ func planServices(d setupDesired, s setupSnapshot) []SetupStep {
 }
 
 func renderSystemdDefinition(id string, d setupDesired, user UserObservation) string {
-	dataDir, runFile, binary := filepath.Join(d.StateRoot, "data"), filepath.Join(d.StateRoot, "running.json"), filepath.Join(d.StateRoot, "bin", "ao")
+	dataDir, runFile, binary := d.DataDir, d.RunFile, filepath.Join(d.StateRoot, "bin", "ao")
+	if dataDir == "" {
+		dataDir = filepath.Join(d.StateRoot, "data")
+	}
+	if runFile == "" {
+		runFile = filepath.Join(d.StateRoot, "running.json")
+	}
 	var b strings.Builder
 	b.WriteString("[Unit]\nDescription=Hosted AO ")
 	if id == "service.gateway" {
@@ -663,7 +751,7 @@ func renderSystemdDefinition(id string, d setupDesired, user UserObservation) st
 		b.WriteString("daemon\nAfter=network-online.target\n")
 	}
 	path := filepath.Join(user.Home, ".local", "bin") + ":" + filepath.Join(user.Home, "bin") + ":/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
-	b.WriteString("\n[Service]\nType=simple\nUser=" + user.Name + "\nWorkingDirectory=" + dataDir + "\nEnvironment=" + systemdQuote("HOME="+user.Home) + "\nEnvironment=" + systemdQuote("PATH="+path) + "\n")
+	b.WriteString("\n[Service]\nType=simple\nUser=" + user.Name + "\nWorkingDirectory=" + dataDir + "\nEnvironment=" + systemdQuote("HOME="+user.Home) + "\nEnvironment=" + systemdQuote("PATH="+path) + "\nEnvironment=" + systemdQuote("AO_DATA_DIR="+dataDir) + "\nEnvironment=" + systemdQuote("AO_RUN_FILE="+runFile) + "\n")
 	if id == "service.gateway" {
 		b.WriteString("Environment=" + systemdQuote("AO_VM_PAIR=on") + "\nEnvironment=" + systemdQuote("AO_VM_HTTPS_ADDR=:"+strconv.Itoa(d.PairPort)) + "\nEnvironment=" + systemdQuote("AO_VM_CERT_DIR="+filepath.Join(d.StateRoot, "vm-gateway", "pair-cert")) + "\nEnvironment=" + systemdQuote("AO_VM_PASSCODE_DIR="+filepath.Join(d.StateRoot, "vm-gateway", "pair-passcode")) + "\n")
 		if d.PairPort < 1024 {
@@ -671,7 +759,7 @@ func renderSystemdDefinition(id string, d setupDesired, user UserObservation) st
 		}
 		b.WriteString("ExecStart=" + systemdQuote(binary) + " vm serve\n")
 	} else {
-		b.WriteString("Environment=" + systemdQuote("AO_DATA_DIR="+dataDir) + "\nEnvironment=" + systemdQuote("AO_RUN_FILE="+runFile) + "\nExecStart=" + systemdQuote(binary) + " daemon\n")
+		b.WriteString("ExecStart=" + systemdQuote(binary) + " daemon\n")
 	}
 	b.WriteString("Restart=on-failure\n\n[Install]\nWantedBy=multi-user.target\n")
 	return b.String()
@@ -749,7 +837,10 @@ func systemdInputsSafe(d setupDesired, user UserObservation) bool {
 	if !systemdUserPattern.MatchString(user.Name) {
 		return false
 	}
-	for _, value := range []string{user.Home, d.StateRoot} {
+	for _, value := range []string{user.Home, d.StateRoot, d.DataDir, d.RunFile} {
+		if value == "" {
+			continue
+		}
 		if !pathpkg.IsAbs(value) {
 			return false
 		}
@@ -815,7 +906,7 @@ func validateSetupPlan(plan SetupPlan) error {
 			return fmt.Errorf("step %s has unsupported action schema", step.ID)
 		}
 		variants := 0
-		for _, present := range []bool{a.File != nil, a.Package != nil, a.Artifact != nil, a.Vendor != nil, a.Service != nil} {
+		for _, present := range []bool{a.File != nil, a.Package != nil, a.Artifact != nil, a.Vendor != nil, a.Service != nil, a.Recovery != nil} {
 			if present {
 				variants++
 			}
@@ -829,16 +920,19 @@ func validateSetupPlan(plan SetupPlan) error {
 				return fmt.Errorf("step %s has incomplete file action", step.ID)
 			}
 		case "package-manager":
-			if a.Package == nil || !filepath.IsAbs(a.Package.Executable) || len(a.Package.Argv) == 0 || a.Package.Version == "" || a.Package.Version == "latest" || a.Package.Source == "" || !validSHA256(a.Package.SHA256) || !strings.Contains(a.Package.Source, a.Package.Version) || !strings.Contains(strings.Join(a.Package.Argv, "\x00"), a.Package.Version) {
+			if a.Package == nil || !filepath.IsAbs(a.Package.Executable) || !verifiedPackageArgv(a.Package.Argv, "--yes") || a.Package.Version == "" || a.Package.Version == "latest" || a.Package.Source == "" || !validSHA256(a.Package.SHA256) || !strings.Contains(a.Package.Source, a.Package.Version) {
 				return fmt.Errorf("step %s has mutable package provenance", step.ID)
 			}
 		case "vendor-package":
-			if a.Vendor == nil || !filepath.IsAbs(a.Vendor.Executable) || len(a.Vendor.Argv) == 0 || a.Vendor.Source == "" || a.Vendor.Version == "" || a.Vendor.Version == "latest" || !validSHA256(a.Vendor.SHA256) || !strings.Contains(a.Vendor.Source, a.Vendor.Version) || !strings.Contains(strings.Join(a.Vendor.Argv, "\x00"), "@"+a.Vendor.Version) {
+			if a.Vendor == nil || !filepath.IsAbs(a.Vendor.Executable) || !verifiedPackageArgv(a.Vendor.Argv, "--global") || a.Vendor.Source == "" || a.Vendor.Version == "" || a.Vendor.Version == "latest" || !validSHA256(a.Vendor.SHA256) || !strings.Contains(a.Vendor.Source, a.Vendor.Version) {
 				return fmt.Errorf("step %s has mutable vendor provenance", step.ID)
 			}
 		case "verified-release-artifact":
 			if a.Artifact == nil || !filepath.IsAbs(a.Artifact.Path) || a.Artifact.Version == "" || a.Artifact.Version == "latest" || a.Artifact.Source == "" || !validSHA256(a.Artifact.SHA256) || !strings.Contains(a.Artifact.Source, a.Artifact.Version) || strings.Contains(a.Artifact.Source, "/latest/") {
 				return fmt.Errorf("step %s has incomplete artifact provenance", step.ID)
+			}
+			if (step.Disposition == "create" && (a.Artifact.ExpectedSHA256 != "" || a.Artifact.ExpectedMode != 0)) || (step.Disposition == "update" && (!validSHA256(a.Artifact.ExpectedSHA256) || a.Artifact.ExpectedMode&0o111 == 0 || a.Artifact.ExpectedMode&0o022 != 0)) {
+				return fmt.Errorf("step %s has an invalid artifact precondition", step.ID)
 			}
 		case "service-definition-v1":
 			if a.Service == nil {
@@ -848,14 +942,25 @@ func validateSetupPlan(plan SetupPlan) error {
 			if !filepath.IsAbs(a.Service.Path) || a.Service.Mode != "0644" || a.Service.Version != "1" || a.Service.Content == "" || a.Service.SHA256 != fmt.Sprintf("%x", digest[:]) {
 				return fmt.Errorf("step %s has invalid service definition contract", step.ID)
 			}
+			if (step.Disposition == "create" && a.Service.ExpectedSHA256 != "") || (step.Disposition == "update" && !validSHA256(a.Service.ExpectedSHA256)) {
+				return fmt.Errorf("step %s has an invalid service precondition", step.ID)
+			}
 			if _, err := consumeSystemdDefinition(a.Service.Content); err != nil {
 				return fmt.Errorf("step %s has unusable service definition: %w", step.ID, err)
+			}
+		case "transaction-recovery-v1":
+			if a.Recovery == nil || step.ID != "transaction.recovery" || !validSHA256(a.Recovery.JournalSHA256) {
+				return fmt.Errorf("step %s has an invalid recovery contract", step.ID)
 			}
 		default:
 			return fmt.Errorf("step %s has unsupported action kind %q", step.ID, a.Kind)
 		}
 	}
 	return nil
+}
+
+func verifiedPackageArgv(argv []string, option string) bool {
+	return len(argv) == 3 && argv[0] == "install" && argv[1] == option && argv[2] == "{verified-file}"
 }
 
 // consumeSetupPlanJSON is the shared plan consumer boundary. It strictly
@@ -894,6 +999,8 @@ func consumeSetupPlanJSON(data []byte) ([]string, error) {
 			operations = append(operations, fmt.Sprintf("file kind=%s path=%s mode=%s", a.Kind, a.File.Path, a.File.Mode))
 		case "package-manager":
 			operations = append(operations, fmt.Sprintf("package executable=%s source=%s version=%s sha256=%s argv=%q", a.Package.Executable, a.Package.Source, a.Package.Version, a.Package.SHA256, a.Package.Argv))
+		case "transaction-recovery-v1":
+			operations = append(operations, "recovery journal-sha256="+a.Recovery.JournalSHA256)
 		}
 	}
 	return operations, nil
@@ -966,5 +1073,7 @@ func writeSetupAction(out io.Writer, action *SetupAction) {
 		for _, line := range strings.Split(strings.TrimSuffix(action.Service.Content, "\n"), "\n") {
 			_, _ = fmt.Fprintln(out, "    "+redactedString(line))
 		}
+	case "transaction-recovery-v1":
+		_, _ = fmt.Fprintln(out, "  action: recover transaction journal-sha256="+action.Recovery.JournalSHA256)
 	}
 }

--- a/backend/internal/haocli/setup.go
+++ b/backend/internal/haocli/setup.go
@@ -22,7 +22,7 @@ import (
 
 const setupPlanSchemaVersion = 1
 
-// SetupPrivilege describes the narrow elevated boundary a future executor needs.
+// SetupPrivilege describes the narrow elevated boundary used by the executor.
 type SetupPrivilege struct {
 	Required bool   `json:"required"`
 	Scope    string `json:"scope,omitempty"`
@@ -142,12 +142,14 @@ type setupSnapshot struct {
 	ServiceFiles                              map[string]observedItem
 	User                                      UserObservation
 	UserState                                 string
+	TrustedArtifact                           ArtifactMetadata
+	ArtifactAuthority                         bool
 }
 
 func newSetupCommand(deps Deps, opts *options) *cobra.Command {
 	var dryRun, nonInteractive, yes bool
 	var install string
-	cmd := &cobra.Command{Use: "setup", Short: "Plan machine preparation", Args: noArgs, RunE: func(cmd *cobra.Command, _ []string) error {
+	cmd := &cobra.Command{Use: "setup", Short: "Prepare this machine for Hosted AO", Args: noArgs, RunE: func(cmd *cobra.Command, _ []string) error {
 		if install != "" && install != "missing" && install != "none" {
 			return commandError{Code: "invalid_usage", Message: "--install must be missing or none", Remediation: "pass --install missing or --install none", ExitStatus: 2}
 		}
@@ -197,8 +199,11 @@ func newSetupCommand(deps Deps, opts *options) *cobra.Command {
 				return nil
 			}
 		}
-		result, executeErr := deps.ExecuteSetup(cmd.Context(), plan, desired.StateRoot, SetupExecutionOptions{NonInteractive: nonInteractive})
+		result, executeErr := deps.ExecuteSetup(cmd.Context(), plan, desired.StateRoot, SetupExecutionOptions{NonInteractive: nonInteractive, Input: cmd.InOrStdin()})
 		if executeErr != nil {
+			if !opts.json {
+				writeSetupFailure(cmd.OutOrStdout(), result)
+			}
 			return executeErr
 		}
 		if opts.json {
@@ -210,8 +215,28 @@ func newSetupCommand(deps Deps, opts *options) *cobra.Command {
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "display the setup plan without changing the machine")
 	cmd.Flags().BoolVar(&nonInteractive, "non-interactive", false, "never prompt for input")
 	cmd.Flags().StringVar(&install, "install", "", "dependency policy: missing or none")
-	cmd.Flags().BoolVar(&yes, "yes", false, "approve the displayed plan for future setup execution")
+	cmd.Flags().BoolVar(&yes, "yes", false, "approve and execute the displayed setup plan")
 	return cmd
+}
+
+func writeSetupFailure(out io.Writer, result SetupExecutionResult) {
+	_, _ = fmt.Fprintln(out, "Setup failed after these completed actions:")
+	if len(result.Completed) == 0 {
+		_, _ = fmt.Fprintln(out, "  none")
+	}
+	for _, step := range result.Completed {
+		_, _ = fmt.Fprintln(out, "  "+redactedString(step))
+	}
+	_, _ = fmt.Fprintln(out, "Rollback results:")
+	if len(result.Rollback) == 0 {
+		_, _ = fmt.Fprintln(out, "  no reversible actions required rollback")
+	}
+	for _, rollback := range result.Rollback {
+		_, _ = fmt.Fprintln(out, "  "+redactedString(rollback))
+	}
+	if result.Retry != "" {
+		_, _ = fmt.Fprintln(out, "Safe retry: "+redactedString(result.Retry))
+	}
 }
 
 func confirmSetup(cmd *cobra.Command) (bool, error) {
@@ -250,6 +275,9 @@ func resolveSetupDesired(deps Deps, path string, object map[string]any, install 
 func observeSetup(ctx context.Context, deps Deps, desired setupDesired) setupSnapshot {
 	osName, arch := deps.Observer.Platform()
 	s := setupSnapshot{OS: osName, Arch: arch, Directories: map[string]observedItem{}, Tools: map[string]observedItem{}, ServiceFiles: map[string]observedItem{}}
+	if deps.TrustedArtifact != nil {
+		s.TrustedArtifact, s.ArtifactAuthority = deps.TrustedArtifact(osName, arch, desired.AOVersion)
+	}
 	if distro, err := deps.Observer.Distribution(); err != nil {
 		s.DistributionState = "unknown"
 	} else {
@@ -260,7 +288,7 @@ func observeSetup(ctx context.Context, deps Deps, desired setupDesired) setupSna
 	} else {
 		s.User, s.UserState = currentUser, "known"
 	}
-	directories := map[string]string{"directory.state": desired.StateRoot, "directory.hao": filepath.Join(desired.StateRoot, "hao"), "directory.bin": filepath.Join(desired.StateRoot, "bin"), "directory.data": filepath.Join(desired.StateRoot, "data")}
+	directories := map[string]string{"directory.parent": filepath.Dir(desired.StateRoot), "directory.state": desired.StateRoot, "directory.hao": filepath.Join(desired.StateRoot, "hao"), "directory.bin": filepath.Join(desired.StateRoot, "bin"), "directory.data": filepath.Join(desired.StateRoot, "data")}
 	if desired.Mode == "pair" {
 		directories["directory.gateway"] = filepath.Join(desired.StateRoot, "vm-gateway")
 	}
@@ -280,14 +308,11 @@ func observeSetup(ctx context.Context, deps Deps, desired setupDesired) setupSna
 	if s.Artifact.State == "present" && s.Artifact.Owner && !s.Artifact.IsDir && !s.Artifact.Link && s.Artifact.Mode.Perm()&0o022 == 0 && s.Artifact.Mode.Perm()&0o111 != 0 {
 		metadata, err := deps.Observer.InspectArtifact(ctx, artifactPath)
 		if err != nil {
-			s.Artifact.State, s.Artifact.Evidence = "unknown", "artifact provenance probe failed: "+safeDiagnostic(err)
+			s.Artifact.Evidence = "artifact provenance probe failed: " + safeDiagnostic(err)
 		} else {
 			s.Artifact.Version, s.Artifact.Source, s.Artifact.SHA256 = metadata.Version, metadata.Source, metadata.SHA256
 			s.Artifact.Evidence = "observed hao artifact provenance from " + metadata.Source
-			if deps.TrustedArtifact != nil {
-				trusted, ok := deps.TrustedArtifact(osName, arch, desired.AOVersion)
-				s.Artifact.Trusted = ok && matchesTrustedArtifact(metadata, trusted)
-			}
+			s.Artifact.Trusted = s.ArtifactAuthority && matchesTrustedArtifact(metadata, s.TrustedArtifact)
 		}
 		s.Artifact.Path = artifactPath
 	}
@@ -399,20 +424,23 @@ func planSetup(d setupDesired, s setupSnapshot) SetupPlan {
 	} else {
 		add(blockedStep("host.platform", "host", "verify-platform", platformBlocked, s.OS+"/"+s.Arch+" "+s.Distribution, "use a supported platform or manage the host manually"))
 	}
-	for _, id := range []string{"directory.state", "directory.hao", "directory.bin", "directory.data", "directory.gateway"} {
+	for _, id := range []string{"directory.parent", "directory.state", "directory.hao", "directory.bin", "directory.data", "directory.gateway"} {
 		item, ok := s.Directories[id]
 		if !ok {
 			continue
 		}
 		step := planDirectory(id, item)
-		if id == "directory.state" {
+		switch id {
+		case "directory.parent":
 			step.Dependencies = []string{"host.platform"}
-		} else {
+		case "directory.state":
+			step.Dependencies = []string{"directory.parent"}
+		default:
 			step.Dependencies = []string{"directory.state"}
 		}
 		add(step)
 	}
-	artifact := planArtifact(d, s.Artifact)
+	artifact := planArtifact(d, s.Artifact, s.TrustedArtifact, s.ArtifactAuthority)
 	artifact.Dependencies = []string{"directory.bin"}
 	add(artifact)
 	needsPackageManager := false
@@ -485,16 +513,20 @@ func planDirectory(id string, item observedItem) SetupStep {
 	if !item.Owner {
 		return blockedStep(id, component, "reconcile-directory", "existing directory has unsafe ownership", item.Evidence, "correct ownership outside hao, then retry")
 	}
-	if item.Mode.Perm()&0o077 != 0 {
+	if id != "directory.parent" && item.Mode.Perm()&0o077 != 0 {
 		return SetupStep{ID: id, Component: component, Operation: "set-directory-mode", Disposition: "update", Reason: "directory permissions are broader than owner-only", Evidence: item.Evidence, Action: &SetupAction{SchemaVersion: 1, Kind: "file-mode", File: &SetupFileAction{Path: item.Path, Mode: "0700"}}}
 	}
 	return noopStep(id, component, "verify-directory", "directory ownership and permissions already match", item.Evidence)
 }
-func planArtifact(d setupDesired, item observedItem) SetupStep {
+func planArtifact(d setupDesired, item observedItem, trusted ArtifactMetadata, authority bool) SetupStep {
+	action := trustedArtifactAction(item.Path, trusted, authority)
 	if item.State == "unknown" {
 		return blockedStep("artifact.ao", "ao-gateway-artifact", "reconcile-artifact", "artifact state or version is unknown", item.Evidence, "inspect the hao-owned AO artifact manually")
 	}
 	if item.State == "absent" {
+		if action != nil {
+			return SetupStep{ID: "artifact.ao", Component: "ao-gateway-artifact", Operation: "install-artifact", Disposition: "create", Reason: "hao-owned AO/gateway artifact is absent", Evidence: item.Evidence, Action: action}
+		}
 		return blockedStep("artifact.ao", "ao-gateway-artifact", "manual-install", "trusted immutable release metadata is unavailable", item.Evidence, "install the requested hao-owned AO artifact manually, then rerun setup")
 	}
 	if item.IsDir {
@@ -509,16 +541,20 @@ func planArtifact(d setupDesired, item observedItem) SetupStep {
 	if item.Mode.Perm()&0o022 != 0 {
 		return blockedStep("artifact.ao", "ao-gateway-artifact", "reconcile-artifact", "existing artifact is writable by group or other users", item.Evidence, "secure or remove the conflicting artifact outside hao")
 	}
-	if item.Mode.Perm()&0o111 == 0 {
+	if action == nil {
 		return blockedStep("artifact.ao", "ao-gateway-artifact", "manual-update", "trusted immutable release metadata is unavailable for replacement", item.Evidence, "replace the artifact manually from a trusted release")
 	}
-	if !item.Trusted || !validSHA256(strings.ToLower(item.SHA256)) || !strings.Contains(item.Source, "/releases/download/v"+item.Version+"/") {
-		return blockedStep("artifact.ao", "ao-gateway-artifact", "verify-provenance", "trusted immutable release metadata is unavailable", item.Evidence, "verify the artifact against trusted immutable release metadata")
+	if item.Trusted && versionMatches(item.Version, d.AOVersion) {
+		return noopStep("artifact.ao", "ao-gateway-artifact", "verify-artifact", "hao-owned AO/gateway artifact version already matches", item.Version)
 	}
-	if !versionMatches(item.Version, d.AOVersion) {
-		return blockedStep("artifact.ao", "ao-gateway-artifact", "manual-update", "trusted immutable metadata for the desired artifact is unavailable", "observed "+item.Version+"; desired "+d.AOVersion, "install the requested artifact version manually from a trusted release")
+	return SetupStep{ID: "artifact.ao", Component: "ao-gateway-artifact", Operation: "update-artifact", Disposition: "update", Reason: "installed artifact does not match trusted immutable metadata", Evidence: item.Evidence, Action: action}
+}
+
+func trustedArtifactAction(path string, metadata ArtifactMetadata, authority bool) *SetupAction {
+	if !authority || path == "" || metadata.Version == "" || metadata.Version == "latest" || !validSHA256(strings.ToLower(metadata.SHA256)) || metadata.Source == "" || strings.Contains(metadata.Source, "/latest/") || !strings.Contains(metadata.Source, "/releases/download/v"+metadata.Version+"/") {
+		return nil
 	}
-	return noopStep("artifact.ao", "ao-gateway-artifact", "verify-artifact", "hao-owned AO/gateway artifact version already matches", item.Version)
+	return &SetupAction{SchemaVersion: 1, Kind: "verified-release-artifact", Artifact: &SetupArtifactAction{Path: path, Version: metadata.Version, Source: metadata.Source, SHA256: strings.ToLower(metadata.SHA256)}}
 }
 func planPrerequisite(d setupDesired, s setupSnapshot, id, component string, item observedItem) SetupStep {
 	stepID := "prerequisite." + id
@@ -760,7 +796,7 @@ func versionMatches(observed, desired string) bool {
 	return false
 }
 
-// validateSetupPlan is the non-mutating consumer boundary for the future executor.
+// validateSetupPlan is the non-mutating consumer boundary for the executor.
 // It rejects ambiguous action variants without opening files, executing programs,
 // contacting networks, or changing machine state.
 func validateSetupPlan(plan SetupPlan) error {
@@ -801,7 +837,7 @@ func validateSetupPlan(plan SetupPlan) error {
 				return fmt.Errorf("step %s has mutable vendor provenance", step.ID)
 			}
 		case "verified-release-artifact":
-			if a.Artifact == nil || !filepath.IsAbs(a.Artifact.Path) || a.Artifact.Version == "" || a.Artifact.Source == "" || !validSHA256(a.Artifact.SHA256) || !strings.Contains(a.Artifact.Source, a.Artifact.Version) || strings.Contains(a.Artifact.Source, "/latest/") {
+			if a.Artifact == nil || !filepath.IsAbs(a.Artifact.Path) || a.Artifact.Version == "" || a.Artifact.Version == "latest" || a.Artifact.Source == "" || !validSHA256(a.Artifact.SHA256) || !strings.Contains(a.Artifact.Source, a.Artifact.Version) || strings.Contains(a.Artifact.Source, "/latest/") {
 				return fmt.Errorf("step %s has incomplete artifact provenance", step.ID)
 			}
 		case "service-definition-v1":
@@ -822,7 +858,7 @@ func validateSetupPlan(plan SetupPlan) error {
 	return nil
 }
 
-// consumeSetupPlanJSON is the planning-only consumer boundary. It strictly
+// consumeSetupPlanJSON is the shared plan consumer boundary. It strictly
 // decodes, validates, and renders every action variant without performing it.
 func consumeSetupPlanJSON(data []byte) ([]string, error) {
 	decoder := json.NewDecoder(bytes.NewReader(data))
@@ -900,13 +936,35 @@ func writeSetupPlan(cmd *cobra.Command, plan SetupPlan, yes bool) error {
 				return err
 			}
 		}
+		if step.Action != nil {
+			writeSetupAction(out, step.Action)
+		}
 	}
 	if _, err := fmt.Fprintf(out, "Summary: create=%d update=%d no-op=%d blocked=%d ready=%t\n", plan.Summary.Create, plan.Summary.Update, plan.Summary.NoOp, plan.Summary.Blocked, plan.Summary.Ready); err != nil {
 		return err
 	}
 	if yes && plan.DryRun {
-		_, err := fmt.Fprintln(out, "Note: --yes has no mutation effect in dry-run; it will approve the displayed plan only when setup execution exists.")
+		_, err := fmt.Fprintln(out, "Note: --yes is ignored during dry-run.")
 		return err
 	}
 	return nil
+}
+
+func writeSetupAction(out io.Writer, action *SetupAction) {
+	switch action.Kind {
+	case "directory", "file-mode":
+		_, _ = fmt.Fprintf(out, "  action: %s path=%s mode=%s\n", action.Kind, redactedString(action.File.Path), action.File.Mode)
+	case "verified-release-artifact":
+		_, _ = fmt.Fprintf(out, "  action: artifact path=%s version=%s source=%s sha256=%s\n", redactedString(action.Artifact.Path), redactedString(action.Artifact.Version), redactedString(action.Artifact.Source), action.Artifact.SHA256)
+	case "package-manager":
+		_, _ = fmt.Fprintf(out, "  action: package executable=%s argv=%q source=%s version=%s sha256=%s\n", redactedString(action.Package.Executable), action.Package.Argv, redactedString(action.Package.Source), redactedString(action.Package.Version), action.Package.SHA256)
+	case "vendor-package":
+		_, _ = fmt.Fprintf(out, "  action: vendor executable=%s argv=%q source=%s version=%s sha256=%s\n", redactedString(action.Vendor.Executable), action.Vendor.Argv, redactedString(action.Vendor.Source), redactedString(action.Vendor.Version), action.Vendor.SHA256)
+	case "service-definition-v1":
+		_, _ = fmt.Fprintf(out, "  action: service path=%s mode=%s version=%s sha256=%s\n", redactedString(action.Service.Path), action.Service.Mode, action.Service.Version, action.Service.SHA256)
+		_, _ = fmt.Fprintln(out, "  definition:")
+		for _, line := range strings.Split(strings.TrimSuffix(action.Service.Content, "\n"), "\n") {
+			_, _ = fmt.Fprintln(out, "    "+redactedString(line))
+		}
+	}
 }

--- a/backend/internal/haocli/setup.go
+++ b/backend/internal/haocli/setup.go
@@ -18,6 +18,8 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/vmgateway"
 )
 
 const setupPlanSchemaVersion = 1
@@ -137,6 +139,7 @@ type setupDesired struct {
 	ServiceEnabled                                      bool
 	PairPort                                            int
 	StateRoot, DataDir, RunFile, ConfigPath             string
+	PairCertDir, PairPasscodeDir                        string
 	OS, Arch                                            string
 }
 
@@ -336,7 +339,33 @@ func resolveSetupDesired(deps Deps, path string, object map[string]any, install 
 	if err != nil {
 		return setupDesired{}, operationalError("resolve run file", err)
 	}
+	if d.Mode == "pair" {
+		d.PairCertDir, d.PairPasscodeDir, err = resolvePairIdentityDirectories()
+		if err != nil {
+			return setupDesired{}, operationalError("resolve pair identity directories", err)
+		}
+	}
 	return d, nil
+}
+
+func resolvePairIdentityDirectories() (string, string, error) {
+	certDir := os.Getenv("AO_VM_CERT_DIR")
+	if strings.TrimSpace(certDir) == "" {
+		var err error
+		certDir, err = vmgateway.DefaultPairCertDir()
+		if err != nil {
+			return "", "", err
+		}
+	}
+	passcodeDir := os.Getenv("AO_VM_PASSCODE_DIR")
+	if strings.TrimSpace(passcodeDir) == "" {
+		var err error
+		passcodeDir, err = vmgateway.DefaultPasscodeDir()
+		if err != nil {
+			return "", "", err
+		}
+	}
+	return certDir, passcodeDir, nil
 }
 
 func observeSetup(ctx context.Context, deps Deps, desired setupDesired) setupSnapshot {
@@ -755,7 +784,7 @@ func renderSystemdDefinition(id string, d setupDesired, user UserObservation) st
 	path := filepath.Join(user.Home, ".local", "bin") + ":" + filepath.Join(user.Home, "bin") + ":/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 	b.WriteString("\n[Service]\nType=simple\nUser=" + user.Name + "\nWorkingDirectory=" + dataDir + "\nEnvironment=" + systemdQuote("HOME="+user.Home) + "\nEnvironment=" + systemdQuote("PATH="+path) + "\nEnvironment=" + systemdQuote("AO_DATA_DIR="+dataDir) + "\nEnvironment=" + systemdQuote("AO_RUN_FILE="+runFile) + "\n")
 	if id == "service.gateway" {
-		b.WriteString("Environment=" + systemdQuote("AO_VM_PAIR=on") + "\nEnvironment=" + systemdQuote("AO_VM_HTTPS_ADDR=:"+strconv.Itoa(d.PairPort)) + "\nEnvironment=" + systemdQuote("AO_VM_CERT_DIR="+filepath.Join(d.StateRoot, "vm-gateway", "pair-cert")) + "\nEnvironment=" + systemdQuote("AO_VM_PASSCODE_DIR="+filepath.Join(d.StateRoot, "vm-gateway", "pair-passcode")) + "\n")
+		b.WriteString("Environment=" + systemdQuote("AO_VM_PAIR=on") + "\nEnvironment=" + systemdQuote("AO_VM_HTTPS_ADDR=:"+strconv.Itoa(d.PairPort)) + "\nEnvironment=" + systemdQuote("AO_VM_CERT_DIR="+d.PairCertDir) + "\nEnvironment=" + systemdQuote("AO_VM_PASSCODE_DIR="+d.PairPasscodeDir) + "\n")
 		if d.PairPort < 1024 {
 			b.WriteString("AmbientCapabilities=CAP_NET_BIND_SERVICE\nCapabilityBoundingSet=CAP_NET_BIND_SERVICE\n")
 		}
@@ -839,7 +868,14 @@ func systemdInputsSafe(d setupDesired, user UserObservation) bool {
 	if !systemdUserPattern.MatchString(user.Name) {
 		return false
 	}
-	for _, value := range []string{user.Home, d.StateRoot, d.DataDir, d.RunFile} {
+	paths := []string{user.Home, d.StateRoot, d.DataDir, d.RunFile}
+	if d.Mode == "pair" {
+		if d.PairCertDir == "" || d.PairPasscodeDir == "" {
+			return false
+		}
+		paths = append(paths, d.PairCertDir, d.PairPasscodeDir)
+	}
+	for _, value := range paths {
 		if value == "" {
 			continue
 		}

--- a/backend/internal/haocli/setup.go
+++ b/backend/internal/haocli/setup.go
@@ -1,6 +1,7 @@
 package haocli
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"crypto/sha256"
@@ -147,10 +148,6 @@ func newSetupCommand(deps Deps, opts *options) *cobra.Command {
 	var dryRun, nonInteractive, yes bool
 	var install string
 	cmd := &cobra.Command{Use: "setup", Short: "Plan machine preparation", Args: noArgs, RunE: func(cmd *cobra.Command, _ []string) error {
-		// This guard intentionally precedes config loading and every observation.
-		if !dryRun {
-			return commandError{Code: "feature_deferred", Message: "hao setup mutation is not yet supported", Remediation: "rerun with --dry-run to inspect the setup plan", ExitStatus: 4}
-		}
 		if install != "" && install != "missing" && install != "none" {
 			return commandError{Code: "invalid_usage", Message: "--install must be missing or none", Remediation: "pass --install missing or --install none", ExitStatus: 2}
 		}
@@ -163,6 +160,7 @@ func newSetupCommand(deps Deps, opts *options) *cobra.Command {
 			return err
 		}
 		plan := planSetup(desired, observeSetup(cmd.Context(), deps, desired))
+		plan.DryRun = dryRun
 		serializedPlan, err := json.Marshal(plan)
 		if err != nil {
 			return operationalError("serialize setup plan", err)
@@ -181,13 +179,53 @@ func newSetupCommand(deps Deps, opts *options) *cobra.Command {
 		if plan.Summary.Blocked > 0 {
 			return commandError{Code: "setup_blocked", ExitStatus: 1, Silent: true}
 		}
-		return nil
+		if dryRun {
+			return nil
+		}
+		if nonInteractive && !yes {
+			return commandError{Code: "invalid_usage", Message: "non-interactive setup requires explicit consent", Remediation: "review the dry-run plan, then rerun with --non-interactive --yes", ExitStatus: 2}
+		}
+		if !yes {
+			confirmed, confirmErr := confirmSetup(cmd)
+			if confirmErr != nil {
+				return operationalError("read setup confirmation", confirmErr)
+			}
+			if !confirmed {
+				if !opts.json {
+					_, _ = fmt.Fprintln(cmd.OutOrStdout(), "Setup cancelled. No changes were made.")
+				}
+				return nil
+			}
+		}
+		result, executeErr := deps.ExecuteSetup(cmd.Context(), plan, desired.StateRoot, SetupExecutionOptions{NonInteractive: nonInteractive})
+		if executeErr != nil {
+			return executeErr
+		}
+		if opts.json {
+			return writeJSON(cmd.OutOrStdout(), haocontractRedact(result))
+		}
+		_, err = fmt.Fprintf(cmd.OutOrStdout(), "Setup %s. Completed %d action(s).\n", result.Status, len(result.Completed))
+		return err
 	}}
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "display the setup plan without changing the machine")
 	cmd.Flags().BoolVar(&nonInteractive, "non-interactive", false, "never prompt for input")
 	cmd.Flags().StringVar(&install, "install", "", "dependency policy: missing or none")
 	cmd.Flags().BoolVar(&yes, "yes", false, "approve the displayed plan for future setup execution")
 	return cmd
+}
+
+func confirmSetup(cmd *cobra.Command) (bool, error) {
+	if _, err := fmt.Fprint(cmd.OutOrStdout(), "Apply this complete setup plan? Type yes to confirm: "); err != nil {
+		return false, err
+	}
+	scanner := bufio.NewScanner(cmd.InOrStdin())
+	if !scanner.Scan() {
+		if err := scanner.Err(); err != nil {
+			return false, err
+		}
+		return false, nil
+	}
+	return strings.EqualFold(strings.TrimSpace(scanner.Text()), "yes"), nil
 }
 
 func resolveSetupDesired(deps Deps, path string, object map[string]any, install string, nonInteractive bool) (setupDesired, error) {
@@ -341,7 +379,7 @@ func observeServiceManager(deps Deps, goos string) observedItem {
 
 func planSetup(d setupDesired, s setupSnapshot) SetupPlan {
 	d.OS, d.Arch = s.OS, s.Arch
-	p := SetupPlan{SchemaVersion: setupPlanSchemaVersion, DryRun: true, Machine: d.Machine, Mode: d.Mode, Platform: s.OS + "/" + s.Arch, InstallPolicy: d.Install}
+	p := SetupPlan{SchemaVersion: setupPlanSchemaVersion, Machine: d.Machine, Mode: d.Mode, Platform: s.OS + "/" + s.Arch, InstallPolicy: d.Install}
 	add := func(step SetupStep) { p.Steps = append(p.Steps, step) }
 	platformBlocked := ""
 	if s.OS == "linux" && s.DistributionState == "unknown" {
@@ -797,8 +835,8 @@ func consumeSetupPlanJSON(data []byte) ([]string, error) {
 	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
 		return nil, errors.New("setup plan contains trailing JSON")
 	}
-	if plan.SchemaVersion != setupPlanSchemaVersion || !plan.DryRun {
-		return nil, errors.New("unsupported or executable setup plan")
+	if plan.SchemaVersion != setupPlanSchemaVersion {
+		return nil, errors.New("unsupported setup plan")
 	}
 	if err := validateSetupPlan(plan); err != nil {
 		return nil, err
@@ -839,7 +877,11 @@ func validSHA256(value string) bool {
 
 func writeSetupPlan(cmd *cobra.Command, plan SetupPlan, yes bool) error {
 	out := cmd.OutOrStdout()
-	if _, err := fmt.Fprintf(out, "HAO setup plan (dry-run): %s (%s) on %s\nInstall policy: %s\n", redactedString(plan.Machine), redactedString(plan.Mode), redactedString(plan.Platform), plan.InstallPolicy); err != nil {
+	label := "execution"
+	if plan.DryRun {
+		label = "dry-run"
+	}
+	if _, err := fmt.Fprintf(out, "HAO setup plan (%s): %s (%s) on %s\nInstall policy: %s\n", label, redactedString(plan.Machine), redactedString(plan.Mode), redactedString(plan.Platform), plan.InstallPolicy); err != nil {
 		return err
 	}
 	for _, step := range plan.Steps {
@@ -847,7 +889,7 @@ func writeSetupPlan(cmd *cobra.Command, plan SetupPlan, yes bool) error {
 		if step.Privilege.Required {
 			privilege = " [privileged:" + step.Privilege.Scope + "]"
 		}
-		if _, err := fmt.Fprintf(out, "%-24s %-8s %s%s — %s\n", step.ID+":", step.Disposition, step.Operation, privilege, redactedString(step.Reason)); err != nil {
+		if _, err := fmt.Fprintf(out, "%-24s %-8s %s%s: %s\n", step.ID+":", step.Disposition, step.Operation, privilege, redactedString(step.Reason)); err != nil {
 			return err
 		}
 		if _, err := fmt.Fprintf(out, "  evidence: %s\n", redactedString(step.Evidence)); err != nil {
@@ -862,7 +904,7 @@ func writeSetupPlan(cmd *cobra.Command, plan SetupPlan, yes bool) error {
 	if _, err := fmt.Fprintf(out, "Summary: create=%d update=%d no-op=%d blocked=%d ready=%t\n", plan.Summary.Create, plan.Summary.Update, plan.Summary.NoOp, plan.Summary.Blocked, plan.Summary.Ready); err != nil {
 		return err
 	}
-	if yes {
+	if yes && plan.DryRun {
 		_, err := fmt.Fprintln(out, "Note: --yes has no mutation effect in dry-run; it will approve the displayed plan only when setup execution exists.")
 		return err
 	}

--- a/backend/internal/haocli/setup.go
+++ b/backend/internal/haocli/setup.go
@@ -87,6 +87,7 @@ type SetupServiceAction struct {
 	Content        string `json:"content"`
 	SHA256         string `json:"sha256"`
 	ExpectedSHA256 string `json:"expectedSha256,omitempty"`
+	ExpectedMode   uint32 `json:"expectedMode,omitempty"`
 }
 
 // SetupStep is one stable desired-versus-observed reconciliation decision.
@@ -178,7 +179,7 @@ func newSetupCommand(deps Deps, opts *options) *cobra.Command {
 			return err
 		}
 		plan := planSetup(desired, observeSetup(cmd.Context(), deps, desired))
-		if recoveryStep, found, recoveryErr := planSetupRecovery(desired.StateRoot); recoveryErr != nil {
+		if recoveryStep, found, recoveryErr := planSetupRecovery(desired.StateRoot, desired.DataDir); recoveryErr != nil {
 			plan.Steps = append([]SetupStep{blockedStep("transaction.recovery", "setup-transaction", "inspect-recovery", "an interrupted setup journal could not be validated safely", safeDiagnostic(recoveryErr), "inspect the transaction journal manually before retrying")}, plan.Steps...)
 			recountSetupPlan(&plan)
 		} else if found {
@@ -232,7 +233,7 @@ func newSetupCommand(deps Deps, opts *options) *cobra.Command {
 				return nil
 			}
 		}
-		result, executeErr := deps.ExecuteSetup(cmd.Context(), plan, desired.StateRoot, SetupExecutionOptions{NonInteractive: nonInteractive, Input: cmd.InOrStdin()})
+		result, executeErr := deps.ExecuteSetup(cmd.Context(), plan, desired.StateRoot, SetupExecutionOptions{NonInteractive: nonInteractive, Input: cmd.InOrStdin(), DataDir: desired.DataDir})
 		if executeErr != nil {
 			if jsonExecution {
 				_ = endSetupExecutionJSON(cmd.OutOrStdout(), result)
@@ -354,7 +355,7 @@ func observeSetup(ctx context.Context, deps Deps, desired setupDesired) setupSna
 	} else {
 		s.User, s.UserState = currentUser, "known"
 	}
-	directories := map[string]string{"directory.parent": filepath.Dir(desired.StateRoot), "directory.state": desired.StateRoot, "directory.hao": filepath.Join(desired.StateRoot, "hao"), "directory.bin": filepath.Join(desired.StateRoot, "bin"), "directory.data": filepath.Join(desired.StateRoot, "data")}
+	directories := map[string]string{"directory.parent": filepath.Dir(desired.StateRoot), "directory.state": desired.StateRoot, "directory.hao": filepath.Join(desired.StateRoot, "hao"), "directory.bin": filepath.Join(desired.StateRoot, "bin"), "directory.data": desired.DataDir}
 	if desired.Mode == "pair" {
 		directories["directory.gateway"] = filepath.Join(desired.StateRoot, "vm-gateway")
 	}
@@ -722,6 +723,7 @@ func planServices(d setupDesired, s setupSnapshot) []SetupStep {
 				step = blockedStep(id, component, "reconcile-definition", "existing service definition has unsafe ownership", item.Evidence, "inspect and reconcile the conflicting definition manually")
 			} else if item.Version != desiredContent {
 				action.Service.ExpectedSHA256 = item.ActualSHA256
+				action.Service.ExpectedMode = uint32(item.Mode.Perm())
 				step = SetupStep{ID: id, Component: component, Operation: "update-definition", Disposition: "update", Privilege: SetupPrivilege{Required: true, Scope: "system-service-definition"}, Reason: "service definition content differs from desired canonical v1 content", Evidence: "canonical content mismatch", Action: action}
 			} else {
 				step = noopStep(id, component, "verify-definition", "service definition is present; setup does not enable or start it", item.Evidence)
@@ -942,7 +944,7 @@ func validateSetupPlan(plan SetupPlan) error {
 			if !filepath.IsAbs(a.Service.Path) || a.Service.Mode != "0644" || a.Service.Version != "1" || a.Service.Content == "" || a.Service.SHA256 != fmt.Sprintf("%x", digest[:]) {
 				return fmt.Errorf("step %s has invalid service definition contract", step.ID)
 			}
-			if (step.Disposition == "create" && a.Service.ExpectedSHA256 != "") || (step.Disposition == "update" && !validSHA256(a.Service.ExpectedSHA256)) {
+			if (step.Disposition == "create" && (a.Service.ExpectedSHA256 != "" || a.Service.ExpectedMode != 0)) || (step.Disposition == "update" && (!validSHA256(a.Service.ExpectedSHA256) || a.Service.ExpectedMode == 0 || a.Service.ExpectedMode&0o022 != 0)) {
 				return fmt.Errorf("step %s has an invalid service precondition", step.ID)
 			}
 			if _, err := consumeSystemdDefinition(a.Service.Content); err != nil {

--- a/backend/internal/haocli/setup_execute.go
+++ b/backend/internal/haocli/setup_execute.go
@@ -1,23 +1,914 @@
 package haocli
 
 import (
+	"bytes"
 	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
 	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"os/user"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"time"
 )
 
-// SetupExecutionOptions carries consent and interaction policy into execution.
+const setupJournalSchemaVersion = 1
+
+var (
+	errSetupBusy        = errors.New("another hao setup invocation is active")
+	errPrivilegeRefused = errors.New("required setup privilege was unavailable or refused")
+)
+
+// SetupExecutionOptions carries interaction policy into one approved run.
 type SetupExecutionOptions struct {
-	NonInteractive bool `json:"nonInteractive"`
+	NonInteractive bool      `json:"nonInteractive"`
+	Input          io.Reader `json:"-"`
 }
 
-// SetupExecutionResult is the stable, non-secret execution summary.
+// SetupExecutionResult reports completed, rollback, recovery, and retry facts.
 type SetupExecutionResult struct {
 	Status    string   `json:"status"`
 	Completed []string `json:"completed"`
 	Rollback  []string `json:"rollback"`
+	Recovery  []string `json:"recovery"`
 	Retry     string   `json:"retry"`
 }
 
-func executeSetupPlan(context.Context, SetupPlan, string, SetupExecutionOptions) (SetupExecutionResult, error) {
-	return SetupExecutionResult{}, errors.New("setup executor is not implemented")
+type setupExecutionSystem interface {
+	Download(context.Context, string) (io.ReadCloser, error)
+	CheckPrivilege(context.Context, bool, io.Reader) error
+	Run(context.Context, bool, bool, io.Reader, string, ...string) error
+}
+
+type systemSetupExecution struct{}
+
+func (systemSetupExecution) Download(ctx context.Context, source string) (io.ReadCloser, error) {
+	if !strings.HasPrefix(source, "https://") {
+		return nil, errors.New("artifact source is not HTTPS")
+	}
+	client := &http.Client{Timeout: 10 * time.Minute, CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, source, http.NoBody)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		_ = resp.Body.Close()
+		return nil, fmt.Errorf("artifact download returned HTTP %d", resp.StatusCode)
+	}
+	if resp.ContentLength > maxArtifactSize {
+		_ = resp.Body.Close()
+		return nil, errors.New("artifact download exceeds size limit")
+	}
+	return resp.Body, nil
+}
+
+func (systemSetupExecution) CheckPrivilege(ctx context.Context, nonInteractive bool, in io.Reader) error {
+	if runningAsRoot() {
+		return nil
+	}
+	if runtime.GOOS != "linux" {
+		return errPrivilegeRefused
+	}
+	const sudo = "/usr/bin/sudo"
+	if _, err := os.Stat(sudo); err != nil {
+		return errPrivilegeRefused
+	}
+	args := []string{"--validate"}
+	if nonInteractive {
+		args = []string{"--non-interactive", "--validate"}
+	}
+	cmd := exec.CommandContext(ctx, sudo, args...)
+	cmd.Stdin = in
+	cmd.Stdout, cmd.Stderr = io.Discard, os.Stderr
+	cmd.Env = []string{"LANG=C", "LC_ALL=C", "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"}
+	if err := cmd.Run(); err != nil {
+		return errPrivilegeRefused
+	}
+	return nil
+}
+
+func (systemSetupExecution) Run(ctx context.Context, privileged, nonInteractive bool, in io.Reader, name string, args ...string) error {
+	command, argv := name, append([]string(nil), args...)
+	if privileged && !runningAsRoot() {
+		const sudo = "/usr/bin/sudo"
+		if _, err := os.Stat(sudo); err != nil {
+			return errPrivilegeRefused
+		}
+		prefix := make([]string, 0, 2)
+		if nonInteractive {
+			prefix = append(prefix, "--non-interactive")
+		}
+		prefix = append(prefix, "--")
+		command, argv = sudo, append(append(prefix, name), argv...)
+	}
+	cmd := exec.CommandContext(ctx, command, argv...)
+	cmd.Stdin = in
+	cmd.Stdout, cmd.Stderr = io.Discard, io.Discard
+	if privileged {
+		cmd.Env = []string{"LANG=C", "LC_ALL=C", "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"}
+	}
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("structured command failed: %w", err)
+	}
+	return nil
+}
+
+func runningAsRoot() bool {
+	current, err := user.Current()
+	return err == nil && current.Uid == "0"
+}
+
+type setupJournal struct {
+	SchemaVersion int             `json:"schemaVersion"`
+	PlanSHA256    string          `json:"planSha256"`
+	State         string          `json:"state"`
+	StartedAt     string          `json:"startedAt"`
+	Records       []journalRecord `json:"records"`
+}
+
+type journalRecord struct {
+	StepID         string `json:"stepId"`
+	Kind           string `json:"kind"`
+	Target         string `json:"target,omitempty"`
+	Backup         string `json:"backup,omitempty"`
+	ManifestTarget string `json:"manifestTarget,omitempty"`
+	ManifestBackup string `json:"manifestBackup,omitempty"`
+	Temporary      string `json:"temporary,omitempty"`
+	PreviousMode   uint32 `json:"previousMode,omitempty"`
+	Created        bool   `json:"created,omitempty"`
+	Completed      bool   `json:"completed"`
+	Reversible     bool   `json:"reversible"`
+}
+
+type setupExecutor struct {
+	system         setupExecutionSystem
+	stateRoot      string
+	journalPath    string
+	backupDir      string
+	options        SetupExecutionOptions
+	journal        setupJournal
+	journalStarted bool
+	result         SetupExecutionResult
+}
+
+func executeSetupPlan(ctx context.Context, plan SetupPlan, stateRoot string, options SetupExecutionOptions) (SetupExecutionResult, error) {
+	return executeSetupPlanWithSystem(ctx, plan, stateRoot, options, systemSetupExecution{})
+}
+
+func executeSetupPlanWithSystem(ctx context.Context, plan SetupPlan, stateRoot string, options SetupExecutionOptions, system setupExecutionSystem) (SetupExecutionResult, error) {
+	if err := validateExecutablePlan(plan, stateRoot); err != nil {
+		return SetupExecutionResult{}, commandError{Code: "invalid_setup_plan", Message: "setup plan cannot be executed", Remediation: "rerun hao setup to produce a fresh trusted plan", Details: map[string]any{"diagnostic": safeDiagnostic(err)}, ExitStatus: 1, Cause: err}
+	}
+	lockName := fmt.Sprintf("hao-setup-%x.lock", sha256.Sum256([]byte(filepath.Clean(stateRoot))))
+	lock, err := acquireSetupLock(filepath.Join(os.TempDir(), lockName))
+	if err != nil {
+		if errors.Is(err, errSetupBusy) {
+			return SetupExecutionResult{}, commandError{Code: "setup_busy", Message: "another hao setup invocation is active", Remediation: "wait for the active setup to finish, then retry", Details: map[string]any{}, ExitStatus: 1, Cause: err}
+		}
+		return SetupExecutionResult{}, operationalError("acquire setup transaction lock", err)
+	}
+	defer func() { _ = releaseSetupLock(lock) }()
+
+	e := &setupExecutor{
+		system:      system,
+		stateRoot:   filepath.Clean(stateRoot),
+		journalPath: filepath.Join(stateRoot, ".hao-setup-transaction.json"),
+		options:     options,
+		result: SetupExecutionResult{
+			Completed: []string{},
+			Rollback:  []string{},
+			Recovery:  []string{},
+		},
+	}
+	if recovered, recoverErr := e.recover(ctx); recoverErr != nil {
+		return e.result, e.failure("recover interrupted setup", recoverErr)
+	} else if recovered != "" {
+		e.result.Recovery = append(e.result.Recovery, recovered)
+	}
+	if planNeedsPrivilege(plan) {
+		if err := system.CheckPrivilege(ctx, options.NonInteractive, options.Input); err != nil {
+			return e.result, commandError{Code: "privilege_required", Message: "setup requires narrowly scoped administrator privileges", Remediation: "approve the displayed privileged operations, or arrange them manually", Details: map[string]any{"completed": []string{}, "rollback": []string{}, "retry": "hao setup --dry-run"}, ExitStatus: 3, Cause: errPrivilegeRefused}
+		}
+	}
+	planBytes, err := json.Marshal(plan)
+	if err != nil {
+		return e.result, operationalError("serialize setup transaction", err)
+	}
+	e.journal = setupJournal{SchemaVersion: setupJournalSchemaVersion, PlanSHA256: digestBytes(planBytes), State: "in_progress", StartedAt: time.Now().UTC().Format(time.RFC3339Nano)}
+	e.backupDir = filepath.Join(stateRoot, "hao", "backups", e.journal.PlanSHA256[:16]+"-"+strconv.FormatInt(time.Now().UnixNano(), 10))
+	for _, step := range plan.Steps {
+		if step.Action == nil {
+			continue
+		}
+		if err := ctx.Err(); err != nil {
+			return e.result, e.rollbackFailure(ctx, step.ID, err)
+		}
+		if err := e.apply(ctx, step); err != nil {
+			return e.result, e.rollbackFailure(ctx, step.ID, err)
+		}
+		e.result.Completed = append(e.result.Completed, step.ID)
+	}
+	if e.journalStarted {
+		e.journal.State = "completed"
+		if err := e.writeJournal(); err != nil {
+			return e.result, e.rollbackFailure(ctx, "transaction.commit", err)
+		}
+		if err := e.cleanupServiceBackups(ctx); err != nil {
+			return e.result, e.failure("clean committed service backups", err)
+		}
+		if err := os.Remove(e.journalPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return e.result, e.failure("remove completed setup journal", err)
+		}
+		_ = syncDirectory(filepath.Dir(e.journalPath))
+	}
+	e.result.Status = "completed"
+	e.result.Retry = "hao setup --dry-run"
+	return e.result, nil
+}
+
+func validateExecutablePlan(plan SetupPlan, stateRoot string) error {
+	if plan.SchemaVersion != setupPlanSchemaVersion || plan.DryRun {
+		return errors.New("plan is not an executable schema v1 plan")
+	}
+	if err := validateSetupPlan(plan); err != nil {
+		return err
+	}
+	root := filepath.Clean(stateRoot)
+	if !filepath.IsAbs(root) {
+		return errors.New("state root is not absolute")
+	}
+	seen := make(map[string]struct{}, len(plan.Steps))
+	for _, step := range plan.Steps {
+		if step.ID == "" {
+			return errors.New("setup plan contains an empty step ID")
+		}
+		if _, duplicate := seen[step.ID]; duplicate {
+			return fmt.Errorf("setup plan contains duplicate step %s", step.ID)
+		}
+		for _, dependency := range step.Dependencies {
+			if _, ready := seen[dependency]; !ready {
+				return fmt.Errorf("step %s has an unresolved or out-of-order dependency", step.ID)
+			}
+		}
+		seen[step.ID] = struct{}{}
+		if step.Action == nil {
+			continue
+		}
+		a := step.Action
+		switch a.Kind {
+		case "directory", "file-mode":
+			expected := managedDirectoryPath(root, step.ID)
+			if expected == "" || filepath.Clean(a.File.Path) != expected || (step.ID == "directory.parent" && a.Kind != "directory") {
+				return fmt.Errorf("step %s targets an unmanaged file", step.ID)
+			}
+		case "verified-release-artifact":
+			if step.ID != "artifact.ao" || filepath.Clean(a.Artifact.Path) != filepath.Join(root, "bin", "ao") {
+				return fmt.Errorf("step %s targets an unmanaged artifact", step.ID)
+			}
+		case "service-definition-v1":
+			expected := map[string]string{"service.daemon": "/etc/systemd/system/ao-daemon.service", "service.gateway": "/etc/systemd/system/ao-gateway.service"}[step.ID]
+			if expected == "" || a.Service.Path != expected {
+				return fmt.Errorf("step %s targets an unmanaged service definition", step.ID)
+			}
+		case "package-manager":
+			if a.Package.Executable != "/usr/bin/apt-get" || !allowedPackageArgv(step.ID, a.Package.Argv, a.Package.Version) {
+				return fmt.Errorf("step %s has a non-allowlisted package command", step.ID)
+			}
+		case "vendor-package":
+			if step.ID != "prerequisite.harness" || a.Vendor.Executable != "/usr/bin/npm" || !allowedVendorArgv(a.Vendor.Argv, a.Vendor.Version) {
+				return fmt.Errorf("step %s has a non-allowlisted vendor command", step.ID)
+			}
+		}
+	}
+	return nil
+}
+
+func managedDirectoryPath(root, stepID string) string {
+	return map[string]string{
+		"directory.parent":  filepath.Dir(root),
+		"directory.state":   root,
+		"directory.hao":     filepath.Join(root, "hao"),
+		"directory.bin":     filepath.Join(root, "bin"),
+		"directory.data":    filepath.Join(root, "data"),
+		"directory.gateway": filepath.Join(root, "vm-gateway"),
+	}[stepID]
+}
+
+func allowedPackageArgv(stepID string, argv []string, version string) bool {
+	if len(argv) != 3 || argv[0] != "install" || argv[1] != "--yes" {
+		return false
+	}
+	name, pinned, ok := strings.Cut(argv[2], "=")
+	expectedName := map[string]string{"prerequisite.git": "git", "prerequisite.gh": "gh"}[stepID]
+	return ok && expectedName != "" && name == expectedName && pinned == version
+}
+
+func allowedVendorArgv(argv []string, version string) bool {
+	return len(argv) == 3 && argv[0] == "install" && argv[1] == "--global" && argv[2] == "@anthropic-ai/claude-code@"+version
+}
+
+func planNeedsPrivilege(plan SetupPlan) bool {
+	for _, step := range plan.Steps {
+		if step.Action != nil && step.Privilege.Required {
+			return true
+		}
+	}
+	return false
+}
+
+func (e *setupExecutor) apply(ctx context.Context, step SetupStep) error {
+	a := step.Action
+	switch a.Kind {
+	case "directory":
+		return e.createDirectory(step.ID, a.File)
+	case "file-mode":
+		return e.changeMode(step.ID, a.File)
+	case "verified-release-artifact":
+		return e.installArtifact(ctx, step.ID, step.Disposition, a.Artifact)
+	case "service-definition-v1":
+		return e.installService(ctx, step.ID, step.Disposition, a.Service)
+	case "package-manager":
+		return e.runIrreversible(ctx, step.ID, a.Kind, true, a.Package.Executable, a.Package.Argv)
+	case "vendor-package":
+		return e.runIrreversible(ctx, step.ID, a.Kind, false, a.Vendor.Executable, a.Vendor.Argv)
+	default:
+		return fmt.Errorf("unsupported action kind %q", a.Kind)
+	}
+}
+
+func (e *setupExecutor) createDirectory(stepID string, action *SetupFileAction) error {
+	if err := ensureNoSymlinkAncestors(filepath.Dir(action.Path)); err != nil {
+		return err
+	}
+	info, err := os.Lstat(action.Path)
+	if err == nil {
+		if !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+			return errors.New("directory target is occupied or linked")
+		}
+		if stepID == "directory.parent" {
+			return nil
+		}
+		return os.Chmod(action.Path, 0o700) //nolint:gosec // owner-only directories require traversal.
+	}
+	if !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	if err := os.Mkdir(action.Path, 0o700); err != nil {
+		return err
+	}
+	if err := syncDirectory(filepath.Dir(action.Path)); err != nil {
+		return err
+	}
+	record := journalRecord{StepID: stepID, Kind: "directory", Target: action.Path, Created: true, Completed: true, Reversible: false}
+	return e.record(record)
+}
+
+func (e *setupExecutor) changeMode(stepID string, action *SetupFileAction) error {
+	if err := ensureNoSymlinkAncestors(action.Path); err != nil {
+		return err
+	}
+	info, err := os.Lstat(action.Path)
+	if err != nil || info.Mode()&os.ModeSymlink != 0 {
+		return errors.New("file mode target is unavailable or linked")
+	}
+	record := journalRecord{StepID: stepID, Kind: "file-mode", Target: action.Path, PreviousMode: uint32(info.Mode().Perm()), Reversible: true}
+	if err := e.record(record); err != nil {
+		return err
+	}
+	if err := os.Chmod(action.Path, 0o700); err != nil { //nolint:gosec // owner-only directories require traversal.
+		return err
+	}
+	return e.completeLastRecord()
+}
+
+func (e *setupExecutor) installArtifact(ctx context.Context, stepID, disposition string, action *SetupArtifactAction) error {
+	if err := ensureNoSymlinkAncestors(action.Path); err != nil {
+		return err
+	}
+	if digest, err := fileDigest(action.Path, maxArtifactSize); err == nil && digest == action.SHA256 {
+		return writeArtifactManifest(action)
+	}
+	_, targetErr := os.Lstat(action.Path)
+	if disposition == "create" && targetErr == nil {
+		return errors.New("artifact target appeared after planning; rerun setup")
+	}
+	if disposition == "update" && errors.Is(targetErr, os.ErrNotExist) {
+		return errors.New("artifact target disappeared after planning; rerun setup")
+	}
+	if targetErr != nil && !errors.Is(targetErr, os.ErrNotExist) {
+		return targetErr
+	}
+	if err := os.MkdirAll(e.backupDir, 0o700); err != nil {
+		return err
+	}
+	temporary, err := randomTemporaryPath(filepath.Dir(action.Path), ".hao-artifact-")
+	if err != nil {
+		return err
+	}
+	record := journalRecord{StepID: stepID, Kind: "verified-release-artifact", Target: action.Path, ManifestTarget: action.Path + ".hao-manifest.json", Temporary: temporary, Reversible: true}
+	if targetErr == nil {
+		record.Backup = filepath.Join(e.backupDir, safeStepName(stepID)+".binary")
+		if err := copyRegularFile(action.Path, record.Backup, 0o700); err != nil {
+			return err
+		}
+	} else {
+		record.Created = true
+	}
+	if _, err := os.Lstat(record.ManifestTarget); err == nil {
+		record.ManifestBackup = filepath.Join(e.backupDir, safeStepName(stepID)+".manifest")
+		if err := copyRegularFile(record.ManifestTarget, record.ManifestBackup, 0o600); err != nil {
+			return err
+		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	if err := e.record(record); err != nil {
+		return err
+	}
+	if err := downloadVerifiedArtifact(ctx, e.system, action, temporary); err != nil {
+		return err
+	}
+	if err := writeArtifactManifest(action); err != nil {
+		return err
+	}
+	return e.completeLastRecord()
+}
+
+func downloadVerifiedArtifact(ctx context.Context, system setupExecutionSystem, action *SetupArtifactAction, tempName string) error {
+	body, err := system.Download(ctx, action.Source)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = body.Close() }()
+	dir := filepath.Dir(action.Path)
+	temp, err := os.OpenFile(tempName, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = os.Remove(tempName) }()
+	hash := sha256.New()
+	written, copyErr := io.Copy(io.MultiWriter(temp, hash), io.LimitReader(body, maxArtifactSize+1))
+	if copyErr != nil {
+		_ = temp.Close()
+		return fmt.Errorf("artifact download interrupted: %w", copyErr)
+	}
+	if written > maxArtifactSize {
+		_ = temp.Close()
+		return errors.New("artifact download exceeds size limit")
+	}
+	actual := hex.EncodeToString(hash.Sum(nil))
+	if actual != action.SHA256 {
+		_ = temp.Close()
+		return fmt.Errorf("artifact digest mismatch: expected %s, received %s", action.SHA256, actual)
+	}
+	if err := temp.Chmod(0o700); err != nil {
+		_ = temp.Close()
+		return err
+	}
+	if err := temp.Sync(); err != nil {
+		_ = temp.Close()
+		return err
+	}
+	if err := temp.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(tempName, action.Path); err != nil {
+		return err
+	}
+	return syncDirectory(dir)
+}
+
+func writeArtifactManifest(action *SetupArtifactAction) error {
+	data, err := json.Marshal(ArtifactMetadata{Version: action.Version, Source: action.Source, SHA256: action.SHA256})
+	if err != nil {
+		return err
+	}
+	return atomicWriteFile(action.Path+".hao-manifest.json", append(data, '\n'), 0o600)
+}
+
+func (e *setupExecutor) installService(ctx context.Context, stepID, disposition string, action *SetupServiceAction) error {
+	digest, digestErr := fileDigest(action.Path, 1<<20)
+	if digestErr == nil && digest == action.SHA256 {
+		return nil
+	}
+	info, targetErr := os.Lstat(action.Path)
+	if disposition == "create" && targetErr == nil {
+		return errors.New("service target appeared after planning; rerun setup")
+	}
+	if disposition == "update" && errors.Is(targetErr, os.ErrNotExist) {
+		return errors.New("service target disappeared after planning; rerun setup")
+	}
+	if targetErr == nil && (!info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0) {
+		return errors.New("service target is not a regular unlinked file")
+	}
+	if targetErr != nil && !errors.Is(targetErr, os.ErrNotExist) {
+		return targetErr
+	}
+	targetTemp, err := randomTemporaryPath(filepath.Dir(action.Path), ".hao-service-")
+	if err != nil {
+		return err
+	}
+	record := journalRecord{StepID: stepID, Kind: "service-definition-v1", Target: action.Path, Temporary: targetTemp, Reversible: true}
+	if targetErr == nil {
+		record.Backup, err = randomTemporaryPath(filepath.Dir(action.Path), ".hao-backup-")
+		if err != nil {
+			return err
+		}
+	} else {
+		record.Created = true
+	}
+	if err := e.record(record); err != nil {
+		return err
+	}
+	if record.Backup != "" {
+		if err := e.system.Run(ctx, true, e.options.NonInteractive, e.options.Input, "/usr/bin/cp", "--no-dereference", "--preserve=mode,ownership,timestamps", "--", action.Path, record.Backup); err != nil {
+			return err
+		}
+	}
+	if err := e.system.Run(ctx, true, e.options.NonInteractive, bytes.NewReader([]byte(action.Content)), "/usr/bin/tee", "--", targetTemp); err != nil {
+		return err
+	}
+	if err := e.system.Run(ctx, true, e.options.NonInteractive, e.options.Input, "/usr/bin/chmod", "0644", "--", targetTemp); err != nil {
+		return err
+	}
+	if err := e.system.Run(ctx, true, e.options.NonInteractive, e.options.Input, "/usr/bin/chown", "root:root", "--", targetTemp); err != nil {
+		return err
+	}
+	if err := e.system.Run(ctx, true, e.options.NonInteractive, e.options.Input, "/usr/bin/mv", "--no-target-directory", "--", targetTemp, action.Path); err != nil {
+		return err
+	}
+	return e.completeLastRecord()
+}
+
+func (e *setupExecutor) runIrreversible(ctx context.Context, stepID, kind string, privileged bool, executable string, argv []string) error {
+	record := journalRecord{StepID: stepID, Kind: kind, Reversible: false}
+	if err := e.record(record); err != nil {
+		return err
+	}
+	if err := e.system.Run(ctx, privileged, e.options.NonInteractive, e.options.Input, executable, argv...); err != nil {
+		return err
+	}
+	return e.completeLastRecord()
+}
+
+func (e *setupExecutor) record(record journalRecord) error {
+	e.journal.Records = append(e.journal.Records, record)
+	if _, err := os.Stat(filepath.Dir(e.journalPath)); err == nil {
+		e.journalStarted = true
+		return e.writeJournal()
+	}
+	return nil
+}
+
+func (e *setupExecutor) completeLastRecord() error {
+	e.journal.Records[len(e.journal.Records)-1].Completed = true
+	if e.journalStarted {
+		return e.writeJournal()
+	}
+	return nil
+}
+
+func (e *setupExecutor) writeJournal() error {
+	data, err := json.Marshal(e.journal)
+	if err != nil {
+		return err
+	}
+	return atomicWriteFile(e.journalPath, append(data, '\n'), 0o600)
+}
+
+func (e *setupExecutor) rollbackFailure(ctx context.Context, stepID string, cause error) error {
+	rollback, complete := e.rollback(ctx)
+	e.result.Rollback = append(e.result.Rollback, rollback...)
+	e.result.Status = "failed"
+	e.result.Retry = "hao setup --dry-run, resolve the reported failure, then rerun hao setup"
+	if e.journalStarted {
+		if complete {
+			e.journal.State = "rolled_back"
+		}
+		_ = e.writeJournal()
+	}
+	return e.failure("execute setup step "+stepID, cause)
+}
+
+func (e *setupExecutor) failure(operation string, cause error) error {
+	diagnostic := safeDiagnostic(cause)
+	retry := e.result.Retry
+	if retry == "" {
+		retry = "inspect the transaction journal and reported diagnostic, then rerun hao setup --dry-run"
+		e.result.Retry = retry
+	}
+	return commandError{Code: "setup_failed", Message: operation + " failed; completed actions and rollback are reported in details", Remediation: retry, Details: map[string]any{"completed": e.result.Completed, "rollback": e.result.Rollback, "recovery": e.result.Recovery, "retry": retry, "diagnostic": diagnostic}, ExitStatus: 1, Cause: errors.New(diagnostic)}
+}
+
+func (e *setupExecutor) rollback(ctx context.Context) ([]string, bool) {
+	results := make([]string, 0)
+	complete := true
+	for i := len(e.journal.Records) - 1; i >= 0; i-- {
+		record := e.journal.Records[i]
+		if !record.Reversible {
+			continue
+		}
+		var err error
+		switch record.Kind {
+		case "file-mode":
+			if err = ensureNoSymlinkAncestors(record.Target); err == nil {
+				err = os.Chmod(record.Target, os.FileMode(record.PreviousMode))
+			}
+		case "verified-release-artifact":
+			if record.Temporary != "" {
+				_ = os.Remove(record.Temporary)
+			}
+			err = rollbackManagedFile(record.Target, record.Backup, record.Created, 0o700)
+			if manifestErr := rollbackManagedFile(record.ManifestTarget, record.ManifestBackup, record.ManifestBackup == "", 0o600); err == nil {
+				err = manifestErr
+			}
+		case "service-definition-v1":
+			if record.Temporary != "" {
+				_ = e.system.Run(ctx, true, e.options.NonInteractive, e.options.Input, "/usr/bin/rm", "--force", "--", record.Temporary)
+			}
+			if record.Backup != "" {
+				err = e.restoreServiceBackup(ctx, record)
+			} else if record.Created {
+				err = e.system.Run(ctx, true, e.options.NonInteractive, e.options.Input, "/usr/bin/rm", "--force", "--", record.Target)
+			}
+		}
+		status := record.StepID + ": restored"
+		if err != nil {
+			status = record.StepID + ": rollback failed: " + safeDiagnostic(err)
+			complete = false
+		}
+		results = append(results, status)
+	}
+	if complete {
+		if err := e.cleanupServiceBackups(ctx); err != nil {
+			results = append(results, "service backups: cleanup failed: "+safeDiagnostic(err))
+			complete = false
+		}
+	}
+	return results, complete
+}
+
+func rollbackManagedFile(target, backup string, created bool, mode os.FileMode) error {
+	if backup != "" {
+		return copyRegularFile(backup, target, mode)
+	}
+	if created {
+		if err := os.Remove(target); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return err
+		}
+		return syncDirectory(filepath.Dir(target))
+	}
+	return nil
+}
+
+func (e *setupExecutor) restoreServiceBackup(ctx context.Context, record journalRecord) error {
+	if _, err := os.Lstat(record.Backup); errors.Is(err, os.ErrNotExist) {
+		return errors.New("service backup is unavailable")
+	} else if err != nil {
+		return err
+	}
+	if err := e.system.Run(ctx, true, e.options.NonInteractive, e.options.Input, "/usr/bin/cp", "--no-dereference", "--preserve=mode,ownership,timestamps", "--", record.Backup, record.Temporary); err != nil {
+		return err
+	}
+	return e.system.Run(ctx, true, e.options.NonInteractive, e.options.Input, "/usr/bin/mv", "--no-target-directory", "--", record.Temporary, record.Target)
+}
+
+func (e *setupExecutor) cleanupServiceBackups(ctx context.Context) error {
+	for _, record := range e.journal.Records {
+		if record.Kind == "service-definition-v1" && record.Backup != "" {
+			if err := e.system.Run(ctx, true, e.options.NonInteractive, e.options.Input, "/usr/bin/rm", "--force", "--", record.Backup); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (e *setupExecutor) recover(ctx context.Context) (string, error) {
+	info, err := os.Lstat(e.journalPath)
+	if errors.Is(err, os.ErrNotExist) {
+		return "", nil
+	}
+	if err != nil {
+		return "", err
+	}
+	if !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 {
+		return "", errors.New("setup transaction journal is not a regular file")
+	}
+	journalFile, err := openManagedRegular(e.journalPath, 1<<20)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = journalFile.Close() }()
+	data, err := io.ReadAll(io.LimitReader(journalFile, 1<<20+1))
+	if err != nil || len(data) > 1<<20 {
+		return "", errors.New("setup transaction journal exceeds size limit")
+	}
+	if err := json.Unmarshal(data, &e.journal); err != nil || e.journal.SchemaVersion != setupJournalSchemaVersion {
+		return "", errors.New("setup transaction journal is invalid; inspect it manually before retrying")
+	}
+	if err := e.validateJournal(); err != nil {
+		return "", fmt.Errorf("setup transaction journal is unsafe: %w", err)
+	}
+	e.journalStarted = true
+	if e.journal.State == "in_progress" {
+		var complete bool
+		e.result.Rollback, complete = e.rollback(ctx)
+		if !complete {
+			return "", errors.New("interrupted setup rollback is incomplete; retry to resume rollback")
+		}
+		e.journal.State = "recovered"
+		if err := e.writeJournal(); err != nil {
+			return "", err
+		}
+	}
+	if e.journal.State != "recovered" && e.journal.State != "rolled_back" && e.journal.State != "completed" {
+		return "", errors.New("setup transaction journal has an unsupported state")
+	}
+	if err := e.cleanupServiceBackups(ctx); err != nil {
+		return "", err
+	}
+	if err := os.Remove(e.journalPath); err != nil {
+		return "", err
+	}
+	e.journalStarted = false
+	return "previous interrupted setup was rolled back; safe retry started", nil
+}
+
+func (e *setupExecutor) validateJournal() error {
+	if !validSHA256(e.journal.PlanSHA256) || len(e.journal.Records) > 64 {
+		return errors.New("journal identity or record count is invalid")
+	}
+	for _, record := range e.journal.Records {
+		switch record.Kind {
+		case "directory":
+			if record.Target != managedDirectoryPath(e.stateRoot, record.StepID) || record.Reversible || !record.Created {
+				return fmt.Errorf("step %s has an invalid directory record", record.StepID)
+			}
+		case "file-mode":
+			if record.Target != managedDirectoryPath(e.stateRoot, record.StepID) || !record.Reversible || record.Created {
+				return fmt.Errorf("step %s has an invalid mode record", record.StepID)
+			}
+		case "verified-release-artifact":
+			target := filepath.Join(e.stateRoot, "bin", "ao")
+			backupCoherent := (record.Created && record.Backup == "") || (!record.Created && record.Backup != "")
+			if record.StepID != "artifact.ao" || record.Target != target || record.ManifestTarget != target+".hao-manifest.json" || !record.Reversible || !backupCoherent || !temporaryPathMatches(record.Temporary, filepath.Dir(target), ".hao-artifact-") || !optionalPathBelow(record.Backup, filepath.Join(e.stateRoot, "hao", "backups")) || !optionalPathBelow(record.ManifestBackup, filepath.Join(e.stateRoot, "hao", "backups")) {
+				return errors.New("artifact record contains an unmanaged path")
+			}
+		case "service-definition-v1":
+			expected := map[string]string{"service.daemon": "/etc/systemd/system/ao-daemon.service", "service.gateway": "/etc/systemd/system/ao-gateway.service"}[record.StepID]
+			backupCoherent := (record.Created && record.Backup == "") || (!record.Created && record.Backup != "")
+			if expected == "" || record.Target != expected || !record.Reversible || !backupCoherent || !temporaryPathMatches(record.Temporary, filepath.Dir(expected), ".hao-service-") || (record.Backup != "" && !temporaryPathMatches(record.Backup, filepath.Dir(expected), ".hao-backup-")) {
+				return errors.New("service record contains an unmanaged path")
+			}
+		case "package-manager":
+			if record.Reversible || (record.StepID != "prerequisite.git" && record.StepID != "prerequisite.gh") {
+				return errors.New("package record has an invalid step")
+			}
+		case "vendor-package":
+			if record.Reversible || record.StepID != "prerequisite.harness" {
+				return errors.New("vendor record has an invalid step")
+			}
+		default:
+			return fmt.Errorf("step %s has an unsupported journal kind", record.StepID)
+		}
+	}
+	return nil
+}
+
+func optionalPathBelow(path, root string) bool {
+	if path == "" {
+		return true
+	}
+	relative, err := filepath.Rel(root, path)
+	return err == nil && relative != "." && relative != ".." && !strings.HasPrefix(relative, ".."+string(os.PathSeparator))
+}
+
+func temporaryPathMatches(path, directory, prefix string) bool {
+	if filepath.Dir(path) != directory {
+		return false
+	}
+	name := strings.TrimPrefix(filepath.Base(path), prefix)
+	if len(name) != 32 {
+		return false
+	}
+	_, err := hex.DecodeString(name)
+	return err == nil
+}
+
+func ensureNoSymlinkAncestors(path string) error {
+	clean := filepath.Clean(path)
+	if !filepath.IsAbs(clean) {
+		return errors.New("managed path is not absolute")
+	}
+	current := string(os.PathSeparator)
+	parts := strings.Split(strings.TrimPrefix(clean, string(os.PathSeparator)), string(os.PathSeparator))
+	for _, part := range parts {
+		if part == "" {
+			continue
+		}
+		current = filepath.Join(current, part)
+		info, err := os.Lstat(current)
+		if errors.Is(err, os.ErrNotExist) {
+			continue
+		}
+		if err != nil {
+			return err
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("managed path traverses symbolic link %s", current)
+		}
+	}
+	return nil
+}
+
+func atomicWriteFile(path string, data []byte, mode os.FileMode) error {
+	if err := ensureNoSymlinkAncestors(filepath.Dir(path)); err != nil {
+		return err
+	}
+	temp, err := os.CreateTemp(filepath.Dir(path), ".hao-write-*")
+	if err != nil {
+		return err
+	}
+	tempName := temp.Name()
+	defer func() { _ = os.Remove(tempName) }()
+	if err := temp.Chmod(mode); err != nil {
+		_ = temp.Close()
+		return err
+	}
+	if _, err := temp.Write(data); err != nil {
+		_ = temp.Close()
+		return err
+	}
+	if err := temp.Sync(); err != nil {
+		_ = temp.Close()
+		return err
+	}
+	if err := temp.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(tempName, path); err != nil {
+		return err
+	}
+	return syncDirectory(filepath.Dir(path))
+}
+
+func copyRegularFile(source, destination string, mode os.FileMode) error {
+	in, err := openManagedRegular(source, maxArtifactSize)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = in.Close() }()
+	data, err := io.ReadAll(io.LimitReader(in, maxArtifactSize+1))
+	if err != nil || len(data) > maxArtifactSize {
+		return errors.New("managed backup exceeds size limit")
+	}
+	return atomicWriteFile(destination, data, mode)
+}
+
+func fileDigest(path string, limit int64) (string, error) {
+	file, err := openManagedRegular(path, limit)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = file.Close() }()
+	hash := sha256.New()
+	written, err := io.Copy(hash, io.LimitReader(file, limit+1))
+	if err != nil {
+		return "", err
+	}
+	if written > limit {
+		return "", errors.New("managed file exceeds size limit")
+	}
+	return hex.EncodeToString(hash.Sum(nil)), nil
+}
+
+func digestBytes(data []byte) string {
+	digest := sha256.Sum256(data)
+	return hex.EncodeToString(digest[:])
+}
+
+func safeStepName(value string) string {
+	return strings.NewReplacer("/", "_", "\\", "_", "..", "_").Replace(value)
+}
+
+func randomTemporaryPath(directory, prefix string) (string, error) {
+	random := make([]byte, 16)
+	if _, err := rand.Read(random); err != nil {
+		return "", err
+	}
+	return filepath.Join(directory, prefix+hex.EncodeToString(random)), nil
 }

--- a/backend/internal/haocli/setup_execute.go
+++ b/backend/internal/haocli/setup_execute.go
@@ -1,0 +1,23 @@
+package haocli
+
+import (
+	"context"
+	"errors"
+)
+
+// SetupExecutionOptions carries consent and interaction policy into execution.
+type SetupExecutionOptions struct {
+	NonInteractive bool `json:"nonInteractive"`
+}
+
+// SetupExecutionResult is the stable, non-secret execution summary.
+type SetupExecutionResult struct {
+	Status    string   `json:"status"`
+	Completed []string `json:"completed"`
+	Rollback  []string `json:"rollback"`
+	Retry     string   `json:"retry"`
+}
+
+func executeSetupPlan(context.Context, SetupPlan, string, SetupExecutionOptions) (SetupExecutionResult, error) {
+	return SetupExecutionResult{}, errors.New("setup executor is not implemented")
+}

--- a/backend/internal/haocli/setup_execute.go
+++ b/backend/internal/haocli/setup_execute.go
@@ -33,6 +33,7 @@ var (
 type SetupExecutionOptions struct {
 	NonInteractive bool      `json:"nonInteractive"`
 	Input          io.Reader `json:"-"`
+	DataDir        string    `json:"-"`
 }
 
 // SetupExecutionResult reports completed, rollback, recovery, and retry facts.
@@ -169,6 +170,7 @@ type journalRecord struct {
 type setupExecutor struct {
 	system         setupExecutionSystem
 	stateRoot      string
+	dataDir        string
 	journalPath    string
 	backupDir      string
 	options        SetupExecutionOptions
@@ -182,7 +184,11 @@ func executeSetupPlan(ctx context.Context, plan SetupPlan, stateRoot string, opt
 }
 
 func executeSetupPlanWithSystem(ctx context.Context, plan SetupPlan, stateRoot string, options SetupExecutionOptions, system setupExecutionSystem) (SetupExecutionResult, error) {
-	if err := validateExecutablePlan(plan, stateRoot); err != nil {
+	dataDir := options.DataDir
+	if dataDir == "" {
+		dataDir = filepath.Join(stateRoot, "data")
+	}
+	if err := validateExecutablePlan(plan, stateRoot, dataDir); err != nil {
 		return SetupExecutionResult{}, commandError{Code: "invalid_setup_plan", Message: "setup plan cannot be executed", Remediation: "rerun hao setup to produce a fresh trusted plan", Details: map[string]any{"diagnostic": safeDiagnostic(err)}, ExitStatus: 1, Cause: err}
 	}
 	lockName := fmt.Sprintf("hao-setup-%x.lock", sha256.Sum256([]byte(filepath.Clean(stateRoot))))
@@ -198,6 +204,7 @@ func executeSetupPlanWithSystem(ctx context.Context, plan SetupPlan, stateRoot s
 	e := &setupExecutor{
 		system:      system,
 		stateRoot:   filepath.Clean(stateRoot),
+		dataDir:     filepath.Clean(dataDir),
 		journalPath: filepath.Join(stateRoot, ".hao-setup-transaction.json"),
 		options:     options,
 		result: SetupExecutionResult{
@@ -262,7 +269,7 @@ func executeSetupPlanWithSystem(ctx context.Context, plan SetupPlan, stateRoot s
 	return e.result, nil
 }
 
-func validateExecutablePlan(plan SetupPlan, stateRoot string) error {
+func validateExecutablePlan(plan SetupPlan, stateRoot, dataDir string) error {
 	if plan.SchemaVersion != setupPlanSchemaVersion || plan.DryRun {
 		return errors.New("plan is not an executable schema v1 plan")
 	}
@@ -270,8 +277,9 @@ func validateExecutablePlan(plan SetupPlan, stateRoot string) error {
 		return err
 	}
 	root := filepath.Clean(stateRoot)
-	if !filepath.IsAbs(root) {
-		return errors.New("state root is not absolute")
+	dataRoot := filepath.Clean(dataDir)
+	if !filepath.IsAbs(root) || !filepath.IsAbs(dataRoot) {
+		return errors.New("state root and data directory must be absolute")
 	}
 	seen := make(map[string]struct{}, len(plan.Steps))
 	for _, step := range plan.Steps {
@@ -296,7 +304,7 @@ func validateExecutablePlan(plan SetupPlan, stateRoot string) error {
 		}
 		switch a.Kind {
 		case "directory", "file-mode":
-			expected := managedDirectoryPath(root, step.ID)
+			expected := managedDirectoryPath(root, dataRoot, step.ID)
 			if expected == "" || filepath.Clean(a.File.Path) != expected || (step.ID == "directory.parent" && a.Kind != "directory") {
 				return fmt.Errorf("step %s targets an unmanaged file", step.ID)
 			}
@@ -321,7 +329,7 @@ func validateExecutablePlan(plan SetupPlan, stateRoot string) error {
 			if step.ID != "transaction.recovery" {
 				return errors.New("recovery action has an invalid step")
 			}
-			expected, found, err := planSetupRecovery(root)
+			expected, found, err := planSetupRecovery(root, dataRoot)
 			if err != nil || !found || expected.Action.Recovery.JournalSHA256 != a.Recovery.JournalSHA256 || expected.Privilege.Required != step.Privilege.Required {
 				return errors.New("recovery action does not match the current interrupted transaction")
 			}
@@ -330,13 +338,13 @@ func validateExecutablePlan(plan SetupPlan, stateRoot string) error {
 	return nil
 }
 
-func managedDirectoryPath(root, stepID string) string {
+func managedDirectoryPath(root, dataDir, stepID string) string {
 	return map[string]string{
 		"directory.parent":  filepath.Dir(root),
 		"directory.state":   root,
 		"directory.hao":     filepath.Join(root, "hao"),
 		"directory.bin":     filepath.Join(root, "bin"),
-		"directory.data":    filepath.Join(root, "data"),
+		"directory.data":    dataDir,
 		"directory.gateway": filepath.Join(root, "vm-gateway"),
 	}[stepID]
 }
@@ -433,24 +441,26 @@ func (e *setupExecutor) installArtifact(ctx context.Context, stepID, disposition
 	}
 	currentDigest, digestErr := fileDigest(action.Path, maxArtifactSize)
 	binaryMatches := digestErr == nil && currentDigest == action.SHA256
-	if binaryMatches && artifactManifestMatches(action) {
-		return nil
-	}
-	_, targetErr := managedLstat(action.Path)
-	if disposition == "create" && targetErr == nil && !binaryMatches {
+	info, targetErr := managedLstat(action.Path)
+	if disposition == "create" && targetErr == nil {
+		if binaryMatches && info.Mode().Perm() == 0o700 && artifactManifestMatches(action) {
+			return nil
+		}
 		return errors.New("artifact target appeared after planning; rerun setup")
 	}
 	if disposition == "update" && errors.Is(targetErr, os.ErrNotExist) {
 		return errors.New("artifact target disappeared after planning; rerun setup")
 	}
-	if disposition == "update" && !binaryMatches {
+	if disposition == "update" {
 		if digestErr != nil || currentDigest != action.ExpectedSHA256 {
 			return errors.New("artifact changed after planning; rerun setup")
 		}
-		info, err := managedLstat(action.Path)
-		if err != nil || uint32(info.Mode().Perm()) != action.ExpectedMode {
+		if targetErr != nil || uint32(info.Mode().Perm()) != action.ExpectedMode {
 			return errors.New("artifact mode changed after planning; rerun setup")
 		}
+	}
+	if binaryMatches && artifactManifestMatches(action) {
+		return nil
 	}
 	if targetErr != nil && !errors.Is(targetErr, os.ErrNotExist) {
 		return targetErr
@@ -579,10 +589,10 @@ func artifactManifestMatches(action *SetupArtifactAction) bool {
 
 func (e *setupExecutor) installService(ctx context.Context, stepID, disposition string, action *SetupServiceAction) error {
 	digest, digestErr := fileDigest(action.Path, 1<<20)
-	if digestErr == nil && digest == action.SHA256 {
-		return nil
-	}
 	info, targetErr := managedLstat(action.Path)
+	if targetErr == nil && (!info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 || info.Mode().Perm()&0o022 != 0) {
+		return errors.New("service target is not a safe regular unlinked file")
+	}
 	if disposition == "create" && targetErr == nil {
 		return errors.New("service target appeared after planning; rerun setup")
 	}
@@ -592,11 +602,14 @@ func (e *setupExecutor) installService(ctx context.Context, stepID, disposition 
 	if disposition == "update" && !fileDigestEquals(digest, digestErr, action.ExpectedSHA256) {
 		return errors.New("service definition changed after planning; rerun setup")
 	}
-	if targetErr == nil && (!info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0) {
-		return errors.New("service target is not a regular unlinked file")
+	if disposition == "update" && targetErr == nil && uint32(info.Mode().Perm()) != action.ExpectedMode {
+		return errors.New("service definition mode changed after planning; rerun setup")
 	}
 	if targetErr != nil && !errors.Is(targetErr, os.ErrNotExist) {
 		return targetErr
+	}
+	if digestErr == nil && digest == action.SHA256 {
+		return nil
 	}
 	targetTemp, err := randomTemporaryPath(filepath.Dir(action.Path), ".hao-service-")
 	if err != nil {
@@ -805,8 +818,12 @@ func (e *setupExecutor) cleanupServiceBackups(ctx context.Context) error {
 	return nil
 }
 
-func planSetupRecovery(stateRoot string) (SetupStep, bool, error) {
-	e := setupExecutor{stateRoot: filepath.Clean(stateRoot), journalPath: filepath.Join(stateRoot, ".hao-setup-transaction.json")}
+func planSetupRecovery(stateRoot string, dataDirs ...string) (SetupStep, bool, error) {
+	dataDir := filepath.Join(stateRoot, "data")
+	if len(dataDirs) > 0 && dataDirs[0] != "" {
+		dataDir = dataDirs[0]
+	}
+	e := setupExecutor{stateRoot: filepath.Clean(stateRoot), dataDir: filepath.Clean(dataDir), journalPath: filepath.Join(stateRoot, ".hao-setup-transaction.json")}
 	journal, digest, found, err := e.readJournal()
 	if err != nil || !found {
 		return SetupStep{}, found, err
@@ -904,11 +921,11 @@ func (e *setupExecutor) validateJournal() error {
 	for _, record := range e.journal.Records {
 		switch record.Kind {
 		case "directory":
-			if record.Target != managedDirectoryPath(e.stateRoot, record.StepID) || record.Reversible || !record.Created {
+			if record.Target != managedDirectoryPath(e.stateRoot, e.dataDir, record.StepID) || record.Reversible || !record.Created {
 				return fmt.Errorf("step %s has an invalid directory record", record.StepID)
 			}
 		case "file-mode":
-			if record.Target != managedDirectoryPath(e.stateRoot, record.StepID) || !record.Reversible || record.Created {
+			if record.Target != managedDirectoryPath(e.stateRoot, e.dataDir, record.StepID) || !record.Reversible || record.Created {
 				return fmt.Errorf("step %s has an invalid mode record", record.StepID)
 			}
 		case "verified-release-artifact":

--- a/backend/internal/haocli/setup_execute.go
+++ b/backend/internal/haocli/setup_execute.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"os/exec"
 	"os/user"
@@ -52,10 +53,11 @@ type setupExecutionSystem interface {
 type systemSetupExecution struct{}
 
 func (systemSetupExecution) Download(ctx context.Context, source string) (io.ReadCloser, error) {
-	if !strings.HasPrefix(source, "https://") {
-		return nil, errors.New("artifact source is not HTTPS")
+	parsed, err := url.Parse(source)
+	if err != nil || parsed.Scheme != "https" || parsed.Hostname() == "" || parsed.User != nil {
+		return nil, errors.New("download source is not a valid HTTPS URL")
 	}
-	client := &http.Client{Timeout: 10 * time.Minute, CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }}
+	client := &http.Client{Timeout: 10 * time.Minute, CheckRedirect: allowArtifactRedirect}
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, source, http.NoBody)
 	if err != nil {
 		return nil, err
@@ -73,6 +75,16 @@ func (systemSetupExecution) Download(ctx context.Context, source string) (io.Rea
 		return nil, errors.New("artifact download exceeds size limit")
 	}
 	return resp.Body, nil
+}
+
+func allowArtifactRedirect(req *http.Request, via []*http.Request) error {
+	if len(via) > 3 {
+		return errors.New("artifact download exceeded redirect limit")
+	}
+	if len(via) == 0 || via[0].URL.Scheme != "https" || via[0].URL.Hostname() != "github.com" || !strings.HasPrefix(via[0].URL.EscapedPath(), "/agentlab-in/hosted-ao/releases/download/v") || req.URL.Scheme != "https" || req.URL.Hostname() != "release-assets.githubusercontent.com" {
+		return errors.New("artifact download redirected to an untrusted host")
+	}
+	return nil
 }
 
 func (systemSetupExecution) CheckPrivilege(ctx context.Context, nonInteractive bool, in io.Reader) error {
@@ -149,6 +161,7 @@ type journalRecord struct {
 	Temporary      string `json:"temporary,omitempty"`
 	PreviousMode   uint32 `json:"previousMode,omitempty"`
 	Created        bool   `json:"created,omitempty"`
+	BackupReady    bool   `json:"backupReady,omitempty"`
 	Completed      bool   `json:"completed"`
 	Reversible     bool   `json:"reversible"`
 }
@@ -193,15 +206,22 @@ func executeSetupPlanWithSystem(ctx context.Context, plan SetupPlan, stateRoot s
 			Recovery:  []string{},
 		},
 	}
-	if recovered, recoverErr := e.recover(ctx); recoverErr != nil {
-		return e.result, e.failure("recover interrupted setup", recoverErr)
-	} else if recovered != "" {
-		e.result.Recovery = append(e.result.Recovery, recovered)
-	}
 	if planNeedsPrivilege(plan) {
 		if err := system.CheckPrivilege(ctx, options.NonInteractive, options.Input); err != nil {
 			return e.result, commandError{Code: "privilege_required", Message: "setup requires narrowly scoped administrator privileges", Remediation: "approve the displayed privileged operations, or arrange them manually", Details: map[string]any{"completed": []string{}, "rollback": []string{}, "retry": "hao setup --dry-run"}, ExitStatus: 3, Cause: errPrivilegeRefused}
 		}
+	}
+	expectedRecovery := ""
+	for _, step := range plan.Steps {
+		if step.Action != nil && step.Action.Kind == "transaction-recovery-v1" {
+			expectedRecovery = step.Action.Recovery.JournalSHA256
+		}
+	}
+	if recovered, recoverErr := e.recover(ctx, expectedRecovery); recoverErr != nil {
+		return e.result, e.failure("recover interrupted setup", recoverErr)
+	} else if recovered != "" {
+		e.result.Recovery = append(e.result.Recovery, recovered)
+		e.result.Completed = append(e.result.Completed, "transaction.recovery")
 	}
 	planBytes, err := json.Marshal(plan)
 	if err != nil {
@@ -211,6 +231,9 @@ func executeSetupPlanWithSystem(ctx context.Context, plan SetupPlan, stateRoot s
 	e.backupDir = filepath.Join(stateRoot, "hao", "backups", e.journal.PlanSHA256[:16]+"-"+strconv.FormatInt(time.Now().UnixNano(), 10))
 	for _, step := range plan.Steps {
 		if step.Action == nil {
+			continue
+		}
+		if step.Action.Kind == "transaction-recovery-v1" {
 			continue
 		}
 		if err := ctx.Err(); err != nil {
@@ -229,7 +252,7 @@ func executeSetupPlanWithSystem(ctx context.Context, plan SetupPlan, stateRoot s
 		if err := e.cleanupServiceBackups(ctx); err != nil {
 			return e.result, e.failure("clean committed service backups", err)
 		}
-		if err := os.Remove(e.journalPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+		if err := managedRemove(e.journalPath); err != nil && !errors.Is(err, os.ErrNotExist) {
 			return e.result, e.failure("remove completed setup journal", err)
 		}
 		_ = syncDirectory(filepath.Dir(e.journalPath))
@@ -268,6 +291,9 @@ func validateExecutablePlan(plan SetupPlan, stateRoot string) error {
 			continue
 		}
 		a := step.Action
+		if (a.Kind == "service-definition-v1" || a.Kind == "package-manager") != step.Privilege.Required && a.Kind != "transaction-recovery-v1" {
+			return fmt.Errorf("step %s has incorrect privilege metadata", step.ID)
+		}
 		switch a.Kind {
 		case "directory", "file-mode":
 			expected := managedDirectoryPath(root, step.ID)
@@ -291,6 +317,14 @@ func validateExecutablePlan(plan SetupPlan, stateRoot string) error {
 			if step.ID != "prerequisite.harness" || a.Vendor.Executable != "/usr/bin/npm" || !allowedVendorArgv(a.Vendor.Argv, a.Vendor.Version) {
 				return fmt.Errorf("step %s has a non-allowlisted vendor command", step.ID)
 			}
+		case "transaction-recovery-v1":
+			if step.ID != "transaction.recovery" {
+				return errors.New("recovery action has an invalid step")
+			}
+			expected, found, err := planSetupRecovery(root)
+			if err != nil || !found || expected.Action.Recovery.JournalSHA256 != a.Recovery.JournalSHA256 || expected.Privilege.Required != step.Privilege.Required {
+				return errors.New("recovery action does not match the current interrupted transaction")
+			}
 		}
 	}
 	return nil
@@ -308,16 +342,15 @@ func managedDirectoryPath(root, stepID string) string {
 }
 
 func allowedPackageArgv(stepID string, argv []string, version string) bool {
-	if len(argv) != 3 || argv[0] != "install" || argv[1] != "--yes" {
+	if len(argv) != 3 || argv[0] != "install" || argv[1] != "--yes" || argv[2] != "{verified-file}" {
 		return false
 	}
-	name, pinned, ok := strings.Cut(argv[2], "=")
 	expectedName := map[string]string{"prerequisite.git": "git", "prerequisite.gh": "gh"}[stepID]
-	return ok && expectedName != "" && name == expectedName && pinned == version
+	return expectedName != "" && version != ""
 }
 
 func allowedVendorArgv(argv []string, version string) bool {
-	return len(argv) == 3 && argv[0] == "install" && argv[1] == "--global" && argv[2] == "@anthropic-ai/claude-code@"+version
+	return version != "" && len(argv) == 3 && argv[0] == "install" && argv[1] == "--global" && argv[2] == "{verified-file}"
 }
 
 func planNeedsPrivilege(plan SetupPlan) bool {
@@ -341,9 +374,9 @@ func (e *setupExecutor) apply(ctx context.Context, step SetupStep) error {
 	case "service-definition-v1":
 		return e.installService(ctx, step.ID, step.Disposition, a.Service)
 	case "package-manager":
-		return e.runIrreversible(ctx, step.ID, a.Kind, true, a.Package.Executable, a.Package.Argv)
+		return e.runVerifiedPackage(ctx, step.ID, a.Kind, true, a.Package.Executable, a.Package.Argv, a.Package.Source, a.Package.SHA256)
 	case "vendor-package":
-		return e.runIrreversible(ctx, step.ID, a.Kind, false, a.Vendor.Executable, a.Vendor.Argv)
+		return e.runVerifiedPackage(ctx, step.ID, a.Kind, false, a.Vendor.Executable, a.Vendor.Argv, a.Vendor.Source, a.Vendor.SHA256)
 	default:
 		return fmt.Errorf("unsupported action kind %q", a.Kind)
 	}
@@ -353,7 +386,7 @@ func (e *setupExecutor) createDirectory(stepID string, action *SetupFileAction) 
 	if err := ensureNoSymlinkAncestors(filepath.Dir(action.Path)); err != nil {
 		return err
 	}
-	info, err := os.Lstat(action.Path)
+	info, err := managedLstat(action.Path)
 	if err == nil {
 		if !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
 			return errors.New("directory target is occupied or linked")
@@ -361,12 +394,12 @@ func (e *setupExecutor) createDirectory(stepID string, action *SetupFileAction) 
 		if stepID == "directory.parent" {
 			return nil
 		}
-		return os.Chmod(action.Path, 0o700) //nolint:gosec // owner-only directories require traversal.
+		return managedChmod(action.Path, 0o700)
 	}
 	if !errors.Is(err, os.ErrNotExist) {
 		return err
 	}
-	if err := os.Mkdir(action.Path, 0o700); err != nil {
+	if err := managedMkdir(action.Path, 0o700); err != nil {
 		return err
 	}
 	if err := syncDirectory(filepath.Dir(action.Path)); err != nil {
@@ -380,7 +413,7 @@ func (e *setupExecutor) changeMode(stepID string, action *SetupFileAction) error
 	if err := ensureNoSymlinkAncestors(action.Path); err != nil {
 		return err
 	}
-	info, err := os.Lstat(action.Path)
+	info, err := managedLstat(action.Path)
 	if err != nil || info.Mode()&os.ModeSymlink != 0 {
 		return errors.New("file mode target is unavailable or linked")
 	}
@@ -388,7 +421,7 @@ func (e *setupExecutor) changeMode(stepID string, action *SetupFileAction) error
 	if err := e.record(record); err != nil {
 		return err
 	}
-	if err := os.Chmod(action.Path, 0o700); err != nil { //nolint:gosec // owner-only directories require traversal.
+	if err := managedChmod(action.Path, 0o700); err != nil {
 		return err
 	}
 	return e.completeLastRecord()
@@ -398,20 +431,31 @@ func (e *setupExecutor) installArtifact(ctx context.Context, stepID, disposition
 	if err := ensureNoSymlinkAncestors(action.Path); err != nil {
 		return err
 	}
-	if digest, err := fileDigest(action.Path, maxArtifactSize); err == nil && digest == action.SHA256 {
-		return writeArtifactManifest(action)
+	currentDigest, digestErr := fileDigest(action.Path, maxArtifactSize)
+	binaryMatches := digestErr == nil && currentDigest == action.SHA256
+	if binaryMatches && artifactManifestMatches(action) {
+		return nil
 	}
-	_, targetErr := os.Lstat(action.Path)
-	if disposition == "create" && targetErr == nil {
+	_, targetErr := managedLstat(action.Path)
+	if disposition == "create" && targetErr == nil && !binaryMatches {
 		return errors.New("artifact target appeared after planning; rerun setup")
 	}
 	if disposition == "update" && errors.Is(targetErr, os.ErrNotExist) {
 		return errors.New("artifact target disappeared after planning; rerun setup")
 	}
+	if disposition == "update" && !binaryMatches {
+		if digestErr != nil || currentDigest != action.ExpectedSHA256 {
+			return errors.New("artifact changed after planning; rerun setup")
+		}
+		info, err := managedLstat(action.Path)
+		if err != nil || uint32(info.Mode().Perm()) != action.ExpectedMode {
+			return errors.New("artifact mode changed after planning; rerun setup")
+		}
+	}
 	if targetErr != nil && !errors.Is(targetErr, os.ErrNotExist) {
 		return targetErr
 	}
-	if err := os.MkdirAll(e.backupDir, 0o700); err != nil {
+	if err := managedMkdirAll(e.backupDir, 0o700); err != nil {
 		return err
 	}
 	temporary, err := randomTemporaryPath(filepath.Dir(action.Path), ".hao-artifact-")
@@ -420,14 +464,19 @@ func (e *setupExecutor) installArtifact(ctx context.Context, stepID, disposition
 	}
 	record := journalRecord{StepID: stepID, Kind: "verified-release-artifact", Target: action.Path, ManifestTarget: action.Path + ".hao-manifest.json", Temporary: temporary, Reversible: true}
 	if targetErr == nil {
+		info, err := managedLstat(action.Path)
+		if err != nil {
+			return err
+		}
+		record.PreviousMode = uint32(info.Mode().Perm())
 		record.Backup = filepath.Join(e.backupDir, safeStepName(stepID)+".binary")
-		if err := copyRegularFile(action.Path, record.Backup, 0o700); err != nil {
+		if err := copyRegularFile(action.Path, record.Backup, os.FileMode(record.PreviousMode)); err != nil {
 			return err
 		}
 	} else {
 		record.Created = true
 	}
-	if _, err := os.Lstat(record.ManifestTarget); err == nil {
+	if _, err := managedLstat(record.ManifestTarget); err == nil {
 		record.ManifestBackup = filepath.Join(e.backupDir, safeStepName(stepID)+".manifest")
 		if err := copyRegularFile(record.ManifestTarget, record.ManifestBackup, 0o600); err != nil {
 			return err
@@ -438,8 +487,10 @@ func (e *setupExecutor) installArtifact(ctx context.Context, stepID, disposition
 	if err := e.record(record); err != nil {
 		return err
 	}
-	if err := downloadVerifiedArtifact(ctx, e.system, action, temporary); err != nil {
-		return err
+	if !binaryMatches {
+		if err := downloadVerifiedArtifact(ctx, e.system, action, temporary); err != nil {
+			return err
+		}
 	}
 	if err := writeArtifactManifest(action); err != nil {
 		return err
@@ -448,17 +499,25 @@ func (e *setupExecutor) installArtifact(ctx context.Context, stepID, disposition
 }
 
 func downloadVerifiedArtifact(ctx context.Context, system setupExecutionSystem, action *SetupArtifactAction, tempName string) error {
-	body, err := system.Download(ctx, action.Source)
+	if err := downloadVerifiedFile(ctx, system, action.Source, action.SHA256, tempName, 0o700); err != nil {
+		return err
+	}
+	if err := managedRename(tempName, action.Path); err != nil {
+		return err
+	}
+	return syncDirectory(filepath.Dir(action.Path))
+}
+
+func downloadVerifiedFile(ctx context.Context, system setupExecutionSystem, source, expectedSHA256, tempName string, mode os.FileMode) error {
+	body, err := system.Download(ctx, source)
 	if err != nil {
 		return err
 	}
 	defer func() { _ = body.Close() }()
-	dir := filepath.Dir(action.Path)
-	temp, err := os.OpenFile(tempName, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+	temp, err := managedCreateExclusive(tempName, 0o600)
 	if err != nil {
 		return err
 	}
-	defer func() { _ = os.Remove(tempName) }()
 	hash := sha256.New()
 	written, copyErr := io.Copy(io.MultiWriter(temp, hash), io.LimitReader(body, maxArtifactSize+1))
 	if copyErr != nil {
@@ -470,11 +529,11 @@ func downloadVerifiedArtifact(ctx context.Context, system setupExecutionSystem, 
 		return errors.New("artifact download exceeds size limit")
 	}
 	actual := hex.EncodeToString(hash.Sum(nil))
-	if actual != action.SHA256 {
+	if actual != expectedSHA256 {
 		_ = temp.Close()
-		return fmt.Errorf("artifact digest mismatch: expected %s, received %s", action.SHA256, actual)
+		return fmt.Errorf("artifact digest mismatch: expected %s, received %s", expectedSHA256, actual)
 	}
-	if err := temp.Chmod(0o700); err != nil {
+	if err := temp.Chmod(mode); err != nil {
 		_ = temp.Close()
 		return err
 	}
@@ -485,18 +544,37 @@ func downloadVerifiedArtifact(ctx context.Context, system setupExecutionSystem, 
 	if err := temp.Close(); err != nil {
 		return err
 	}
-	if err := os.Rename(tempName, action.Path); err != nil {
-		return err
-	}
-	return syncDirectory(dir)
+	return nil
 }
 
 func writeArtifactManifest(action *SetupArtifactAction) error {
-	data, err := json.Marshal(ArtifactMetadata{Version: action.Version, Source: action.Source, SHA256: action.SHA256})
+	data, err := artifactManifestBytes(action)
 	if err != nil {
 		return err
 	}
-	return atomicWriteFile(action.Path+".hao-manifest.json", append(data, '\n'), 0o600)
+	return atomicWriteFile(action.Path+".hao-manifest.json", data, 0o600)
+}
+
+func artifactManifestBytes(action *SetupArtifactAction) ([]byte, error) {
+	data, err := json.Marshal(ArtifactMetadata{Version: action.Version, Source: action.Source, SHA256: action.SHA256})
+	if err != nil {
+		return nil, err
+	}
+	return append(data, '\n'), nil
+}
+
+func artifactManifestMatches(action *SetupArtifactAction) bool {
+	want, err := artifactManifestBytes(action)
+	if err != nil {
+		return false
+	}
+	file, err := openManagedRegular(action.Path+".hao-manifest.json", 1<<20)
+	if err != nil {
+		return false
+	}
+	defer func() { _ = file.Close() }()
+	got, err := io.ReadAll(io.LimitReader(file, int64(len(want)+1)))
+	return err == nil && bytes.Equal(got, want)
 }
 
 func (e *setupExecutor) installService(ctx context.Context, stepID, disposition string, action *SetupServiceAction) error {
@@ -504,12 +582,15 @@ func (e *setupExecutor) installService(ctx context.Context, stepID, disposition 
 	if digestErr == nil && digest == action.SHA256 {
 		return nil
 	}
-	info, targetErr := os.Lstat(action.Path)
+	info, targetErr := managedLstat(action.Path)
 	if disposition == "create" && targetErr == nil {
 		return errors.New("service target appeared after planning; rerun setup")
 	}
 	if disposition == "update" && errors.Is(targetErr, os.ErrNotExist) {
 		return errors.New("service target disappeared after planning; rerun setup")
+	}
+	if disposition == "update" && !fileDigestEquals(digest, digestErr, action.ExpectedSHA256) {
+		return errors.New("service definition changed after planning; rerun setup")
 	}
 	if targetErr == nil && (!info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0) {
 		return errors.New("service target is not a regular unlinked file")
@@ -537,6 +618,10 @@ func (e *setupExecutor) installService(ctx context.Context, stepID, disposition 
 		if err := e.system.Run(ctx, true, e.options.NonInteractive, e.options.Input, "/usr/bin/cp", "--no-dereference", "--preserve=mode,ownership,timestamps", "--", action.Path, record.Backup); err != nil {
 			return err
 		}
+		e.journal.Records[len(e.journal.Records)-1].BackupReady = true
+		if err := e.writeJournal(); err != nil {
+			return err
+		}
 	}
 	if err := e.system.Run(ctx, true, e.options.NonInteractive, bytes.NewReader([]byte(action.Content)), "/usr/bin/tee", "--", targetTemp); err != nil {
 		return err
@@ -553,12 +638,26 @@ func (e *setupExecutor) installService(ctx context.Context, stepID, disposition 
 	return e.completeLastRecord()
 }
 
-func (e *setupExecutor) runIrreversible(ctx context.Context, stepID, kind string, privileged bool, executable string, argv []string) error {
-	record := journalRecord{StepID: stepID, Kind: kind, Reversible: false}
+func fileDigestEquals(actual string, err error, expected string) bool {
+	return err == nil && actual == expected
+}
+
+func (e *setupExecutor) runVerifiedPackage(ctx context.Context, stepID, kind string, privileged bool, executable string, argv []string, source, sha256Digest string) error {
+	temporary, err := randomTemporaryPath(filepath.Join(e.stateRoot, "hao"), ".hao-package-")
+	if err != nil {
+		return err
+	}
+	record := journalRecord{StepID: stepID, Kind: kind, Temporary: temporary, Reversible: false}
 	if err := e.record(record); err != nil {
 		return err
 	}
-	if err := e.system.Run(ctx, privileged, e.options.NonInteractive, e.options.Input, executable, argv...); err != nil {
+	defer func() { _ = removeManagedIfExists(temporary) }()
+	if err := downloadVerifiedFile(ctx, e.system, source, sha256Digest, temporary, 0o600); err != nil {
+		return err
+	}
+	localArgv := append([]string(nil), argv...)
+	localArgv[len(localArgv)-1] = temporary
+	if err := e.system.Run(ctx, privileged, e.options.NonInteractive, e.options.Input, executable, localArgv...); err != nil {
 		return err
 	}
 	return e.completeLastRecord()
@@ -618,6 +717,9 @@ func (e *setupExecutor) rollback(ctx context.Context) ([]string, bool) {
 	complete := true
 	for i := len(e.journal.Records) - 1; i >= 0; i-- {
 		record := e.journal.Records[i]
+		if (record.Kind == "package-manager" || record.Kind == "vendor-package") && record.Temporary != "" {
+			_ = removeManagedIfExists(record.Temporary)
+		}
 		if !record.Reversible {
 			continue
 		}
@@ -625,13 +727,17 @@ func (e *setupExecutor) rollback(ctx context.Context) ([]string, bool) {
 		switch record.Kind {
 		case "file-mode":
 			if err = ensureNoSymlinkAncestors(record.Target); err == nil {
-				err = os.Chmod(record.Target, os.FileMode(record.PreviousMode))
+				err = managedChmod(record.Target, os.FileMode(record.PreviousMode))
 			}
 		case "verified-release-artifact":
 			if record.Temporary != "" {
-				_ = os.Remove(record.Temporary)
+				_ = removeManagedIfExists(record.Temporary)
 			}
-			err = rollbackManagedFile(record.Target, record.Backup, record.Created, 0o700)
+			mode := os.FileMode(record.PreviousMode)
+			if record.Created {
+				mode = 0o700
+			}
+			err = rollbackManagedFile(record.Target, record.Backup, record.Created, mode)
 			if manifestErr := rollbackManagedFile(record.ManifestTarget, record.ManifestBackup, record.ManifestBackup == "", 0o600); err == nil {
 				err = manifestErr
 			}
@@ -639,8 +745,10 @@ func (e *setupExecutor) rollback(ctx context.Context) ([]string, bool) {
 			if record.Temporary != "" {
 				_ = e.system.Run(ctx, true, e.options.NonInteractive, e.options.Input, "/usr/bin/rm", "--force", "--", record.Temporary)
 			}
-			if record.Backup != "" {
+			if record.Backup != "" && record.BackupReady {
 				err = e.restoreServiceBackup(ctx, record)
+			} else if record.Backup != "" {
+				err = e.system.Run(ctx, true, e.options.NonInteractive, e.options.Input, "/usr/bin/rm", "--force", "--", record.Backup)
 			} else if record.Created {
 				err = e.system.Run(ctx, true, e.options.NonInteractive, e.options.Input, "/usr/bin/rm", "--force", "--", record.Target)
 			}
@@ -666,7 +774,7 @@ func rollbackManagedFile(target, backup string, created bool, mode os.FileMode) 
 		return copyRegularFile(backup, target, mode)
 	}
 	if created {
-		if err := os.Remove(target); err != nil && !errors.Is(err, os.ErrNotExist) {
+		if err := managedRemove(target); err != nil && !errors.Is(err, os.ErrNotExist) {
 			return err
 		}
 		return syncDirectory(filepath.Dir(target))
@@ -675,7 +783,7 @@ func rollbackManagedFile(target, backup string, created bool, mode os.FileMode) 
 }
 
 func (e *setupExecutor) restoreServiceBackup(ctx context.Context, record journalRecord) error {
-	if _, err := os.Lstat(record.Backup); errors.Is(err, os.ErrNotExist) {
+	if _, err := managedLstat(record.Backup); errors.Is(err, os.ErrNotExist) {
 		return errors.New("service backup is unavailable")
 	} else if err != nil {
 		return err
@@ -697,29 +805,70 @@ func (e *setupExecutor) cleanupServiceBackups(ctx context.Context) error {
 	return nil
 }
 
-func (e *setupExecutor) recover(ctx context.Context) (string, error) {
-	info, err := os.Lstat(e.journalPath)
+func planSetupRecovery(stateRoot string) (SetupStep, bool, error) {
+	e := setupExecutor{stateRoot: filepath.Clean(stateRoot), journalPath: filepath.Join(stateRoot, ".hao-setup-transaction.json")}
+	journal, digest, found, err := e.readJournal()
+	if err != nil || !found {
+		return SetupStep{}, found, err
+	}
+	e.journal = journal
+	if err := e.validateJournal(); err != nil {
+		return SetupStep{}, true, err
+	}
+	privileged := false
+	for _, record := range journal.Records {
+		privileged = privileged || record.Kind == "service-definition-v1"
+	}
+	return SetupStep{
+		ID: "transaction.recovery", Component: "setup-transaction", Operation: "recover-interrupted-setup", Disposition: "update",
+		Privilege: SetupPrivilege{Required: privileged, Scope: "system-service-definition-recovery"},
+		Reason:    "an interrupted setup transaction must be rolled back before retry", Evidence: "journal sha256 " + digest,
+		Action: &SetupAction{SchemaVersion: 1, Kind: "transaction-recovery-v1", Recovery: &SetupRecoveryAction{JournalSHA256: digest}},
+	}, true, nil
+}
+
+func (e *setupExecutor) readJournal() (setupJournal, string, bool, error) {
+	info, err := managedLstat(e.journalPath)
 	if errors.Is(err, os.ErrNotExist) {
-		return "", nil
+		return setupJournal{}, "", false, nil
 	}
 	if err != nil {
-		return "", err
+		return setupJournal{}, "", true, err
 	}
 	if !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 {
-		return "", errors.New("setup transaction journal is not a regular file")
+		return setupJournal{}, "", true, errors.New("setup transaction journal is not a regular file")
 	}
 	journalFile, err := openManagedRegular(e.journalPath, 1<<20)
 	if err != nil {
-		return "", err
+		return setupJournal{}, "", true, err
 	}
 	defer func() { _ = journalFile.Close() }()
 	data, err := io.ReadAll(io.LimitReader(journalFile, 1<<20+1))
 	if err != nil || len(data) > 1<<20 {
-		return "", errors.New("setup transaction journal exceeds size limit")
+		return setupJournal{}, "", true, errors.New("setup transaction journal exceeds size limit")
 	}
-	if err := json.Unmarshal(data, &e.journal); err != nil || e.journal.SchemaVersion != setupJournalSchemaVersion {
-		return "", errors.New("setup transaction journal is invalid; inspect it manually before retrying")
+	var journal setupJournal
+	if err := json.Unmarshal(data, &journal); err != nil || journal.SchemaVersion != setupJournalSchemaVersion {
+		return setupJournal{}, "", true, errors.New("setup transaction journal is invalid; inspect it manually before retrying")
 	}
+	return journal, digestBytes(data), true, nil
+}
+
+func (e *setupExecutor) recover(ctx context.Context, expectedDigest string) (string, error) {
+	journal, digest, found, err := e.readJournal()
+	if err != nil {
+		return "", err
+	}
+	if !found {
+		if expectedDigest != "" {
+			return "", errors.New("approved recovery journal disappeared; rerun setup")
+		}
+		return "", nil
+	}
+	if expectedDigest == "" || digest != expectedDigest {
+		return "", errors.New("setup recovery journal changed after planning; rerun setup")
+	}
+	e.journal = journal
 	if err := e.validateJournal(); err != nil {
 		return "", fmt.Errorf("setup transaction journal is unsafe: %w", err)
 	}
@@ -741,7 +890,7 @@ func (e *setupExecutor) recover(ctx context.Context) (string, error) {
 	if err := e.cleanupServiceBackups(ctx); err != nil {
 		return "", err
 	}
-	if err := os.Remove(e.journalPath); err != nil {
+	if err := managedRemove(e.journalPath); err != nil {
 		return "", err
 	}
 	e.journalStarted = false
@@ -764,22 +913,23 @@ func (e *setupExecutor) validateJournal() error {
 			}
 		case "verified-release-artifact":
 			target := filepath.Join(e.stateRoot, "bin", "ao")
-			backupCoherent := (record.Created && record.Backup == "") || (!record.Created && record.Backup != "")
-			if record.StepID != "artifact.ao" || record.Target != target || record.ManifestTarget != target+".hao-manifest.json" || !record.Reversible || !backupCoherent || !temporaryPathMatches(record.Temporary, filepath.Dir(target), ".hao-artifact-") || !optionalPathBelow(record.Backup, filepath.Join(e.stateRoot, "hao", "backups")) || !optionalPathBelow(record.ManifestBackup, filepath.Join(e.stateRoot, "hao", "backups")) {
+			backupCoherent := !record.BackupReady && ((record.Created && record.Backup == "") || (!record.Created && record.Backup != ""))
+			modeCoherent := (record.Created && record.PreviousMode == 0) || (!record.Created && record.PreviousMode&0o111 != 0 && record.PreviousMode&0o022 == 0)
+			if record.StepID != "artifact.ao" || record.Target != target || record.ManifestTarget != target+".hao-manifest.json" || !record.Reversible || !backupCoherent || !modeCoherent || !temporaryPathMatches(record.Temporary, filepath.Dir(target), ".hao-artifact-") || !optionalPathBelow(record.Backup, filepath.Join(e.stateRoot, "hao", "backups")) || !optionalPathBelow(record.ManifestBackup, filepath.Join(e.stateRoot, "hao", "backups")) {
 				return errors.New("artifact record contains an unmanaged path")
 			}
 		case "service-definition-v1":
 			expected := map[string]string{"service.daemon": "/etc/systemd/system/ao-daemon.service", "service.gateway": "/etc/systemd/system/ao-gateway.service"}[record.StepID]
-			backupCoherent := (record.Created && record.Backup == "") || (!record.Created && record.Backup != "")
+			backupCoherent := (record.Created && record.Backup == "" && !record.BackupReady) || (!record.Created && record.Backup != "")
 			if expected == "" || record.Target != expected || !record.Reversible || !backupCoherent || !temporaryPathMatches(record.Temporary, filepath.Dir(expected), ".hao-service-") || (record.Backup != "" && !temporaryPathMatches(record.Backup, filepath.Dir(expected), ".hao-backup-")) {
 				return errors.New("service record contains an unmanaged path")
 			}
 		case "package-manager":
-			if record.Reversible || (record.StepID != "prerequisite.git" && record.StepID != "prerequisite.gh") {
+			if record.Reversible || !temporaryPathMatches(record.Temporary, filepath.Join(e.stateRoot, "hao"), ".hao-package-") || (record.StepID != "prerequisite.git" && record.StepID != "prerequisite.gh") {
 				return errors.New("package record has an invalid step")
 			}
 		case "vendor-package":
-			if record.Reversible || record.StepID != "prerequisite.harness" {
+			if record.Reversible || !temporaryPathMatches(record.Temporary, filepath.Join(e.stateRoot, "hao"), ".hao-package-") || record.StepID != "prerequisite.harness" {
 				return errors.New("vendor record has an invalid step")
 			}
 		default:
@@ -839,12 +989,22 @@ func atomicWriteFile(path string, data []byte, mode os.FileMode) error {
 	if err := ensureNoSymlinkAncestors(filepath.Dir(path)); err != nil {
 		return err
 	}
-	temp, err := os.CreateTemp(filepath.Dir(path), ".hao-write-*")
+	if info, err := managedLstat(path); err == nil {
+		if !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 {
+			return errors.New("managed write target is not a regular unlinked file")
+		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	tempName, err := randomTemporaryPath(filepath.Dir(path), ".hao-write-")
 	if err != nil {
 		return err
 	}
-	tempName := temp.Name()
-	defer func() { _ = os.Remove(tempName) }()
+	temp, err := managedCreateExclusive(tempName, mode)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = removeManagedIfExists(tempName) }()
 	if err := temp.Chmod(mode); err != nil {
 		_ = temp.Close()
 		return err
@@ -860,10 +1020,43 @@ func atomicWriteFile(path string, data []byte, mode os.FileMode) error {
 	if err := temp.Close(); err != nil {
 		return err
 	}
-	if err := os.Rename(tempName, path); err != nil {
+	if err := managedRename(tempName, path); err != nil {
 		return err
 	}
 	return syncDirectory(filepath.Dir(path))
+}
+
+func managedMkdirAll(path string, mode os.FileMode) error {
+	clean := filepath.Clean(path)
+	if !filepath.IsAbs(clean) {
+		return errors.New("managed directory path is not absolute")
+	}
+	current := string(os.PathSeparator)
+	for _, part := range strings.FieldsFunc(strings.TrimPrefix(clean, string(os.PathSeparator)), func(r rune) bool { return r == filepath.Separator }) {
+		current = filepath.Join(current, part)
+		info, err := managedLstat(current)
+		if err == nil {
+			if !info.IsDir() {
+				return errors.New("managed directory path is occupied")
+			}
+			continue
+		}
+		if !errors.Is(err, os.ErrNotExist) {
+			return err
+		}
+		if err := managedMkdir(current, mode); err != nil && !errors.Is(err, os.ErrExist) {
+			return err
+		}
+	}
+	return nil
+}
+
+func removeManagedIfExists(path string) error {
+	err := managedRemove(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	return err
 }
 
 func copyRegularFile(source, destination string, mode os.FileMode) error {

--- a/backend/internal/haocli/setup_execute_test.go
+++ b/backend/internal/haocli/setup_execute_test.go
@@ -8,9 +8,11 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -85,6 +87,20 @@ func artifactStep(root string, payload []byte, disposition string) SetupStep {
 	}}}
 }
 
+func setArtifactPrecondition(t *testing.T, step *SetupStep) {
+	t.Helper()
+	digest, err := fileDigest(step.Action.Artifact.Path, maxArtifactSize)
+	if err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(step.Action.Artifact.Path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	step.Action.Artifact.ExpectedSHA256 = digest
+	step.Action.Artifact.ExpectedMode = uint32(info.Mode().Perm())
+}
+
 func preparedExecutorRoot(t *testing.T) string {
 	t.Helper()
 	root, err := filepath.EvalSymlinks(t.TempDir())
@@ -133,6 +149,28 @@ func TestSetupExecutorVerifiesArtifactAndReplayIsNoOp(t *testing.T) {
 	}
 }
 
+func TestArtifactRedirectAllowlist(t *testing.T) {
+	origin, _ := http.NewRequest(http.MethodGet, "https://github.com/agentlab-in/hosted-ao/releases/download/v0.14.0/ao-linux-x64", http.NoBody)
+	allowed, _ := http.NewRequest(http.MethodGet, "https://release-assets.githubusercontent.com/github-production-release-asset/file", http.NoBody)
+	if err := allowArtifactRedirect(allowed, []*http.Request{origin}); err != nil {
+		t.Fatalf("release asset redirect rejected: %v", err)
+	}
+	for _, target := range []string{
+		"http://release-assets.githubusercontent.com/file",
+		"https://evil.example/file",
+		"https://release-assets.githubusercontent.com.evil.example/file",
+	} {
+		request, _ := http.NewRequest(http.MethodGet, target, http.NoBody)
+		if err := allowArtifactRedirect(request, []*http.Request{origin}); err == nil {
+			t.Fatalf("untrusted redirect accepted: %s", target)
+		}
+	}
+	mutable, _ := http.NewRequest(http.MethodGet, "https://github.com/agentlab-in/hosted-ao/releases/latest/download/ao", http.NoBody)
+	if err := allowArtifactRedirect(allowed, []*http.Request{mutable}); err == nil {
+		t.Fatal("mutable release redirect accepted")
+	}
+}
+
 func TestSetupExecutorRejectsDigestMismatchAndInterruptedDownloadBeforeReplacement(t *testing.T) {
 	tests := []struct {
 		name   string
@@ -170,7 +208,7 @@ func (r errorAfterReader) Read(p []byte) (int, error) {
 
 func TestSetupExecutorPrivilegeRefusalIsExitThreeBeforeMutation(t *testing.T) {
 	root := preparedExecutorRoot(t)
-	action := &SetupPackageAction{Executable: "/usr/bin/apt-get", Argv: []string{"install", "--yes", "git=1.2.3"}, Version: "1.2.3", Source: "https://packages.example.invalid/git-1.2.3.deb", SHA256: strings.Repeat("a", 64)}
+	action := &SetupPackageAction{Executable: "/usr/bin/apt-get", Argv: []string{"install", "--yes", "{verified-file}"}, Version: "1.2.3", Source: "https://packages.example.invalid/git-1.2.3.deb", SHA256: strings.Repeat("a", 64)}
 	plan := executablePlan(SetupStep{ID: "prerequisite.git", Disposition: "create", Privilege: SetupPrivilege{Required: true, Scope: "system-package"}, Action: &SetupAction{SchemaVersion: 1, Kind: "package-manager", Package: action}})
 	system := &fakeSetupExecutionSystem{privilegeErr: errPrivilegeRefused}
 	result, err := executeSetupPlanWithSystem(context.Background(), plan, root, SetupExecutionOptions{NonInteractive: true}, system)
@@ -180,25 +218,53 @@ func TestSetupExecutorPrivilegeRefusalIsExitThreeBeforeMutation(t *testing.T) {
 	}
 }
 
+func TestSetupRecoveryPrivilegeRefusalIsExitThreeBeforeMutation(t *testing.T) {
+	root := preparedExecutorRoot(t)
+	record := journalRecord{StepID: "service.daemon", Kind: "service-definition-v1", Target: "/etc/systemd/system/ao-daemon.service", Backup: "/etc/systemd/system/.hao-backup-" + strings.Repeat("a", 32), Temporary: "/etc/systemd/system/.hao-service-" + strings.Repeat("b", 32), Reversible: true, BackupReady: true}
+	journal := setupJournal{SchemaVersion: 1, PlanSHA256: strings.Repeat("a", 64), State: "in_progress", Records: []journalRecord{record}}
+	data, _ := json.Marshal(journal)
+	journalPath := filepath.Join(root, ".hao-setup-transaction.json")
+	if err := os.WriteFile(journalPath, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	recovery, found, err := planSetupRecovery(root)
+	if err != nil || !found || !recovery.Privilege.Required {
+		t.Fatalf("recovery=%+v found=%v err=%v", recovery, found, err)
+	}
+	system := &fakeSetupExecutionSystem{privilegeErr: errPrivilegeRefused}
+	result, err := executeSetupPlanWithSystem(context.Background(), executablePlan(recovery), root, SetupExecutionOptions{NonInteractive: true}, system)
+	var typed commandError
+	if !errors.As(err, &typed) || typed.ExitStatus != 3 || typed.Code != "privilege_required" || len(result.Completed) != 0 || len(system.calls) != 0 {
+		t.Fatalf("result=%+v error=%+v calls=%+v", result, typed, system.calls)
+	}
+	if _, err := os.Stat(journalPath); err != nil {
+		t.Fatalf("privilege refusal changed recovery journal: %v", err)
+	}
+}
+
 func TestSetupExecutorRunsOnlyAllowlistedStructuredPackageAndVendorArgv(t *testing.T) {
 	root := preparedExecutorRoot(t)
-	digest := strings.Repeat("a", 64)
-	packageAction := &SetupPackageAction{Executable: "/usr/bin/apt-get", Argv: []string{"install", "--yes", "git=1.2.3"}, Version: "1.2.3", Source: "https://packages.example.invalid/git-1.2.3.deb", SHA256: digest}
-	vendorAction := &SetupVendorAction{Executable: "/usr/bin/npm", Argv: []string{"install", "--global", "@anthropic-ai/claude-code@2.3.4"}, Version: "2.3.4", Source: "https://registry.example.invalid/claude-code-2.3.4.tgz", SHA256: digest}
+	payload := []byte("verified package payload")
+	digestBytes := sha256.Sum256(payload)
+	digest := fmt.Sprintf("%x", digestBytes[:])
+	packageAction := &SetupPackageAction{Executable: "/usr/bin/apt-get", Argv: []string{"install", "--yes", "{verified-file}"}, Version: "1.2.3", Source: "https://packages.example.invalid/git-1.2.3.deb", SHA256: digest}
+	vendorAction := &SetupVendorAction{Executable: "/usr/bin/npm", Argv: []string{"install", "--global", "{verified-file}"}, Version: "2.3.4", Source: "https://registry.example.invalid/claude-code-2.3.4.tgz", SHA256: digest}
 	plan := executablePlan(
 		SetupStep{ID: "prerequisite.git", Disposition: "create", Privilege: SetupPrivilege{Required: true, Scope: "system-package"}, Action: &SetupAction{SchemaVersion: 1, Kind: "package-manager", Package: packageAction}},
 		SetupStep{ID: "prerequisite.harness", Disposition: "create", Action: &SetupAction{SchemaVersion: 1, Kind: "vendor-package", Vendor: vendorAction}},
 	)
-	system := &fakeSetupExecutionSystem{}
+	system := &fakeSetupExecutionSystem{payload: payload}
 	if _, err := executeSetupPlanWithSystem(context.Background(), plan, root, SetupExecutionOptions{NonInteractive: true}, system); err != nil {
 		t.Fatal(err)
 	}
-	want := []setupCommandCall{
-		{Privileged: true, Executable: "/usr/bin/apt-get", Argv: []string{"install", "--yes", "git=1.2.3"}},
-		{Privileged: false, Executable: "/usr/bin/npm", Argv: []string{"install", "--global", "@anthropic-ai/claude-code@2.3.4"}},
+	if len(system.calls) != 2 || !system.calls[0].Privileged || system.calls[0].Executable != "/usr/bin/apt-get" || system.calls[1].Privileged || system.calls[1].Executable != "/usr/bin/npm" {
+		t.Fatalf("calls=%+v", system.calls)
 	}
-	if !reflect.DeepEqual(system.calls, want) {
-		t.Fatalf("calls=%+v want=%+v", system.calls, want)
+	for _, call := range system.calls {
+		verifiedPath := call.Argv[len(call.Argv)-1]
+		if !temporaryPathMatches(verifiedPath, filepath.Join(root, "hao"), ".hao-package-") {
+			t.Fatalf("command did not receive verified local package path: %+v", call)
+		}
 	}
 
 	hostile := executablePlan(SetupStep{ID: "bad", Disposition: "create", Action: &SetupAction{SchemaVersion: 1, Kind: "vendor-package", Vendor: &SetupVendorAction{Executable: "/bin/sh", Argv: []string{"-c", "id"}, Version: "1", Source: "https://example.invalid/tool-1", SHA256: digest}}})
@@ -208,6 +274,9 @@ func TestSetupExecutorRunsOnlyAllowlistedStructuredPackageAndVendorArgv(t *testi
 }
 
 func TestSetupExecutorUsesAtomicStructuredServiceDefinitionCommands(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("systemd service definition execution is supported on Linux")
+	}
 	root := preparedExecutorRoot(t)
 	desired := setupDesired{StateRoot: root, PairPort: 443}
 	content := renderSystemdDefinition("service.gateway", desired, UserObservation{Name: "agent", UID: 1000, Home: "/home/agent"})
@@ -292,7 +361,7 @@ func TestSetupExecutorRollsBackArtifactAndRedactsFailure(t *testing.T) {
 	root := preparedExecutorRoot(t)
 	path := filepath.Join(root, "bin", "ao")
 	old := []byte("old artifact")
-	if err := os.WriteFile(path, old, 0o700); err != nil {
+	if err := os.WriteFile(path, old, 0o500); err != nil {
 		t.Fatal(err)
 	}
 	oldDigest := sha256.Sum256(old)
@@ -302,8 +371,10 @@ func TestSetupExecutorRollsBackArtifactAndRedactsFailure(t *testing.T) {
 		t.Fatal(err)
 	}
 	newPayload := []byte("new artifact")
-	vendor := &SetupVendorAction{Executable: "/usr/bin/npm", Argv: []string{"install", "--global", "@anthropic-ai/claude-code@2.3.4"}, Version: "2.3.4", Source: "https://registry.example.invalid/claude-code-2.3.4.tgz", SHA256: strings.Repeat("a", 64)}
-	plan := executablePlan(artifactStep(root, newPayload, "update"), SetupStep{ID: "prerequisite.harness", Disposition: "create", Action: &SetupAction{SchemaVersion: 1, Kind: "vendor-package", Vendor: vendor}})
+	vendor := &SetupVendorAction{Executable: "/usr/bin/npm", Argv: []string{"install", "--global", "{verified-file}"}, Version: "2.3.4", Source: "https://registry.example.invalid/claude-code-2.3.4.tgz", SHA256: fmt.Sprintf("%x", sha256.Sum256(newPayload))}
+	artifact := artifactStep(root, newPayload, "update")
+	setArtifactPrecondition(t, &artifact)
+	plan := executablePlan(artifact, SetupStep{ID: "prerequisite.harness", Disposition: "create", Action: &SetupAction{SchemaVersion: 1, Kind: "vendor-package", Vendor: vendor}})
 	system := &fakeSetupExecutionSystem{payload: newPayload, runErr: errors.New("token=super-secret installer failed")}
 	result, err := executeSetupPlanWithSystem(context.Background(), plan, root, SetupExecutionOptions{}, system)
 	if err == nil || result.Status != "failed" || len(result.Rollback) == 0 {
@@ -312,6 +383,11 @@ func TestSetupExecutorRollsBackArtifactAndRedactsFailure(t *testing.T) {
 	restored, readErr := os.ReadFile(path)
 	if readErr != nil || !bytes.Equal(restored, old) {
 		t.Fatalf("artifact was not restored: %q err=%v", restored, readErr)
+	}
+	if info, statErr := os.Stat(path); statErr != nil {
+		t.Fatalf("artifact mode stat failed: %v", statErr)
+	} else if info.Mode().Perm() != 0o500 {
+		t.Fatalf("artifact mode was not restored: %v", info.Mode().Perm())
 	}
 	var typed commandError
 	if !errors.As(err, &typed) {
@@ -337,12 +413,16 @@ func TestSetupExecutorRecoversInterruptedJournalBeforeRetry(t *testing.T) {
 	if err := os.WriteFile(backup, []byte("old-safe"), 0o700); err != nil {
 		t.Fatal(err)
 	}
-	journal := setupJournal{SchemaVersion: 1, PlanSHA256: strings.Repeat("a", 64), State: "in_progress", Records: []journalRecord{{StepID: "artifact.ao", Kind: "verified-release-artifact", Target: target, Backup: backup, ManifestTarget: target + ".hao-manifest.json", Temporary: filepath.Join(root, "bin", ".hao-artifact-"+strings.Repeat("a", 32)), Reversible: true}}}
+	journal := setupJournal{SchemaVersion: 1, PlanSHA256: strings.Repeat("a", 64), State: "in_progress", Records: []journalRecord{{StepID: "artifact.ao", Kind: "verified-release-artifact", Target: target, Backup: backup, ManifestTarget: target + ".hao-manifest.json", Temporary: filepath.Join(root, "bin", ".hao-artifact-"+strings.Repeat("a", 32)), PreviousMode: 0o700, Reversible: true}}}
 	journalBytes, _ := json.Marshal(journal)
 	if err := os.WriteFile(filepath.Join(root, ".hao-setup-transaction.json"), journalBytes, 0o600); err != nil {
 		t.Fatal(err)
 	}
-	result, err := executeSetupPlanWithSystem(context.Background(), executablePlan(), root, SetupExecutionOptions{}, &fakeSetupExecutionSystem{})
+	recovery, found, recoveryErr := planSetupRecovery(root)
+	if recoveryErr != nil || !found {
+		t.Fatalf("recovery plan found=%v err=%v", found, recoveryErr)
+	}
+	result, err := executeSetupPlanWithSystem(context.Background(), executablePlan(recovery), root, SetupExecutionOptions{}, &fakeSetupExecutionSystem{})
 	if err != nil || len(result.Recovery) != 1 || len(result.Rollback) != 1 {
 		t.Fatalf("result=%+v err=%v", result, err)
 	}
@@ -400,6 +480,68 @@ func TestSetupExecutorRejectsStaleArtifactCreateTarget(t *testing.T) {
 	}
 }
 
+func TestSetupExecutorRejectsStaleArtifactUpdate(t *testing.T) {
+	root := preparedExecutorRoot(t)
+	path := filepath.Join(root, "bin", "ao")
+	if err := os.WriteFile(path, []byte("observed"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	artifact := artifactStep(root, []byte("desired"), "update")
+	setArtifactPrecondition(t, &artifact)
+	if err := os.WriteFile(path, []byte("changed after planning"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	system := &fakeSetupExecutionSystem{payload: []byte("desired")}
+	if _, err := executeSetupPlanWithSystem(context.Background(), executablePlan(artifact), root, SetupExecutionOptions{}, system); err == nil || commandErrorCode(t, err) != "setup_failed" {
+		t.Fatalf("stale artifact update accepted: %v", err)
+	}
+	if system.downloadCalls != 0 {
+		t.Fatalf("stale update downloaded %d artifacts", system.downloadCalls)
+	}
+}
+
+func TestAtomicWriteRejectsLinkedTargetAndAncestor(t *testing.T) {
+	root := preparedExecutorRoot(t)
+	outside := filepath.Join(t.TempDir(), "outside")
+	if err := os.WriteFile(outside, []byte("safe"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(root, "linked-target")
+	if err := os.Symlink(outside, target); err != nil {
+		t.Fatal(err)
+	}
+	if err := atomicWriteFile(target, []byte("hostile"), 0o600); err == nil {
+		t.Fatal("linked target was replaced")
+	}
+	linkedDir := filepath.Join(root, "linked-dir")
+	if err := os.Symlink(filepath.Dir(outside), linkedDir); err != nil {
+		t.Fatal(err)
+	}
+	if err := atomicWriteFile(filepath.Join(linkedDir, "child"), []byte("hostile"), 0o600); err == nil {
+		t.Fatal("linked ancestor was traversed")
+	}
+	content, _ := os.ReadFile(outside)
+	if string(content) != "safe" {
+		t.Fatalf("outside file changed: %q", content)
+	}
+}
+
+func TestIncompleteServiceBackupIsNeverRestored(t *testing.T) {
+	system := &fakeSetupExecutionSystem{}
+	e := setupExecutor{system: system, options: SetupExecutionOptions{}, journal: setupJournal{Records: []journalRecord{{
+		StepID: "service.daemon", Kind: "service-definition-v1", Target: "/etc/systemd/system/ao-daemon.service", Backup: "/etc/systemd/system/.hao-backup-" + strings.Repeat("a", 32), Temporary: "/etc/systemd/system/.hao-service-" + strings.Repeat("b", 32), Reversible: true,
+	}}}}
+	results, complete := e.rollback(context.Background())
+	if !complete || len(results) != 1 {
+		t.Fatalf("results=%v complete=%v", results, complete)
+	}
+	for _, call := range system.calls {
+		if call.Executable == "/usr/bin/mv" {
+			t.Fatalf("incomplete backup was restored: %+v", system.calls)
+		}
+	}
+}
+
 func TestSetupExecutorRejectsHostileRecoveryJournalBeforePrivilege(t *testing.T) {
 	root := preparedExecutorRoot(t)
 	journal := setupJournal{SchemaVersion: 1, PlanSHA256: strings.Repeat("a", 64), State: "in_progress", Records: []journalRecord{{
@@ -444,5 +586,12 @@ func TestSetupDryRunAndExecutionUseIdenticalActionSchema(t *testing.T) {
 	}
 	if !reflect.DeepEqual(dry.Steps, executed.Steps) || dry.SchemaVersion != executed.SchemaVersion || !dry.DryRun || executed.DryRun {
 		t.Fatalf("dry-run and execution drifted\ndry=%+v\nexecution=%+v", dry, executed)
+	}
+	var report SetupExecutionReport
+	if err := json.Unmarshal([]byte(execOut), &report); err != nil {
+		t.Fatalf("execution output is not one JSON document: %v\n%s", err, execOut)
+	}
+	if report.SchemaVersion != 1 || report.Result.Status != "completed" || !reflect.DeepEqual(report.Plan, executed) {
+		t.Fatalf("execution report=%+v", report)
 	}
 }

--- a/backend/internal/haocli/setup_execute_test.go
+++ b/backend/internal/haocli/setup_execute_test.go
@@ -1,0 +1,448 @@
+package haocli
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"sync"
+	"testing"
+)
+
+type setupCommandCall struct {
+	Privileged bool
+	Executable string
+	Argv       []string
+	Input      string
+}
+
+type fakeSetupExecutionSystem struct {
+	payload        []byte
+	downloadErr    error
+	reader         io.ReadCloser
+	privilegeErr   error
+	runErr         error
+	calls          []setupCommandCall
+	downloadCalls  int
+	downloadStart  chan struct{}
+	downloadResume chan struct{}
+	mu             sync.Mutex
+}
+
+func (f *fakeSetupExecutionSystem) Download(context.Context, string) (io.ReadCloser, error) {
+	f.mu.Lock()
+	f.downloadCalls++
+	f.mu.Unlock()
+	if f.downloadStart != nil {
+		select {
+		case f.downloadStart <- struct{}{}:
+		default:
+		}
+		<-f.downloadResume
+	}
+	if f.downloadErr != nil {
+		return nil, f.downloadErr
+	}
+	if f.reader != nil {
+		return f.reader, nil
+	}
+	return io.NopCloser(bytes.NewReader(f.payload)), nil
+}
+
+func (f *fakeSetupExecutionSystem) CheckPrivilege(context.Context, bool, io.Reader) error {
+	return f.privilegeErr
+}
+
+func (f *fakeSetupExecutionSystem) Run(_ context.Context, privileged, _ bool, input io.Reader, executable string, argv ...string) error {
+	var inputData []byte
+	if input != nil && executable == "/usr/bin/tee" {
+		inputData, _ = io.ReadAll(input)
+	}
+	f.mu.Lock()
+	f.calls = append(f.calls, setupCommandCall{Privileged: privileged, Executable: executable, Argv: append([]string(nil), argv...), Input: string(inputData)})
+	f.mu.Unlock()
+	return f.runErr
+}
+
+func executablePlan(steps ...SetupStep) SetupPlan {
+	return SetupPlan{SchemaVersion: setupPlanSchemaVersion, DryRun: false, Machine: "test", Mode: "local", Platform: "linux/amd64", InstallPolicy: "missing", Steps: steps}
+}
+
+func artifactStep(root string, payload []byte, disposition string) SetupStep {
+	digest := sha256.Sum256(payload)
+	version := "0.14.0"
+	return SetupStep{ID: "artifact.ao", Disposition: disposition, Action: &SetupAction{SchemaVersion: 1, Kind: "verified-release-artifact", Artifact: &SetupArtifactAction{
+		Path: filepath.Join(root, "bin", "ao"), Version: version,
+		Source: "https://github.com/agentlab-in/hosted-ao/releases/download/v" + version + "/ao-linux-x64",
+		SHA256: fmt.Sprintf("%x", digest[:]),
+	}}}
+}
+
+func preparedExecutorRoot(t *testing.T) string {
+	t.Helper()
+	root, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, path := range []string{filepath.Join(root, "hao"), filepath.Join(root, "bin")} {
+		if err := os.Mkdir(path, 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return root
+}
+
+func commandErrorCode(t *testing.T, err error) string {
+	t.Helper()
+	var typed commandError
+	if !errors.As(err, &typed) {
+		t.Fatalf("error type=%T value=%v", err, err)
+	}
+	return typed.Code
+}
+
+func TestSetupExecutorVerifiesArtifactAndReplayIsNoOp(t *testing.T) {
+	root := preparedExecutorRoot(t)
+	payload := []byte("verified ao artifact")
+	step := artifactStep(root, payload, "create")
+	system := &fakeSetupExecutionSystem{payload: payload}
+	result, err := executeSetupPlanWithSystem(context.Background(), executablePlan(step), root, SetupExecutionOptions{NonInteractive: true}, system)
+	if err != nil || result.Status != "completed" || !reflect.DeepEqual(result.Completed, []string{"artifact.ao"}) {
+		t.Fatalf("result=%+v err=%v", result, err)
+	}
+	binary, err := os.ReadFile(step.Action.Artifact.Path)
+	if err != nil || !bytes.Equal(binary, payload) {
+		t.Fatalf("installed artifact=%q err=%v", binary, err)
+	}
+	metadata, err := inspectArtifact(context.Background(), step.Action.Artifact.Path)
+	if err != nil || metadata.Version != "0.14.0" || metadata.SHA256 != step.Action.Artifact.SHA256 {
+		t.Fatalf("metadata=%+v err=%v", metadata, err)
+	}
+	if _, err := executeSetupPlanWithSystem(context.Background(), executablePlan(step), root, SetupExecutionOptions{NonInteractive: true}, system); err != nil {
+		t.Fatalf("replay failed: %v", err)
+	}
+	if system.downloadCalls != 1 {
+		t.Fatalf("replay downloaded artifact %d times", system.downloadCalls)
+	}
+}
+
+func TestSetupExecutorRejectsDigestMismatchAndInterruptedDownloadBeforeReplacement(t *testing.T) {
+	tests := []struct {
+		name   string
+		system *fakeSetupExecutionSystem
+	}{
+		{name: "digest mismatch", system: &fakeSetupExecutionSystem{payload: []byte("wrong")}},
+		{name: "interrupted", system: &fakeSetupExecutionSystem{reader: io.NopCloser(errorAfterReader{data: []byte("partial"), err: io.ErrUnexpectedEOF})}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			root := preparedExecutorRoot(t)
+			step := artifactStep(root, []byte("expected"), "create")
+			result, err := executeSetupPlanWithSystem(context.Background(), executablePlan(step), root, SetupExecutionOptions{}, tc.system)
+			if err == nil || commandErrorCode(t, err) != "setup_failed" || result.Status != "failed" {
+				t.Fatalf("result=%+v err=%v", result, err)
+			}
+			if _, statErr := os.Stat(step.Action.Artifact.Path); !errors.Is(statErr, os.ErrNotExist) {
+				t.Fatalf("failed download replaced target: %v", statErr)
+			}
+		})
+	}
+}
+
+type errorAfterReader struct {
+	data []byte
+	err  error
+}
+
+func (r errorAfterReader) Read(p []byte) (int, error) {
+	if len(r.data) > 0 {
+		return copy(p, r.data), r.err
+	}
+	return 0, r.err
+}
+
+func TestSetupExecutorPrivilegeRefusalIsExitThreeBeforeMutation(t *testing.T) {
+	root := preparedExecutorRoot(t)
+	action := &SetupPackageAction{Executable: "/usr/bin/apt-get", Argv: []string{"install", "--yes", "git=1.2.3"}, Version: "1.2.3", Source: "https://packages.example.invalid/git-1.2.3.deb", SHA256: strings.Repeat("a", 64)}
+	plan := executablePlan(SetupStep{ID: "prerequisite.git", Disposition: "create", Privilege: SetupPrivilege{Required: true, Scope: "system-package"}, Action: &SetupAction{SchemaVersion: 1, Kind: "package-manager", Package: action}})
+	system := &fakeSetupExecutionSystem{privilegeErr: errPrivilegeRefused}
+	result, err := executeSetupPlanWithSystem(context.Background(), plan, root, SetupExecutionOptions{NonInteractive: true}, system)
+	var typed commandError
+	if !errors.As(err, &typed) || typed.ExitStatus != 3 || typed.Code != "privilege_required" || len(result.Completed) != 0 || len(system.calls) != 0 {
+		t.Fatalf("result=%+v error=%+v calls=%+v", result, typed, system.calls)
+	}
+}
+
+func TestSetupExecutorRunsOnlyAllowlistedStructuredPackageAndVendorArgv(t *testing.T) {
+	root := preparedExecutorRoot(t)
+	digest := strings.Repeat("a", 64)
+	packageAction := &SetupPackageAction{Executable: "/usr/bin/apt-get", Argv: []string{"install", "--yes", "git=1.2.3"}, Version: "1.2.3", Source: "https://packages.example.invalid/git-1.2.3.deb", SHA256: digest}
+	vendorAction := &SetupVendorAction{Executable: "/usr/bin/npm", Argv: []string{"install", "--global", "@anthropic-ai/claude-code@2.3.4"}, Version: "2.3.4", Source: "https://registry.example.invalid/claude-code-2.3.4.tgz", SHA256: digest}
+	plan := executablePlan(
+		SetupStep{ID: "prerequisite.git", Disposition: "create", Privilege: SetupPrivilege{Required: true, Scope: "system-package"}, Action: &SetupAction{SchemaVersion: 1, Kind: "package-manager", Package: packageAction}},
+		SetupStep{ID: "prerequisite.harness", Disposition: "create", Action: &SetupAction{SchemaVersion: 1, Kind: "vendor-package", Vendor: vendorAction}},
+	)
+	system := &fakeSetupExecutionSystem{}
+	if _, err := executeSetupPlanWithSystem(context.Background(), plan, root, SetupExecutionOptions{NonInteractive: true}, system); err != nil {
+		t.Fatal(err)
+	}
+	want := []setupCommandCall{
+		{Privileged: true, Executable: "/usr/bin/apt-get", Argv: []string{"install", "--yes", "git=1.2.3"}},
+		{Privileged: false, Executable: "/usr/bin/npm", Argv: []string{"install", "--global", "@anthropic-ai/claude-code@2.3.4"}},
+	}
+	if !reflect.DeepEqual(system.calls, want) {
+		t.Fatalf("calls=%+v want=%+v", system.calls, want)
+	}
+
+	hostile := executablePlan(SetupStep{ID: "bad", Disposition: "create", Action: &SetupAction{SchemaVersion: 1, Kind: "vendor-package", Vendor: &SetupVendorAction{Executable: "/bin/sh", Argv: []string{"-c", "id"}, Version: "1", Source: "https://example.invalid/tool-1", SHA256: digest}}})
+	if _, err := executeSetupPlanWithSystem(context.Background(), hostile, root, SetupExecutionOptions{}, system); err == nil || commandErrorCode(t, err) != "invalid_setup_plan" {
+		t.Fatalf("hostile command accepted: %v", err)
+	}
+}
+
+func TestSetupExecutorUsesAtomicStructuredServiceDefinitionCommands(t *testing.T) {
+	root := preparedExecutorRoot(t)
+	desired := setupDesired{StateRoot: root, PairPort: 443}
+	content := renderSystemdDefinition("service.gateway", desired, UserObservation{Name: "agent", UID: 1000, Home: "/home/agent"})
+	digest := sha256.Sum256([]byte(content))
+	action := &SetupServiceAction{Path: "/etc/systemd/system/ao-gateway.service", Mode: "0644", Version: "1", Content: content, SHA256: fmt.Sprintf("%x", digest[:])}
+	step := SetupStep{ID: "service.gateway", Disposition: "create", Privilege: SetupPrivilege{Required: true, Scope: "system-service-definition"}, Action: &SetupAction{SchemaVersion: 1, Kind: "service-definition-v1", Service: action}}
+	system := &fakeSetupExecutionSystem{}
+	result, err := executeSetupPlanWithSystem(context.Background(), executablePlan(step), root, SetupExecutionOptions{NonInteractive: true}, system)
+	if err != nil || result.Status != "completed" {
+		t.Fatalf("result=%+v err=%v", result, err)
+	}
+	if len(system.calls) != 4 || system.calls[0].Executable != "/usr/bin/tee" || system.calls[0].Input != content || system.calls[1].Executable != "/usr/bin/chmod" || system.calls[2].Executable != "/usr/bin/chown" || system.calls[3].Executable != "/usr/bin/mv" {
+		t.Fatalf("service commands=%+v", system.calls)
+	}
+	for _, call := range system.calls {
+		if !call.Privileged {
+			t.Fatalf("service command was not privileged: %+v", call)
+		}
+	}
+	for _, required := range []string{"AmbientCapabilities=CAP_NET_BIND_SERVICE", "CapabilityBoundingSet=CAP_NET_BIND_SERVICE"} {
+		if !strings.Contains(content, required) {
+			t.Fatalf("service capability scope missing %q", required)
+		}
+	}
+}
+
+func TestSetupExecutorDirectoryAndModeActionsAreIdempotent(t *testing.T) {
+	root := preparedExecutorRoot(t)
+	target := filepath.Join(root, "data")
+	create := SetupStep{ID: "directory.data", Disposition: "create", Action: &SetupAction{SchemaVersion: 1, Kind: "directory", File: &SetupFileAction{Path: target, Mode: "0700"}}}
+	system := &fakeSetupExecutionSystem{}
+	if _, err := executeSetupPlanWithSystem(context.Background(), executablePlan(create), root, SetupExecutionOptions{}, system); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(target, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mode := SetupStep{ID: "directory.data", Disposition: "update", Action: &SetupAction{SchemaVersion: 1, Kind: "file-mode", File: &SetupFileAction{Path: target, Mode: "0700"}}}
+	for i := 0; i < 2; i++ {
+		if _, err := executeSetupPlanWithSystem(context.Background(), executablePlan(mode), root, SetupExecutionOptions{}, system); err != nil {
+			t.Fatal(err)
+		}
+	}
+	info, err := os.Stat(target)
+	if err != nil || info.Mode().Perm() != 0o700 {
+		t.Fatalf("mode=%v err=%v", info.Mode().Perm(), err)
+	}
+}
+
+func TestSetupExecutorCreatesCleanStateRootHierarchy(t *testing.T) {
+	base, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	root := filepath.Join(base, ".ao", "hosted")
+	directory := func(id, path string, dependencies ...string) SetupStep {
+		return SetupStep{ID: id, Disposition: "create", Dependencies: dependencies, Action: &SetupAction{SchemaVersion: 1, Kind: "directory", File: &SetupFileAction{Path: path, Mode: "0700"}}}
+	}
+	plan := executablePlan(
+		directory("directory.parent", filepath.Dir(root)),
+		directory("directory.state", root, "directory.parent"),
+		directory("directory.hao", filepath.Join(root, "hao"), "directory.state"),
+		directory("directory.bin", filepath.Join(root, "bin"), "directory.state"),
+		directory("directory.data", filepath.Join(root, "data"), "directory.state"),
+	)
+	result, err := executeSetupPlanWithSystem(context.Background(), plan, root, SetupExecutionOptions{}, &fakeSetupExecutionSystem{})
+	if err != nil || len(result.Completed) != 5 {
+		t.Fatalf("result=%+v err=%v", result, err)
+	}
+	for _, path := range []string{filepath.Dir(root), root, filepath.Join(root, "hao"), filepath.Join(root, "bin"), filepath.Join(root, "data")} {
+		info, statErr := os.Stat(path)
+		if statErr != nil {
+			t.Fatalf("directory %s error=%v", path, statErr)
+		}
+		if !info.IsDir() || info.Mode().Perm() != 0o700 {
+			t.Fatalf("directory %s mode=%v", path, info.Mode().Perm())
+		}
+	}
+}
+
+func TestSetupExecutorRollsBackArtifactAndRedactsFailure(t *testing.T) {
+	root := preparedExecutorRoot(t)
+	path := filepath.Join(root, "bin", "ao")
+	old := []byte("old artifact")
+	if err := os.WriteFile(path, old, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	oldDigest := sha256.Sum256(old)
+	oldMetadata := ArtifactMetadata{Version: "0.13.0", Source: "https://example.invalid/v0.13.0/ao", SHA256: fmt.Sprintf("%x", oldDigest[:])}
+	metadataBytes, _ := json.Marshal(oldMetadata)
+	if err := os.WriteFile(path+".hao-manifest.json", metadataBytes, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	newPayload := []byte("new artifact")
+	vendor := &SetupVendorAction{Executable: "/usr/bin/npm", Argv: []string{"install", "--global", "@anthropic-ai/claude-code@2.3.4"}, Version: "2.3.4", Source: "https://registry.example.invalid/claude-code-2.3.4.tgz", SHA256: strings.Repeat("a", 64)}
+	plan := executablePlan(artifactStep(root, newPayload, "update"), SetupStep{ID: "prerequisite.harness", Disposition: "create", Action: &SetupAction{SchemaVersion: 1, Kind: "vendor-package", Vendor: vendor}})
+	system := &fakeSetupExecutionSystem{payload: newPayload, runErr: errors.New("token=super-secret installer failed")}
+	result, err := executeSetupPlanWithSystem(context.Background(), plan, root, SetupExecutionOptions{}, system)
+	if err == nil || result.Status != "failed" || len(result.Rollback) == 0 {
+		t.Fatalf("result=%+v err=%v", result, err)
+	}
+	restored, readErr := os.ReadFile(path)
+	if readErr != nil || !bytes.Equal(restored, old) {
+		t.Fatalf("artifact was not restored: %q err=%v", restored, readErr)
+	}
+	var typed commandError
+	if !errors.As(err, &typed) {
+		t.Fatal(err)
+	}
+	encoded, _ := json.Marshal(typed.Details)
+	if strings.Contains(err.Error()+string(encoded), "super-secret") || !strings.Contains(err.Error()+string(encoded), "[REDACTED]") {
+		t.Fatalf("failure was not redacted: %v details=%s", err, encoded)
+	}
+}
+
+func TestSetupExecutorRecoversInterruptedJournalBeforeRetry(t *testing.T) {
+	root := preparedExecutorRoot(t)
+	target := filepath.Join(root, "bin", "ao")
+	backupDir := filepath.Join(root, "hao", "backups", "crash")
+	if err := os.MkdirAll(backupDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	backup := filepath.Join(backupDir, "ao")
+	if err := os.WriteFile(target, []byte("partial-new"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(backup, []byte("old-safe"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	journal := setupJournal{SchemaVersion: 1, PlanSHA256: strings.Repeat("a", 64), State: "in_progress", Records: []journalRecord{{StepID: "artifact.ao", Kind: "verified-release-artifact", Target: target, Backup: backup, ManifestTarget: target + ".hao-manifest.json", Temporary: filepath.Join(root, "bin", ".hao-artifact-"+strings.Repeat("a", 32)), Reversible: true}}}
+	journalBytes, _ := json.Marshal(journal)
+	if err := os.WriteFile(filepath.Join(root, ".hao-setup-transaction.json"), journalBytes, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	result, err := executeSetupPlanWithSystem(context.Background(), executablePlan(), root, SetupExecutionOptions{}, &fakeSetupExecutionSystem{})
+	if err != nil || len(result.Recovery) != 1 || len(result.Rollback) != 1 {
+		t.Fatalf("result=%+v err=%v", result, err)
+	}
+	restored, _ := os.ReadFile(target)
+	if string(restored) != "old-safe" {
+		t.Fatalf("recovery left %q", restored)
+	}
+}
+
+func TestSetupExecutorRejectsConcurrentInvocation(t *testing.T) {
+	root := preparedExecutorRoot(t)
+	payload := []byte("artifact")
+	system := &fakeSetupExecutionSystem{payload: payload, downloadStart: make(chan struct{}, 1), downloadResume: make(chan struct{})}
+	done := make(chan error, 1)
+	go func() {
+		_, err := executeSetupPlanWithSystem(context.Background(), executablePlan(artifactStep(root, payload, "create")), root, SetupExecutionOptions{}, system)
+		done <- err
+	}()
+	<-system.downloadStart
+	_, err := executeSetupPlanWithSystem(context.Background(), executablePlan(), root, SetupExecutionOptions{}, &fakeSetupExecutionSystem{})
+	if err == nil || commandErrorCode(t, err) != "setup_busy" {
+		t.Fatalf("concurrent invocation error=%v", err)
+	}
+	close(system.downloadResume)
+	if err := <-done; err != nil {
+		t.Fatalf("first invocation failed: %v", err)
+	}
+}
+
+func TestSetupExecutorRejectsHostileManagedPaths(t *testing.T) {
+	root := preparedExecutorRoot(t)
+	hostile := executablePlan(SetupStep{ID: "directory.escape", Disposition: "create", Action: &SetupAction{SchemaVersion: 1, Kind: "directory", File: &SetupFileAction{Path: filepath.Join(root, "..", "escape"), Mode: "0700"}}})
+	if _, err := executeSetupPlanWithSystem(context.Background(), hostile, root, SetupExecutionOptions{}, &fakeSetupExecutionSystem{}); err == nil || commandErrorCode(t, err) != "invalid_setup_plan" {
+		t.Fatalf("escape accepted: %v", err)
+	}
+	outside := t.TempDir()
+	link := filepath.Join(root, "linked")
+	if err := os.Symlink(outside, link); err != nil {
+		t.Fatal(err)
+	}
+	linkedPlan := executablePlan(SetupStep{ID: "directory.linked", Disposition: "create", Action: &SetupAction{SchemaVersion: 1, Kind: "directory", File: &SetupFileAction{Path: filepath.Join(link, "child"), Mode: "0700"}}})
+	if _, err := executeSetupPlanWithSystem(context.Background(), linkedPlan, root, SetupExecutionOptions{}, &fakeSetupExecutionSystem{}); err == nil || commandErrorCode(t, err) != "invalid_setup_plan" {
+		t.Fatalf("linked ancestor accepted: %v", err)
+	}
+}
+
+func TestSetupExecutorRejectsStaleArtifactCreateTarget(t *testing.T) {
+	root := preparedExecutorRoot(t)
+	artifact := artifactStep(root, []byte("expected"), "create")
+	if err := os.WriteFile(artifact.Action.Artifact.Path, []byte("appeared"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := executeSetupPlanWithSystem(context.Background(), executablePlan(artifact), root, SetupExecutionOptions{}, &fakeSetupExecutionSystem{}); err == nil || commandErrorCode(t, err) != "setup_failed" {
+		t.Fatalf("stale artifact plan accepted: %v", err)
+	}
+}
+
+func TestSetupExecutorRejectsHostileRecoveryJournalBeforePrivilege(t *testing.T) {
+	root := preparedExecutorRoot(t)
+	journal := setupJournal{SchemaVersion: 1, PlanSHA256: strings.Repeat("a", 64), State: "in_progress", Records: []journalRecord{{
+		StepID: "service.daemon", Kind: "service-definition-v1", Target: "/etc/passwd", Backup: "/tmp/hostile", Temporary: "/tmp/hostile-temp", Reversible: true,
+	}}}
+	data, err := json.Marshal(journal)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, ".hao-setup-transaction.json"), data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	system := &fakeSetupExecutionSystem{}
+	if _, err := executeSetupPlanWithSystem(context.Background(), executablePlan(), root, SetupExecutionOptions{}, system); err == nil || commandErrorCode(t, err) != "setup_failed" {
+		t.Fatalf("hostile journal accepted: %v", err)
+	}
+	if len(system.calls) != 0 {
+		t.Fatalf("hostile journal ran commands: %+v", system.calls)
+	}
+}
+
+func TestSetupDryRunAndExecutionUseIdenticalActionSchema(t *testing.T) {
+	obs := healthyObserver()
+	deps, root := setupDeps(t, "local", obs)
+	obs.statErr[filepath.Join(root, "data")] = os.ErrNotExist
+	dryOut, _, dryCode := runCLI(t, deps, "--json", "--config", fixturePath("valid", "local.yaml"), "setup", "--dry-run")
+	if dryCode != 0 {
+		t.Fatalf("dry-run code=%d out=%s", dryCode, dryOut)
+	}
+	var executed SetupPlan
+	deps.ExecuteSetup = func(_ context.Context, plan SetupPlan, _ string, _ SetupExecutionOptions) (SetupExecutionResult, error) {
+		executed = plan
+		return SetupExecutionResult{Status: "completed"}, nil
+	}
+	execOut, _, execCode := runCLI(t, deps, "--json", "--config", fixturePath("valid", "local.yaml"), "setup", "--non-interactive", "--yes")
+	if execCode != 0 {
+		t.Fatalf("execution code=%d out=%s", execCode, execOut)
+	}
+	var dry SetupPlan
+	if err := json.Unmarshal([]byte(strings.Split(strings.TrimSpace(dryOut), "\n")[0]), &dry); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(dry.Steps, executed.Steps) || dry.SchemaVersion != executed.SchemaVersion || !dry.DryRun || executed.DryRun {
+		t.Fatalf("dry-run and execution drifted\ndry=%+v\nexecution=%+v", dry, executed)
+	}
+}

--- a/backend/internal/haocli/setup_execute_test.go
+++ b/backend/internal/haocli/setup_execute_test.go
@@ -500,6 +500,79 @@ func TestSetupExecutorRejectsStaleArtifactUpdate(t *testing.T) {
 	}
 }
 
+func TestSetupExecutorRejectsDesiredArtifactBytesWithStaleMode(t *testing.T) {
+	root := preparedExecutorRoot(t)
+	path := filepath.Join(root, "bin", "ao")
+	if err := os.WriteFile(path, []byte("observed"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	desired := []byte("desired")
+	artifact := artifactStep(root, desired, "update")
+	setArtifactPrecondition(t, &artifact)
+	if err := os.WriteFile(path, desired, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(path, 0o666); err != nil {
+		t.Fatal(err)
+	}
+	system := &fakeSetupExecutionSystem{payload: desired}
+	if _, err := executeSetupPlanWithSystem(context.Background(), executablePlan(artifact), root, SetupExecutionOptions{}, system); err == nil || commandErrorCode(t, err) != "setup_failed" {
+		t.Fatalf("desired bytes with stale mode accepted: %v", err)
+	}
+	if system.downloadCalls != 0 {
+		t.Fatalf("stale update downloaded %d artifacts", system.downloadCalls)
+	}
+	if _, err := os.Stat(path + ".hao-manifest.json"); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("stale update wrote trusted manifest: %v", err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stale target stat failed: %v", err)
+	}
+	if info.Mode().Perm() != 0o666 {
+		t.Fatalf("stale target was mutated: mode=%v", info.Mode().Perm())
+	}
+}
+
+func TestSetupExecutorRejectsStaleServiceBeforeDesiredContentFastPath(t *testing.T) {
+	oldContent := []byte("old service definition\n")
+	desiredContent := []byte("desired service definition\n")
+	oldDigest := sha256.Sum256(oldContent)
+	desiredDigest := sha256.Sum256(desiredContent)
+
+	for _, tc := range []struct {
+		name    string
+		content []byte
+		mode    os.FileMode
+	}{
+		{name: "desired content and unsafe mode", content: desiredContent, mode: 0o666},
+		{name: "observed content and changed safe mode", content: oldContent, mode: 0o600},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			root := preparedExecutorRoot(t)
+			path := filepath.Join(root, "service.fixture")
+			if err := os.WriteFile(path, tc.content, tc.mode); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.Chmod(path, tc.mode); err != nil {
+				t.Fatal(err)
+			}
+			action := &SetupServiceAction{
+				Path: path, Mode: "0644", Version: "1", Content: string(desiredContent), SHA256: fmt.Sprintf("%x", desiredDigest[:]),
+				ExpectedSHA256: fmt.Sprintf("%x", oldDigest[:]), ExpectedMode: 0o644,
+			}
+			system := &fakeSetupExecutionSystem{}
+			executor := setupExecutor{system: system, stateRoot: root, dataDir: filepath.Join(root, "data"), options: SetupExecutionOptions{}}
+			if err := executor.installService(context.Background(), "service.daemon", "update", action); err == nil {
+				t.Fatal("stale service update was accepted")
+			}
+			if len(system.calls) != 0 {
+				t.Fatalf("stale service update ran commands: %+v", system.calls)
+			}
+		})
+	}
+}
+
 func TestAtomicWriteRejectsLinkedTargetAndAncestor(t *testing.T) {
 	root := preparedExecutorRoot(t)
 	outside := filepath.Join(t.TempDir(), "outside")
@@ -593,5 +666,51 @@ func TestSetupDryRunAndExecutionUseIdenticalActionSchema(t *testing.T) {
 	}
 	if report.SchemaVersion != 1 || report.Result.Status != "completed" || !reflect.DeepEqual(report.Plan, executed) {
 		t.Fatalf("execution report=%+v", report)
+	}
+}
+
+func TestSetupCustomDataDirFlowsFromPlannerThroughExecutorAndServices(t *testing.T) {
+	obs := healthyObserver()
+	deps, root := setupDeps(t, "pair", obs)
+	customData := filepath.Join(root, "custom-db")
+	customRunFile := filepath.Join(root, "custom-running.json")
+	deps.DataDir = func() (string, error) { return customData, nil }
+	deps.RunFile = func() (string, error) { return customRunFile, nil }
+	obs.statErr[customData] = os.ErrNotExist
+
+	out, stderr, code := runCLI(t, deps, "--json", "--config", fixturePath("valid", "pair.yaml"), "setup", "--dry-run")
+	if code != 0 || stderr != "" {
+		t.Fatalf("plan code=%d stderr=%q out=%s", code, stderr, out)
+	}
+	plan := decodeSetupPlan(t, out)
+	directory := stepByID(t, plan, "directory.data")
+	if directory.Action == nil || directory.Action.File == nil || directory.Action.File.Path != customData {
+		t.Fatalf("data directory action=%+v want=%q", directory.Action, customData)
+	}
+	for _, id := range []string{"service.daemon", "service.gateway"} {
+		service := stepByID(t, plan, id)
+		if service.Action == nil || service.Action.Service == nil {
+			t.Fatalf("%s action=%+v", id, service.Action)
+		}
+		parsed, err := consumeSystemdDefinition(service.Action.Service.Content)
+		if err != nil {
+			t.Fatalf("consume %s: %v", id, err)
+		}
+		if parsed.Environment["AO_DATA_DIR"] != customData || parsed.Environment["AO_RUN_FILE"] != customRunFile {
+			t.Fatalf("%s runtime paths=%v", id, parsed.Environment)
+		}
+	}
+
+	directory.Dependencies = nil
+	directoryPlan := executablePlan(directory)
+	result, err := executeSetupPlanWithSystem(context.Background(), directoryPlan, root, SetupExecutionOptions{DataDir: customData}, &fakeSetupExecutionSystem{})
+	if err != nil || result.Status != "completed" {
+		t.Fatalf("execution result=%+v err=%v", result, err)
+	}
+	if info, err := os.Stat(customData); err != nil || !info.IsDir() || info.Mode().Perm() != 0o700 {
+		t.Fatalf("custom data directory info=%v err=%v", info, err)
+	}
+	if _, err := os.Stat(filepath.Join(root, "data")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("default data directory was unexpectedly created: %v", err)
 	}
 }

--- a/backend/internal/haocli/setup_lock_unix.go
+++ b/backend/internal/haocli/setup_lock_unix.go
@@ -1,0 +1,42 @@
+//go:build !windows
+
+package haocli
+
+import (
+	"errors"
+	"os"
+	"syscall"
+)
+
+func acquireSetupLock(path string) (*os.File, error) {
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, err
+	}
+	if err := syscall.Flock(int(file.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		_ = file.Close()
+		if errors.Is(err, syscall.EWOULDBLOCK) {
+			return nil, errSetupBusy
+		}
+		return nil, err
+	}
+	return file, nil
+}
+
+func releaseSetupLock(file *os.File) error {
+	unlockErr := syscall.Flock(int(file.Fd()), syscall.LOCK_UN)
+	closeErr := file.Close()
+	if unlockErr != nil {
+		return unlockErr
+	}
+	return closeErr
+}
+
+func syncDirectory(path string) error {
+	directory, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = directory.Close() }()
+	return directory.Sync()
+}

--- a/backend/internal/haocli/setup_lock_windows.go
+++ b/backend/internal/haocli/setup_lock_windows.go
@@ -1,0 +1,38 @@
+//go:build windows
+
+package haocli
+
+import (
+	"errors"
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+func acquireSetupLock(path string) (*os.File, error) {
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, err
+	}
+	overlapped := new(windows.Overlapped)
+	if err := windows.LockFileEx(windows.Handle(file.Fd()), windows.LOCKFILE_EXCLUSIVE_LOCK|windows.LOCKFILE_FAIL_IMMEDIATELY, 0, 1, 0, overlapped); err != nil {
+		_ = file.Close()
+		if errors.Is(err, windows.ERROR_LOCK_VIOLATION) {
+			return nil, errSetupBusy
+		}
+		return nil, err
+	}
+	return file, nil
+}
+
+func releaseSetupLock(file *os.File) error {
+	overlapped := new(windows.Overlapped)
+	unlockErr := windows.UnlockFileEx(windows.Handle(file.Fd()), 0, 1, 0, overlapped)
+	closeErr := file.Close()
+	if unlockErr != nil {
+		return unlockErr
+	}
+	return closeErr
+}
+
+func syncDirectory(string) error { return nil }

--- a/backend/internal/haocli/setup_test.go
+++ b/backend/internal/haocli/setup_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/agentlaunch"
+	"github.com/aoagents/agent-orchestrator/backend/internal/config"
 	"github.com/aoagents/agent-orchestrator/backend/internal/vmgateway"
 )
 
@@ -32,6 +33,8 @@ func setupDeps(t *testing.T, fixture string, obs *fakeObserver) (Deps, string) {
 	obs.files["/etc/systemd/system/ao-daemon.service"] = FileObservation{Mode: 0o644, UID: 0}
 	obs.files["/etc/systemd/system/ao-gateway.service"] = FileObservation{Mode: 0o644, UID: 0}
 	desired := setupDesired{StateRoot: root, DataDir: filepath.Join(root, "data"), RunFile: filepath.Join(root, "running.json"), PairPort: 443}
+	desired.PairCertDir, _ = vmgateway.DefaultPairCertDir()
+	desired.PairPasscodeDir, _ = vmgateway.DefaultPasscodeDir()
 	obs.readFiles["/etc/systemd/system/ao-daemon.service"] = []byte(renderSystemdDefinition("service.daemon", desired, obs.user))
 	obs.readFiles["/etc/systemd/system/ao-gateway.service"] = []byte(renderSystemdDefinition("service.gateway", desired, obs.user))
 	return deps, root
@@ -685,6 +688,65 @@ func TestSystemdDefinitionsPreserveExactStateOverrides(t *testing.T) {
 		if parsed.Environment["AO_DATA_DIR"] != desired.DataDir || parsed.Environment["AO_RUN_FILE"] != desired.RunFile {
 			t.Fatalf("%s overrides=%v", id, parsed.Environment)
 		}
+	}
+}
+
+func TestPairSystemdIdentityPathsDoNotFollowRuntimeOverrides(t *testing.T) {
+	defaultCertDir, err := vmgateway.DefaultPairCertDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defaultPasscodeDir, err := vmgateway.DefaultPasscodeDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	user := UserObservation{Name: "agent", UID: 1000, Home: "/home/agent"}
+
+	for _, tc := range []struct {
+		name, dataDir, runFile, certDir, passcodeDir string
+	}{
+		{name: "data only", dataDir: filepath.Join(t.TempDir(), "custom-data")},
+		{name: "run only", runFile: filepath.Join(t.TempDir(), "custom-run", "running.json")},
+		{name: "combined", dataDir: filepath.Join(t.TempDir(), "custom-data"), runFile: filepath.Join(t.TempDir(), "custom-run", "running.json")},
+		{name: "explicit identity", dataDir: filepath.Join(t.TempDir(), "custom-data"), runFile: filepath.Join(t.TempDir(), "custom-run", "running.json"), certDir: filepath.Join(t.TempDir(), "certs"), passcodeDir: filepath.Join(t.TempDir(), "passcode")},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("AO_DATA_DIR", tc.dataDir)
+			t.Setenv("AO_RUN_FILE", tc.runFile)
+			t.Setenv("AO_VM_CERT_DIR", tc.certDir)
+			t.Setenv("AO_VM_PASSCODE_DIR", tc.passcodeDir)
+			desired, err := resolveSetupDesired(Deps{
+				StateDir: config.ResolveStateRoot,
+				DataDir:  config.ResolveDataDir,
+				RunFile:  config.ResolveRunFilePath,
+			}, "", map[string]any{"mode": "pair"}, "", false)
+			if err != nil {
+				t.Fatal(err)
+			}
+			desired.PairPort = 443
+			parsed, err := consumeSystemdDefinition(renderSystemdDefinition("service.gateway", desired, user))
+			if err != nil {
+				t.Fatal(err)
+			}
+			resolved, err := vmgateway.Resolve(vmgateway.Options{
+				Pair: true, HTTPSAddr: parsed.Environment["AO_VM_HTTPS_ADDR"],
+				CertDir: parsed.Environment["AO_VM_CERT_DIR"], PasscodeDir: parsed.Environment["AO_VM_PASSCODE_DIR"],
+				MachineFile: filepath.Join(t.TempDir(), "absent-machine.json"),
+			}, desired.DataDir)
+			if err != nil {
+				t.Fatal(err)
+			}
+			wantCertDir, wantPasscodeDir := defaultCertDir, defaultPasscodeDir
+			if tc.certDir != "" {
+				wantCertDir = tc.certDir
+			}
+			if tc.passcodeDir != "" {
+				wantPasscodeDir = tc.passcodeDir
+			}
+			if resolved.CertDir != wantCertDir || resolved.PasscodeDir != wantPasscodeDir {
+				t.Fatalf("identity dirs=(%q,%q) want=(%q,%q)", resolved.CertDir, resolved.PasscodeDir, wantCertDir, wantPasscodeDir)
+			}
+		})
 	}
 }
 

--- a/backend/internal/haocli/setup_test.go
+++ b/backend/internal/haocli/setup_test.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -711,40 +710,44 @@ func TestSetupPairOrderingAndSetupInitSeparation(t *testing.T) {
 	}
 }
 
-func TestSetupWithoutDryRunFailsBeforeEveryBoundary(t *testing.T) {
-	panicRead := func(string) ([]byte, error) { panic("config read invoked") }
-	panicPath := func() (string, error) { panic("path resolution invoked") }
-	out, stderr, code := runCLI(t, Deps{ReadFile: panicRead, StateDir: panicPath, RunFile: panicPath, Observer: panicObserver{}}, "--json", "setup", "--non-interactive", "--install", "missing", "--yes")
-	if code != 4 || out != "" {
-		t.Fatalf("code=%d out=%q stderr=%q", code, out, stderr)
+func TestSetupExecutionPrintsExactPlanBeforeConsent(t *testing.T) {
+	obs := healthyObserver()
+	deps, root := setupDeps(t, "local", obs)
+	called := false
+	deps.ExecuteSetup = func(_ context.Context, plan SetupPlan, stateRoot string, _ SetupExecutionOptions) (SetupExecutionResult, error) {
+		called = true
+		if plan.DryRun || stateRoot != root {
+			t.Fatalf("executor plan=%+v root=%q", plan, stateRoot)
+		}
+		return SetupExecutionResult{Status: "completed"}, nil
 	}
-	assertEnvelope(t, stderr, code, 4, "feature_deferred", "setup")
+	out, stderr, code := runCLI(t, deps, "--config", fixturePath("valid", "local.yaml"), "setup")
+	if code != 0 || stderr != "" || called {
+		t.Fatalf("refusal code=%d called=%v out=%q stderr=%q", code, called, out, stderr)
+	}
+	if !strings.Contains(out, "HAO setup plan (execution)") || !strings.Contains(out, "Type yes to confirm") || !strings.Contains(out, "Setup cancelled") {
+		t.Fatalf("refusal did not print the complete plan and prompt: %s", out)
+	}
+
+	deps.In = strings.NewReader("yes\n")
+	out, stderr, code = runCLI(t, deps, "--config", fixturePath("valid", "local.yaml"), "setup")
+	if code != 0 || stderr != "" || !called || !strings.Contains(out, "Setup completed") {
+		t.Fatalf("confirmation code=%d called=%v out=%q stderr=%q", code, called, out, stderr)
+	}
 }
 
-func TestSetupWithoutDryRunProcessExitFourHumanAndJSON(t *testing.T) {
-	binary := filepath.Join(t.TempDir(), "hao")
-	build := exec.Command("go", "build", "-o", binary, "./cmd/hao")
-	build.Dir = filepath.Join("..", "..")
-	if output, err := build.CombinedOutput(); err != nil {
-		t.Fatalf("build hao: %v\n%s", err, output)
+func TestSetupNonInteractiveRequiresYesWithExactExitTwo(t *testing.T) {
+	obs := healthyObserver()
+	deps, _ := setupDeps(t, "local", obs)
+	deps.ExecuteSetup = func(context.Context, SetupPlan, string, SetupExecutionOptions) (SetupExecutionResult, error) {
+		t.Fatal("executor ran without non-interactive consent")
+		return SetupExecutionResult{}, nil
 	}
-	for _, tc := range []struct {
-		name string
-		args []string
-		want string
-	}{
-		{name: "human", args: []string{"setup"}, want: "hao setup mutation is not yet supported"},
-		{name: "json", args: []string{"--json", "setup"}, want: `"code":"feature_deferred"`},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			cmd := exec.Command(binary, tc.args...)
-			output, err := cmd.CombinedOutput()
-			var exitErr *exec.ExitError
-			if !errors.As(err, &exitErr) || exitErr.ExitCode() != 4 || !strings.Contains(string(output), tc.want) {
-				t.Fatalf("exit=%v output=%s", err, output)
-			}
-		})
+	out, stderr, code := runCLI(t, deps, "--json", "--config", fixturePath("valid", "local.yaml"), "setup", "--non-interactive")
+	if code != 2 || out == "" {
+		t.Fatalf("code=%d out=%q stderr=%q", code, out, stderr)
 	}
+	assertEnvelope(t, stderr, code, 2, "invalid_usage", "setup")
 }
 
 type panicObserver struct{}

--- a/backend/internal/haocli/setup_test.go
+++ b/backend/internal/haocli/setup_test.go
@@ -13,7 +13,6 @@ import (
 	"testing"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/agentlaunch"
-	"github.com/aoagents/agent-orchestrator/backend/internal/runfile"
 	"github.com/aoagents/agent-orchestrator/backend/internal/vmgateway"
 )
 
@@ -126,6 +125,7 @@ func TestSetupInstallPoliciesAndStructuredPrivilege(t *testing.T) {
 			delete(obs.paths, name)
 		}
 		deps, root := setupDeps(t, "pair", obs)
+		deps.TrustedArtifact = nil
 		obs.statErr[filepath.Join(root, "bin", "ao")] = os.ErrNotExist
 		obs.statErr["/etc/systemd/system/ao-daemon.service"] = os.ErrNotExist
 		obs.statErr["/etc/systemd/system/ao-gateway.service"] = os.ErrNotExist
@@ -223,11 +223,11 @@ func TestSetupWrongVersionsPermissionsAndManagerUnknown(t *testing.T) {
 	obs.artifacts[artifact] = ArtifactMetadata{Version: "0.13.9", SHA256: strings.Repeat("b", 64), Source: "old-release"}
 	obs.files[filepath.Join(root, "data")] = FileObservation{Mode: 0o755, Owner: true, IsDir: true}
 	out, _, code := runCLI(t, deps, "--json", "--config", fixturePath("valid", "pair.yaml"), "setup", "--dry-run")
-	if code != 1 {
+	if code != 0 {
 		t.Fatalf("code=%d out=%s", code, out)
 	}
 	plan := decodeSetupPlan(t, out)
-	if stepByID(t, plan, "artifact.ao").Disposition != "blocked" || stepByID(t, plan, "directory.data").Disposition != "update" {
+	if stepByID(t, plan, "artifact.ao").Disposition != "update" || stepByID(t, plan, "artifact.ao").Action == nil || stepByID(t, plan, "directory.data").Disposition != "update" {
 		t.Fatalf("plan=%+v", plan)
 	}
 
@@ -266,6 +266,7 @@ func TestSetupUntrustedArtifactProvenanceNeverBecomesExecutableOrNoOp(t *testing
 		obs := healthyObserver()
 		delete(obs.paths, "claude")
 		deps, root := setupDeps(t, "local", obs)
+		deps.TrustedArtifact = nil
 		obs.statErr[filepath.Join(root, "bin", "ao")] = os.ErrNotExist
 		out, _, code := runCLI(t, deps, "--json", "--config", fixturePath("valid", "local.yaml"), "setup", "--dry-run", "--install", "missing")
 		if code != 1 {
@@ -279,6 +280,39 @@ func TestSetupUntrustedArtifactProvenanceNeverBecomesExecutableOrNoOp(t *testing
 			}
 		}
 	})
+}
+
+func TestSetupTrustedArtifactMetadataPlansVerifiedInstall(t *testing.T) {
+	obs := healthyObserver()
+	deps, root := setupDeps(t, "local", obs)
+	obs.statErr[filepath.Join(root, "bin", "ao")] = os.ErrNotExist
+	out, _, code := runCLI(t, deps, "--json", "--config", fixturePath("valid", "local.yaml"), "setup", "--dry-run")
+	if code != 0 {
+		t.Fatalf("code=%d out=%s", code, out)
+	}
+	step := stepByID(t, decodeSetupPlan(t, out), "artifact.ao")
+	if step.Disposition != "create" || step.Action == nil || step.Action.Artifact == nil || step.Action.Artifact.Version != "0.14.0" || !validSHA256(step.Action.Artifact.SHA256) {
+		t.Fatalf("artifact step=%+v", step)
+	}
+}
+
+func TestTrustedBuildArtifactRequiresExactReleaseTuple(t *testing.T) {
+	restoreVersion, restoreSource, restoreDigest := AOArtifactVersion, AOArtifactSource, AOArtifactSHA256
+	t.Cleanup(func() {
+		AOArtifactVersion, AOArtifactSource, AOArtifactSHA256 = restoreVersion, restoreSource, restoreDigest
+	})
+	AOArtifactVersion = "0.14.0"
+	AOArtifactSource = "https://github.com/agentlab-in/hosted-ao/releases/download/v0.14.0/ao-linux-arm64"
+	AOArtifactSHA256 = strings.Repeat("A", 64)
+	metadata, ok := trustedBuildArtifact("linux", "arm64", "0.14.0")
+	if !ok || metadata.SHA256 != strings.Repeat("a", 64) {
+		t.Fatalf("metadata=%+v ok=%v", metadata, ok)
+	}
+	for _, input := range []struct{ goos, arch, version string }{{"darwin", "arm64", "0.14.0"}, {"linux", "amd64", "0.14.0"}, {"linux", "arm64", "latest"}} {
+		if _, ok := trustedBuildArtifact(input.goos, input.arch, input.version); ok {
+			t.Fatalf("accepted mismatched tuple %+v", input)
+		}
+	}
 }
 
 func TestSetupLocalNeverPlansGatewayAndUnsafeArtifactIsNotExecuted(t *testing.T) {
@@ -750,28 +784,6 @@ func TestSetupNonInteractiveRequiresYesWithExactExitTwo(t *testing.T) {
 	assertEnvelope(t, stderr, code, 2, "invalid_usage", "setup")
 }
 
-type panicObserver struct{}
-
-func (panicObserver) Platform() (string, string)            { panic("platform probe") }
-func (panicObserver) Distribution() (string, error)         { panic("distribution probe") }
-func (panicObserver) CurrentUser() (UserObservation, error) { panic("user probe") }
-func (panicObserver) Stat(string) (FileObservation, error)  { panic("filesystem probe") }
-func (panicObserver) ReadFile(string) ([]byte, error)       { panic("file read") }
-func (panicObserver) InspectArtifact(context.Context, string) (ArtifactMetadata, error) {
-	panic("artifact probe")
-}
-func (panicObserver) Disk(string) (uint64, error)     { panic("disk probe") }
-func (panicObserver) LookPath(string) (string, error) { panic("path probe") }
-func (panicObserver) Run(context.Context, string, ...string) (string, error) {
-	panic("subprocess probe")
-}
-func (panicObserver) ReadRunFile(string) (*runfile.Info, error)   { panic("runfile probe") }
-func (panicObserver) ProcessAlive(int) bool                       { panic("process probe") }
-func (panicObserver) GET(context.Context, string) ([]byte, error) { panic("network probe") }
-func (panicObserver) PortAvailable(context.Context, string, int) (bool, error) {
-	panic("listener probe")
-}
-
 func TestSetupHumanJSONRedactionAndYesSemantics(t *testing.T) {
 	obs := healthyObserver()
 	deps, _ := setupDeps(t, "local", obs)
@@ -781,7 +793,7 @@ func TestSetupHumanJSONRedactionAndYesSemantics(t *testing.T) {
 		if code != 0 || stderr != "" || strings.Contains(out, "setup-secret") || !strings.Contains(out, "[REDACTED]") {
 			t.Fatalf("args=%v code=%d out=%s err=%s", args, code, out, stderr)
 		}
-		if args[0] != "--json" && !strings.Contains(out, "--yes has no mutation effect") {
+		if args[0] != "--json" && !strings.Contains(out, "--yes is ignored during dry-run") {
 			t.Fatalf("missing --yes note: %s", out)
 		}
 	}

--- a/backend/internal/haocli/setup_test.go
+++ b/backend/internal/haocli/setup_test.go
@@ -23,13 +23,15 @@ func setupDeps(t *testing.T, fixture string, obs *fakeObserver) (Deps, string) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	deps.DataDir = func() (string, error) { return filepath.Join(root, "data"), nil }
+	deps.RunFile = func() (string, error) { return filepath.Join(root, "running.json"), nil }
 	obs.files[filepath.Join(root, "bin", "ao")] = FileObservation{Mode: 0o755, Owner: true}
 	trusted := ArtifactMetadata{Version: "0.14.0", SHA256: strings.Repeat("a", 64), Source: "https://github.com/agentlab-in/hosted-ao/releases/download/v0.14.0/ao-linux-x64"}
 	obs.artifacts[filepath.Join(root, "bin", "ao")] = trusted
 	deps.TrustedArtifact = func(_, _, _ string) (ArtifactMetadata, bool) { return trusted, true }
 	obs.files["/etc/systemd/system/ao-daemon.service"] = FileObservation{Mode: 0o644, UID: 0}
 	obs.files["/etc/systemd/system/ao-gateway.service"] = FileObservation{Mode: 0o644, UID: 0}
-	desired := setupDesired{StateRoot: root, PairPort: 443}
+	desired := setupDesired{StateRoot: root, DataDir: filepath.Join(root, "data"), RunFile: filepath.Join(root, "running.json"), PairPort: 443}
 	obs.readFiles["/etc/systemd/system/ao-daemon.service"] = []byte(renderSystemdDefinition("service.daemon", desired, obs.user))
 	obs.readFiles["/etc/systemd/system/ao-gateway.service"] = []byte(renderSystemdDefinition("service.gateway", desired, obs.user))
 	return deps, root
@@ -611,14 +613,14 @@ func TestImmutableActionJSONRoundTripsThroughNonMutatingConsumer(t *testing.T) {
 	}, {
 		ID: "prerequisite.git", Disposition: "create", Action: &SetupAction{
 			SchemaVersion: 1, Kind: "package-manager", Package: &SetupPackageAction{
-				Executable: "/usr/bin/apt-get", Argv: []string{"install", "git=1.2.3"}, Version: "1.2.3",
+				Executable: "/usr/bin/apt-get", Argv: []string{"install", "--yes", "{verified-file}"}, Version: "1.2.3",
 				Source: "https://packages.example.invalid/git-1.2.3.deb", SHA256: digest,
 			},
 		},
 	}, {
 		ID: "prerequisite.harness", Disposition: "create", Action: &SetupAction{
 			SchemaVersion: 1, Kind: "vendor-package", Vendor: &SetupVendorAction{
-				Executable: "/usr/bin/npm", Argv: []string{"install", "--global", "pkg@1.2.3"}, Version: "1.2.3",
+				Executable: "/usr/bin/npm", Argv: []string{"install", "--global", "{verified-file}"}, Version: "1.2.3",
 				Source: "https://registry.example.invalid/pkg/-/pkg-1.2.3.tgz", SHA256: digest,
 			},
 		},
@@ -633,7 +635,7 @@ func TestImmutableActionJSONRoundTripsThroughNonMutatingConsumer(t *testing.T) {
 	}
 	want := []string{
 		"artifact source=https://releases.example.invalid/v0.14.0/ao-linux-x64 version=0.14.0 sha256=" + digest + " path=/managed/ao",
-		"package executable=/usr/bin/apt-get source=https://packages.example.invalid/git-1.2.3.deb version=1.2.3 sha256=" + digest + ` argv=["install" "git=1.2.3"]`,
+		"package executable=/usr/bin/apt-get source=https://packages.example.invalid/git-1.2.3.deb version=1.2.3 sha256=" + digest + ` argv=["install" "--yes" "{verified-file}"]`,
 		"vendor source=https://registry.example.invalid/pkg/-/pkg-1.2.3.tgz version=1.2.3 sha256=" + digest,
 	}
 	if !reflect.DeepEqual(operations, want) {
@@ -667,6 +669,22 @@ func TestPairSystemdConsumerCarriesPortCapabilitiesAndHarnessPath(t *testing.T) 
 	parsed, err = consumeSystemdDefinition(renderSystemdDefinition("service.gateway", desired, user))
 	if err != nil || !parsed.HasNetBindCapability {
 		t.Fatalf("privileged port consumer capability=%v err=%v", parsed.HasNetBindCapability, err)
+	}
+}
+
+func TestSystemdDefinitionsPreserveExactStateOverrides(t *testing.T) {
+	desired := setupDesired{
+		StateRoot: "/srv/hao/state", DataDir: "/mnt/ao-db", RunFile: "/run/user/1000/hao-running.json", PairPort: 443,
+	}
+	user := UserObservation{Name: "agent", UID: 1000, Home: "/home/agent"}
+	for _, id := range []string{"service.daemon", "service.gateway"} {
+		parsed, err := consumeSystemdDefinition(renderSystemdDefinition(id, desired, user))
+		if err != nil {
+			t.Fatalf("%s: %v", id, err)
+		}
+		if parsed.Environment["AO_DATA_DIR"] != desired.DataDir || parsed.Environment["AO_RUN_FILE"] != desired.RunFile {
+			t.Fatalf("%s overrides=%v", id, parsed.Environment)
+		}
 	}
 }
 

--- a/backend/internal/vmgateway/config.go
+++ b/backend/internal/vmgateway/config.go
@@ -321,7 +321,7 @@ func resolvePair(cfg Config, opts Options) (Config, error) {
 
 	cfg.CertDir = firstNonEmpty(opts.CertDir, os.Getenv("AO_VM_CERT_DIR"))
 	if cfg.CertDir == "" {
-		stateDir, err := config.DefaultStateDir()
+		certDir, err := DefaultPairCertDir()
 		if err != nil {
 			return Config{}, fmt.Errorf("resolve pair cert dir: %w", err)
 		}
@@ -333,7 +333,7 @@ func resolvePair(cfg Config, opts Options) (Config, error) {
 		// defaults under the state root rather than the data dir, mirroring
 		// the asymmetry DefaultMachineFilePath's comment explains for the same
 		// reason.
-		cfg.CertDir = filepath.Join(stateDir, "vm-gateway", "pair-cert")
+		cfg.CertDir = certDir
 	}
 
 	cfg.PasscodeDir = firstNonEmpty(opts.PasscodeDir, os.Getenv("AO_VM_PASSCODE_DIR"))
@@ -426,6 +426,17 @@ func DefaultPasscodeDir() (string, error) {
 		return "", fmt.Errorf("resolve pair passcode dir: %w", err)
 	}
 	return filepath.Join(stateDir, "vm-gateway", "pair-passcode"), nil
+}
+
+// DefaultPairCertDir is the persistent pair certificate directory used when
+// AO_VM_CERT_DIR is unset. It intentionally does not follow runtime data or
+// run-file overrides because changing it invalidates client fingerprint pins.
+func DefaultPairCertDir() (string, error) {
+	stateDir, err := config.DefaultStateDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve pair certificate dir: %w", err)
+	}
+	return filepath.Join(stateDir, "vm-gateway", "pair-cert"), nil
 }
 
 // firstNonEmpty returns the first non-empty (after trimming) candidate, or ""

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -45,23 +45,31 @@ surface (`npm run sqlc`, `npm run api`).
   time-bounded tool authentication probes. When the daemon is reachable it
   aggregates the daemon's shared doctor report instead of redefining AO runtime
   or terminal readiness.
-- `hao setup --dry-run` loads the same validated v1 configuration, captures a
-  read-only host snapshot, and emits a deterministic ordered preparation plan.
+- `hao setup` loads the same validated v1 configuration, captures a read-only
+  host snapshot, and emits a deterministic ordered preparation plan before any
+  mutation. Interactive execution requires typed confirmation and unattended
+  execution requires `--non-interactive --yes`.
   Steps are classified as create, update, no-op, or blocked with stable IDs,
   structured privilege/action metadata, dependencies, evidence, and safe
   remediation. Managed paths are inspected through bounded no-follow handles.
   Adjacent AO manifests are observed but are not trusted release authority, so
   artifact or vendor install/no-op steps remain blocked unless immutable trusted
-  version/source/digest provenance is supplied by an injected resolver. The
-  release-metadata resolver and mutation executor are deferred. Canonical
+  version/source/digest provenance is supplied by an injected resolver. Linux
+  release builds inject the exact AO artifact version, immutable release URL,
+  and digest after building and hashing AO. Canonical
   systemd definition content is compared byte-for-byte. Dependency
   installation policy, Ubuntu systemd support, macOS
   desktop supervision, pair prerequisites, and profile-conditional `gh` are
-  planned without executing anything. `--yes` is forward-compatible and has no
-  mutation effect. Setup without `--dry-run` fails closed.
-- Configuration mutation, setup execution, initialization, service lifecycle
-  changes, pairing activation, gateway exposure, authentication flows, and
-  other host mutation are not performed by these commands.
+  planned without executing anything during dry-run. Execution holds a
+  per-state-root lock, verifies bounded downloads before same-filesystem atomic
+  replacement, writes durable transaction journals, retains backups, and rolls
+  reversible file changes back in reverse order. Package and vendor actions use
+  fixed structured argv only when their action metadata is trusted. Service
+  definitions are installed atomically through narrowly scoped privilege and
+  are not enabled or started by setup.
+- Configuration mutation, initialization, service activation, pairing
+  activation, gateway exposure, authentication flows, and other host mutation
+  remain deferred.
 
 ### Backend (Go daemon)
 


### PR DESCRIPTION
## Summary

- Execute the same validated setup action schema emitted by `hao setup --dry-run`.
- Require interactive typed consent or `--non-interactive --yes` before mutation.
- Resolve AO artifacts only from release-embedded version, source, and SHA-256 metadata.
- Apply idempotent directory, mode, artifact, package, vendor, and systemd definition actions.
- Verify bounded downloads before same-filesystem atomic replacement.
- Use structured privileged argv, durable journals, backups, rollback, crash recovery, and per-root locking.
- Preserve service activation, initialization, pairing, authentication, and public exposure as deferred work.

## Verification

- `go test ./internal/haocli -count=1 -timeout=90s`
- `go test -race -timeout=15m ./...` in a clean AO environment
- `go vet ./...`
- `golangci-lint v2.12.2 run ./internal/haocli`
- OpenAPI spec and frontend type regeneration with no drift
- Windows amd64 HAO package compilation
- Linux amd64 and arm64 AO plus HAO release-style builds with embedded artifact metadata

## Review

Independent architecture and security reviews requested against exact head `e419a5351`.

Closes #153
